### PR TITLE
## feat: Per-item loyalty cashback, unified checkout UI, settings cleanup

### DIFF
--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -105,7 +105,7 @@ router.post('/generate', (req: Request, res: Response) => {
 
 router.post('/:id/payment', (req: Request, res: Response) => {
   try {
-    const { method, amount, transaction_id, notes } = req.body;
+    const { method, amount, transaction_id, notes, customer_id: bodyCustomerId } = req.body;
 
     if (!method) {
       return res.status(400).json({ error: 'Payment method is required' });
@@ -158,6 +158,43 @@ router.post('/:id/payment', (req: Request, res: Response) => {
     })();
     existingPayments.push({ method, amount: paidAmount, transaction_id, notes, timestamp: now() });
 
+    const effectiveCustomerId = bill.customer_id || (bodyCustomerId ? String(bodyCustomerId) : null);
+
+    // Pre-compute per-item cashback (only when this payment will fully settle the bill)
+    let loyaltyCashbackToCredit = 0;
+    let loyaltyExpiresAt: string | null = null;
+    if (paymentStatus === 'paid' && effectiveCustomerId) {
+      const loyaltySetting = (db.prepare(
+        `SELECT value FROM settings WHERE key = 'loyalty_enabled'`
+      ).get() as any)?.value;
+      if (loyaltySetting === 'true') {
+        const expiryRow = (db.prepare(
+          `SELECT value FROM settings WHERE key = 'loyalty_expiry_days'`
+        ).get() as any)?.value;
+        const expiryDays = parseInt(expiryRow || '365');
+        const expires = new Date();
+        expires.setDate(expires.getDate() + expiryDays);
+        loyaltyExpiresAt = expires.toISOString().slice(0, 19).replace('T', ' ');
+
+        const items = db.prepare(`
+          SELECT oi.subtotal, p.cb_percent
+          FROM order_items oi
+          JOIN products p ON p.id = oi.product_id
+          WHERE oi.order_id = ? AND p.cb_percent > 0
+        `).all(bill.order_id) as { subtotal: number; cb_percent: number }[];
+        for (const item of items) {
+          loyaltyCashbackToCredit += Math.floor(item.subtotal * item.cb_percent / 100);
+        }
+      }
+    }
+
+    // Update bill's customer_id if it was missing and one was provided
+    if (!bill.customer_id && effectiveCustomerId) {
+      db.prepare('UPDATE bills SET customer_id = ?, updated_at = ? WHERE id = ?')
+        .run(effectiveCustomerId, now(), req.params.id);
+      bill.customer_id = effectiveCustomerId;
+    }
+
     const result = withTxn(() => {
       let walletDebited = false;
 
@@ -186,16 +223,32 @@ router.post('/:id/payment', (req: Request, res: Response) => {
         db.prepare("UPDATE orders SET status = 'completed', completed_at = ?, updated_at = ? WHERE id = ?")
           .run(now(), now(), bill.order_id);
 
-
         const order = db.prepare('SELECT table_id FROM orders WHERE id = ?').get(bill.order_id) as any;
         if (order && order.table_id) {
           db.prepare("UPDATE tables SET status = 'available', updated_at = ? WHERE id = ?")
             .run(now(), order.table_id);
         }
+
+        // Credit per-item cashback (idempotent — skip if already credited for this bill)
+        if (loyaltyCashbackToCredit > 0 && effectiveCustomerId) {
+          const alreadyCredited = db.prepare(
+            `SELECT id FROM loyalty_ledger WHERE bill_id = ? AND type = 'credit'`
+          ).get(bill.id);
+          if (!alreadyCredited) {
+            db.prepare(`
+              INSERT INTO loyalty_ledger (customer_id, bill_id, type, amount, description, expires_at, created_at, updated_at)
+              VALUES (?, ?, 'credit', ?, ?, ?, ?, ?)
+            `).run(
+              effectiveCustomerId, bill.id, loyaltyCashbackToCredit,
+              `Cashback on bill ${bill.bill_number}`,
+              loyaltyExpiresAt, now(), now()
+            );
+          }
+        }
       }
 
       const updatedBill = db.prepare('SELECT * FROM bills WHERE id = ?').get(req.params.id);
-      return { bill: updatedBill, walletDebited };
+      return { bill: updatedBill, walletDebited, loyaltyPointsEarned: loyaltyCashbackToCredit };
     });
 
     if (paymentStatus === 'paid') notifyKdsUpdate();

--- a/main/routes/customers.ts
+++ b/main/routes/customers.ts
@@ -11,7 +11,8 @@ function parseCustomer(c: any): any {
 
 const router = Router();
 
-function getWalletBalance(customerId: string | number): number {
+function getWalletBalance(customerId: string | number | null): number {
+  if (!customerId) return 0;
   const db = getDatabase();
   const credits = db.prepare(`
     SELECT COALESCE(SUM(amount), 0) as total FROM loyalty_ledger
@@ -40,7 +41,14 @@ router.delete('/admin/cleanup', (req: Request, res: Response) => {
 router.get('/', (req: Request, res: Response) => {
   try {
     const db = getDatabase();
-    let query = 'SELECT c.*, COALESCE((SELECT COUNT(*) FROM orders o WHERE o.customer_id = c.id), 0) as visits_count, COALESCE((SELECT SUM(total) FROM orders o WHERE o.customer_id = c.id), 0) as total_spent FROM customers c WHERE 1=1';
+    let query = `SELECT c.*,
+      COALESCE((SELECT COUNT(*) FROM orders o WHERE o.customer_id = c.id), 0) as visits_count,
+      COALESCE((SELECT SUM(total) FROM orders o WHERE o.customer_id = c.id), 0) as total_spent,
+      MAX(0,
+        COALESCE((SELECT SUM(ll.amount) FROM loyalty_ledger ll WHERE ll.customer_id = c.id AND ll.type = 'credit' AND (ll.expires_at IS NULL OR ll.expires_at > datetime('now'))), 0) -
+        COALESCE((SELECT SUM(ll.amount) FROM loyalty_ledger ll WHERE ll.customer_id = c.id AND ll.type = 'debit'), 0)
+      ) as wallet_balance
+      FROM customers c WHERE 1=1`;
     const params: any[] = [];
 
     if (req.query.search) {
@@ -111,7 +119,7 @@ router.get('/:id', (req: Request, res: Response) => {
 router.get('/:id/wallet', (req: Request, res: Response) => {
   try {
     const db = getDatabase();
-    const customerId = parseInt(req.params.id);
+    const customerId = req.params.id;
     const customer = db.prepare('SELECT * FROM customers WHERE id = ?').get(customerId);
     if (!customer) {
       return res.status(404).json({ error: 'Customer not found' });
@@ -119,10 +127,14 @@ router.get('/:id/wallet', (req: Request, res: Response) => {
 
     const balance = getWalletBalance(customerId);
     const transactions = db.prepare(`
-      SELECT * FROM loyalty_ledger WHERE customer_id = ? ORDER BY created_at DESC LIMIT 50
-    `).all(req.params.id);
+      SELECT * FROM loyalty_ledger WHERE customer_id = ? ORDER BY created_at DESC LIMIT 100
+    `).all(customerId);
+    const nextExpiryRow = db.prepare(`
+      SELECT MIN(expires_at) as next_expiry FROM loyalty_ledger
+      WHERE customer_id = ? AND type = 'credit' AND expires_at IS NOT NULL AND expires_at > datetime('now')
+    `).get(customerId) as { next_expiry: string | null };
 
-    res.json({ balance, transactions });
+    res.json({ balance, transactions, next_expiry: nextExpiryRow?.next_expiry || null });
   } catch (error: any) {
     res.status(500).json({ error: error.message });
   }


### PR DESCRIPTION
### Changes
 
**Loyalty System**
- Implement per-item cashback crediting on bill payment — credits `cb_percent` of each order item's subtotal to the customer's loyalty wallet
- Loyalty points are now credited per-item (not per-order total), aligned with per-product cashback configuration
- Removed configurable "Points per ₹" and "Redemption Value" fields from Settings (loyalty is managed per-product via the existing `cb_percent` field)
- Add `GET /customers/:id/loyalty-ledger` — returns balance, next expiry, full transaction history
- Customers list now includes live loyalty balance (pts) from the ledger
 
**Checkout UI Consistency**
- Unified [PrepaidCheckoutModal](cci:1://file:///Users/architvarma/Documents/FloCafe/FloCafe/frontend/src/components/pos/PrepaidCheckoutModal.tsx:26:0-263:1) and [PaymentModal](cci:1://file:///Users/architvarma/Documents/FloCafe/FloCafe/frontend/src/components/pos/PaymentModal.tsx:28:0-291:1) to use the same dark card header (TOTAL DUE + customer name)
- Removed redundant phone number from checkout card
- Added staff-facing loyalty strip in both modals: current pts + expiry date
- Removed marketing-language "earn X points" banner
 
**Customers Page**
- Added loyalty ledger modal (history icon) — shows total balance, next expiry, full transaction table
- Fixed duplicate country code display in phone numbers
- Fixed customer topbar showing raw tag data ("7 x1")
- Loyalty column now shows live pts balance instead of always showing "—"
 
**Settings**
- Loyalty settings page now shows only: Enable toggle + Points Expiry (days)