### PR TITLE
fix(build): use install-app-deps for native modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Flo Cafe are documented here. Dates are release dates, not commit dates. Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.9.1] - 2026-07-14
+
+### Fixed
+- Windows: Fix `better_sqlite3.node is not a valid Win32 application` error by ensuring native dependencies are correctly built for the Electron target runtime using `electron-builder install-app-deps`.
+
 ## [1.8.7] - 2026-07-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Flo - Self-hosted Point of Sale System",
   "engines": {
     "node": ">=22.0.0"
@@ -16,7 +16,7 @@
     "lint": "npm run lint:backend && cd frontend && npm run lint",
     "build:frontend": "cd frontend && npm ci && npx cross-env NEXT_BUILD_MODE=desktop NEXT_PUBLIC_API_URL=http://localhost:3001/api npm run build",
     "build:all-platforms": "npm run build:frontend && npm run build && electron-builder --win --mac --linux",
-    "postinstall": "npx @electron/rebuild -f -w better-sqlite3",
+    "postinstall": "electron-builder install-app-deps",
     "build:win": "npm run build:frontend && npm run build && electron-builder --win",
     "build:appx": "npm run build:frontend && npm run build && electron-builder --win appx",
     "build:mac": "npm run build:frontend && npm run build && electron-builder --mac",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,12 @@
           "arch": [
             "x64"
           ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "icon": "assets/icon.ico"


### PR DESCRIPTION
Fixes the `better_sqlite3.node is not a valid Win32 application` error on Windows by ensuring native dependencies are correctly built for the Electron target runtime instead of the local Node runtime using `electron-builder install-app-deps`.