### PR TITLE
chore(release): bump version to 2.0.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,17 @@ jobs:
         # Required for both matrix entries: x64 and arm64 each produce a snap.
         run: sudo snap install snapcraft --classic
 
+      - name: Install LXD
+        # useLXD=true in package.json snapcraft config requires an LXD daemon
+        # running on the host. snapcraft manages the container lifecycle, but
+        # daemon install + init is on us. Both ubuntu-24.04 and the arm64
+        # variant support this. --minimal answers all of lxd init's prompts
+        # with sane defaults (dir storage backend, lxdbr0 bridge, no IPv6).
+        run: |
+          sudo snap install lxd
+          sudo lxd init --minimal
+          sudo lxd waitready
+
       - name: Install npm dependencies
         run: npm ci
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Flo Cafe are documented here. Dates are release dates, not commit dates. Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.0.8] - 2026-07-24
+
+### Fixed
+- Linux snap builds never actually shipped despite 2.0.5 wiring the publish step. The chain was: (a) release runners were stuck on `ubuntu-22.04` which can't host core24 destructive builds (`ERR_ELECTRON_BUILDER_CANNOT_EXECUTE — Ubuntu 24.04 builds cannot be performed on this Ubuntu 22.04 system`); (b) once runners moved to `ubuntu-24.04` / `ubuntu-24.04-arm64`, destructive mode ran but the `gnome` extension can't resolve its `command-chain` source on a host build (`/usr/share/snapcraft/extensions/desktop/command-chain` lives in the snapcraft snap, not on the host). Switched to `useLXD: true`: snapcraft now runs inside an LXD container that matches the core24 base and has the gnome SDK + command-chain source mounted. Release runners remain on `ubuntu-24.04` / `ubuntu-24.04-arm64`; the LXD install + init step is restored in the workflow.
+
+### Changed
+- Linux AppImage, deb, rpm and snap are now built on `ubuntu-24.04` and `ubuntu-24.04-arm64`. Every release ships the full target quartet (AppImage + deb + rpm + snap) for **both** `x86_64` / `amd64` and `arm64`. The arm64 build was previously declared but never ran.
+- Linux snap is now actually published to the Snap Store as part of the release pipeline. 2.0.5 added the wiring, but 2.0.6 (the first attempt) failed at the snapcraft step and shipped without a snap. 2.0.8 is the first release with a working snap upload under the `flocafe` name, on `amd64` and `arm64` revisions.
+
 ## [2.0.6] - 2026-07-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "2.0.5",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "2.0.5",
+      "version": "2.0.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Flo - Self-hosted Point of Sale System",
   "engines": {
     "node": ">=22.0.0"
@@ -303,7 +303,7 @@
         "extensions": [
           "gnome"
         ],
-        "useDestructiveMode": true,
+        "useLXD": true,
         "plugs": [
           "default",
           "cups-control",


### PR DESCRIPTION
## Summary

Bump Flo Cafe to 2.0.8 and prepare the Linux release pipeline update for publication.

## Changes

- Update `package.json` and `package-lock.json` to 2.0.8.
- Rename the changelog release entry to 2.0.8.
- Document Linux AppImage, deb, rpm, and snap publishing on amd64 and arm64.
- Use LXD for core24 snap builds.

## Checklist

- [x] `npm run build` passes
- [x] Backend and frontend lint pass with existing warnings
- [ ] `npm test` blocked by an incomplete Electron installation
- [ ] `npm run build:frontend` blocked by npm `EALLOWSCRIPTS`
- [x] No database migrations
