### PR TITLE
fix(release): run snap builds on ubuntu-24.04 for core24 destructive mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,9 @@ jobs:
       matrix:
         include:
           - arch: x64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
           - arch: arm64
-            runner: ubuntu-22.04-arm64
+            runner: ubuntu-24.04-arm64
     concurrency:
       # Independent per-arch so an arm64 build doesn't cancel x64 (or vice versa).
       group: release-linux-${{ github.ref }}-${{ matrix.arch }}
@@ -99,17 +99,6 @@ jobs:
       - name: Install snapcraft
         # Required for both matrix entries: x64 and arm64 each produce a snap.
         run: sudo snap install snapcraft --classic
-
-      - name: Install LXD
-        # useLXD=true in package.json snapcraft config requires an LXD daemon
-        # running on the host. snapcraft manages the container lifecycle, but
-        # daemon install + init is on us. Both ubuntu-22.04 and the arm64
-        # variant support this. --minimal answers all of lxd init's prompts
-        # with sane defaults (dir storage backend, lxdbr0 bridge, no IPv6).
-        run: |
-          sudo snap install lxd
-          sudo lxd init --minimal
-          sudo lxd waitready
 
       - name: Install npm dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
         "extensions": [
           "gnome"
         ],
-        "useLXD": true,
+        "useDestructiveMode": true,
         "plugs": [
           "default",
           "cups-control",

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -129,8 +129,8 @@ function run() {
     'release-linux job must run scripts/update-metainfo.js before the electron-builder build.'
   );
   assert.ok(
-    /ubuntu-22\.04-arm64/.test(linuxJob),
-    'release-linux job must include an ubuntu-22.04-arm64 matrix entry so arm64 AppImages ' +
+    /ubuntu-24\.04-arm64/.test(linuxJob),
+    'release-linux job must include an ubuntu-24.04-arm64 matrix entry so arm64 AppImages ' +
     'are actually built — declaring arm64 in build.linux.target is not enough without a runner.'
   );
   assert.ok(


### PR DESCRIPTION
v2.0.6's release run failed:

  ⨯ snapcraft process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
  Ubuntu 24.04 builds cannot be performed on this Ubuntu 22.04 system.

The snap base is core24. snapcraft.core24.useDestructiveMode runs the
build on the host, which only works when the host matches the base.
The release runners were on ubuntu-22.04, so destructive mode bailed.

d823951 ("build snap via LXD") tried to work around this with LXD on
the 22.04 host. It works, but it pulls in a daemon install and an
extra --use-lxd flag path. None of that is needed when the host
matches the base, so I'm reverting it.

Two changes:

1. Move the runners to ubuntu-24.04 / ubuntu-24.04-arm64. Both are
   GA on GitHub Actions and ship snapd preinstalled.

2. Revert d823951: drop the LXD install step from release.yml and
   restore useDestructiveMode: true in package.json.

Net effect: snap builds run directly on the host, no container, no
daemon install, no extra CLI flag.

SNAPCRAFT_BUILD_ENVIRONMENT=host stays in the build env. Electron-builder
sets the same value internally when useDestructiveMode is on, so the
env var is redundant but harmless.