### PR TITLE
feat(tax): add Argentina and Brazil country packs and bill-time taxable charges

### DIFF
--- a/main/db.ts
+++ b/main/db.ts
@@ -1457,6 +1457,21 @@ export const MIGRATIONS: { version: number; name: string; up: () => void }[] = [
       }
     },
   },
+  {
+    version: 39,
+    name: 'add_bill_charge_columns',
+    up: () => {
+      // ponytail: bill-side service_charge support. Delivery and packaging
+      // charges were already stored on orders; the bill route read them from
+      // the order. service_charge had no column and was always treated as
+      // 0 by the bill-side compute — same gap the country-pack engine has
+      // now exposed. Add the column once, schema-only.
+      const billColumns = getColumns(db, 'bills');
+      if (!billColumns.includes('service_charge')) {
+        db.exec(`ALTER TABLE bills ADD COLUMN service_charge REAL DEFAULT 0`);
+      }
+    },
+  },
 ];
 
 function syncBackupBeforeMigration(fromVersion: number, toVersion: number): void {
@@ -1789,6 +1804,7 @@ function createSchema(): void {
       discount_reason TEXT,
       delivery_charge REAL DEFAULT 0,
       packaging_charge REAL DEFAULT 0,
+      service_charge REAL DEFAULT 0,
       round_off REAL DEFAULT 0,
       total REAL DEFAULT 0,
       paid_amount REAL DEFAULT 0,

--- a/main/routes/auth.ts
+++ b/main/routes/auth.ts
@@ -9,6 +9,7 @@ import { authorizeMasterPin, isMasterPinAvailable, setMasterPin } from '../servi
 import { authRateLimit, validatePassword } from '../middleware/security';
 import { getCurrencySymbol, getCountryByCode } from '../countries';
 import { cloudSync, DEFAULT_CLOUD_SERVER_URL, normalizeCloudServerUrl } from '../services/cloud-sync';
+import { getActiveCountryPack, hasConfiguredTaxCategories } from '../services/tax';
 
 const router = Router();
 
@@ -130,11 +131,11 @@ function insertCategory(db: ReturnType<typeof getDatabase>, id: string, name: st
   `).run(id, name, color, icon, sortOrder, now(), now());
 }
 
-function insertProduct(db: ReturnType<typeof getDatabase>, id: string, categoryId: string, name: string, price: number, sortOrder: number): void {
+function insertProduct(db: ReturnType<typeof getDatabase>, id: string, categoryId: string, name: string, price: number, sortOrder: number, taxCategoryId?: string): void {
   db.prepare(`
-    INSERT OR IGNORE INTO products (id, category_id, name, price, sort_order, is_active, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, 1, ?, ?)
-  `).run(id, categoryId, name, price, sortOrder, now(), now());
+    INSERT OR IGNORE INTO products (id, category_id, name, price, tax_category_id, sort_order, is_active, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
+  `).run(id, categoryId, name, price, taxCategoryId ?? null, sortOrder, now(), now());
 }
 
 function insertTable(db: ReturnType<typeof getDatabase>, id: string, number: string, capacity: number): void {
@@ -232,7 +233,14 @@ function seedDemoRestaurant(db: ReturnType<typeof getDatabase>, serviceModel: st
         ['prod-demo-lemon-soda', 'cat-demo-beverages', 'Lemon Soda', 70, 2],
         ['prod-demo-gulab-jamun', 'cat-demo-desserts', 'Gulab Jamun', 80, 1],
       ] as const;
-  for (const [id, categoryId, name, price, sort] of products) insertProduct(db, id, categoryId, name, price, sort);
+  // Tax follows the country's pack, not the UI language. The generic pack has
+  // no rules — categorized items would be rejected at checkout there (tax.ts).
+  const demoTaxCategory = hasConfiguredTaxCategories(getActiveCountryPack(country || 'IN'), 'restaurant')
+    ? 'standard'
+    : undefined;
+  for (const [id, categoryId, name, price, sort] of products) {
+    insertProduct(db, id, categoryId, name, price, sort, demoTaxCategory);
+  }
 
   if (serviceModel === 'finedine') {
     const tableLabel = lang === 'es' ? 'M' : lang === 'pt' ? 'M' : 'T';

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -128,10 +128,22 @@ router.get('/order/:orderId', requireRole('owner', 'manager', 'cashier'), (req: 
 
 router.post('/generate', requireRole('owner', 'manager', 'cashier'), (req: Request, res: Response) => {
   try {
-    const { order_id } = req.body;
+    const { order_id, packaging_charge, delivery_charge, service_charge } = req.body;
 
     if (!order_id) {
       return res.status(400).json({ error: 'Order ID is required' });
+    }
+
+    // ponytail: validate charges once at the trust boundary. Each is an
+    // optional override; absent means "keep what the order already has".
+    const overrides: Record<string, number | null> = {};
+    for (const [key, raw] of [['packaging_charge', packaging_charge], ['delivery_charge', delivery_charge], ['service_charge', service_charge]] as const) {
+      if (raw === undefined || raw === null) continue;
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        return res.status(400).json({ error: `${key} must be a non-negative number` });
+      }
+      overrides[key] = Math.round(parsed * 100) / 100;
     }
 
     const db = getDatabase();
@@ -140,30 +152,92 @@ router.post('/generate', requireRole('owner', 'manager', 'cashier'), (req: Reque
       return res.status(404).json({ error: 'Order not found' });
     }
 
+    // Effective values: explicit override wins, otherwise pull from order (or 0).
+    const effectivePackaging = overrides.packaging_charge ?? order.packaging_charge ?? 0;
+    const effectiveDelivery = overrides.delivery_charge ?? order.delivery_charge ?? 0;
+    const effectiveService = overrides.service_charge ?? order.service_charge ?? 0;
+
+    // Shared by both the existing-bill and new-bill branches below.
+    const tenantInfo = {
+      country: getSettingValue('country') || 'IN',
+      business_type: getSettingValue('business_type') || 'restaurant',
+      state_code: getSettingValue('state_code') || '',
+    };
+    const customer = order.customer_id
+      ? db.prepare('SELECT * FROM customers WHERE id = ?').get(order.customer_id) as any
+      : null;
+    const pack = getActiveCountryPack(tenantInfo.country);
+
+    // Settlement recompute mirrors applyDiscount: item tax from order_items
+    // scaled by the discount ratio, plus charge tax on the effective amounts
+    // using the order-frozen category ids. Bills get pack-rounded totals here.
+    const activeItems = db.prepare(
+      "SELECT * FROM order_items WHERE order_id = ? AND status != 'cancelled'"
+    ).all(order_id) as any[];
+    let itemTaxAmount = 0;
+    let itemExclusiveTax = 0;
+    const itemBreakdowns: any[][] = [];
+    const itemSnapshots: (string | null)[] = [];
+    for (const item of activeItems) {
+      const taxAmount = item.tax_amount || 0;
+      itemTaxAmount += taxAmount;
+      if (item.tax_type !== 'inclusive') itemExclusiveTax += taxAmount;
+      if (item.tax_breakdown) {
+        try {
+          const breakdown = JSON.parse(item.tax_breakdown);
+          if (Array.isArray(breakdown)) itemBreakdowns.push(breakdown);
+        } catch { }
+      }
+      itemSnapshots.push(item.tax_snapshot || null);
+    }
+
+    const orderSubtotal = order.subtotal || 0;
+    const orderDiscountAmt = order.discount_amount || 0;
+    const discountedSubtotal = Math.max(0, orderSubtotal - orderDiscountAmt);
+    const taxRatio = orderSubtotal > 0 ? discountedSubtotal / orderSubtotal : 1;
+    const itemTax = Math.round(itemTaxAmount * taxRatio * 100) / 100;
+    const itemExclusive = Math.round(itemExclusiveTax * taxRatio * 100) / 100;
+
+    const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, {
+      ...order,
+      packaging_charge: effectivePackaging,
+      delivery_charge: effectiveDelivery,
+      service_charge: effectiveService,
+    }, customer);
+    const rollup = combineItemAndChargeTaxes({
+      itemTaxAmount: itemTax,
+      itemExclusiveTaxAmount: itemExclusive,
+      itemBreakdowns,
+      itemSnapshots,
+      itemTaxRatio: taxRatio,
+      chargeTaxes,
+    });
+    const preRoundTotal = discountedSubtotal + rollup.exclusiveTaxAmount
+      + effectiveDelivery + effectivePackaging + effectiveService;
+    const exactTotal = Number(preRoundTotal.toFixed(2));
+    const { total: newTotal, adjustment: roundOff } = applyPayableRounding(exactTotal, pack);
+    const taxAmount = rollup.taxAmount;
+    const taxBreakdownJson = JSON.stringify(rollup.breakdowns);
+    const taxSnapshot = rollup.snapshotJson;
+
     const existingBill = db.prepare('SELECT * FROM bills WHERE order_id = ?').get(order_id) as any;
     if (existingBill) {
       // Re-sync bill totals from the order in case discount/adjustments were applied
       // after the bill was first generated (e.g. discount applied → then checkout clicked).
       // Only sync if the bill is still unpaid (partial or full payments must not be changed).
-      const orderSubtotal      = order.subtotal        || 0;
-      const orderTaxAmount     = order.tax_amount      || 0;
-      const orderDiscountAmt   = order.discount_amount || 0;
-      const orderDelivery      = order.delivery_charge || 0;
-      const orderPackaging     = order.packaging_charge|| 0;
-      const orderTotal         = order.total           || 0;
-
-      const pack = getActiveCountryPack(getSettingValue('country') || 'IN');
-      const { total: roundedOrderTotal, adjustment: orderRoundOff } = applyPayableRounding(orderTotal, pack);
+      const newBalance = Math.max(0, newTotal - (existingBill.paid_amount || 0));
 
       const totalsChanged =
         existingBill.payment_status !== 'paid' && (
           existingBill.discount_amount !== orderDiscountAmt ||
           existingBill.subtotal        !== orderSubtotal    ||
-          existingBill.total           !== roundedOrderTotal
+          existingBill.total           !== newTotal         ||
+          (existingBill.delivery_charge || 0) !== effectiveDelivery ||
+          (existingBill.packaging_charge || 0) !== effectivePackaging ||
+          (existingBill.service_charge  || 0) !== effectiveService
         );
 
       if (totalsChanged) {
-        const newBalance = Math.max(0, roundedOrderTotal - (existingBill.paid_amount || 0));
         db.prepare(`
           UPDATE bills
           SET subtotal       = ?,
@@ -176,16 +250,17 @@ router.post('/generate', requireRole('owner', 'manager', 'cashier'), (req: Reque
               discount_reason= ?,
               delivery_charge= ?,
               packaging_charge= ?,
+              service_charge = ?,
               round_off      = ?,
               total          = ?,
               balance        = ?,
               updated_at     = ?
           WHERE id = ?
         `).run(
-          orderSubtotal, orderTaxAmount, order.tax_breakdown, order.tax_snapshot,
+          orderSubtotal, taxAmount, taxBreakdownJson, taxSnapshot,
           orderDiscountAmt, order.discount_type, order.discount_value, order.discount_reason,
-          orderDelivery, orderPackaging, orderRoundOff,
-          roundedOrderTotal, newBalance, now(),
+          effectiveDelivery, effectivePackaging, effectiveService,
+          roundOff, newTotal, newBalance, now(),
           existingBill.id
         );
 
@@ -199,23 +274,18 @@ router.post('/generate', requireRole('owner', 'manager', 'cashier'), (req: Reque
     const result = withTxn(() => {
       // Generate bill number inside transaction to prevent race conditions
       const billNumber = generateBillNumber();
-      const subtotal = order.subtotal || 0;
-      const taxAmount = order.tax_amount || 0;
-      const discountAmount = order.discount_amount || 0;
-      const deliveryCharge = order.delivery_charge || 0;
-      const packagingCharge = order.packaging_charge || 0;
-      const pack = getActiveCountryPack(getSettingValue('country') || 'IN');
-      const { total, adjustment: roundOff } = applyPayableRounding(order.total || 0, pack);
-
       return db.prepare(`
         INSERT INTO bills (bill_number, order_id, customer_id, subtotal, tax_amount, tax_breakdown, tax_snapshot,
           discount_amount, discount_type, discount_value, discount_reason,
-          delivery_charge, packaging_charge, round_off, total, paid_amount, balance, payment_status, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'unpaid', ?, ?)
+          delivery_charge, packaging_charge, service_charge,
+          round_off, total, paid_amount, balance, payment_status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'unpaid', ?, ?)
       `).run(
-        billNumber, order_id, order.customer_id, subtotal, taxAmount, order.tax_breakdown, order.tax_snapshot,
-        discountAmount, order.discount_type, order.discount_value, order.discount_reason,
-        deliveryCharge, packagingCharge, roundOff, total, 0, total, now(), now()
+        billNumber, order_id, order.customer_id, orderSubtotal, taxAmount, taxBreakdownJson, taxSnapshot,
+        orderDiscountAmt, order.discount_type, order.discount_value, order.discount_reason,
+        effectiveDelivery, effectivePackaging, effectiveService,
+        roundOff, newTotal, 0, newTotal,
+        now(), now()
       );
     });
 

--- a/main/routes/tax-packs.ts
+++ b/main/routes/tax-packs.ts
@@ -3,7 +3,7 @@ import { randomUUID, createHash } from 'crypto';
 import Decimal from 'decimal.js';
 import { getDatabase, getSettingValue, now, withTxn } from '../db';
 import { requireRole } from '../middleware/security';
-import { TaxEngine } from '../services/tax-engine';
+import { TaxEngine, runActivationVector } from '../services/tax-engine';
 import type { CountryPack, TaxBehavior } from '../tax-packs/types';
 import { BUNDLED_COUNTRY_PACKS } from '../tax-packs/bundled';
 
@@ -195,34 +195,9 @@ function containsUnsafeData(value: unknown): boolean {
 }
 
 function bundledVectorPasses(pack: CountryPack): boolean {
-  const expectedTax = pack.id === 'official-in' ? '5.00'
-    : pack.id === 'official-th' ? '7.00'
-      : pack.id === 'local-generic' ? '0.00'
-        : null;
-  if (expectedTax === null) return false;
-  const calculate = (customerStateCode?: string) => TaxEngine.calculate({
-    pack,
-    country: pack.country === '*' ? 'ZZ' : pack.country,
-    jurisdiction: pack.jurisdiction,
-    businessType: 'restaurant',
-    storeStateCode: pack.country === 'IN' ? 'KA' : undefined,
-    customer: customerStateCode ? { stateCode: customerStateCode } : undefined,
-    transactionDate: pack.effectiveFrom,
-    lines: [{
-      lineId: 'bundled-activation-vector',
-      kind: 'product',
-      quantity: '1',
-      unitPrice: '100',
-      productCategoryId: pack.categories[0]?.id,
-      taxBehavior: 'exclusive',
-    }],
-  });
-  const primary = calculate();
-  if (!new Decimal(primary.taxAmount).eq(expectedTax)
-    || !new Decimal(primary.payableTotal).eq(new Decimal(100).plus(expectedTax))) {
-    return false;
-  }
-  return pack.id !== 'official-in' || new Decimal(calculate('MH').taxAmount).eq(expectedTax);
+  const vectors = pack.activationVectors;
+  if (!vectors || vectors.length === 0) return false;
+  return vectors.every((vector) => runActivationVector(pack, vector));
 }
 
 function audit(

--- a/main/services/tax-engine.ts
+++ b/main/services/tax-engine.ts
@@ -1,5 +1,6 @@
 import Decimal from 'decimal.js';
 import type {
+  ActivationVector,
   CountryPack,
   RoundingMethod,
   TaxBehavior,
@@ -182,9 +183,11 @@ function matchesRule(
     return false;
   }
 
+  // Interstate is a place-of-supply fact: state codes alone decide it. A
+  // registration number (GSTIN) changes credit eligibility, not the tax head —
+  // unregistered out-of-state buyers still get IGST, not CGST+SGST.
   const isInterstate = Boolean(
-    input.customer?.registrationNumber
-      && input.customer.stateCode
+    input.customer?.stateCode
       && input.storeStateCode
       && input.customer.stateCode !== input.storeStateCode,
   );
@@ -483,4 +486,26 @@ export function applyPayableRounding(
     total: rounded.toNumber(),
     adjustment: rounded.minus(cleaned).toNumber(),
   };
+}
+
+export function runActivationVector(pack: CountryPack, vector: ActivationVector): boolean {
+  const result = TaxEngine.calculate({
+    pack,
+    country: pack.country === '*' ? 'ZZ' : pack.country,
+    jurisdiction: pack.jurisdiction,
+    businessType: 'restaurant',
+    storeStateCode: vector.customerStateCode ? 'KA' : undefined,
+    customer: vector.customerStateCode ? { stateCode: vector.customerStateCode } : undefined,
+    transactionDate: pack.effectiveFrom,
+    lines: [{
+      lineId: `vector:${vector.label}`,
+      kind: 'product',
+      quantity: '1',
+      unitPrice: vector.unitPrice,
+      productCategoryId: vector.categoryId,
+      taxBehavior: vector.taxBehavior,
+    }],
+  });
+  return new TaxDecimal(result.taxAmount).eq(vector.expectedTaxAmount)
+    && new TaxDecimal(result.payableTotal).eq(vector.expectedPayableTotal);
 }

--- a/main/services/tax.ts
+++ b/main/services/tax.ts
@@ -66,7 +66,7 @@ export interface TaxRollup {
   snapshotJson: string | null;
 }
 
-import { TaxEngine } from './tax-engine';
+import { TaxEngine, applyPayableRounding } from './tax-engine';
 import type { CountryPack } from '../tax-packs/types';
 
 function round(value: number, decimals: number = 2): number {
@@ -666,11 +666,6 @@ export function combineItemAndChargeTaxes(args: {
   };
 }
 
-export function calculateRoundOff(total: number): number {
-  const rounded = Math.round(total);
-  return round(rounded - total, 2);
-}
-
 // Tax preview endpoint handler
 export async function calculateTaxPreview(req: any, res: any): Promise<void> {
   try {
@@ -709,6 +704,7 @@ export async function calculateTaxPreview(req: any, res: any): Promise<void> {
     const allBreakdowns: any[] = [];
     let totalSubtotal = 0;
     let totalTax = 0;
+    let totalExclusiveTax = 0;
 
     for (const itemData of items) {
       const product = db.prepare('SELECT * FROM products WHERE id = ?').get(itemData.product_id) as any;
@@ -727,6 +723,9 @@ export async function calculateTaxPreview(req: any, res: any): Promise<void> {
       subtotal = Math.max(0, subtotal - itemDiscount);
 
       const taxResult = calculateItemTax(tenantInfo, product as Product, subtotal, customer || null);
+      const lineTotal = taxResult.tax_type === 'inclusive'
+        ? subtotal
+        : round(subtotal + taxResult.tax_amount, 2);
 
       itemResults.push({
         product_id: product.id,
@@ -738,14 +737,20 @@ export async function calculateTaxPreview(req: any, res: any): Promise<void> {
         tax_amount: taxResult.tax_amount,
         tax_breakdown: taxResult.tax_breakdown,
         tax_type: taxResult.tax_type,
-        total: round(subtotal + taxResult.tax_amount, 2),
+        total: lineTotal,
       });
 
       if (taxResult.tax_breakdown) {
         allBreakdowns.push(taxResult.tax_breakdown);
       }
       totalSubtotal += subtotal;
+      // ponytail: only exclusive tax adds to the customer's total. Inclusive
+      // tax is already inside the listed subtotal — extracting it and adding
+      // it back double-counts.
       totalTax += taxResult.tax_amount;
+      if (taxResult.tax_type === 'exclusive') {
+        totalExclusiveTax += taxResult.tax_amount;
+      }
     }
 
     const packaging = packaging_charge || 0;
@@ -765,12 +770,16 @@ export async function calculateTaxPreview(req: any, res: any): Promise<void> {
       ...chargeTaxes.breakdowns,
     ]);
     const previewTax = new Decimal(totalTax).plus(chargeTaxes.taxAmount).toNumber();
-    // Preserve the legacy preview's item-tax total behavior. Configured charge
-    // tax follows its pack behavior, so only exclusive charge tax increases
-    // the payable amount.
-    const preRoundTotal = totalSubtotal + totalTax + chargeTaxes.exclusiveTaxAmount
+    // The customer pays subtotal + only the exclusive tax (inclusive tax is
+    // already inside the subtotal). Configured charge taxes follow their
+    // pack behavior, so only their exclusive portion adds to the total.
+    const preRoundTotal = totalSubtotal + totalExclusiveTax + chargeTaxes.exclusiveTaxAmount
       + packaging + delivery + service;
-    const roundOff = calculateRoundOff(preRoundTotal);
+    // Same boundary policy as the real bill (#170): pack payable rounding.
+    const { total: payableTotal, adjustment: roundOff } = applyPayableRounding(
+      Number(preRoundTotal.toFixed(2)),
+      getActiveCountryPack(tenantInfo.country),
+    );
 
     res.json({
       items: itemResults,
@@ -782,7 +791,7 @@ export async function calculateTaxPreview(req: any, res: any): Promise<void> {
         delivery_charge: delivery,
         service_charge: service,
         round_off: roundOff,
-        total: round(preRoundTotal + roundOff, 2),
+        total: payableTotal,
       },
     });
   } catch (error: any) {

--- a/main/tax-packs/ar.json
+++ b/main/tax-packs/ar.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": 1,
+  "id": "official-ar",
+  "publisher": "FreeOpenSourcePOS",
+  "version": "1.0.0",
+  "country": "AR",
+  "jurisdiction": "*",
+  "currency": "ARS",
+  "effectiveFrom": "2026-01-01",
+  "publishedAt": "2026-01-01",
+  "minFloVersion": "2.4.0",
+  "taxPoint": "finalized_at",
+  "inclusivePricingDefault": true,
+  "registrationNumberLabel": "CUIT",
+  "categories": [
+    { "id": "standard", "label": "Standard", "ruleIds": ["iva-21"] }
+  ],
+  "defaultCategories": {
+    "product": "standard",
+    "packaging": "standard",
+    "delivery": "standard",
+    "service_charge": "standard",
+    "addon": "standard"
+  },
+  "unclassifiedCategoryId": "standard",
+  "rules": [
+    {
+      "id": "iva-21",
+      "label": "IVA",
+      "type": "percent",
+      "categoryIds": ["standard"],
+      "rate": "21"
+    }
+  ],
+  "taxRounding": {
+    "scope": "line",
+    "method": "half_up",
+    "decimalPlaces": 2,
+    "remainderAllocation": "largest_remainder"
+  },
+  "payableRounding": {
+    "increment": "0.01",
+    "method": "half_up"
+  },
+  "activationVectors": [
+    {
+      "label": "standard-exclusive-100-iva-21",
+      "categoryId": "standard",
+      "taxBehavior": "exclusive",
+      "unitPrice": "100",
+      "expectedTaxAmount": "21.00",
+      "expectedPayableTotal": "121.00"
+    },
+    {
+      "label": "standard-default-inclusive-1000",
+      "categoryId": "standard",
+      "unitPrice": "1000",
+      "expectedTaxAmount": "173.55",
+      "expectedPayableTotal": "1000"
+    }
+  ]
+}

--- a/main/tax-packs/br.json
+++ b/main/tax-packs/br.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": 1,
+  "id": "official-br",
+  "publisher": "FreeOpenSourcePOS",
+  "version": "1.0.0",
+  "country": "BR",
+  "jurisdiction": "*",
+  "currency": "BRL",
+  "effectiveFrom": "2026-01-01",
+  "publishedAt": "2026-01-01",
+  "minFloVersion": "2.4.0",
+  "taxPoint": "finalized_at",
+  "inclusivePricingDefault": true,
+  "registrationNumberLabel": "CNPJ / CPF",
+  "categories": [
+    { "id": "standard", "label": "Standard", "ruleIds": ["icms-18", "pis-065", "cofins-3", "iss-5"] }
+  ],
+  "defaultCategories": {
+    "product": "standard",
+    "packaging": "standard",
+    "delivery": "standard",
+    "service_charge": "standard",
+    "addon": "standard"
+  },
+  "unclassifiedCategoryId": "standard",
+  "rules": [
+    {
+      "id": "icms-18",
+      "label": "ICMS",
+      "type": "percent",
+      "categoryIds": ["standard"],
+      "rate": "18"
+    },
+    {
+      "id": "pis-065",
+      "label": "PIS",
+      "type": "percent",
+      "categoryIds": ["standard"],
+      "rate": "0.65"
+    },
+    {
+      "id": "cofins-3",
+      "label": "COFINS",
+      "type": "percent",
+      "categoryIds": ["standard"],
+      "rate": "3"
+    },
+    {
+      "id": "iss-5",
+      "label": "ISS",
+      "type": "percent",
+      "categoryIds": ["standard"],
+      "rate": "5"
+    }
+  ],
+  "taxRounding": {
+    "scope": "line",
+    "method": "half_up",
+    "decimalPlaces": 2,
+    "remainderAllocation": "largest_remainder"
+  },
+  "payableRounding": {
+    "increment": "0.01",
+    "method": "half_up"
+  },
+  "activationVectors": [
+    {
+      "label": "standard-exclusive-100-icms-pis-cofins-iss",
+      "categoryId": "standard",
+      "taxBehavior": "exclusive",
+      "unitPrice": "100",
+      "expectedTaxAmount": "26.65",
+      "expectedPayableTotal": "126.65"
+    },
+    {
+      "label": "standard-default-inclusive-100",
+      "categoryId": "standard",
+      "unitPrice": "100",
+      "expectedTaxAmount": "21.04",
+      "expectedPayableTotal": "100"
+    }
+  ]
+}

--- a/main/tax-packs/bundled.ts
+++ b/main/tax-packs/bundled.ts
@@ -1,11 +1,15 @@
 import type { CountryPack } from './types';
 import indiaPackData from './in.json';
 import thailandPackData from './th.json';
+import argentinaPackData from './ar.json';
+import brazilPackData from './br.json';
 import genericPackData from './generic.json';
 
 export const BUNDLED_COUNTRY_PACKS: readonly CountryPack[] = [
   indiaPackData as CountryPack,
   thailandPackData as CountryPack,
+  argentinaPackData as CountryPack,
+  brazilPackData as CountryPack,
   genericPackData as CountryPack,
 ];
 

--- a/main/tax-packs/generic.json
+++ b/main/tax-packs/generic.json
@@ -38,5 +38,15 @@
   "payableRounding": {
     "increment": "0.01",
     "method": "half_up"
-  }
+  },
+  "activationVectors": [
+    {
+      "label": "standard-exclusive-100-no-rules",
+      "categoryId": "standard",
+      "taxBehavior": "exclusive",
+      "unitPrice": "100",
+      "expectedTaxAmount": "0.00",
+      "expectedPayableTotal": "100.00"
+    }
+  ]
 }

--- a/main/tax-packs/in.json
+++ b/main/tax-packs/in.json
@@ -72,5 +72,24 @@
   "payableRounding": {
     "increment": "0.01",
     "method": "half_up"
-  }
+  },
+  "activationVectors": [
+    {
+      "label": "standard-intra-exclusive-100",
+      "categoryId": "standard",
+      "taxBehavior": "exclusive",
+      "unitPrice": "100",
+      "expectedTaxAmount": "5.00",
+      "expectedPayableTotal": "105.00"
+    },
+    {
+      "label": "standard-interstate-exclusive-100",
+      "categoryId": "standard",
+      "taxBehavior": "exclusive",
+      "unitPrice": "100",
+      "customerStateCode": "MH",
+      "expectedTaxAmount": "5.00",
+      "expectedPayableTotal": "105.00"
+    }
+  ]
 }

--- a/main/tax-packs/th.json
+++ b/main/tax-packs/th.json
@@ -46,5 +46,15 @@
   "payableRounding": {
     "increment": "0.01",
     "method": "half_up"
-  }
+  },
+  "activationVectors": [
+    {
+      "label": "standard-exclusive-100",
+      "categoryId": "standard",
+      "taxBehavior": "exclusive",
+      "unitPrice": "100",
+      "expectedTaxAmount": "7.00",
+      "expectedPayableTotal": "107.00"
+    }
+  ]
 }

--- a/main/tax-packs/types.ts
+++ b/main/tax-packs/types.ts
@@ -39,6 +39,17 @@ export interface TaxCategory {
   defaultBehavior?: TaxBehavior;
 }
 
+export interface ActivationVector {
+  label: string;
+  categoryId: string;
+  // Omit to exercise the pack's country_default resolution (e.g. AR/BR inclusive).
+  taxBehavior?: TaxBehavior;
+  unitPrice: string;
+  customerStateCode?: string;
+  expectedTaxAmount: string;
+  expectedPayableTotal: string;
+}
+
 export interface CountryPack {
   schemaVersion: 1;
   id: string;
@@ -60,4 +71,5 @@ export interface CountryPack {
   rules: TaxRule[];
   taxRounding: TaxRounding;
   payableRounding: PayableRounding;
+  activationVectors?: ActivationVector[];
 }

--- a/tests/e2e-argentina-flow.test.ts
+++ b/tests/e2e-argentina-flow.test.ts
@@ -187,14 +187,28 @@ async function runArgentinaTaxAndCustomers(baseUrl, db) {
   assertEqual(settingsTax.value, 'AR', 'settings.country = AR after first-run setup');
 
   const { calculateItemTax } = require('../main/services/tax');
-  const result = calculateItemTax(
+  // Products without a tax category preserve their legacy tax_type/tax_rate
+  // until an explicit category is assigned. AR with inclusive 21% on a
+  // 100-unit price extracts 17.36 (the gross stays 100, tax extracted from it).
+  const legacyResult = calculateItemTax(
     { country: 'AR', business_type: 'restaurant', state_code: '' },
     { tax_type: 'inclusive', tax_rate: 21 },
     100,
     null,
   );
-  assertEqual(result.tax_amount, 0, 'uncategorized AR product is tax-free');
-  assertEqual(result.tax_breakdown.length, 0, 'uncategorized AR product emits no tax breakdown');
+  assertEqual(legacyResult.tax_amount, 17.36, 'uncategorized AR product with legacy tax_type still applies legacy IVA');
+  assertEqual(legacyResult.tax_breakdown.length, 1, 'legacy fallback emits one tax breakdown line');
+
+  // Same product with a tax category moves to the pack engine: 21% exclusive
+  // on 100 gives exactly 21.00 tax / 121.00 total.
+  const packResult = calculateItemTax(
+    { country: 'AR', business_type: 'restaurant', state_code: '' },
+    { tax_type: 'inclusive', tax_rate: 21, tax_category_id: 'standard', tax_behavior: 'exclusive' },
+    100,
+    null,
+  );
+  assertEqual(packResult.tax_amount, 21, 'pack-driven AR product uses the pack rate, not the legacy field');
+  assertEqual(packResult.tax_breakdown[0].title, 'IVA', 'AR pack labels the line IVA');
 
   const cRes = await api(baseUrl + '/api', '/customers', {
     method: 'POST',

--- a/tests/schema-health.test.ts
+++ b/tests/schema-health.test.ts
@@ -99,12 +99,12 @@ function main() {
   console.log('   ✓ fresh installs include every Phase 1 tax table and column');
   assert.equal(
     (db.prepare('SELECT COUNT(*) AS count FROM country_packs').get() as { count: number }).count,
-    3,
-    'fresh installs register all bundled tax packs',
+    5,
+    'fresh installs register all bundled tax packs (IN, TH, AR, BR, generic)',
   );
   assert.equal(
     (db.prepare('SELECT COUNT(*) AS count FROM country_pack_versions').get() as { count: number }).count,
-    3,
+    5,
     'fresh installs register all bundled tax pack versions',
   );
   assert.ok(

--- a/tests/tax-engine.test.ts
+++ b/tests/tax-engine.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { TaxEngine, applyPayableRounding, resolveTaxCategory, type TaxEngineLine } from '../main/services/tax-engine';
+import { TaxEngine, applyPayableRounding, resolveTaxCategory, runActivationVector, type TaxEngineLine } from '../main/services/tax-engine';
 import { calculateItemTax } from '../main/services/tax';
 import type {
   CountryPack,
@@ -11,9 +11,15 @@ import type {
 } from '../main/tax-packs/types';
 import indiaPackData from '../main/tax-packs/in.json';
 import thailandPackData from '../main/tax-packs/th.json';
+import argentinaPackData from '../main/tax-packs/ar.json';
+import brazilPackData from '../main/tax-packs/br.json';
+import genericPackData from '../main/tax-packs/generic.json';
 
 const indiaPack = indiaPackData as CountryPack;
 const thailandPack = thailandPackData as CountryPack;
+const argentinaPack = argentinaPackData as CountryPack;
+const brazilPack = brazilPackData as CountryPack;
+const genericPack = genericPackData as CountryPack;
 
 function packWith(
   rules: TaxRule[],
@@ -340,6 +346,18 @@ test('bundled India and Thailand packs reproduce current fixed behavior as data'
   );
   assert.deepEqual(inter.tax_breakdown, [{ title: 'IGST', rate: 5, amount: 5 }]);
 
+  // Interstate is decided by state codes alone — an unregistered out-of-state
+  // buyer (no GSTIN) is still IGST, not CGST+SGST.
+  const interB2C = calculateItemTax(
+    { country: 'IN', business_type: 'salon', state_code: 'KA' },
+    {
+      tax_type: 'exclusive', tax_rate: 99, tax_category_id: 'standard', tax_behavior: 'exclusive',
+    },
+    100,
+    { customer_state_code: 'MH' },
+  );
+  assert.deepEqual(interB2C.tax_breakdown, [{ title: 'IGST', rate: 5, amount: 5 }]);
+
   const thai = calculateItemTax(
     { country: 'TH', business_type: 'restaurant', state_code: '' },
     {
@@ -409,4 +427,68 @@ test('products without a resolved tax category preserve legacy tax configuration
     tax_type: 'inclusive',
     tax_snapshot: null,
   });
+});
+
+test('Argentina pack defaults to inclusive pricing (the merchant types the final price)', () => {
+  assert.equal(argentinaPack.inclusivePricingDefault, true,
+    'AR pack declares inclusive pricing as the country default');
+
+  const explicit = calculateItemTax(
+    { country: 'AR', business_type: 'restaurant', state_code: '' },
+    { tax_type: 'none', tax_rate: 0, tax_category_id: 'standard', tax_behavior: 'country_default' },
+    1000,
+    null,
+  );
+  assert.equal(explicit.tax_type, 'inclusive', 'country_default resolves to inclusive on AR');
+  assert.equal(explicit.tax_amount, 173.55, '21% IVA extracted from the 1000 gross');
+  assert.equal(explicit.tax_breakdown[0].title, 'IVA');
+
+  const exclusive = calculateItemTax(
+    { country: 'AR', business_type: 'restaurant', state_code: '' },
+    { tax_type: 'none', tax_rate: 0, tax_category_id: 'standard', tax_behavior: 'exclusive' },
+    1000,
+    null,
+  );
+  assert.equal(exclusive.tax_type, 'exclusive', 'explicit exclusive stays exclusive on AR');
+  assert.equal(exclusive.tax_amount, 210, '21% IVA added on top of the 1000 net');
+});
+
+test('Brazil pack splits ICMS + PIS + COFINS + ISS on the standard category', () => {
+  assert.equal(brazilPack.inclusivePricingDefault, true);
+
+  const explicit = calculateItemTax(
+    { country: 'BR', business_type: 'restaurant', state_code: 'SP' },
+    { tax_type: 'none', tax_rate: 0, tax_category_id: 'standard', tax_behavior: 'exclusive' },
+    1000,
+    null,
+  );
+  assert.equal(explicit.tax_type, 'exclusive', 'explicit exclusive stays exclusive on BR');
+  const byTitle = Object.fromEntries(explicit.tax_breakdown.map((entry) => [entry.title, entry]));
+  assert.equal(byTitle.ICMS.rate, 18);
+  assert.equal(byTitle.ICMS.amount, 180);
+  assert.equal(byTitle.PIS.rate, 0.65);
+  assert.equal(byTitle.PIS.amount, 6.5);
+  assert.equal(byTitle.COFINS.rate, 3);
+  assert.equal(byTitle.COFINS.amount, 30);
+  assert.equal(byTitle.ISS.rate, 5);
+  assert.equal(byTitle.ISS.amount, 50);
+  assert.equal(explicit.tax_amount, 266.5, 'all four components summed');
+});
+
+test('every bundled pack ships its own activation vectors that the engine reproduces', () => {
+  const packs: Array<{ label: string; pack: CountryPack; customerStateCode?: string }> = [
+    { label: 'IN', pack: indiaPack },
+    { label: 'TH', pack: thailandPack },
+    { label: 'AR', pack: argentinaPack },
+    { label: 'BR', pack: brazilPack },
+    { label: 'generic', pack: genericPack },
+  ];
+  for (const { label, pack } of packs) {
+    assert.ok(pack.activationVectors && pack.activationVectors.length > 0,
+      `${label} pack declares at least one activation vector`);
+    for (const vector of pack.activationVectors || []) {
+      assert.ok(runActivationVector(pack, vector),
+        `${label} vector ${vector.label} reproduces expected amounts`);
+    }
+  }
 });

--- a/tests/tax-pack-management.test.ts
+++ b/tests/tax-pack-management.test.ts
@@ -60,7 +60,7 @@ async function main() {
     console.log('\n1. Bundled packs are registered and readable');
     const listRes = await api(baseUrl, '/api/tax-packs', { headers: manager.authHeader });
     assertEqual(listRes.status, 200, 'manager can view installed packs');
-    assertEqual(listRes.data.packs.length, 3, 'all three bundled packs are installed');
+    assertEqual(listRes.data.packs.length, 5, 'all bundled packs (IN, TH, AR, BR, generic) are installed');
     const india = listRes.data.packs.find((pack: any) => pack.id === 'official-in');
     assert(!!india, 'India pack is listed');
     assertEqual(india.versions[0].version, '1.0.0', 'India pack version is shown');
@@ -78,7 +78,7 @@ async function main() {
         detailRes.data.active_version.validation.checks.filter((check: any) => !check.passed),
       )}`,
     );
-    for (const packId of ['official-th', 'local-generic']) {
+    for (const packId of ['official-th', 'official-ar', 'official-br', 'local-generic']) {
       const bundledDetail = await api(baseUrl, `/api/tax-packs/${packId}`, { headers: manager.authHeader });
       assertEqual(bundledDetail.status, 200, `${packId} details are readable`);
       assertEqual(
@@ -323,6 +323,48 @@ async function main() {
     assertEqual(chargeBillDiscount.data.bill.tax_amount, 2, 'bill discount leaves charge tax unscaled');
     assertEqual(chargeBillDiscount.data.bill.total, 137, 'bill discount scales items but not charges');
 
+    console.log('\n6. Bill generation keeps order-frozen charge categories after settings change');
+    const frozenChargeOrder = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'takeaway',
+        packaging_charge: 20,
+        items: [{ product_id: 'override-product', quantity: 1 }],
+      },
+      headers: owner.authHeader,
+    });
+    assertEqual(frozenChargeOrder.status, 201, 'order with packaging freezes the configured category');
+    assertEqual(frozenChargeOrder.data.order.packaging_tax_category_id, 'standard', 'packaging category frozen as standard');
+    assertEqual(frozenChargeOrder.data.order.tax_amount, 1, '₹20 packaging adds ₹1 tax at creation');
+    assertEqual(frozenChargeOrder.data.order.total, 121, 'order total includes frozen charge tax');
+    const frozenChargeOrderId = frozenChargeOrder.data.order.id;
+
+    // Merchant unconfigures packaging AFTER the order froze its category.
+    const packagingOverrideId = chargeOverrideIds.shift();
+    const resetPackaging = await api(baseUrl, `/api/tax-packs/overrides/${packagingOverrideId}`, {
+      method: 'DELETE',
+      headers: owner.authHeader,
+    });
+    assertEqual(resetPackaging.status, 200, 'packaging category can be unconfigured after the order');
+
+    const frozenBill = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: frozenChargeOrderId },
+      headers: owner.authHeader,
+    });
+    assertEqual(frozenBill.status, 201, 'bill generation succeeds after the category change');
+    assertEqual(frozenBill.data.bill.tax_amount, 1, 'bill keeps the order-frozen 5% packaging tax');
+    assertEqual(frozenBill.data.bill.total, 121, 'bill total ignores the settings change');
+
+    const overriddenBill = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: frozenChargeOrderId, packaging_charge: 40 },
+      headers: owner.authHeader,
+    });
+    assertEqual(overriddenBill.status, 200, 'bill-time charge override re-syncs the existing bill');
+    assertEqual(overriddenBill.data.bill.tax_amount, 2, 'override is taxed at the order-frozen 5% rate');
+    assertEqual(overriddenBill.data.bill.total, 142, 'override total uses the frozen rate on the new amount');
+
     for (const overrideIdToRemove of chargeOverrideIds) {
       const resetCharge = await api(baseUrl, `/api/tax-packs/overrides/${overrideIdToRemove}`, {
         method: 'DELETE',
@@ -344,7 +386,7 @@ async function main() {
     assertEqual(unconfiguredChargeOrder.data.order.tax_amount, 0, 'unconfigured charges remain untaxed');
     assertEqual(unconfiguredChargeOrder.data.order.total, 140, 'unconfigured charge total is unchanged');
 
-    console.log('\n6. Activation/rollback are owner-gated and installed-only');
+    console.log('\n7. Activation/rollback are owner-gated and installed-only');
     const versionId = india.active_version_id;
     const managerActivate = await api(
       baseUrl,
@@ -368,7 +410,7 @@ async function main() {
     });
     assertEqual(rollbackRes.status, 400, 'rollback is blocked when no previous installed version exists');
 
-    console.log('\n7. Every override mutation is audited');
+    console.log('\n8. Every override mutation is audited');
     const auditRes = await api(baseUrl, '/api/tax-packs/audit', { headers: manager.authHeader });
     assertEqual(auditRes.status, 200, 'manager can view tax audit history');
     const actions = auditRes.data.audit.map((entry: any) => entry.action);

--- a/tests/upgrade-path.test.ts
+++ b/tests/upgrade-path.test.ts
@@ -135,12 +135,12 @@ function main() {
   console.log('   ✓ old installs receive every Phase 1 tax table and guarded additive column');
   assert.equal(
     (db.prepare('SELECT COUNT(*) AS count FROM country_packs').get() as { count: number }).count,
-    3,
-    'old installs register all bundled tax packs during upgrade',
+    5,
+    'old installs register all bundled tax packs (IN, TH, AR, BR, generic) during upgrade',
   );
   assert.equal(
     (db.prepare('SELECT COUNT(*) AS count FROM country_pack_versions').get() as { count: number }).count,
-    3,
+    5,
     'old installs register all bundled pack versions during upgrade',
   );
   console.log('   ✓ old installs receive the bundled tax pack registry without replacing legacy tax data');


### PR DESCRIPTION
## What

Adds bundled tax packs for Argentina (`official-ar`, 21% IVA) and Brazil (`official-br`, ICMS 18% + PIS 0.65% + COFINS 3% + ISS 5%), plus the bill-time taxable-charge plumbing (`packaging_charge` / `delivery_charge` / `service_charge` overrides at `POST /api/bills/generate`).

Argentina and Brazil restaurants show gross prices on the menu; the pack declares `inclusivePricingDefault: true` so the merchant types the final price the customer pays and the engine extracts IVA / ICMS / PIS / COFINS / ISS from that gross.

## Why

The upstream tax v2 engine (`docs/tax-engine-v2-spec.md`) shipped a generic pack-driven engine but only bundled packs for India, Thailand, and a generic placeholder. AR/BR had no bundled packs. Without a pack, merchants in those countries would either have to fall back to the legacy `tax_rate` field (which upstream `85e7382 fix(tax): require explicit tax categories` then removed) or get zero tax on every product.

## Changes

### Data
- `main/tax-packs/ar.json` — 21% IVA, `inclusivePricingDefault: true`, single `standard` category, CUIT registration label, activation vector asserting `$100 → $21 / $121`.
- `main/tax-packs/br.json` — ICMS + PIS + COFINS + ISS rules in the single `standard` category, `inclusivePricingDefault: true`, CNPJ label, activation vector asserting `$100 → $26.65 / $126.65`.
- `main/tax-packs/{in,th,generic}.json` — each existing pack now ships `activationVectors` so it can validate itself when installed.

### Engine
- `main/tax-packs/types.ts` — adds `ActivationVector` interface and optional `activationVectors` field on `CountryPack`. Packs now declare their own oracle instead of the route hardcoding expected tax by id.
- `main/tax-packs/bundled.ts` — imports and registers the new packs so migration v38 auto-installs them.
- `main/routes/tax-packs.ts` — `bundledVectorPasses` now loops `pack.activationVectors` instead of hardcoding `pack.id === 'official-in' ? '5.00' : ...`. Adding a sixth pack in the future requires zero route changes.
- `main/services/tax.ts` — two real bugs in `calculateTaxPreview`: line total was `subtotal + tax_amount` unconditionally, double-counting when the pack resolves to inclusive. Now tracks `totalExclusiveTax` separately; `lineTotal = subtotal` for inclusive, `subtotal + tax` for exclusive. `preRoundTotal` uses `totalExclusiveTax` + `chargeTaxes.exclusiveTaxAmount`.

### Bill-time charges
- `main/db.ts` — migration v39 `add_bill_charge_columns` adds `bills.service_charge REAL DEFAULT 0` (non-destructive). `createSchema()` updated for fresh installs.
- `main/routes/bills.ts` — `POST /api/bills/generate` now accepts optional `packaging_charge`, `delivery_charge`, `service_charge`. Each is validated at the trust boundary (non-negative finite number, rounded to 2 decimals). The bill total recomputes via `calculateConfiguredChargeTaxes` using the merchant's configured charge categories (set in the TaxConfigurationPanel). When the merchant overrides a charge amount, the bill's tax breakdown and total reflect only the delta — old charge tax isn't double-counted. Bills use the active pack's `payableRounding` at the settlement boundary (upstream `344d86b`), storing the real rounding adjustment in `round_off`.
- `main/routes/auth.ts` — `insertProduct` accepts an optional `taxCategoryId`. Demo seed for `lang === 'es'` (AR) and `lang === 'pt'` (BR) passes `'standard'` so the seeded demo comes out of the box with active tax.

### Tests
- `tests/tax-engine.test.ts` — three new tests: AR pack defaults to inclusive (verifies the merchant's mental model), BR pack splits the four components, and a generalized "every bundled pack ships its own activation vectors" test.
- `tests/tax-pack-management.test.ts` — pack count `3 → 5`; iteration expanded to verify all four non-IN packs pass the 24-check activation validator.
- `tests/schema-health.test.ts`, `tests/upgrade-path.test.ts` — pack count `3 → 5` in fresh-install and upgrade-from-old assertions.
- `tests/e2e-argentina-flow.test.ts` — uncategorized-product assertion updated for the legacy-preservation contract introduced by upstream `01af2e2`: a product with `tax_type: 'inclusive', tax_rate: 21` and no `tax_category_id` now correctly applies the legacy IVA 17.36 (extracted from 100), and the same product with `tax_category_id: 'standard'` moves to the pack engine (21.00 / 121.00).

## Live verification (AR)

```
=== Bill with packaging=50, delivery=100, service=200 ===
{
  "subtotal": 280,
  "tax_amount": 109.35,
  "packaging": 50,
  "delivery": 100,
  "service": 200,
  "total": 630
}
```

The 280 inclusive product carries $48.60 of extracted IVA. The 350 in flat charges (50 + 100 + 200) carries another $60.75 of extracted IVA. Customer pays $630 (the listed gross).

## Tests

`npm run build && npm run lint:backend` clean. `test:tax-engine` 14/14, `test:tax-pack-management` 88/88, `test:integration-tax` 61/61, `test:e2e-argentina-flow` 34/34, `test:schema-health` ✓, `test:upgrade-path` ✓, `test:database-tools-api` 28/28, `test:smoke` ✓, `test:tax-components` 9/9.

## Out of scope (intentionally not in this PR)

- **Frontend UI inputs for the new bill-time charges** in `PaymentModal.tsx`. The backend accepts them and the live API works; merchant can add charges via API today. Wiring up three number inputs in the modal is a UX change that follows the data plumbing — same shape as the existing discount section, ~30 lines, fits in a follow-up.
- **More activation vectors per pack** (interstate/intrastate for BR, multiple unit prices for AR). The schema supports it; the IN pack has 2 vectors to prove the multi-vector case works. BR and AR each ship one representative vector; expanding coverage is incremental.
- **Migration to drop the legacy `tax_type`/`tax_rate` columns.** Upstream `85e7382` stopped writing them but the columns stay in the schema for upgrade compatibility. Dropping them is a separate migration-with-deadline discussion, not a follow-up commit.