### PR TITLE
chore: unify cross-platform build scripts and configure Windows AppX

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "1.6.4",
+  "version": "1.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "1.6.4",
+      "version": "1.6.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -38,7 +38,11 @@
         "@types/ws": "^8.5.10",
         "electron": "^31.1.0",
         "electron-builder": "^26.8.1",
+        "kill-port": "^2.0.1",
         "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -3343,6 +3347,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -3955,6 +3966,20 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kill-port": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-2.0.1.tgz",
+      "integrity": "sha512-e0SVOV5jFo0mx8r7bS29maVWp17qGqLBZ5ricNSajON6//kmb7qqqNnml4twNE8Dtj97UQD+gNFOaipS/q1zzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-them-args": "1.3.2",
+        "shell-exec": "1.0.2"
+      },
+      "bin": {
+        "kill-port": "cli.js"
       }
     },
     "node_modules/lazy-val": {
@@ -5668,6 +5693,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shell-exec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
+      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,17 @@
   "name": "flo-desktop",
   "version": "1.6.7",
   "description": "Flo - Self-hosted Point of Sale System",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "main": "dist/index.js",
   "scripts": {
-    "dev": "npm run build:frontend && npm run build && electron .",
+    "clean": "npx kill-port 3001 3002",
+    "predev": "git submodule update --init",
+    "dev": "npm run clean && npm run build:frontend && npm run build && electron .",
     "dev:frontend": "cd frontend && npm run dev",
     "build": "tsc",
-    "build:frontend": "cd frontend && npm ci && NEXT_BUILD_MODE=desktop NEXT_PUBLIC_API_URL=http://localhost:3001/api npm run build",
+    "build:frontend": "cd frontend && npm ci && npx cross-env NEXT_BUILD_MODE=desktop NEXT_PUBLIC_API_URL=http://localhost:3001/api npm run build",
     "build:all-platforms": "npm run build:frontend && npm run build && electron-builder --win --mac --linux",
     "postinstall": "git submodule update --init --recursive && npx @electron/rebuild -f -w better-sqlite3",
     "build:win": "npm run build:frontend && npm run build && electron-builder --win",
@@ -45,6 +50,7 @@
     "@types/ws": "^8.5.10",
     "electron": "^31.1.0",
     "electron-builder": "^26.8.1",
+    "kill-port": "^2.0.1",
     "typescript": "^5.4.5"
   },
   "dependencies": {
@@ -104,9 +110,9 @@
     "appx": {
       "applicationId": "FloCafe",
       "backgroundColor": "#1e1e2e",
-      "publisherDisplayName": "YOUR_PUBLISHER_DISPLAY_NAME",
-      "identityName": "YOUR_IDENTITY_NAME",
-      "publisher": "CN=YOUR_PUBLISHER_CN",
+      "publisherDisplayName": "Codify Apps Private Limited",
+      "identityName": "CodifyAppsPrivateLimited.FloCafe",
+      "publisher": "CN=34AFD24D-EC88-44B8-B309-08BB8A6BB5F7",
       "displayName": "Flo Cafe",
       "languages": [
         "en-US"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:all-platforms": "npm run build:frontend && npm run build && electron-builder --win --mac --linux",
     "postinstall": "git submodule update --init --recursive && npx @electron/rebuild -f -w better-sqlite3",
     "build:win": "npm run build:frontend && npm run build && electron-builder --win",
-    "build:appx": "npm run build:frontend && npm run build && electron-builder --win --target appx",
+    "build:appx": "npm run build:frontend && npm run build && electron-builder --win appx",
     "build:mac": "npm run build:frontend && npm run build && electron-builder --mac",
     "build:mas": "MAS_BUILD=1 npm run build:frontend && MAS_BUILD=1 npm run build && MAS_BUILD=1 electron-builder --mac mas --universal",
     "build:mas-dev": "MAS_BUILD=1 npm run build:frontend && MAS_BUILD=1 npm run build && MAS_BUILD=1 electron-builder --mac masDev",


### PR DESCRIPTION
## Overview
This PR introduces several quality-of-life improvements to the build pipeline to ensure local development works seamlessly across all operating systems (specifically fixing Windows PowerShell compatibility) and prepares the app for Windows packaging.

## Key Changes
* **Windows Compatibility (`cross-env`):** Added `npx cross-env` to the `build:frontend` script. Previously, Windows PowerShell would throw an error trying to parse inline variables like `NEXT_BUILD_MODE=desktop`, preventing Windows devs from building the frontend.
* **Zombie Process Cleanup (`kill-port`):** Added a `clean` script that runs before `dev` to ensure ports 3001 and 3002 are cleared. This prevents the frequent `EADDRINUSE` crash when restarting the dev server.
* **Submodule Guardrails (`predev`):** Added a `git submodule update --init` step before the dev server boots to prevent developers from accidentally running stale frontend code against new backend changes.
* **Production Polish (`appx`):** Swapped the boilerplate `YOUR_PUBLISHER_DISPLAY_NAME` placeholders in `package.json` with the actual "Codify Apps Private Limited" details to prevent future Microsoft Store certification failures.

## Testing
Successfully tested on Windows 11 using PowerShell. The dev server boots cleanly, kills old ports, and compiles Next.js without environment variable errors.