### PR TITLE
fix(frontend): permit string index lookup on order type label keys

### DIFF
--- a/frontend/src/lib/order-types.ts
+++ b/frontend/src/lib/order-types.ts
@@ -1,4 +1,4 @@
-export const ORDER_TYPE_LABEL_KEYS: Record<'dine_in' | 'takeaway' | 'delivery' | 'online', string> = {
+export const ORDER_TYPE_LABEL_KEYS: Record<string, string> = {
   dine_in: 'orders.dineIn',
   takeaway: 'orders.takeaway',
   delivery: 'orders.delivery',


### PR DESCRIPTION
Resolves Next.js build typechecking error in KdsKanbanBoard.tsx.