### PR TITLE
fix(security): replace kill-port pkg with native zero-dependency script

### DIFF
--- a/kill-ports.js
+++ b/kill-ports.js
@@ -1,0 +1,40 @@
+/**
+ * kill-ports.js
+ * Zero-dependency cross-platform port killer.
+ * Usage: node kill-ports.js 3001 3002
+ */
+const { exec } = require('child_process');
+const os = require('os');
+
+const ports = process.argv.slice(2);
+
+if (ports.length === 0) {
+  console.log('[kill-ports] No ports specified. Usage: node kill-ports.js 3001 3002');
+  process.exit(0);
+}
+
+const isWindows = os.platform() === 'win32';
+
+function killPort(port) {
+  return new Promise((resolve) => {
+    const command = isWindows
+      ? `FOR /F "tokens=5" %a IN ('netstat -aon ^| findstr ":${port} "') DO @taskkill /F /PID %a 2>nul`
+      : `lsof -ti tcp:${port} | xargs kill -9 2>/dev/null`;
+
+    exec(command, { shell: isWindows ? 'cmd.exe' : '/bin/sh' }, (err) => {
+      if (err && err.code !== 1) {
+        // code 1 just means nothing was using that port — not a real error
+        console.log(`[kill-ports] Port ${port} was already free.`);
+      } else {
+        console.log(`[kill-ports] Cleared port ${port}.`);
+      }
+      resolve();
+    });
+  });
+}
+
+(async () => {
+  for (const port of ports) {
+    await killPort(port);
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@types/ws": "^8.5.10",
         "electron": "^31.7.7",
         "electron-builder": "^26.8.1",
-        "kill-port": "^2.0.1",
         "typescript": "^5.4.5"
       },
       "engines": {
@@ -442,6 +441,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -463,6 +463,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -479,6 +480,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -493,6 +495,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1131,7 +1134,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2137,7 +2139,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2392,7 +2395,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -2792,6 +2794,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -2812,6 +2815,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3341,13 +3345,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/get-them-args": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
-      "integrity": "sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
@@ -3963,20 +3960,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/kill-port": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-2.0.1.tgz",
-      "integrity": "sha512-e0SVOV5jFo0mx8r7bS29maVWp17qGqLBZ5ricNSajON6//kmb7qqqNnml4twNE8Dtj97UQD+gNFOaipS/q1zzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-them-args": "1.3.2",
-        "shell-exec": "1.0.2"
-      },
-      "bin": {
-        "kill-port": "cli.js"
-      }
-    },
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
@@ -4420,6 +4403,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -4881,7 +4865,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -4979,7 +4962,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5057,6 +5039,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -5074,6 +5057,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -5480,6 +5464,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5686,13 +5671,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shell-exec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
-      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -6144,6 +6122,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "dist/index.js",
   "scripts": {
-    "clean": "npx kill-port 3001 3002",
+    "clean": "node kill-ports.js 3001 3002",
     "predev": "git submodule update --init",
     "dev": "npm run clean && npm run build:frontend && npm run build && electron .",
     "dev:frontend": "cd frontend && npm run dev",
@@ -50,7 +50,6 @@
     "@types/ws": "^8.5.10",
     "electron": "^31.7.7",
     "electron-builder": "^26.8.1",
-    "kill-port": "^2.0.1",
     "typescript": "^5.4.5"
   },
   "dependencies": {


### PR DESCRIPTION
Removed kill-port npm package which was compromised in the Shai-Hulud 2.0 supply chain attack (versions 2.0.2 & 2.0.3 contained credential harvesting malware). The 2.0.1 pin with a caret (^) could auto-upgrade to malicious versions during npm install.

Replaced with kill-ports.js - a zero-dependency Node.js script using only Node built-ins (child_process, os) that works cross-platform on Windows (taskkill) and Mac/Linux (lsof/kill).