### PR TITLE
fix(windows): add Express path-rewriting middleware for Next.js static exports

### DIFF
--- a/main/kds-server.ts
+++ b/main/kds-server.ts
@@ -33,6 +33,27 @@ function getStaticDir(): string | null {
   return null;
 }
 
+/**
+ * Helper to rewrite dotted Next.js static segment file requests to nested paths on Windows.
+ * E.g., /products/__next.!KGRhc2hib2FyZCk.products.__PAGE__.txt -> /products/__next.!KGRhc2hib2FyZCk/products/__PAGE__.txt
+ */
+function rewriteNextExportPath(reqPath: string): string {
+  const nextIndex = reqPath.indexOf('__next.');
+  if (nextIndex === -1) return reqPath;
+
+  const prefix = reqPath.substring(0, nextIndex + '__next.'.length);
+  const rest = reqPath.substring(nextIndex + '__next.'.length);
+
+  const lastDotIndex = rest.lastIndexOf('.');
+  if (lastDotIndex === -1) return reqPath;
+
+  const namePart = rest.substring(0, lastDotIndex);
+  const extPart = rest.substring(lastDotIndex);
+
+  const rewrittenName = namePart.replace(/\./g, '/');
+  return prefix + rewrittenName + extPart;
+}
+
 export function startKdsServer(): Promise<void> {
   return new Promise((resolve, reject) => {
     const app: Express = express();
@@ -171,6 +192,22 @@ export function startKdsServer(): Promise<void> {
     const staticDir = getStaticDir();
     if (staticDir) {
       console.log(`[KDS Server] Serving static files from: ${staticDir}`);
+
+      // Middleware to patch Windows-specific Next.js static export path nesting
+      app.use((req: Request, res: Response, next: NextFunction) => {
+        if (req.path.includes('__next.')) {
+          const originalPath = req.path;
+          const rewritten = rewriteNextExportPath(originalPath);
+          if (rewritten !== originalPath) {
+            const fullPath = path.join(staticDir, rewritten);
+            if (fs.existsSync(fullPath)) {
+              req.url = rewritten;
+            }
+          }
+        }
+        next();
+      });
+
       app.use(express.static(staticDir, { index: false }));
 
       // Redirect root to standalone KDS

--- a/main/server.ts
+++ b/main/server.ts
@@ -41,6 +41,27 @@ function getFrontendDir(): string | null {
   return null;
 }
 
+/**
+ * Helper to rewrite dotted Next.js static segment file requests to nested paths on Windows.
+ * E.g., /products/__next.!KGRhc2hib2FyZCk.products.__PAGE__.txt -> /products/__next.!KGRhc2hib2FyZCk/products/__PAGE__.txt
+ */
+function rewriteNextExportPath(reqPath: string): string {
+  const nextIndex = reqPath.indexOf('__next.');
+  if (nextIndex === -1) return reqPath;
+
+  const prefix = reqPath.substring(0, nextIndex + '__next.'.length);
+  const rest = reqPath.substring(nextIndex + '__next.'.length);
+
+  const lastDotIndex = rest.lastIndexOf('.');
+  if (lastDotIndex === -1) return reqPath;
+
+  const namePart = rest.substring(0, lastDotIndex);
+  const extPart = rest.substring(lastDotIndex);
+
+  const rewrittenName = namePart.replace(/\./g, '/');
+  return prefix + rewrittenName + extPart;
+}
+
 export function startServer(): Promise<void> {
   return new Promise((resolve, reject) => {
     app = express();
@@ -68,6 +89,22 @@ export function startServer(): Promise<void> {
     const frontendDir = getFrontendDir();
     if (frontendDir) {
       console.log(`[Server] Serving frontend from: ${frontendDir}`);
+
+      // Middleware to patch Windows-specific Next.js static export path nesting
+      app.use((req: Request, res: Response, next: NextFunction) => {
+        if (req.path.includes('__next.')) {
+          const originalPath = req.path;
+          const rewritten = rewriteNextExportPath(originalPath);
+          if (rewritten !== originalPath) {
+            const fullPath = path.join(frontendDir, rewritten);
+            if (fs.existsSync(fullPath)) {
+              req.url = rewritten;
+            }
+          }
+        }
+        next();
+      });
+
       app.use(express.static(frontendDir));
 
       // SPA fallback: any unknown path returns index.html so Next.js


### PR DESCRIPTION
## The Problem

There is a severe Next.js routing bug affecting local Windows development. On Windows, Next.js static exports (`output: "export"`) use backslashes (`\`), which causes the build to generate **nested directories** (e.g., `__next.A\B\__PAGE__.txt`) instead of the expected flat files (e.g., `__next.A.B.__PAGE__.txt`).

When the client router requests the flat file with dots, Windows Express fails to find it. Instead of throwing a 404, the catch-all route silently serves `index.html` as a fallback. React attempts to parse this HTML as an RSC data payload and fails.

**The Symptom:** Because the payload fails to parse, React aborts the navigation. The app gets "stuck" on the current screen. Clicking sidebar links does nothing without a hard manual refresh, effectively breaking SPA navigation for local Windows developers.

*(Note: This does not affect the official GitHub releases because CI/CD runs on Linux runners, which correctly generate the flat files).*

## The Solution

Added a lightweight Express middleware to both `main/server.ts` and `main/kds-server.ts`.

This middleware:

1. Intercepts incoming requests containing `__next.`.
2. Rewrites the dotted segments into directory slashes.
3. Checks `fs.existsSync()` to verify the nested Windows directory actually exists on disk.
4. If it exists, it transparently rewrites `req.url` so `express.static` can serve the correct chunk.

Because of the `fs.existsSync` check, this middleware is a safe "no-op" on Linux/macOS machines and will not interfere with production CI/CD builds.

## Testing

* **Windows (Local):** Verified that navigating between pages (e.g., POS to Products) now successfully transitions the UI immediately instead of getting stuck on the same screen.
* **Builds:** Ran `npm run build` and `npm run build:frontend` to confirm no compilation errors were introduced.