### PR TITLE
fix(linux): resolve single-instance locking on AppImage, gate updater, and improve window control

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,127 @@
+﻿# ---------------------------------------------------------------
+# FloCafe — Linux Build (Manual Only)
+#
+# Trigger: "Run workflow" button in the Actions tab.
+# No automatic triggers (no push, pull_request, release, or tag).
+#
+# Output: Uploads AppImage + .deb as workflow artifacts.
+# Nothing is published to GitHub Releases or any remote store.
+# ---------------------------------------------------------------
+
+name: Build Linux
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      # ----------------------------------------------------------
+      # 1. Check out the repo and all submodules recursively.
+      #    The `frontend` submodule (FloUI) is required by
+      #    build:frontend. The `specs` submodule has update=none
+      #    so git will skip it automatically.
+      # ----------------------------------------------------------
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # ----------------------------------------------------------
+      # 2. Set up Node.js 22 (matches package.json "engines":
+      #    "node": ">=22.0.0").
+      #    Cache is keyed on package-lock.json so subsequent runs
+      #    skip re-downloading the root node_modules.
+      # ----------------------------------------------------------
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # ----------------------------------------------------------
+      # 3. Install Linux packaging tools needed by electron-builder
+      #    for the deb target. fakeroot + dpkg are required to
+      #    produce a valid .deb file. appimagetool is auto-
+      #    downloaded by electron-builder; no manual install needed.
+      # ----------------------------------------------------------
+      - name: Install Linux packaging tools (fakeroot, dpkg)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y fakeroot dpkg
+
+      # ----------------------------------------------------------
+      # 4. Install Node dependencies.
+      #    `npm ci` respects the lockfile exactly, then runs the
+      #    postinstall script defined in package.json:
+      #      - git submodule update --init frontend  (idempotent)
+      #      - npx @electron/rebuild -f -w better-sqlite3
+      #    This compiles better-sqlite3 against the Linux Electron
+      #    headers - the correct binary for the target platform.
+      # ----------------------------------------------------------
+      - name: Install dependencies (triggers postinstall / better-sqlite3 rebuild)
+        run: npm ci
+
+      # ----------------------------------------------------------
+      # 5a. Cache frontend/node_modules.
+      #     Keyed on the frontend's own lockfile so the cache is
+      #     invalidated whenever frontend dependencies change.
+      #     Falls back to any prior frontend cache on a partial miss.
+      # ----------------------------------------------------------
+      - name: Cache frontend node_modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-
+
+      # ----------------------------------------------------------
+      # 5b. Build the Next.js frontend (NEXT_BUILD_MODE=desktop).
+      #     This is the same step build:linux runs internally;
+      #     doing it separately surfaces frontend errors clearly.
+      #     NEXT_TELEMETRY_DISABLED suppresses outbound telemetry
+      #     calls during the build (faster, no network noise in logs).
+      # ----------------------------------------------------------
+      - name: Build frontend (Next.js static export)
+        run: npm run build:frontend
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+
+      # ----------------------------------------------------------
+      # 5c. Compile TypeScript main process.
+      # ----------------------------------------------------------
+      - name: Build main process (tsc)
+        run: npm run build
+
+      # ----------------------------------------------------------
+      # 5d. Package with electron-builder.
+      #     We call electron-builder directly (not via the
+      #     build:linux npm script) so we can pass --publish never,
+      #     preventing any accidental upload to GitHub Releases even
+      #     though the package.json "publish.provider" is "github".
+      #     No GH_TOKEN is set in this workflow by design.
+      # ----------------------------------------------------------
+      - name: Package Linux (AppImage + deb)
+        run: npx electron-builder --linux --publish never
+
+      # ----------------------------------------------------------
+      # 6. Upload artifacts.
+      #    Output directory is "release/" (set via
+      #    build.directories.output in package.json).
+      #    Only the final AppImage and .deb are uploaded - not
+      #    intermediate builder files (builder-debug.yml, etc.).
+      #    if-no-files-found: error ensures a failed build that
+      #    produces no output is caught immediately, not silently.
+      # ----------------------------------------------------------
+      - name: Upload AppImage and deb artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: flo-cafe-linux-${{ github.run_number }}
+          path: |
+            release/*.AppImage
+            release/*.deb
+          if-no-files-found: error
+          retention-days: 30

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "frontend"]
 	path = frontend
-	url = https://github.com/FreeOpenSourcePOS/FloUI.git
+	url = https://github.com/khaira777/FloUI.git
 [submodule "specs"]
 	path = specs
 	url = https://github.com/FreeOpenSourcePOS/specs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "frontend"]
 	path = frontend
-	url = https://github.com/khaira777/FloUI.git
+	url = https://github.com/FreeOpenSourcePOS/FloUI.git
 [submodule "specs"]
 	path = specs
 	url = https://github.com/FreeOpenSourcePOS/specs.git

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,0 +1,99 @@
+# Flo Cafe — Linux Notes
+
+---
+
+## Packages
+
+| Format | For |
+|--------|-----|
+| **AppImage** (`Flo-Cafe-*.AppImage`) | Any distro — no install needed |
+| **deb** (`flo-cafe_*.deb`) | Debian / Ubuntu and derivatives |
+
+Both are `x86_64` only.
+
+```bash
+# deb
+sudo dpkg -i flo-cafe_*.deb && sudo apt-get install -f
+
+# AppImage
+chmod +x Flo-Cafe-*.AppImage && ./Flo-Cafe-*.AppImage
+```
+
+---
+
+## AppImage — FUSE
+
+AppImage needs FUSE to mount at runtime.
+
+```bash
+# Ubuntu 22.04 / Debian 12
+sudo apt install libfuse2
+
+# Ubuntu 24.04+
+sudo apt install libfuse2t64
+```
+
+No FUSE? Run extracted:
+
+```bash
+./Flo-Cafe-*.AppImage --appimage-extract
+./squashfs-root/AppRun
+```
+
+---
+
+## Updates
+
+**No auto-update on Linux.** Download the new release manually from
+[GitHub Releases](https://github.com/FreeOpenSourcePOS/FloCafe/releases) and
+replace the AppImage or re-run `dpkg -i`.
+
+`electron-updater` doesn't support deb (apt manages it) and requires the
+`APPIMAGE` env var for AppImage (not always set). The updater is disabled on
+Linux at the source level — no error noise.
+
+---
+
+## Thermal Printing
+
+| Capability | Status |
+|------------|--------|
+| Network (TCP port 9100) | ✅ Works |
+| USB via CUPS (`lp`) | ✅ Works — needs CUPS |
+| Auto-detect make/model | ⚠ Returns Generic for everything |
+
+```bash
+# Install CUPS
+sudo apt install cups && sudo systemctl enable --now cups
+
+# Add yourself to the lp group if USB access is denied
+sudo usermod -aG lp $USER
+```
+
+Add/configure printers at `http://localhost:631`.
+
+---
+
+## System Tray
+
+Window close hides the app — use the tray to get it back or quit.
+
+| Action | Result |
+|--------|--------|
+| Click **×** | Window hides |
+| Left-click tray / **Show** | Window shows |
+| **Quit** | Clean shutdown (DB, servers, mDNS) |
+
+> If the tray icon doesn't appear (i3, Sway, bare WMs), install `trayer` or
+> `stalonetray`. Alternatively use **File → Exit** inside the app.
+
+---
+
+## Known Issues / TODO
+
+- **Window menu zoom/front** — macOS-only roles, no-ops on Linux. Cosmetic. See `TODO(linux)` in `main/index.ts`.
+- **Printer make/model** — `detectLinuxPrinters()` always returns Generic. Needs `lpoptions`/`lsusb` integration. Medium effort. See `main/printers/thermal.ts`.
+- **Auto-updater** — manual re-download for now. Future: apt repo, Flatpak, or [AppImageUpdate](https://github.com/AppImageCommunity/AppImageUpdate).
+- **Single-instance locking on AppImage (Custom PID File Lock)** — The default Electron `app.requestSingleInstanceLock()` checks process executable paths in the temporary mounts (e.g. `/tmp/.mount_FloXXXXXX/`), causing it to fail. To resolve this, a custom lock file containing the running process PID is written to `~/.config/flo-desktop/singleton.lock` (the user data path is explicitly set to `~/.config/flo-desktop` at startup on Linux). Startup checks `/proc/<pid>` to verify if the locking process is active.
+
+

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -94,6 +94,9 @@ Window close hides the app — use the tray to get it back or quit.
 - **Window menu zoom/front** — macOS-only roles, no-ops on Linux. Cosmetic. See `TODO(linux)` in `main/index.ts`.
 - **Printer make/model** — `detectLinuxPrinters()` always returns Generic. Needs `lpoptions`/`lsusb` integration. Medium effort. See `main/printers/thermal.ts`.
 - **Auto-updater** — manual re-download for now. Future: apt repo, Flatpak, or [AppImageUpdate](https://github.com/AppImageCommunity/AppImageUpdate).
-- **Single-instance locking on AppImage (Custom PID File Lock)** — The default Electron `app.requestSingleInstanceLock()` checks process executable paths in the temporary mounts (e.g. `/tmp/.mount_FloXXXXXX/`), causing it to fail. To resolve this, a custom lock file containing the running process PID is written to `~/.config/flo-desktop/singleton.lock` (the user data path is explicitly set to `~/.config/flo-desktop` at startup on Linux). Startup checks `/proc/<pid>` to verify if the locking process is active.
+- **Single-instance locking on AppImage (Custom PID File Lock)** — Resolved by implementing a custom lock file containing the running process PID written to a persistent user data path (`~/.config/flo-desktop/singleton.lock`), checking process existence via `/proc/<pid>`.
+- **System Tray "Quit" menu item** — The "Quit" context menu item on the tray does not fully close the app in some environments, requiring investigation of `isQuitting` state lifecycle, event order, and DB/server tear-down sequence.
+- **Debian Package (`.deb`) App Store Metadata** — The built `.deb` lacks standard AppStream metadata (no screenshots, description, or age rating, showing "potentially unsafe" warnings in software centers). Requires adding an AppStream `.metainfo.xml` file and configuring the `desktop` file fields in the packaging configuration.
+
 
 

--- a/main/index.ts
+++ b/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, dialog, Menu, Tray, nativeImage, shell } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import { Bonjour } from 'bonjour-service';
 import { initDatabase, closeDatabase } from './db';
 import { startServer, stopServer, getLocalIP, isServerRunning } from './server';
@@ -118,6 +119,12 @@ function setupAutoUpdater(): void {
 }
 
 function checkForUpdates(): void {
+  // Linux: auto-updater is not supported.
+  // AppImage requires the APPIMAGE env var (not always set) and the deb
+  // package is managed by apt — electron-updater cannot update either.
+  // Skip silently so no error is logged and no error status is sent to the UI.
+  if (process.platform === 'linux') return;
+
   if (isStoreBuild) {
     log.debug('[Update] Store build — updates handled by the platform store');
     mainWindow?.webContents.send('update-status', { status: 'store' });
@@ -140,6 +147,69 @@ let isQuitting = false;
 
 const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 const PORT = parseInt(process.env.PORT || '3001', 10);
+
+let ownsLinuxLock = false;
+let gotSingleInstanceLock = false;
+
+// ── Single-instance lock ──────────────────────────────────────────────────────
+// Prevent multiple instances of the app from running simultaneously.
+// This is especially important on Linux where the AppImage can be launched
+// multiple times without the OS preventing it.
+if (process.platform === 'linux') {
+  // Explicitly set app name and userData path to prevent Electron from
+  // resolving them inside temporary mount paths (e.g. /tmp/.mount_FloXXXXXX)
+  app.name = 'flo-desktop';
+  app.setPath('userData', path.join(os.homedir(), '.config', 'flo-desktop'));
+
+  const lockFilePath = path.join(app.getPath('userData'), 'singleton.lock');
+  let isRunning = false;
+  if (fs.existsSync(lockFilePath)) {
+    try {
+      const lockContent = fs.readFileSync(lockFilePath, 'utf8').trim();
+      const lockPid = parseInt(lockContent, 10);
+      if (!isNaN(lockPid) && fs.existsSync(`/proc/${lockPid}`)) {
+        isRunning = true;
+      }
+    } catch (err) {
+      console.error('[Lock] Failed to read existing lock file:', err);
+    }
+  }
+
+  if (isRunning) {
+    console.log('[Lock] Another instance is already running on Linux. Quitting.');
+    app.quit();
+    process.exit(0);
+  } else {
+    try {
+      // Ensure the directory exists
+      const userDataPath = app.getPath('userData');
+      if (!fs.existsSync(userDataPath)) {
+        fs.mkdirSync(userDataPath, { recursive: true });
+      }
+      fs.writeFileSync(lockFilePath, process.pid.toString(), 'utf8');
+      gotSingleInstanceLock = true;
+      ownsLinuxLock = true;
+    } catch (err) {
+      console.error('[Lock] Failed to write lock file:', err);
+    }
+  }
+} else {
+  gotSingleInstanceLock = app.requestSingleInstanceLock();
+  if (!gotSingleInstanceLock) {
+    app.quit();
+  }
+}
+
+if (gotSingleInstanceLock) {
+  // Focus the existing window if a second launch is attempted.
+  app.on('second-instance', () => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.show();
+      mainWindow.focus();
+    }
+  });
+}
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({
@@ -203,7 +273,11 @@ function createWindow(): void {
   mainWindow.on('close', (event) => {
     if (!isQuitting) {
       event.preventDefault();
-      mainWindow?.hide();
+      if (process.platform === 'linux') {
+        mainWindow?.minimize();
+      } else {
+        mainWindow?.hide();
+      }
     }
   });
 
@@ -245,6 +319,61 @@ function createWindow(): void {
 }
 
 function createTray(): void {
+  if (process.platform === 'linux') {
+    // ── Linux system tray ────────────────────────────────────────────────────
+    // On Linux the window close button hides the window (same as other
+    // platforms), but there is no native macOS-style dock or Windows taskbar
+    // integration to bring it back. A system-tray icon gives Linux users a
+    // persistent, discoverable way to show the window or fully quit the app
+    // (which triggers the existing quit handler that tears down DB, servers,
+    // mDNS, etc.).
+    const linuxIconPath = isDev
+      ? path.join(__dirname, '../../assets/icon-512.png')
+      : path.join(process.resourcesPath, 'assets/icon-512.png');
+
+    try {
+      const linuxIcon = nativeImage.createFromPath(linuxIconPath);
+      tray = new Tray(linuxIcon.resize({ width: 22, height: 22 }));
+
+      const linuxMenu = Menu.buildFromTemplate([
+        {
+          label: 'Show',
+          click: () => {
+            if (mainWindow) {
+              if (mainWindow.isMinimized()) mainWindow.restore();
+              mainWindow.show();
+              mainWindow.focus();
+            }
+          },
+        },
+        {
+          label: 'Quit',
+          click: () => {
+            isQuitting = true;
+            app.quit();
+          },
+        },
+      ]);
+
+      tray.setToolTip('Flo Cafe');
+      tray.setContextMenu(linuxMenu);
+      // Single-click also shows the window on Linux (no double-click standard).
+      tray.on('click', () => {
+        if (mainWindow) {
+          if (mainWindow.isMinimized()) mainWindow.restore();
+          mainWindow.show();
+          mainWindow.focus();
+        }
+      });
+
+      console.log('[Tray] Linux tray created');
+    } catch {
+      console.log('[Tray] Linux icon not found, skipping tray');
+    }
+    return;
+  }
+
+  // ── macOS / Windows tray ─────────────────────────────────────────────────
   const iconPath = isDev
     ? path.join(__dirname, '../../assets/icon.png')
     : path.join(process.resourcesPath, 'assets/icon.png');
@@ -336,6 +465,8 @@ function createMenu(): void {
         { label: 'Flo Cafe', click: () => { mainWindow?.show(); mainWindow?.focus(); } },
         { type: 'separator' },
         { role: 'minimize' },
+        // TODO(linux): 'zoom' and 'front' are macOS-only roles and are no-ops
+        // on Linux and Windows. Wrap in a platform check when cleaning up menus.
         { role: 'zoom' },
         { type: 'separator' },
         { role: 'front' },
@@ -442,7 +573,9 @@ async function initialize(): Promise<void> {
     createWindow();
     createTray();
     createMenu();
-    if (!isStoreBuild) {
+    // Auto-updater: not supported on Linux (AppImage needs APPIMAGE env var;
+    // deb is managed by apt). Skip entirely on Linux to avoid error noise.
+    if (!isStoreBuild && process.platform !== 'linux') {
       setupAutoUpdater();
       setTimeout(() => checkForUpdates(), 5000);
     }
@@ -452,6 +585,7 @@ async function initialize(): Promise<void> {
     console.error('[Flo] Initialization error:', error);
     dialog.showErrorBox('Initialization Error', `Failed to start Flo: ${error}`);
     app.quit();
+    process.exit(1);
   }
 }
 
@@ -477,6 +611,16 @@ app.on('before-quit', () => {
 
 app.on('quit', () => {
   console.log('[Flo] Shutting down...');
+  if (process.platform === 'linux' && ownsLinuxLock) {
+    try {
+      const lockFilePath = path.join(app.getPath('userData'), 'singleton.lock');
+      if (fs.existsSync(lockFilePath)) {
+        fs.unlinkSync(lockFilePath);
+      }
+    } catch (err) {
+      console.error('[Lock] Failed to remove lock file on quit:', err);
+    }
+  }
   cloudSync.stop();
   stopMdns();
   stopKdsServer();

--- a/main/kds-server.ts
+++ b/main/kds-server.ts
@@ -9,8 +9,8 @@ import { getDatabase, parseItemJson } from './db';
 import { setupKdsWebSocket } from './services/kds';
 
 let kdsServer: http.Server | null = null;
-
 const KDS_PORT = parseInt(process.env.KDS_PORT || '3002', 10);
+let activeKdsPort = KDS_PORT;
 
 export function isKdsServerRunning(): boolean {
   return kdsServer !== null;
@@ -193,20 +193,25 @@ export function startKdsServer(): Promise<void> {
     if (staticDir) {
       console.log(`[KDS Server] Serving static files from: ${staticDir}`);
 
-      // Middleware to patch Windows-specific Next.js static export path nesting
-      app.use((req: Request, res: Response, next: NextFunction) => {
-        if (req.path.includes('__next.')) {
-          const originalPath = req.path;
-          const rewritten = rewriteNextExportPath(originalPath);
-          if (rewritten !== originalPath) {
-            const fullPath = path.join(staticDir, rewritten);
-            if (fs.existsSync(fullPath)) {
-              req.url = rewritten;
+      // Middleware to patch Windows-specific Next.js static export path nesting.
+      // On Windows, the Next.js static export uses dotted segments (e.g.
+      // __next.!KGRhc2hib2FyZCk.products.__PAGE__.txt) instead of nested
+      // directories. This rewrite is only needed when the app runs on Windows.
+      if (process.platform === 'win32') {
+        app.use((req: Request, res: Response, next: NextFunction) => {
+          if (req.path.includes('__next.')) {
+            const originalPath = req.path;
+            const rewritten = rewriteNextExportPath(originalPath);
+            if (rewritten !== originalPath) {
+              const fullPath = path.join(staticDir, rewritten);
+              if (fs.existsSync(fullPath)) {
+                req.url = rewritten;
+              }
             }
           }
-        }
-        next();
-      });
+          next();
+        });
+      }
 
       app.use(express.static(staticDir, { index: false }));
 
@@ -243,13 +248,17 @@ export function startKdsServer(): Promise<void> {
       res.status(500).json({ error: err.message || 'Internal server error' });
     });
 
-    kdsServer = app.listen(KDS_PORT, '0.0.0.0', () => {
-      console.log(`[KDS Server] HTTP server running on http://localhost:${KDS_PORT}`);
+    let currentKdsPort = KDS_PORT;
+    let attempts = 0;
+
+    kdsServer = app.listen(currentKdsPort, '0.0.0.0', () => {
+      activeKdsPort = currentKdsPort;
+      console.log(`[KDS Server] HTTP server running on http://localhost:${activeKdsPort}`);
 
       if (kdsServer) {
         const wss = new WebSocketServer({ server: kdsServer, path: '/kds' });
         setupKdsWebSocket(wss);
-        console.log(`[KDS Server] WebSocket running on ws://localhost:${KDS_PORT}/kds`);
+        console.log(`[KDS Server] WebSocket running on ws://localhost:${activeKdsPort}/kds`);
       }
 
       resolve();
@@ -257,8 +266,16 @@ export function startKdsServer(): Promise<void> {
 
     kdsServer?.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'EADDRINUSE') {
-        console.log(`[KDS Server] Port ${KDS_PORT} in use, trying ${KDS_PORT + 1}`);
-        kdsServer?.listen(KDS_PORT + 1, '0.0.0.0');
+        attempts++;
+        if (attempts >= 10) {
+          const errorMsg = `[KDS Server] Failed to bind to any port after 10 attempts starting from ${KDS_PORT}`;
+          console.error(errorMsg);
+          reject(new Error(errorMsg));
+          return;
+        }
+        currentKdsPort++;
+        console.log(`[KDS Server] Port ${currentKdsPort - 1} in use, trying ${currentKdsPort}`);
+        kdsServer?.listen(currentKdsPort, '0.0.0.0');
       } else {
         reject(err);
       }
@@ -275,5 +292,5 @@ export function stopKdsServer(): void {
 }
 
 export function getKdsPort(): number {
-  return KDS_PORT;
+  return activeKdsPort;
 }

--- a/main/server.ts
+++ b/main/server.ts
@@ -90,20 +90,25 @@ export function startServer(): Promise<void> {
     if (frontendDir) {
       console.log(`[Server] Serving frontend from: ${frontendDir}`);
 
-      // Middleware to patch Windows-specific Next.js static export path nesting
-      app.use((req: Request, res: Response, next: NextFunction) => {
-        if (req.path.includes('__next.')) {
-          const originalPath = req.path;
-          const rewritten = rewriteNextExportPath(originalPath);
-          if (rewritten !== originalPath) {
-            const fullPath = path.join(frontendDir, rewritten);
-            if (fs.existsSync(fullPath)) {
-              req.url = rewritten;
+      // Middleware to patch Windows-specific Next.js static export path nesting.
+      // On Windows, the Next.js static export uses dotted segments (e.g.
+      // __next.!KGRhc2hib2FyZCk.products.__PAGE__.txt) instead of nested
+      // directories. This rewrite is only needed when the app runs on Windows.
+      if (process.platform === 'win32') {
+        app.use((req: Request, res: Response, next: NextFunction) => {
+          if (req.path.includes('__next.')) {
+            const originalPath = req.path;
+            const rewritten = rewriteNextExportPath(originalPath);
+            if (rewritten !== originalPath) {
+              const fullPath = path.join(frontendDir, rewritten);
+              if (fs.existsSync(fullPath)) {
+                req.url = rewritten;
+              }
             }
           }
-        }
-        next();
-      });
+          next();
+        });
+      }
 
       app.use(express.static(frontendDir));
 
@@ -130,13 +135,16 @@ export function startServer(): Promise<void> {
       res.status(500).json({ error: err.message || 'Internal server error' });
     });
 
-    server = app.listen(PORT, '0.0.0.0', () => {
-      console.log(`[Server] HTTP server running on http://localhost:${PORT}`);
+    let currentPort = PORT;
+    let attempts = 0;
+
+    server = app.listen(currentPort, '0.0.0.0', () => {
+      console.log(`[Server] HTTP server running on http://localhost:${currentPort}`);
 
       if (server) {
         wss = new WebSocketServer({ server, path: '/kds' });
         setupKdsWebSocket(wss);
-        console.log(`[Server] KDS WebSocket running on ws://localhost:${PORT}/kds`);
+        console.log(`[Server] KDS WebSocket running on ws://localhost:${currentPort}/kds`);
       }
 
       resolve();
@@ -144,8 +152,16 @@ export function startServer(): Promise<void> {
 
     server?.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'EADDRINUSE') {
-        console.log(`[Server] Port ${PORT} in use, trying ${PORT + 1}`);
-        server?.listen(PORT + 1, '0.0.0.0');
+        attempts++;
+        if (attempts >= 10) {
+          const errorMsg = `[Server] Failed to bind to any port after 10 attempts starting from ${PORT}`;
+          console.error(errorMsg);
+          reject(new Error(errorMsg));
+          return;
+        }
+        currentPort++;
+        console.log(`[Server] Port ${currentPort - 1} in use, trying ${currentPort}`);
+        server?.listen(currentPort, '0.0.0.0');
       } else {
         reject(err);
       }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "build": {
     "appId": "com.flo.desktop",
     "productName": "Flo Cafe",
+    "icon": "assets/icon-512.png",
     "asar": true,
     "asarUnpack": "**/node_modules/better-sqlite3/**/*",
     "directories": {


### PR DESCRIPTION
## Description
This PR addresses several critical platform-specific issues to stabilize the Linux build (AppImage and Debian package variants) of Flo Cafe, which was previously only optimized for macOS and Windows. 

### Key Enhancements & Fixes
1. **AppImage Single-Instance Locking (Resolved)**
   * **The Issue:** The default Electron `app.requestSingleInstanceLock()` checks process executable paths inside the mount points (e.g., `/tmp/.mount_FloXXXXXX/`), causing it to consider previous locks stale and launch duplicate windows.
   * **The Fix:** Implemented a custom PID-based file lock at `~/.config/flo-desktop/singleton.lock` using `/proc/<pid>` process checks. 
   * **Persistent Paths:** Explicitly set the `userData` directory to `~/.config/flo-desktop` early in the main process lifecycle to prevent path resolution discrepancies between AppImage mount iterations.

2. **Improved Process Resource Control**
   * Capped the port scanning loops in `server.ts` and `kds-server.ts` to a maximum of 10 attempts (terminating at 3010/3011).
   * Enforced immediate `process.exit()` on initialization failure and lock detection to prevent CPU/memory-hogging zombie background processes from accumulating.

3. **Window Close & Tray Integration**
   * Configured the close handler on Linux to minimize the window to the taskbar/dock instead of hiding it. This keeps the app recoverable in environments where GNOME extensions or tiling window managers do not support status icons.
   * Silently gated the auto-updater to avoid startup crash logs on unsupported platforms.
   * Wrapped Windows-specific Next.js path rewriting middleware to only execute on `win32` hosts.

4. **Linux Documentation**
   * Added `docs/linux.md` mapping package options (AppImage vs deb), FUSE dependencies (Ubuntu `libfuse2`/`libfuse2t64`), CUPS printer setup, and current limitations.

---

## Known Issues / Future Work (Captured in TODOs)
- **Tray "Quit" Handler:** Investigate why right-clicking the system tray icon and selecting "Quit" fails to trigger clean exits in some Linux window managers.
- **Debian Store Metadata:** Create AppStream `.metainfo.xml` files to resolve "unknown license / potentially unsafe" warnings in graphical software centers (Gnome Software / Discover).
- **Thermal Printers Make/Model:** Integrate `lpoptions` or `lsusb` to enrich make/model detection on Linux.
