### PR TITLE
perf(queries): index migration + tz-aware days (closes #208)

### DIFF
--- a/frontend/src/app/(dashboard)/customers/page.tsx
+++ b/frontend/src/app/(dashboard)/customers/page.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import toast from 'react-hot-toast';
 import { Plus, Search, X, Edit, Wallet, History, TrendingUp, TrendingDown, AlertCircle } from 'lucide-react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import { parseDbTimestamp } from '@/lib/utils';
 
 import type { Customer } from '@/lib/types';
 import { countryName } from '@/lib/countries';
@@ -61,7 +62,7 @@ export default function CustomersPage() {
   };
 
   const fmtDate = (d: string) => {
-    try { return new Date(d).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' }); }
+    try { return parseDbTimestamp(d).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' }); }
     catch { return d; }
   };
 
@@ -232,6 +233,7 @@ export default function CustomersPage() {
           </tbody>
         </table>
         {customers.length === 0 && <p className="text-center text-gray-500 py-12">{t('customers.empty')}</p>}
+        {customers.length >= 200 && <p className="text-center text-xs text-gray-400 py-3">{t('customers.first200')}</p>}
       </div>
 
       {/* Loyalty Ledger Modal */}

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -12,6 +12,7 @@ import { useConfirm } from '@/hooks/use-confirm';
 import type { OrderItem, Table, Product, Customer } from '@/lib/types';
 import type { Order, Bill } from '@/lib/types';
 import { getCurrencySymbol, getCountryByCode } from '@/lib/countries';
+import { parseDbTimestamp } from '@/lib/utils';
 import { usePrinterStore } from '@/hooks/usePrinter';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useHeldOrdersStore } from '@/store/held-orders';
@@ -289,7 +290,7 @@ export default function OrdersPage() {
   };
 
   const getTimeSince = (dateStr: string) => {
-    const minutes = Math.floor((now - new Date(dateStr).getTime()) / 60000);
+    const minutes = Math.floor((now - parseDbTimestamp(dateStr).getTime()) / 60000);
     if (minutes < 1) return t('common.justNow');
     if (minutes < 60) return `${minutes}m ago`;
     return `${Math.floor(minutes / 60)}h ${minutes % 60}m ago`;

--- a/frontend/src/app/(dashboard)/products/page.tsx
+++ b/frontend/src/app/(dashboard)/products/page.tsx
@@ -8,6 +8,7 @@ import toast from 'react-hot-toast';
 import { Plus, Pencil, Trash2, X, Package, Folder, Puzzle, FileSpreadsheet, Download, Upload, CheckCircle, AlertCircle, AlertTriangle } from 'lucide-react';
 import type { Product, Category, AddonGroup } from '@/lib/types';
 import TagBadge, { tagLabel } from '@/components/pos/DietaryBadge';
+import { parseDbTimestamp } from '@/lib/utils';
 import ImageUploader from '@/components/products/ImageUploader';
 import { getCurrencySymbol, getCountryByCode } from '@/lib/countries';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
@@ -523,7 +524,7 @@ export default function ProductsPage() {
                       </div>
                       {product.has_image && (
                         <img 
-                          src={`${api.defaults.baseURL}/products/${product.id}/image?t=${product.updated_at ? new Date(product.updated_at).getTime() : 0}`}
+                          src={`${api.defaults.baseURL}/products/${product.id}/image?t=${product.updated_at ? parseDbTimestamp(product.updated_at).getTime() : 0}`}
                           alt="" 
                           className="absolute inset-0 w-full h-full object-cover"
                           onError={(e) => { e.currentTarget.style.display = 'none'; }}

--- a/frontend/src/app/(dashboard)/tables/page.tsx
+++ b/frontend/src/app/(dashboard)/tables/page.tsx
@@ -251,7 +251,7 @@ export default function TablesPage() {
   useEffect(() => {
     if (!showDetails) return;
     const fetchOrders = () => {
-      api.get('/orders', { params: { status: 'pending,preparing,ready,served' } })
+      api.get('/orders', { params: { status: 'pending,preparing,ready,served', per_page: 500 } })
         .then(({ data }) => setOrders(data.orders || []))
         .catch(() => {
           // silently fail — tables still show

--- a/frontend/src/app/(dashboard)/whatsapp/page.tsx
+++ b/frontend/src/app/(dashboard)/whatsapp/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { parseDbTimestamp } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import {
@@ -632,7 +633,7 @@ export default function WhatsAppPage() {
                             <TableRow key={b.phone_e164}>
                               <TableCell className="font-mono text-sm">{b.phone_e164}</TableCell>
                               <TableCell className="text-sm text-gray-600">{b.reason ?? '—'}</TableCell>
-                              <TableCell className="text-sm text-gray-600">{new Date(b.blocked_at).toLocaleString()}</TableCell>
+                              <TableCell className="text-sm text-gray-600">{parseDbTimestamp(b.blocked_at).toLocaleString()}</TableCell>
                               <TableCell><Button size="sm" variant="ghost" onClick={() => removeBlock(b.phone_e164)}>{t('whatsapp.blocklist.removeCta')}</Button></TableCell>
                             </TableRow>
                           ))}

--- a/frontend/src/components/kds/KdsKanbanBoard.tsx
+++ b/frontend/src/components/kds/KdsKanbanBoard.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/hooks/useKdsConnection';
 import { ORDER_TYPE_LABEL_KEYS } from '@/lib/order-types';
 import { useI18n } from '@/hooks/useI18n';
+import { parseDbTimestamp } from '@/lib/utils';
 
 export interface KdsKanbanBoardProps {
   orders: KdsOrder[];
@@ -104,7 +105,7 @@ export function KdsKanbanBoard({ orders, updating, updateItemStatus }: KdsKanban
   }, []);
 
   const timeSince = (dateStr: string) => {
-    const totalSeconds = Math.max(0, Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000));
+    const totalSeconds = Math.max(0, Math.floor((Date.now() - parseDbTimestamp(dateStr).getTime()) / 1000));
     const hours = Math.floor(totalSeconds / 3600);
     const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = totalSeconds % 60;

--- a/frontend/src/components/kds/KdsTabsView.tsx
+++ b/frontend/src/components/kds/KdsTabsView.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/hooks/useKdsConnection';
 import { ORDER_TYPE_LABEL_KEYS } from '@/lib/order-types';
 import { useI18n } from '@/hooks/useI18n';
+import { parseDbTimestamp } from '@/lib/utils';
 
 export interface KdsTabsViewProps {
   orders: KdsOrder[];
@@ -40,7 +41,7 @@ export function KdsTabsView({ orders, updating, updateItemStatus }: KdsTabsViewP
   }, []);
 
   const timeSince = useCallback((dateStr: string) => {
-    const totalSeconds = Math.max(0, Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000));
+    const totalSeconds = Math.max(0, Math.floor((Date.now() - parseDbTimestamp(dateStr).getTime()) / 1000));
     const hours = Math.floor(totalSeconds / 3600);
     const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = totalSeconds % 60;

--- a/frontend/src/components/pos/ProductGrid.tsx
+++ b/frontend/src/components/pos/ProductGrid.tsx
@@ -8,6 +8,7 @@ import { nameToColor } from '@/lib/image-utils';
 import TagBadge from './DietaryBadge';
 import api from '@/lib/api';
 import { useI18n } from '@/hooks/useI18n';
+import { parseDbTimestamp } from '@/lib/utils';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 
 const CATEGORY_COLORS: Record<string, { bg: string; text: string; border: string; activeBg: string; activeText: string }> = {
@@ -173,7 +174,7 @@ export default function ProductGrid({
                     {/* Image overlays the tile when available */}
                     {product.has_image && (
                       <img
-                        src={`${api.defaults.baseURL}/products/${product.id}/image?t=${product.updated_at ? new Date(product.updated_at).getTime() : 0}`}
+                        src={`${api.defaults.baseURL}/products/${product.id}/image?t=${product.updated_at ? parseDbTimestamp(product.updated_at).getTime() : 0}`}
                         alt={product.name}
                         className="absolute inset-0 w-full h-full object-cover rounded-lg"
                         onError={(e) => {

--- a/frontend/src/components/settings/TaxConfigurationPanel.tsx
+++ b/frontend/src/components/settings/TaxConfigurationPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { parseDbTimestamp } from '@/lib/utils';
 import {
   AlertTriangle,
   Calculator,
@@ -152,7 +153,8 @@ function apiMessage(error: unknown, fallback: string): string {
 }
 
 function dateTime(value: string): string {
-  const date = new Date(value);
+  // Backend timestamps are UTC space form — parse as UTC, not machine-local.
+  const date = parseDbTimestamp(value);
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 }
 

--- a/frontend/src/hooks/useFormatDate.ts
+++ b/frontend/src/hooks/useFormatDate.ts
@@ -1,6 +1,14 @@
 import { useCallback } from 'react';
 import { useAuthStore } from '@/store/auth';
 import { getCountryByCode } from '@/lib/countries';
+import { parseDbTimestamp } from '@/lib/utils';
+
+// String timestamps arrive in the DB's UTC space form (`YYYY-MM-DD HH:MM:SS`);
+// V8's legacy parser reads that form as machine-local, so only Date/number
+// inputs may use `new Date` directly.
+function toDate(date: string | Date | number): Date {
+  return typeof date === 'string' ? parseDbTimestamp(date) : new Date(date);
+}
 
 export function useFormatDate() {
   const currentTenant = useAuthStore((s) => s.currentTenant);
@@ -18,7 +26,7 @@ export function useFormatDate() {
   const formatDate = useCallback((date?: string | Date | number | null, options?: Intl.DateTimeFormatOptions) => {
     if (!date) return '';
     try {
-      const d = new Date(date);
+      const d = toDate(date);
       if (isNaN(d.getTime())) return String(date);
       return new Intl.DateTimeFormat(locale, {
         timeZone,
@@ -35,7 +43,7 @@ export function useFormatDate() {
   const formatTime = useCallback((date?: string | Date | number | null, options?: Intl.DateTimeFormatOptions) => {
     if (!date) return '';
     try {
-      const d = new Date(date);
+      const d = toDate(date);
       if (isNaN(d.getTime())) return String(date);
       return new Intl.DateTimeFormat(locale, {
         timeZone,
@@ -51,7 +59,7 @@ export function useFormatDate() {
   const formatDateTime = useCallback((date?: string | Date | number | null, options?: Intl.DateTimeFormatOptions) => {
     if (!date) return '';
     try {
-      const d = new Date(date);
+      const d = toDate(date);
       if (isNaN(d.getTime())) return String(date);
       return new Intl.DateTimeFormat(locale, {
         timeZone,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -74,6 +74,7 @@
   "customers.columnDate": "Date",
   "customers.columnLedger": "Ledger",
   "customers.empty": "No customers found",
+  "customers.first200": "Showing the first 200 customers — refine your search to see more.",
   "customers.loyaltyLedger": "Loyalty Ledger",
   "customers.noTransactions": "No transactions yet",
   "customers.totalBalance": "Total Balance",

--- a/frontend/src/lib/i18n/es.json
+++ b/frontend/src/lib/i18n/es.json
@@ -1573,5 +1573,6 @@
   "update.downloadingDetail": "Descargando la versión {version}...",
   "update.versionReady": "La versión {version} está lista para instalar",
   "update.currentVersion": "Versión actual: {version}",
-  "update.restartNow": "Reiniciar ahora"
+  "update.restartNow": "Reiniciar ahora",
+  "customers.first200": "Mostrando los primeros 200 clientes — afina la búsqueda para ver más."
 }

--- a/frontend/src/lib/i18n/pt.json
+++ b/frontend/src/lib/i18n/pt.json
@@ -1573,5 +1573,6 @@
   "update.downloadingDetail": "Baixando a versão {version}...",
   "update.versionReady": "A versão {version} está pronta para instalar",
   "update.currentVersion": "Versão atual: {version}",
-  "update.restartNow": "Reiniciar agora"
+  "update.restartNow": "Reiniciar agora",
+  "customers.first200": "Mostrando os primeiros 200 clientes — refine a busca para ver mais."
 }

--- a/frontend/src/lib/printer/format-date.ts
+++ b/frontend/src/lib/printer/format-date.ts
@@ -1,7 +1,9 @@
+import { parseDbTimestamp } from '@/lib/utils';
+
 export function formatDate(iso?: string, locale: string = 'en-US', options?: Intl.DateTimeFormatOptions): string {
   if (!iso) return '';
   try {
-    const d = new Date(iso);
+    const d = parseDbTimestamp(iso);
     if (isNaN(d.getTime())) return iso;
     return new Intl.DateTimeFormat(locale, {
       year: 'numeric',
@@ -19,7 +21,7 @@ export function formatDate(iso?: string, locale: string = 'en-US', options?: Int
 export function formatTime(iso?: string, locale: string = 'en-US', options?: Intl.DateTimeFormatOptions): string {
   if (!iso) return '';
   try {
-    const d = new Date(iso);
+    const d = parseDbTimestamp(iso);
     if (isNaN(d.getTime())) return iso;
     return new Intl.DateTimeFormat(locale, {
       hour: '2-digit',

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Parse a backend timestamp into a Date. The API stores timestamps in UTC
+ * wall time as `YYYY-MM-DD HH:MM:SS` (space form); V8's legacy parser reads
+ * that form as machine-LOCAL time, so `new Date(ts)` shifts by the host's
+ * offset on machines outside UTC. ISO rows (pre-v45 data) parse as UTC
+ * natively. Use this for every `created_at`/`paid_at`-style field.
+ */
+export function parseDbTimestamp(ts: string | null | undefined): Date {
+  if (!ts) return new Date(NaN)
+  return /^\d{4}-\d{2}-\d{2} /.test(ts) ? new Date(`${ts.replace(' ', 'T')}Z`) : new Date(ts)
+}

--- a/main/db.ts
+++ b/main/db.ts
@@ -1475,7 +1475,7 @@ export const MIGRATIONS: { version: number; name: string; up: () => void }[] = [
     name: 'add_users_tokens_valid_after',
     up: () => {
       // Backs the JWT-revocation-on-credential-change fix (#173): requireAuth
-      // rejects any token whose `iat` predates this timestamp, so changing a
+      // rejects any token whose `iat` predates this `tokens_valid_after`, so changing a
       // password/PIN can invalidate every outstanding session for that user
       // without maintaining a per-token blocklist across devices.
       if (!getColumns(db, 'users').includes('tokens_valid_after')) {
@@ -1577,6 +1577,83 @@ export const MIGRATIONS: { version: number; name: string; up: () => void }[] = [
         CREATE INDEX IF NOT EXISTS idx_store_diagnostics_outbox_retry
           ON store_diagnostics_outbox(status, next_attempt_at, created_at);
       `);
+    },
+  },
+  {
+    // Performance fixes for ~100k+ orders (issue #208) plus timestamp
+    // normalization, in one migration because v40 never shipped outside this
+    // PR (upstream's v40-v44 landed first; this is v45). Indexes are all
+    // `IF NOT EXISTS` so reruns are safe. Range queries
+    // (`created_at >= ? AND created_at < ?`) and the composite used by the
+    // orders list pagination both depend on the indexes.
+    //
+    // The normalization: `now()` used to write ISO-8601 (`...T10:00:00.123Z`)
+    // while rows inserted via CURRENT_TIMESTAMP defaults carry SQLite's
+    // `YYYY-MM-DD HH:MM:SS` form. Mixed formats break string range compares
+    // at day boundaries, intra-day ORDER BY, `expires_at > datetime('now')`
+    // expiry checks, and JS `new Date(ts)` parsing (the space form is read as
+    // machine-local time). Normalize every legacy ISO row to the space form
+    // once, so all rows in a column share one sortable, UTC-wall format.
+    // Only rows containing 'T' are touched; each column is verified to exist
+    // before the UPDATE so odd legacy installs cannot crash the migration.
+    version: 45,
+    name: 'add_performance_indexes_and_normalize_timestamps',
+    up: () => {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_orders_customer ON orders(customer_id);
+        CREATE INDEX IF NOT EXISTS idx_orders_table_id ON orders(table_id);
+        CREATE INDEX IF NOT EXISTS idx_orders_type ON orders(type);
+        CREATE INDEX IF NOT EXISTS idx_bills_created_at ON bills(created_at);
+        CREATE INDEX IF NOT EXISTS idx_bills_paid_status_paid_at ON bills(payment_status, paid_at);
+        CREATE INDEX IF NOT EXISTS idx_bills_customer_id ON bills(customer_id);
+        CREATE INDEX IF NOT EXISTS idx_print_logs_bill_id ON print_logs(bill_id);
+        CREATE INDEX IF NOT EXISTS idx_ledger_bill_id_type ON loyalty_ledger(bill_id, type);
+        CREATE INDEX IF NOT EXISTS idx_order_items_product_id ON order_items(product_id);
+        CREATE INDEX IF NOT EXISTS idx_customers_created_at ON customers(created_at);
+        -- idx_bills_paid_at: payment-method breakdown scans paid_at ranges
+        -- (including NULL for still-open bills); a plain single-column index
+        -- lets the OR optimization use both branches.
+        CREATE INDEX IF NOT EXISTS idx_bills_paid_at ON bills(paid_at);
+      `);
+      const normalize: [string, string][] = [
+        ['orders', 'created_at'], ['orders', 'updated_at'],
+        ['orders', 'cooking_started_at'], ['orders', 'ready_at'],
+        ['orders', 'served_at'], ['orders', 'completed_at'], ['orders', 'cancelled_at'],
+        ['order_items', 'created_at'], ['order_items', 'updated_at'], ['order_items', 'voided_at'],
+        ['bills', 'created_at'], ['bills', 'updated_at'], ['bills', 'paid_at'], ['bills', 'printed_at'],
+        ['customers', 'created_at'], ['customers', 'updated_at'],
+        ['users', 'created_at'], ['users', 'updated_at'],
+        ['users', 'terms_accepted_at'], ['users', 'tokens_valid_after'],
+        ['loyalty_ledger', 'created_at'], ['loyalty_ledger', 'updated_at'], ['loyalty_ledger', 'expires_at'],
+        ['products', 'created_at'], ['products', 'updated_at'],
+        ['addons', 'created_at'], ['addons', 'updated_at'],
+        ['addon_groups', 'created_at'], ['addon_groups', 'updated_at'],
+        ['tables', 'created_at'], ['tables', 'updated_at'],
+        ['settings', 'updated_at'],
+        ['print_logs', 'printed_at'],
+        ['order_item_addons', 'created_at'],
+        ['whatsapp_messages', 'queued_at'], ['whatsapp_messages', 'seen_at'],
+        ['whatsapp_messages', 'typing_at'], ['whatsapp_messages', 'sent_at'],
+        ['whatsapp_messages', 'delivered_at'], ['whatsapp_messages', 'read_at'],
+        ['whatsapp_messages', 'failed_at'],
+        ['whatsapp_blocklist', 'blocked_at'],
+        ['held_orders', 'created_at'], ['held_orders', 'updated_at'],
+        ['kds_pairing_tokens', 'expires_at'], ['kds_pairing_tokens', 'created_at'],
+        // Outbox tables (created by migrations v3/v41, before this one): rows
+        // that failed pre-upgrade carry ISO next_attempt_at, which would sort
+        // after space-form `now()` and defer retries by up to a day.
+        ['cloud_sync_outbox', 'created_at'], ['cloud_sync_outbox', 'updated_at'], ['cloud_sync_outbox', 'next_attempt_at'],
+        ['support_ticket_outbox', 'created_at'], ['support_ticket_outbox', 'updated_at'],
+        ['support_ticket_outbox', 'next_attempt_at'], ['support_ticket_outbox', 'delivered_at'],
+      ];
+      for (const [table, column] of normalize) {
+        if (!getColumns(db, table).includes(column)) continue;
+        // '2026-08-01T10:00:00.123Z' -> '2026-08-01 10:00:00' (second precision,
+        // matching now()/CURRENT_TIMESTAMP). Milliseconds are never relied on.
+        db.prepare(
+          `UPDATE ${table} SET ${column} = substr(REPLACE(${column}, 'T', ' '), 1, 19) WHERE ${column} LIKE '%T%'`
+        ).run();
+      }
     },
   },
 ];
@@ -2384,7 +2461,52 @@ export function generateBillNumber(): string {
 }
 
 export function now(): string {
-  return new Date().toISOString();
+  // Match SQLite's CURRENT_TIMESTAMP format (`YYYY-MM-DD HH:MM:SS`, UTC). The
+  // legacy `new Date().toISOString()` form (with `T`, `Z`, milliseconds) was
+  // mixed into columns whose `CREATE TABLE` defaults use CURRENT_TIMESTAMP, so
+  // range and ordering operations on those columns stopped sorting correctly.
+  // Migration v45 normalized the legacy ISO rows to this format. #208
+  return new Date().toISOString().replace('T', ' ').replace(/\..*$/, '');
+}
+
+/**
+ * Parse a DB timestamp into a Date. Columns are stored in UTC wall time in
+ * `YYYY-MM-DD HH:MM:SS` (space) form — V8's legacy parser treats that form as
+ * machine-LOCAL time, so `new Date(ts)` silently shifts by the host's offset
+ * on machines outside UTC. ISO rows (`...T10:00:00.123Z`, pre-v40 data) parse
+ * as UTC natively. Use this everywhere a stored timestamp is turned into a
+ * Date (reports, receipts, KDS clocks, auth token staleness, telemetry).
+ */
+export function parseDbTimestamp(ts: string | null | undefined): Date {
+  if (!ts) return new Date(NaN);
+  // Space form: append a Z so V8 parses it as UTC instead of machine-local.
+  return /^\d{4}-\d{2}-\d{2} /.test(ts) ? new Date(`${ts.replace(' ', 'T')}Z`) : new Date(ts);
+}
+
+/**
+ * "Today" as a `YYYY-MM-DD` string in UTC. All daily boundaries are UTC —
+ * the tenant timezone setting only drives the insights hour/day bucketing,
+ * never which day a row belongs to.
+ */
+export function utcTodayDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * `[start, end)` half-open range strings (UTC wall, `YYYY-MM-DD HH:MM:SS`)
+ * for a given `YYYY-MM-DD` date. Use with `WHERE col >= ? AND col < ?`
+ * against the UTC timestamp columns (`created_at`, `paid_at`, etc.) so
+ * indexes apply instead of `date(col) = date('now')`, which can't. #208
+ *
+ * Bounds are emitted in the space form so string comparisons line up exactly
+ * with stored rows (migration v40 normalized all rows to it).
+ */
+export function utcDayBounds(date: string): [string, string] {
+  const [y, m, d] = date.split('-').map(Number);
+  const start = new Date(Date.UTC(y, m - 1, d, 0, 0, 0));
+  const end = new Date(start.getTime() + 24 * 3600 * 1000);
+  const fmt = (dt: Date) => dt.toISOString().replace('T', ' ').replace(/\..*$/, '');
+  return [fmt(start), fmt(end)];
 }
 
 /** Verify a user PIN against the stored pin_hash. */
@@ -2408,7 +2530,7 @@ export const KDS_VOIDED_ITEM_VISIBILITY_MS = 15 * 60 * 1000;
  */
 export function isVoidedItemKdsVisible(voidedAt: string | null | undefined): boolean {
   if (!voidedAt) return true;
-  return Date.now() - new Date(voidedAt).getTime() < KDS_VOIDED_ITEM_VISIBILITY_MS;
+  return Date.now() - parseDbTimestamp(voidedAt).getTime() < KDS_VOIDED_ITEM_VISIBILITY_MS;
 }
 
 /**

--- a/main/middleware/security.ts
+++ b/main/middleware/security.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { getDatabase, isKdsEnabled } from '../db';
+import { getDatabase, isKdsEnabled, parseDbTimestamp } from '../db';
 
 interface RateLimitRecord {
   count: number;
@@ -167,12 +167,13 @@ export function invalidateUserAuthCache(userId: string): void {
  */
 export function isTokenStale(iat: number | undefined, tokensValidAfter: string | null | undefined): boolean {
   if (!tokensValidAfter || typeof iat !== 'number') return false;
-  // JWT `iat` only has whole-second resolution, but tokens_valid_after is written with
-  // millisecond precision — comparing them directly would flag a token minted in the
-  // very same second as the change (e.g. the fresh login right after a password reset)
-  // as stale, even though it was actually issued after. Floor tokens_valid_after to
-  // seconds too so both sides compare at the same resolution.
-  const tokensValidAfterSeconds = Math.floor(new Date(tokensValidAfter).getTime() / 1000);
+  // `tokens_valid_after` is stored in the DB's UTC space form; parse it as
+  // UTC — `new Date()` would read it as machine-local and shift the
+  // revocation window by the host's offset. Both sides are compared at
+  // whole-second resolution, so a token minted in the very same second as
+  // the change (e.g. the fresh login right after a password reset) is not
+  // flagged as stale.
+  const tokensValidAfterSeconds = Math.floor(parseDbTimestamp(tokensValidAfter).getTime() / 1000);
   return iat < tokensValidAfterSeconds;
 }
 

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { execSync, exec, execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
-import { getDatabase } from '../db';
+import { getDatabase, parseDbTimestamp } from '../db';
 import { PrinterCutMode, resolvePrinterProfile, matchSupportedPrinterProfile, SupportedPrinterProfile } from './profiles';
 import { getCountryByCode } from '../countries';
 import { resolveTaxComponents } from '../services/tax-components';
@@ -634,7 +634,7 @@ function normalizeReceiptTemplate(template?: string): 'classic' | 'compact' | 'd
 
 function formatCompactReceipt(order: any, bill: any, biz: any, cols: number = 48, useUnicode: boolean = false, isReprint: boolean = false, cutMode: PrinterCutMode = 'full'): Buffer {
   const lines: string[] = [];
-  const date = new Date(order.created_at);
+  const date = parseDbTimestamp(order.created_at);
 
   const bar = '='.repeat(cols);
   const dash = '-'.repeat(cols);
@@ -712,7 +712,7 @@ function formatCompactReceipt(order: any, bill: any, biz: any, cols: number = 48
 
 function formatClassicReceipt(order: any, bill: any, biz: any, cols: number = 48, useUnicode: boolean = false, isReprint: boolean = false, cutMode: PrinterCutMode = 'full'): Buffer {
   const lines: string[] = [];
-  const date = new Date(order.created_at);
+  const date = parseDbTimestamp(order.created_at);
 
   const dash = '-'.repeat(cols);
 
@@ -813,7 +813,7 @@ function formatClassicReceipt(order: any, bill: any, biz: any, cols: number = 48
 
 function formatDetailedReceipt(order: any, bill: any, biz: any, cols: number = 48, useUnicode: boolean = false, isReprint: boolean = false, cutMode: PrinterCutMode = 'full'): Buffer {
   const lines: string[] = [];
-  const date = new Date(order.created_at);
+  const date = parseDbTimestamp(order.created_at);
 
   const bar = '='.repeat(cols);
   const dash = '-'.repeat(cols);
@@ -958,7 +958,7 @@ export function formatKOT(order: any, items: any[], stationName: string, cols: n
   if (order.table) {
     lines.push('Table: ' + order.table.name);
   }
-  lines.push('Time: ' + new Date(order.created_at).toLocaleTimeString(locale + '-u-nu-latn', tzOptions));
+  lines.push('Time: ' + parseDbTimestamp(order.created_at).toLocaleTimeString(locale + '-u-nu-latn', tzOptions));
   lines.push(bar);
   lines.push('');
 

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -1,12 +1,14 @@
 import { Router, Request, Response } from 'express';
 import {
   attachEffectiveAddons,
+  utcDayBounds,
   generateBillNumber,
   getDatabase,
   getSettingValue,
   now,
   parseItemJson,
   parseRowJson,
+  utcTodayDate,
   verifyPin,
   withTxn,
 } from '../db';
@@ -76,16 +78,23 @@ router.get('/', requireRole('owner', 'manager', 'cashier'), (req: Request, res: 
       params.push(req.query.customer_id);
     }
     if (req.query.today === 'true') {
-      query += " AND date(created_at) = date('now')";
+      // #208: UTC-day range hits `idx_bills_created_at` instead of date() on every row.
+      const [s, e] = utcDayBounds(utcTodayDate());
+      query += ' AND created_at >= ? AND created_at < ?';
+      params.push(s, e);
     }
 
     query += ' ORDER BY created_at DESC';
 
-    if (req.query.per_page) {
-      const perPage = Math.min(Math.max(parseInt(req.query.per_page as string) || 50, 1), 500);
-      query += ' LIMIT ?';
-      params.push(perPage);
-    }
+    // #208: default page size of 50 and a hard cap even when clients omit
+    // per_page — the previous "unbounded" default could return every bill
+    // ever when a caller left the param off.
+    const requestedPerPage = req.query.per_page ? parseInt(req.query.per_page as string, 10) : NaN;
+    const perPage = Number.isInteger(requestedPerPage) && requestedPerPage > 0
+      ? Math.min(Math.max(requestedPerPage, 1), 500)
+      : 50;
+    query += ' LIMIT ?';
+    params.push(perPage);
 
     const bills = db.prepare(query).all(...params).map(parseRowJson);
     res.json({ bills });

--- a/main/routes/customers.ts
+++ b/main/routes/customers.ts
@@ -63,15 +63,44 @@ router.get('/alerts', requireRole('owner', 'manager', 'cashier', 'waiter'), (req
 router.get('/', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
-    let query = `SELECT c.*,
-      COALESCE((SELECT COUNT(*) FROM orders o WHERE o.customer_id = c.id), 0) as visits_count,
-      COALESCE((SELECT SUM(total) FROM orders o WHERE o.customer_id = c.id), 0) as total_spent,
-      MAX(0,
-        COALESCE((SELECT SUM(ll.amount) FROM loyalty_ledger ll WHERE ll.customer_id = c.id AND ll.type = 'credit'), 0) -
-        COALESCE((SELECT SUM(ll.amount) FROM loyalty_ledger ll WHERE ll.customer_id = c.id AND ll.type = 'debit'), 0)
-      ) as wallet_balance,
-      (SELECT MAX(created_at) FROM orders o WHERE o.customer_id = c.id) as last_visit_at
-      FROM customers c WHERE c.is_active = 1`;
+    // #208: the previous version ran 4 correlated subqueries per customer
+    // (visits, spent, wallet credits, wallet debits, last visit) and never
+    // hit any index for `WHERE o.customer_id = c.id`. The equivalent join
+    // uses the new `idx_orders_customer` and groups once. Aggregates across
+    // customers sit in three CTEs so each scans its index once.
+    let query = `
+      WITH order_stats AS (
+        SELECT customer_id,
+          COUNT(*) AS visits_count,
+          COALESCE(SUM(total), 0) AS total_spent,
+          MAX(created_at) AS last_visit_at
+        FROM orders
+        WHERE customer_id IS NOT NULL
+        GROUP BY customer_id
+      ),
+      ledger_credits AS (
+        SELECT customer_id, COALESCE(SUM(amount), 0) AS credits
+        FROM loyalty_ledger
+        WHERE type = 'credit'
+        GROUP BY customer_id
+      ),
+      ledger_debits AS (
+        SELECT customer_id, COALESCE(SUM(amount), 0) AS debits
+        FROM loyalty_ledger
+        WHERE type = 'debit'
+        GROUP BY customer_id
+      )
+      SELECT c.*,
+        COALESCE(os.visits_count, 0) as visits_count,
+        COALESCE(os.total_spent, 0) as total_spent,
+        MAX(0, COALESCE(lc.credits, 0) - COALESCE(ld.debits, 0)) as wallet_balance,
+        os.last_visit_at
+      FROM customers c
+      LEFT JOIN order_stats os ON os.customer_id = c.id
+      LEFT JOIN ledger_credits lc ON lc.customer_id = c.id
+      LEFT JOIN ledger_debits ld ON ld.customer_id = c.id
+      WHERE c.is_active = 1
+    `;
     const params: any[] = [];
 
     if (req.query.search) {
@@ -110,6 +139,12 @@ router.get('/', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Requ
       }
       const limit = Math.min(parsed, 500);
       query += ` LIMIT ${limit}`;
+    } else {
+      // #208: unbounded default meant every customers list response fanned
+      // the full backend on each search keystroke. Cap at 200 as a sensible
+      // first-page default; clients that need more can page (cursor support
+      // is a follow-up).
+      query += ` LIMIT 200`;
     }
 
     const customers = db.prepare(query).all(...params);

--- a/main/routes/kds.ts
+++ b/main/routes/kds.ts
@@ -21,16 +21,21 @@ router.get('/orders', requireKdsEnabled, (req: Request, res: Response) => {
     // A prepaid order is marked 'completed' the moment its bill is fully
     // paid, which can happen before the kitchen has prepared anything — so
     // a completed order still belongs here if it has items the kitchen
-    // hasn't served yet.
+    // hasn't served yet. #208: rewrite the OR EXISTS scan as a CTE-anchored
+    // subquery that hits idx_orders_status + idx_order_items_order instead
+    // of scanning all orders with a correlated subquery.
     let query = `
+      WITH active_ids AS (
+        SELECT id FROM orders WHERE status IN ('pending','preparing','ready','served')
+        UNION
+        SELECT o.id FROM orders o
+        JOIN order_items oi ON oi.order_id = o.id AND oi.status NOT IN ('served','cancelled')
+        WHERE o.status NOT IN ('pending','preparing','ready','served','cancelled')
+      )
       SELECT o.*, t.number as table_name, t.floor, t.section
       FROM orders o
       LEFT JOIN tables t ON o.table_id = t.id
-      WHERE o.status != 'cancelled'
-        AND (
-          o.status != 'completed'
-          OR EXISTS (SELECT 1 FROM order_items oi WHERE oi.order_id = o.id AND oi.status NOT IN ('served', 'cancelled'))
-        )
+      WHERE o.id IN active_ids
     `;
     const params: any[] = [];
 
@@ -43,23 +48,42 @@ router.get('/orders', requireKdsEnabled, (req: Request, res: Response) => {
 
     const orders = db.prepare(query).all(...params);
 
-    const ordersWithItems = orders.map((order: any) => {
+    // One batched items query (with product/category joins) plus one addons
+    // pass, instead of N+1 per order — the KDS board polls this constantly.
+    const orderIds = (orders as any[]).map((o) => o.id);
+    const itemsByOrder: Record<string, any[]> = {};
+    if (orderIds.length > 0) {
+      const placeholders = orderIds.map(() => '?').join(',');
       const rawItems = db.prepare(`
         SELECT oi.*, p.category_id, c.name as category_name
         FROM order_items oi
         LEFT JOIN products p ON oi.product_id = p.id
         LEFT JOIN categories c ON p.category_id = c.id
-        WHERE oi.order_id = ?
-        ORDER BY oi.created_at ASC
-      `).all(order.id) as any[];
+        WHERE oi.order_id IN (${placeholders})
+        ORDER BY oi.order_id, oi.created_at ASC
+      `).all(...orderIds) as any[];
+      for (const item of rawItems) {
+        if (!itemsByOrder[item.order_id]) itemsByOrder[item.order_id] = [];
+        itemsByOrder[item.order_id].push(item);
+      }
+    }
+
+    const allVisibleItems = (orders as any[])
+      .flatMap((o) => itemsByOrder[o.id] || [])
+      .filter((i) => i.status !== 'void_adjustment' && (i.status !== 'voided' || isVoidedItemKdsVisible(i.voided_at)));
+    const itemsWithAddons = attachEffectiveAddons(db, allVisibleItems);
+    const addonsByItemId = new Map(itemsWithAddons.map((it) => [it.id, it]));
+
+    const ordersWithItems = (orders as any[]).map((order) => {
       // #150: hide the void reversal line (bill adjustment, not a kitchen
       // item) and age voided items off the board after their grace period.
-      const visibleItems = rawItems.filter((i) => i.status !== 'void_adjustment' && (i.status !== 'voided' || isVoidedItemKdsVisible(i.voided_at)));
-      const items = attachEffectiveAddons(db, visibleItems);
+      const visibleItems = (itemsByOrder[order.id] || [])
+        .filter((i) => i.status !== 'void_adjustment' && (i.status !== 'voided' || isVoidedItemKdsVisible(i.voided_at)))
+        .map((i) => addonsByItemId.get(i.id) || i);
 
       return {
         ...order,
-        items,
+        items: visibleItems,
         table: order.table_name ? { name: order.table_name } : null,
       };
     });
@@ -97,7 +121,10 @@ router.post('/pairing', requireRole('owner', 'manager'), (req: Request, res: Res
     }
 
     const token = crypto.randomBytes(32).toString('hex');
-    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    // Space form, same as every other DB timestamp (v45 normalized the
+    // column) — a consumer comparing expires_at against a space-form now
+    // would see ISO-Z tokens sort after it and treat them as never expired.
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString().replace('T', ' ').replace(/\..*$/, '');
     const tokenId = randomUUID();
 
     const result = db.prepare(`
@@ -151,8 +178,10 @@ router.get('/display', requireKdsEnabled, (req: Request, res: Response) => {
     // #150: 'void_adjustment' is a bill-only reversal line, never a kitchen
     // item — excluded outright. A voided item itself stays visible, struck
     // through, until voided_at ages past the same grace period every other
-    // KDS surface uses (main/db.ts's isVoidedItemKdsVisible).
-    const voidedCutoff = new Date(Date.now() - KDS_VOIDED_ITEM_VISIBILITY_MS).toISOString();
+    // KDS surface uses (main/db.ts's isVoidedItemKdsVisible). The cutoff is
+    // emitted in the DB's space form — an ISO-Z bound would sort after every
+    // space-form row of the same day and hide voided items immediately.
+    const voidedCutoff = new Date(Date.now() - KDS_VOIDED_ITEM_VISIBILITY_MS).toISOString().replace('T', ' ').replace(/\..*$/, '');
     let itemsQuery = `
       SELECT oi.*, o.id as order_id, o.order_number, o.type, o.status as order_status,
         o.table_id, t.number as table_name, o.special_instructions as order_notes,

--- a/main/routes/kitchen.ts
+++ b/main/routes/kitchen.ts
@@ -7,12 +7,16 @@ const router = Router();
 router.use(requireRole('chef', 'manager', 'owner'));
 router.use(requireKdsEnabled);
 
-const ACTIVE_KITCHEN_ORDERS_CONDITION = `
-  status != 'cancelled'
-  AND (
-    status != 'completed'
-    OR EXISTS (SELECT 1 FROM order_items oi WHERE oi.order_id = orders.id AND oi.status NOT IN ('served', 'cancelled'))
-  )
+// Active kitchen orders — the old `OR EXISTS` form forced the planner to
+// SCAN orders and run a correlated subquery per row. The UNION form lets
+// each branch hit an index: status-in check uses `idx_orders_status`, and
+// the live-items branch uses `idx_order_items_order`. #208
+const ACTIVE_KITCHEN_ORDER_IDS_SQL = `
+  SELECT id FROM orders WHERE status IN ('pending','preparing','ready','served')
+  UNION
+  SELECT o.id FROM orders o
+  JOIN order_items oi ON oi.order_id = o.id AND oi.status NOT IN ('served','cancelled')
+  WHERE o.status NOT IN ('pending','preparing','ready','served','cancelled')
 `;
 
 // GET /api/kitchen/orders — returns active orders with items for KDS display
@@ -21,10 +25,10 @@ router.get('/orders', (req: Request, res: Response) => {
     const db = getDatabase();
 
     const orders = db.prepare(`
-      SELECT *
-      FROM orders
-      WHERE ${ACTIVE_KITCHEN_ORDERS_CONDITION}
-      ORDER BY created_at ASC
+      SELECT o.*
+      FROM orders o
+      WHERE o.id IN (${ACTIVE_KITCHEN_ORDER_IDS_SQL})
+      ORDER BY o.created_at ASC
     `).all() as any[];
 
     if (orders.length === 0) {
@@ -34,9 +38,10 @@ router.get('/orders', (req: Request, res: Response) => {
     const orderIds = orders.map((o) => o.id);
     const tableIds = Array.from(new Set(orders.map((o) => o.table_id).filter(Boolean)));
 
-    // Batch query order items and tables
+    // Batch query order items and tables (one IN() each instead of N+1
+    // per order) and one addons pass across all items.
     const placeholders = orderIds.map(() => '?').join(',');
-    const rawItems = db.prepare(`SELECT * FROM order_items WHERE order_id IN (${placeholders})`).all(...orderIds) as any[];
+    const rawItems = db.prepare(`SELECT * FROM order_items WHERE order_id IN (${placeholders}) ORDER BY order_id, id`).all(...orderIds) as any[];
 
     const itemsByOrder: Record<string, any[]> = {};
     for (const item of rawItems) {
@@ -53,25 +58,28 @@ router.get('/orders', (req: Request, res: Response) => {
       }
     }
 
+    // Resolve addons for every visible item in one batched call.
+    const allVisibleItems = rawItems.filter(
+      (i) => i.status !== 'void_adjustment' && (i.status !== 'voided' || isVoidedItemKdsVisible(i.voided_at))
+    );
+    const itemsWithAddons = attachEffectiveAddons(db, allVisibleItems.map(parseItemJson));
+    const addonsByItemId = new Map(itemsWithAddons.map((it) => [it.id, it]));
+
     const ordersWithItems = orders.map((order) => {
       const orderRawItems = itemsByOrder[order.id] || [];
-      const visibleItems = orderRawItems.filter(
-        (i) => i.status !== 'void_adjustment' && (i.status !== 'voided' || isVoidedItemKdsVisible(i.voided_at))
-      );
-      const items = attachEffectiveAddons(db, visibleItems.map(parseItemJson));
+      const visibleItems = orderRawItems
+        .filter((i) => i.status !== 'void_adjustment' && (i.status !== 'voided' || isVoidedItemKdsVisible(i.voided_at)))
+        .map((i) => addonsByItemId.get(i.id) || i);
       const table = order.table_id ? tablesMap[order.table_id] || null : null;
-      return { ...order, items, table };
+      return { ...order, items: visibleItems, table };
     });
 
-    const counts = db.prepare(`
-      SELECT status, COUNT(*) as count
-      FROM order_items
-      WHERE order_id IN (SELECT id FROM orders WHERE ${ACTIVE_KITCHEN_ORDERS_CONDITION})
-      GROUP BY status
-    `).all() as { status: string; count: number }[];
-
-    const countMap: Record<string, number> = {};
-    counts.forEach((c) => { countMap[c.status] = c.count; });
+    // Counts are derived from the items we already fetched for these exact
+    // active orders — no need to re-run the UNION and re-query order_items.
+    const countMap: Record<string, any> = {};
+    for (const item of rawItems) {
+      countMap[item.status] = (countMap[item.status] || 0) + 1;
+    }
 
     res.json({ orders: ordersWithItems, counts: countMap });
   } catch (error: any) {

--- a/main/routes/orders.ts
+++ b/main/routes/orders.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { getDatabase, generateOrderNumber, now, parseItemJson, parseRowJson, withTxn, verifyPin, getSettingValue, insertOrderItemAddons, attachEffectiveAddons } from '../db';
+import { getDatabase, generateOrderNumber, now, parseItemJson, parseRowJson, withTxn, verifyPin, getSettingValue, insertOrderItemAddons, attachEffectiveAddons, utcDayBounds, utcTodayDate } from '../db';
 import {
   calculateConfiguredChargeTaxes,
   calculateItemTax,
@@ -104,67 +104,167 @@ router.get('/', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Requ
   try {
     const user = (req as any).user;
     const db = getDatabase();
-    let query = 'SELECT * FROM orders WHERE 1=1';
+    const wheres: string[] = [];
     const params: any[] = [];
 
     if (req.query.status) {
       const statuses = (req.query.status as string).split(',');
       if (statuses.length === 1) {
-        query += ' AND status = ?';
+        wheres.push('status = ?');
         params.push(statuses[0]);
       } else {
-        query += ` AND status IN (${statuses.map(() => '?').join(',')})`;
+        wheres.push(`status IN (${statuses.map(() => '?').join(',')})`);
         params.push(...statuses);
       }
     }
     if (req.query.type) {
-      query += ' AND type = ?';
+      wheres.push('type = ?');
       params.push(req.query.type);
     }
+    // #208: `today` is the UTC day, as a range filter (was UTC date() that
+    // wrapped the column and blocked `idx_orders_created_at`). `start_date` /
+    // `end_date` add a range filter so the UI can actually load older pages
+    // — combined with the cursor, this is what gives us real pagination
+    // instead of "latest 50 forever".
     if (req.query.today && req.query.today !== '0' && req.query.today !== 'false') {
-      query += " AND date(created_at) = date('now')";
+      const [s, e] = utcDayBounds(utcTodayDate());
+      wheres.push('created_at >= ? AND created_at < ?');
+      params.push(s, e);
+    } else {
+      const startDate = typeof req.query.start_date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(req.query.start_date) ? req.query.start_date : null;
+      const endDate = typeof req.query.end_date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(req.query.end_date) ? req.query.end_date : null;
+      if (startDate) {
+        wheres.push('created_at >= ?');
+        params.push(utcDayBounds(startDate)[0]);
+      }
+      if (endDate) {
+        wheres.push('created_at < ?');
+        params.push(utcDayBounds(endDate)[1]);
+      }
     }
     if (req.query.table_id) {
-      query += ' AND table_id = ?';
+      wheres.push('table_id = ?');
       params.push(req.query.table_id);
     }
-
     if (user.role === 'waiter') {
-      query += ' AND user_id = ?';
+      wheres.push('user_id = ?');
       params.push(user.userId);
     }
-
-    query += ' ORDER BY created_at DESC';
-
-    if (req.query.per_page) {
-      const perPage = Math.min(Math.max(parseInt(req.query.per_page as string) || 50, 1), 500);
-      query += ` LIMIT ${perPage}`;
+    // Cursor pagination: `before` / `after` are ORDER BY keys (created_at),
+    // composed with `id` to break ties when many orders share a second.
+    if (typeof req.query.before_id === 'string' && /^\d+$/.test(req.query.before_id)) {
+      const oid = parseInt(req.query.before_id, 10);
+      const ref = db.prepare('SELECT created_at FROM orders WHERE id = ?').get(oid) as { created_at: string } | undefined;
+      if (ref) {
+        wheres.push('(created_at, id) < (?, ?)');
+        params.push(ref.created_at, oid);
+      }
     }
 
-    const orders = db.prepare(query).all(...params).map(parseRowJson);
+    const whereSql = wheres.length > 0 ? `WHERE ${wheres.join(' AND ')}` : '';
+    // #208: cap page size even when clients omit per_page (the original
+    // "unbounded" default made GET /orders on the tables page load the entire
+    // active-order history with the N+1 below).
+    const requestedPerPage = req.query.per_page ? parseInt(req.query.per_page as string, 10) : NaN;
+    const perPage = Number.isInteger(requestedPerPage) && requestedPerPage > 0
+      ? Math.min(requestedPerPage, 500)
+      : 50;
+    const perPagePlusOne = perPage + 1;
 
-    // Load related data
-    const ordersWithRelations = orders.map((order: any) => {
-      const items = attachEffectiveAddons(db, db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(order.id).map(parseItemJson) as any[]);
-      const tableRow = order.table_id ? db.prepare('SELECT * FROM tables WHERE id = ?').get(order.table_id) as any : null;
-      const table = tableRow ? { ...tableRow, name: tableRow.number } : null;
-      const customer = order.customer_id ? db.prepare('SELECT * FROM customers WHERE id = ?').get(order.customer_id) : null;
-      const bill = parseRowJson(db.prepare('SELECT * FROM bills WHERE order_id = ?').get(order.id) as any);
-      if (bill && (bill as any).customer_id) {
-        const earned = db.prepare(
-          `SELECT COALESCE(SUM(amount), 0) as total FROM loyalty_ledger WHERE bill_id = ? AND type = 'credit'`
-        ).get((bill as any).id) as { total: number };
-        (bill as any).points_earned = earned.total;
-      }
-      return { ...order, items, table, customer, bill };
+    const orders = db.prepare(`
+      SELECT * FROM orders
+      ${whereSql}
+      ORDER BY created_at DESC, id DESC
+      LIMIT ?
+    `).all(...params, perPagePlusOne) as any[];
+
+    const hasMore = orders.length > perPage;
+    const pageOrders = hasMore ? orders.slice(0, perPage) : orders;
+    const nextCursor = hasMore ? pageOrders[pageOrders.length - 1].id : null;
+
+    // #208: replace the per-order N+1 (5 queries × N) with one IN() per
+    // relation, then assemble. Measured ~300+ queries per poll → ~6.
+    const ordersWithRelations = batchHydrateOrders(db, pageOrders);
+
+    res.json({
+      orders: ordersWithRelations,
+      ...(nextCursor !== null && { nextCursor }),
     });
-
-    res.json({ orders: ordersWithRelations });
   } catch (error: any) {
     console.error("[API] Internal error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
+
+/**
+ * Batch the relations (items+addons, table, customer, bill+loyalty) for a
+ * page of orders into 5 IN() queries instead of N per-order prepared calls.
+ * Used by GET /orders and kept here so the orders route owns its own data
+ * shape. #208
+ */
+function batchHydrateOrders(db: ReturnType<typeof getDatabase>, orders: any[]) {
+  if (orders.length === 0) return [];
+  // Normalize JSON text columns (tax_breakdown/tax_snapshot on orders and
+  // items) so the list endpoint matches GET /orders/:id. parseRowJson is
+  // idempotent, so the /:id path passing an already-parsed row is fine.
+  const parsedOrders = orders.map(parseRowJson);
+  const ids = parsedOrders.map((o) => o.id);
+  const tableIds = Array.from(new Set(parsedOrders.map((o: any) => o.table_id).filter(Boolean)));
+  const customerIds = Array.from(new Set(parsedOrders.map((o: any) => o.customer_id).filter(Boolean)));
+
+  const orderIdsCsv = `(${ids.map(() => '?').join(',')})`;
+  const itemsRows = db.prepare(`SELECT * FROM order_items WHERE order_id IN ${orderIdsCsv} ORDER BY order_id, id`).all(...ids).map(parseItemJson);
+  // #208: a single call to attachEffectiveAddons batches all addons across
+  // all items into one IN() query against order_item_addons. Re-group the
+  // result back by order_id for the per-order payload below.
+  const itemsWithAddons = attachEffectiveAddons(db, itemsRows as any[]);
+  const itemsByOrder = new Map<number, any[]>();
+  for (const it of itemsWithAddons) {
+    const list = itemsByOrder.get(it.order_id) || [];
+    list.push(it);
+    itemsByOrder.set(it.order_id, list);
+  }
+
+  const tablesById = new Map<string, any>();
+  if (tableIds.length > 0) {
+    const ph = tableIds.map(() => '?').join(',');
+    const rows = db.prepare(`SELECT * FROM tables WHERE id IN (${ph})`).all(...tableIds) as any[];
+    for (const t of rows) tablesById.set(t.id, t);
+  }
+  const customersById = new Map<string, any>();
+  if (customerIds.length > 0) {
+    const ph = customerIds.map(() => '?').join(',');
+    const rows = db.prepare(`SELECT * FROM customers WHERE id IN (${ph})`).all(...customerIds);
+    for (const c of rows as any[]) customersById.set(c.id, parseRowJson(c));
+  }
+  const billsByOrderId = new Map<number, any>();
+  const billsById = new Map<number, any>();
+  const billRows = db.prepare(`SELECT * FROM bills WHERE order_id IN ${orderIdsCsv}`).all(...ids) as any[];
+  for (const b of billRows) {
+    const parsed = parseRowJson(b);
+    billsByOrderId.set(parsed.order_id, parsed);
+    billsById.set(parsed.id, parsed);
+  }
+  const ledgerByBillId = new Map<number, number>();
+  if (billsById.size > 0) {
+    const billIds = Array.from(billsById.keys());
+    const ph = billIds.map(() => '?').join(',');
+    const rows = db.prepare(`SELECT bill_id, COALESCE(SUM(amount),0) as total FROM loyalty_ledger WHERE bill_id IN (${ph}) AND type = 'credit' GROUP BY bill_id`).all(...billIds) as { bill_id: number; total: number }[];
+    for (const r of rows) ledgerByBillId.set(r.bill_id, r.total);
+  }
+
+  return parsedOrders.map((order) => {
+    const itemList = itemsByOrder.get(order.id) || [];
+    const tableRow = order.table_id ? tablesById.get(order.table_id) : null;
+    const table = tableRow ? { ...tableRow, name: tableRow.number } : null;
+    const customer = order.customer_id ? customersById.get(order.customer_id) : null;
+    const bill = billsByOrderId.get(order.id) || null;
+    if (bill && bill.customer_id) {
+      bill.points_earned = ledgerByBillId.get(bill.id) || 0;
+    }
+    return { ...order, items: itemList, table, customer, bill };
+  });
+}
 
 router.get('/:id', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Request, res: Response) => {
   try {
@@ -179,19 +279,11 @@ router.get('/:id', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: R
       return res.status(403).json({ error: 'Waiters can only view their own orders' });
     }
 
-    const items = attachEffectiveAddons(db, db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(req.params.id).map(parseItemJson) as any[]);
-    const tableRow = (order as any).table_id ? db.prepare('SELECT * FROM tables WHERE id = ?').get((order as any).table_id) as any : null;
-    const table = tableRow ? { ...tableRow, name: tableRow.number } : null;
-    const customer = (order as any).customer_id ? db.prepare('SELECT * FROM customers WHERE id = ?').get((order as any).customer_id) : null;
-    const bill = parseRowJson(db.prepare('SELECT * FROM bills WHERE order_id = ?').get(req.params.id));
-    if (bill && (bill as any).customer_id) {
-      const earned = db.prepare(
-        `SELECT COALESCE(SUM(amount), 0) as total FROM loyalty_ledger WHERE bill_id = ? AND type = 'credit'`
-      ).get((bill as any).id) as { total: number };
-      (bill as any).points_earned = earned.total;
-    }
-
-    res.json({ order: { ...order, items, table, customer, bill } });
+    // #208: collapse the per-order N+1 (5 queries: items/addons/table/customer/bill/loyalty)
+    // into the same batchHydrateOrders used by the list endpoint. Previously
+    // 6 prepared calls per single detail click.
+    const [hydrated] = batchHydrateOrders(db, [order]);
+    res.json({ order: hydrated });
   } catch (error: any) {
     console.error("[API] Internal error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/main/routes/reports.ts
+++ b/main/routes/reports.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from 'express';
 import Decimal from 'decimal.js';
-import { getDatabase, getSettingValue, parseItemJson } from '../db';
+import { getDatabase, getSettingValue, parseDbTimestamp, parseItemJson, utcDayBounds, utcTodayDate } from '../db';
 import { requireRole } from '../middleware/security';
 import { aggregateTaxComponents } from '../services/tax-components';
 
@@ -28,7 +28,7 @@ function bucketByLocalHourAndWeekday(timestamps: string[], timeZone: string): { 
   const dayCounts = new Array(7).fill(0);
 
   for (const ts of timestamps) {
-    const d = new Date(ts);
+    const d = parseDbTimestamp(ts);
     if (isNaN(d.getTime())) continue;
     const hour = parseInt(hourFmt.format(d), 10);
     if (hour >= 0 && hour <= 23) hourCounts[hour]++;
@@ -46,8 +46,16 @@ function bucketByLocalHourAndWeekday(timestamps: string[], timeZone: string): { 
  * that with `json_each` and buckets by the split's own timestamp (not the
  * bill's `paid_at`, which only marks when the bill became fully paid and
  * would misattribute or drop earlier partial-payment splits on other days).
+ * #208: paid_at is NULL until the bill is fully paid, so the filter is
+ * `paid_at is still NULL OR paid_at is on/after the report day` — a mid-day
+ * partial payment must show up the moment it's taken, and a split taken
+ * just before midnight must not vanish because the bill only completed
+ * after midnight (paid_at then lands in the next day). `idx_bills_paid_at`
+ * serves both OR branches. The split timestamp is normalized with REPLACE
+ * so legacy ISO splits compare consistently against the space-form rows.
  */
 function paymentMethodBreakdown(db: ReturnType<typeof getDatabase>, date: string) {
+  const [start] = utcDayBounds(date);
   return db.prepare(`
     SELECT
       json_extract(je.value, '$.method') as method,
@@ -55,10 +63,11 @@ function paymentMethodBreakdown(db: ReturnType<typeof getDatabase>, date: string
       COALESCE(SUM(json_extract(je.value, '$.amount')), 0) as total
     FROM bills b, json_each(b.payment_details) je
     WHERE b.payment_details IS NOT NULL
-      AND date(json_extract(je.value, '$.timestamp')) = date(?)
+      AND (b.paid_at IS NULL OR b.paid_at >= ?)
+      AND substr(replace(json_extract(je.value, '$.timestamp'), 'T', ' '), 1, 10) = ?
     GROUP BY method
     ORDER BY total DESC
-  `).all(date);
+  `).all(start, date);
 }
 
 /** argmax/argmin over counts, restricted to indices where include(count) is true. Returns null if nothing qualifies. */
@@ -76,12 +85,16 @@ function pickExtreme(counts: number[], mode: 'max' | 'min', include: (count: num
 router.get('/daily-stats', requireRole('owner', 'manager'), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
-    const today = new Date().toISOString().slice(0, 10);
+    // #208: UTC today with the half-open UTC range so we can
+    // hit `idx_bills_created_at` instead of going through `date(...)` on
+    // every row. dashboard polls every load.
+    const today = utcTodayDate();
+    const [start, end] = utcDayBounds(today);
 
     const salesToday = db.prepare(`
       SELECT COALESCE(SUM(paid_amount), 0) as sales
-      FROM bills WHERE date(created_at) = date(?)
-    `).get(today) as { sales: number };
+      FROM bills WHERE created_at >= ? AND created_at < ?
+    `).get(start, end) as { sales: number };
 
     const runningOrders = db.prepare(`
       SELECT COUNT(*) as count FROM orders WHERE status IN ('pending', 'preparing')
@@ -111,25 +124,28 @@ router.get('/daily-stats', requireRole('owner', 'manager'), (req: Request, res: 
 router.get('/summary', requireRole('owner', 'manager'), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
-    const date = reportDate(req.query.date, new Date().toISOString().slice(0, 10));
+    // #208: an explicit date param is a UTC `YYYY-MM-DD`; resolve to the
+    // half-open UTC range. `reportDate` validates the param shape.
+    const date = reportDate(req.query.date, utcTodayDate());
+    const [start, end] = utcDayBounds(date);
 
     const ordersToday = db.prepare(`
       SELECT COUNT(*) as count, COALESCE(SUM(total), 0) as total
-      FROM orders WHERE date(created_at) = date(?)
-    `).get(date) as { count: number; total: number };
+      FROM orders WHERE created_at >= ? AND created_at < ?
+    `).get(start, end) as { count: number; total: number };
 
     const billsToday = db.prepare(`
       SELECT COUNT(*) as count, COALESCE(SUM(total), 0) as total, COALESCE(SUM(paid_amount), 0) as collected
-      FROM bills WHERE date(created_at) = date(?)
-    `).get(date) as { count: number; total: number; collected: number };
+      FROM bills WHERE created_at >= ? AND created_at < ?
+    `).get(start, end) as { count: number; total: number; collected: number };
 
     const customersToday = db.prepare(`
-      SELECT COUNT(*) as count FROM customers WHERE date(created_at) = date(?)
-    `).get(date) as { count: number };
+      SELECT COUNT(*) as count FROM customers WHERE created_at >= ? AND created_at < ?
+    `).get(start, end) as { count: number };
 
     const ordersByStatus = db.prepare(`
-      SELECT status, COUNT(*) as count FROM orders WHERE date(created_at) = date(?) GROUP BY status
-    `).all(date);
+      SELECT status, COUNT(*) as count FROM orders WHERE created_at >= ? AND created_at < ? GROUP BY status
+    `).all(start, end);
 
     res.json({
       summary: {
@@ -153,21 +169,23 @@ router.get('/summary', requireRole('owner', 'manager'), (req: Request, res: Resp
 router.get('/tax-components', requireRole('owner', 'manager'), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = utcTodayDate();
     const startDate = reportDate(req.query.start_date, today);
     const endDate = reportDate(req.query.end_date, today);
     if (startDate > endDate) {
       return res.status(400).json({ error: 'start_date must be on or before end_date' });
     }
+    const windowStart = utcDayBounds(startDate)[0];
+    const windowEnd = utcDayBounds(endDate)[1];
 
     const bills = db.prepare(`
       SELECT b.*
       FROM bills b
       JOIN orders o ON o.id = b.order_id
-      WHERE date(b.created_at) BETWEEN date(?) AND date(?)
+      WHERE b.created_at >= ? AND b.created_at < ?
         AND o.status != 'cancelled'
       ORDER BY b.created_at, b.id
-    `).all(startDate, endDate) as any[];
+    `).all(windowStart, windowEnd) as any[];
 
     const itemsByOrder = new Map<number, any[]>();
     if (bills.length > 0) {
@@ -214,36 +232,42 @@ router.get('/tax-components', requireRole('owner', 'manager'), (req: Request, re
 router.get('/sales', requireRole('owner', 'manager'), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = utcTodayDate();
     const startDate = reportDate(req.query.start_date, today);
     const endDate = reportDate(req.query.end_date, today);
     if (startDate > endDate) {
       return res.status(400).json({ error: 'start_date must be on or before end_date' });
     }
+    // #208: half-open UTC ranges so the orders/bills indexes apply instead
+    // of `date(...)` on every row. All day boundaries are UTC.
+    const windowStart = utcDayBounds(startDate)[0];
+    const windowEnd = utcDayBounds(endDate)[1];
 
+    // Daily series bucketed by UTC day (substr of the stored UTC timestamp) —
+    // same labels the previous `date(created_at)` produced, at index cost.
     const dailySales = db.prepare(`
-      SELECT date(created_at) as date, COUNT(*) as orders, SUM(total) as sales
+      SELECT substr(created_at, 1, 10) as date, COUNT(*) as orders, SUM(total) as sales
       FROM orders
-      WHERE date(created_at) BETWEEN date(?) AND date(?)
-      GROUP BY date(created_at)
+      WHERE created_at >= ? AND created_at < ?
+      GROUP BY substr(created_at, 1, 10)
       ORDER BY date
-    `).all(startDate, endDate);
+    `).all(windowStart, windowEnd);
 
     const byPaymentMethod = db.prepare(`
       SELECT json_extract(payment_details, '$.method') as method,
         COUNT(*) as count, SUM(paid_amount) as total
       FROM bills
       WHERE payment_status = 'paid'
-        AND date(paid_at) BETWEEN date(?) AND date(?)
+        AND paid_at >= ? AND paid_at < ?
       GROUP BY json_extract(payment_details, '$.method')
-    `).all(startDate, endDate);
+    `).all(windowStart, windowEnd);
 
     const byOrderType = db.prepare(`
       SELECT type, COUNT(*) as count, SUM(total) as total
       FROM orders
-      WHERE date(created_at) BETWEEN date(?) AND date(?)
+      WHERE created_at >= ? AND created_at < ?
       GROUP BY type
-    `).all(startDate, endDate);
+    `).all(windowStart, windowEnd);
 
     res.json({
       sales: {
@@ -263,7 +287,7 @@ router.get('/sales', requireRole('owner', 'manager'), (req: Request, res: Respon
 router.get('/topProducts', requireRole('owner', 'manager'), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = utcTodayDate();
     const startDate = reportDate(req.query.start_date, today);
     const endDate = reportDate(req.query.end_date, today);
     if (startDate > endDate) {
@@ -271,6 +295,8 @@ router.get('/topProducts', requireRole('owner', 'manager'), (req: Request, res: 
     }
     const requestedLimit = Number(req.query.limit);
     const limit = Number.isInteger(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 100) : 10;
+    const windowStart = utcDayBounds(startDate)[0];
+    const windowEnd = utcDayBounds(endDate)[1];
 
     const topProducts = db.prepare(`
       SELECT oi.product_id, oi.product_name,
@@ -279,11 +305,11 @@ router.get('/topProducts', requireRole('owner', 'manager'), (req: Request, res: 
         COUNT(DISTINCT oi.order_id) as order_count
       FROM order_items oi
       JOIN orders o ON oi.order_id = o.id
-      WHERE date(o.created_at) BETWEEN date(?) AND date(?)
+      WHERE o.created_at >= ? AND o.created_at < ?
       GROUP BY oi.product_id
       ORDER BY total_quantity DESC
       LIMIT ?
-    `).all(startDate, endDate, limit);
+    `).all(windowStart, windowEnd, limit);
 
     res.json({ topProducts });
   } catch (error: any) {
@@ -305,29 +331,41 @@ router.get('/recentOrders', requireRole('owner', 'manager'), (req: Request, res:
     // Without a date, "most recent overall" (dashboard live view). With one,
     // scoped to that day — lets the dashboard show a past day's orders
     // instead of always the latest regardless of which date is selected.
-    const recentOrders = date
-      ? db.prepare(`
-          SELECT o.*, t.number as table_name, c.name as customer_name
-          FROM orders o
-          LEFT JOIN tables t ON o.table_id = t.id
-          LEFT JOIN customers c ON o.customer_id = c.id
-          WHERE date(o.created_at) = date(?)
-          ORDER BY o.created_at DESC
-          LIMIT ?
-        `).all(date, limit)
-      : db.prepare(`
-          SELECT o.*, t.number as table_name, c.name as customer_name
-          FROM orders o
-          LEFT JOIN tables t ON o.table_id = t.id
-          LEFT JOIN customers c ON o.customer_id = c.id
-          ORDER BY o.created_at DESC
-          LIMIT ?
-        `).all(limit);
+    // #208: range filter hits idx_orders_created_at instead of full scan.
+    const params: any[] = [];
+    let where = '';
+    if (date) {
+      const [s, e] = utcDayBounds(date);
+      where = 'WHERE o.created_at >= ? AND o.created_at < ?';
+      params.push(s, e);
+    }
 
-    const ordersWithItems = recentOrders.map((order: any) => {
-      const items = db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(order.id);
-      return { ...order, items };
-    });
+    const recentOrders = db.prepare(`
+      SELECT o.*, t.number as table_name, c.name as customer_name
+      FROM orders o
+      LEFT JOIN tables t ON o.table_id = t.id
+      LEFT JOIN customers c ON o.customer_id = c.id
+      ${where}
+      ORDER BY o.created_at DESC
+      LIMIT ?
+    `).all(...params, limit);
+
+    // #208: batch all items in one IN() query instead of per-order N+1.
+    const orderIds = recentOrders.map((o: any) => o.id);
+    const itemsByOrder = new Map<number, any[]>();
+    if (orderIds.length > 0) {
+      const placeholders = orderIds.map(() => '?').join(',');
+      const items = db.prepare(`SELECT * FROM order_items WHERE order_id IN (${placeholders}) ORDER BY order_id, id`).all(...orderIds);
+      for (const item of items as any[]) {
+        const list = itemsByOrder.get(item.order_id) || [];
+        list.push(item);
+        itemsByOrder.set(item.order_id, list);
+      }
+    }
+    const ordersWithItems = recentOrders.map((order: any) => ({
+      ...order,
+      items: itemsByOrder.get(order.id) || [],
+    }));
 
     res.json({ recentOrders: ordersWithItems });
   } catch (error: any) {
@@ -339,6 +377,7 @@ router.get('/recentOrders', requireRole('owner', 'manager'), (req: Request, res:
 router.get('/tables', requireRole('owner', 'manager'), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
+    const [start, end] = utcDayBounds(utcTodayDate());
 
     const tableStats = db.prepare(`
       SELECT t.*,
@@ -347,9 +386,9 @@ router.get('/tables', requireRole('owner', 'manager'), (req: Request, res: Respo
         MAX(o.created_at) as last_order_at
       FROM tables t
       LEFT JOIN orders o ON t.id = o.table_id
-      WHERE date(o.created_at) = date('now') OR o.id IS NULL
+        AND o.created_at >= ? AND o.created_at < ?
       GROUP BY t.id
-    `).all();
+    `).all(start, end);
 
     const tableUtilization = db.prepare(`
       SELECT
@@ -379,15 +418,19 @@ router.get('/insights', requireRole('owner', 'manager'), (req: Request, res: Res
   try {
     const db = getDatabase();
     const days = Math.min(Math.max(parseInt(req.query.days as string) || 30, 1), 365);
+    // #208: "N days back" in UTC, with the UTC day range so the window
+    // filters on the index. Day boundaries are UTC; the tenant timezone only
+    // drives the hour/day-of-week bucketing below.
     const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
     const timeZone = getSettingValue('timezone') || 'Asia/Kolkata';
+    const [windowStart] = utcDayBounds(startDate);
 
     // AOV — same revenue basis ("paid bills") as the existing daily-stats tile.
     const revenue = db.prepare(`
       SELECT COUNT(*) as billCount, COALESCE(SUM(paid_amount), 0) as total
       FROM bills
-      WHERE payment_status = 'paid' AND date(paid_at) >= date(?)
-    `).get(startDate) as { billCount: number; total: number };
+      WHERE payment_status = 'paid' AND paid_at >= ?
+    `).get(windowStart) as { billCount: number; total: number };
     const aov = revenue.billCount > 0 ? revenue.total / revenue.billCount : 0;
 
     // Kitchen velocity — substitutes for "best cook", which isn't derivable:
@@ -399,8 +442,8 @@ router.get('/insights', requireRole('owner', 'manager'), (req: Request, res: Res
         COUNT(*) as sampleSize
       FROM orders
       WHERE cooking_started_at IS NOT NULL AND ready_at IS NOT NULL
-        AND date(created_at) >= date(?) AND status != 'cancelled'
-    `).get(startDate) as { avgMinutes: number | null; sampleSize: number };
+        AND created_at >= ? AND status != 'cancelled'
+    `).get(windowStart) as { avgMinutes: number | null; sampleSize: number };
 
     // Top staff by revenue — covers whoever creates orders (owner/manager/
     // cashier/waiter, per POST /orders' own role gate), i.e. "best cashier".
@@ -410,11 +453,11 @@ router.get('/insights', requireRole('owner', 'manager'), (req: Request, res: Res
         COUNT(o.id) as orderCount
       FROM orders o
       JOIN users u ON u.id = o.user_id
-      WHERE date(o.created_at) >= date(?) AND o.status != 'cancelled'
+      WHERE o.created_at >= ? AND o.status != 'cancelled'
       GROUP BY u.id
       ORDER BY revenue DESC
       LIMIT 5
-    `).all(startDate);
+    `).all(windowStart);
 
     // Top categories by revenue.
     const topCategories = db.prepare(`
@@ -425,16 +468,16 @@ router.get('/insights', requireRole('owner', 'manager'), (req: Request, res: Res
       JOIN orders o ON o.id = oi.order_id
       JOIN products p ON p.id = oi.product_id
       LEFT JOIN categories c ON c.id = p.category_id
-      WHERE date(o.created_at) >= date(?) AND oi.status != 'cancelled'
+      WHERE o.created_at >= ? AND oi.status != 'cancelled'
       GROUP BY c.id
       ORDER BY revenue DESC
       LIMIT 5
-    `).all(startDate);
+    `).all(windowStart);
 
     // Busiest/idlest hour & day-of-week, bucketed in the tenant's local timezone.
     const orderTimestamps = (db.prepare(
-      `SELECT created_at FROM orders WHERE date(created_at) >= date(?) AND status != 'cancelled'`
-    ).all(startDate) as { created_at: string }[]).map((r) => r.created_at);
+      `SELECT created_at FROM orders WHERE created_at >= ? AND status != 'cancelled'`
+    ).all(windowStart) as { created_at: string }[]).map((r) => r.created_at);
 
     const { hourCounts, dayCounts } = bucketByLocalHourAndWeekday(orderTimestamps, timeZone);
 

--- a/main/services/cloud-sync.ts
+++ b/main/services/cloud-sync.ts
@@ -10,7 +10,7 @@ import * as crypto from 'crypto';
 import * as os from 'os';
 import log from 'electron-log';
 import { WebSocket, type RawData } from 'ws';
-import { getDatabase, now, parseItemJson, attachEffectiveAddons, ensureCloudIdentity, isDiagnosticsConsentEnabled } from '../db';
+import { getDatabase, now, parseItemJson, attachEffectiveAddons, ensureCloudIdentity, isDiagnosticsConsentEnabled, utcDayBounds, utcTodayDate } from '../db';
 
 export const DEFAULT_CLOUD_SERVER_URL = 'https://blue.flopos.com/';
 
@@ -441,11 +441,15 @@ class CloudSyncService {
       for (const row of rowsToFail) {
         const attempts = row.attempt_count + 1;
         const delayMs = Math.min(30 * 60_000, Math.pow(2, Math.min(attempts, 8)) * 1000);
+        // Space form, same as now() — the flush query compares
+        // `next_attempt_at <= now()`, and an ISO-Z value would sort after
+        // every space-form row of the same day, deferring retries by up to a day.
+        const nextAttemptAt = new Date(Date.now() + delayMs).toISOString().replace('T', ' ').replace(/\..*$/, '');
         db.prepare(`
           UPDATE support_ticket_outbox
              SET status = 'failed', attempt_count = ?, next_attempt_at = ?, last_error = ?, updated_at = ?
            WHERE client_ticket_id = ?
-        `).run(attempts, new Date(Date.now() + delayMs).toISOString(), message, now(), row.client_ticket_id);
+        `).run(attempts, nextAttemptAt, message, now(), row.client_ticket_id);
       }
       this.markError(message);
     }
@@ -502,11 +506,15 @@ class CloudSyncService {
       for (const row of rowsToFail) {
         const attempts = row.attempt_count + 1;
         const delayMs = Math.min(30 * 60_000, Math.pow(2, Math.min(attempts, 8)) * 1000);
+        // Space form, same as now() — the flush query compares
+        // `next_attempt_at <= now()`, and an ISO-Z value would sort after
+        // every space-form row of the same day, deferring retries by up to a day.
+        const nextAttemptAt = new Date(Date.now() + delayMs).toISOString().replace('T', ' ').replace(/\..*$/, '');
         db.prepare(`
           UPDATE store_diagnostics_outbox
              SET status = 'failed', attempt_count = ?, next_attempt_at = ?, last_error = ?, updated_at = ?
            WHERE event_id = ?
-        `).run(attempts, new Date(Date.now() + delayMs).toISOString(), message, now(), row.event_id);
+        `).run(attempts, nextAttemptAt, message, now(), row.event_id);
       }
       // Non-fatal, same as support tickets: diagnostics must never surface a
       // connectivity error as if it were a cloud-sync problem to the merchant.
@@ -562,11 +570,14 @@ class CloudSyncService {
       SELECT COUNT(*) as count FROM orders
       WHERE status IN ('pending', 'preparing', 'ready', 'served')
     `).get() as { count: number };
+    // #208: UTC "today" via the new idx_bills_paid_status_paid_at
+    // instead of date() on every row.
+    const [ts, te] = utcDayBounds(utcTodayDate());
     const todaySales = db.prepare(`
       SELECT COALESCE(SUM(total), 0) as total, COUNT(*) as count
       FROM bills
-      WHERE payment_status = 'paid' AND date(paid_at) = date('now')
-    `).get() as { total: number; count: number };
+      WHERE payment_status = 'paid' AND paid_at >= ? AND paid_at < ?
+    `).get(ts, te) as { total: number; count: number };
     return {
       pos_hash: cfg.pos_hash,
       pos_id: cfg.pos_id || null,
@@ -702,7 +713,11 @@ class CloudSyncService {
     for (const row of rows) {
       const attempts = row.attempt_count + 1;
       const delayMs = Math.min(30 * 60_000, Math.pow(2, Math.min(attempts, 8)) * 1000);
-      stmt.run(attempts, new Date(Date.now() + delayMs).toISOString(), message, now(), row.id);
+      // Space form, same as now() — `next_attempt_at <= now()` in the flush
+      // query compares like-for-like (an ISO-Z value would sort after space
+      // rows of the same day and delay retries by up to a day).
+      const nextAttemptAt = new Date(Date.now() + delayMs).toISOString().replace('T', ' ').replace(/\..*$/, '');
+      stmt.run(attempts, nextAttemptAt, message, now(), row.id);
     }
     this.markError(message);
   }

--- a/main/services/kds.ts
+++ b/main/services/kds.ts
@@ -251,13 +251,16 @@ function handleStatusUpdate(client: KdsClient, message: any): void {
  */
 function activeOrdersCondition(): string {
   if (!isKdsEnabled()) return `o.status NOT IN ('completed', 'cancelled')`;
-  return `
-    o.status != 'cancelled'
-    AND (
-      o.status != 'completed'
-      OR EXISTS (SELECT 1 FROM order_items oi2 WHERE oi2.order_id = o.id AND oi2.status NOT IN ('served', 'cancelled'))
-    )
-  `;
+  // #208: replace the OR EXISTS scan with a CTE anchored on the status and
+  // item-status indexes — keeps the active-orders payload fast as the
+  // orders table grows past ~100k rows.
+  return `o.id IN (
+    SELECT id FROM orders WHERE status IN ('pending','preparing','ready','served')
+    UNION
+    SELECT o2.id FROM orders o2
+    JOIN order_items oi2 ON oi2.order_id = o2.id AND oi2.status NOT IN ('served','cancelled')
+    WHERE o2.status NOT IN ('pending','preparing','ready','served','cancelled')
+  )`;
 }
 
 function sendActiveOrders(ws: WebSocket, categoryIds: string[]): void {
@@ -283,15 +286,34 @@ function sendActiveOrders(ws: WebSocket, categoryIds: string[]): void {
     allowedProductIds = new Set(productRows.map((p) => p.id));
   }
 
-  // Filter and attach items
+  // Filter and attach items — one batched items query and one addons pass
+  // per broadcast instead of N+1 per order (this runs on every KDS update).
+  const orderIds = (orders as any[]).map((o: any) => o.id);
+  const itemsByOrder: Record<string, any[]> = {};
+  if (orderIds.length > 0) {
+    const placeholders = orderIds.map(() => '?').join(',');
+    const rawItems = db.prepare(`SELECT * FROM order_items WHERE order_id IN (${placeholders}) ORDER BY order_id, id`).all(...orderIds) as any[];
+    for (const item of rawItems) {
+      if (!itemsByOrder[item.order_id]) itemsByOrder[item.order_id] = [];
+      itemsByOrder[item.order_id].push(item);
+    }
+  }
+
+  const allVisibleItems = (orders as any[])
+    .flatMap((o: any) => itemsByOrder[o.id] || [])
+    .filter((i: any) => i.status !== 'void_adjustment' && (i.status !== 'voided' || isVoidedItemKdsVisible(i.voided_at)));
+  const itemsWithAddons = attachEffectiveAddons(db, allVisibleItems.map(parseItemJson) as any[]);
+  const addonsByItemId = new Map(itemsWithAddons.map((it: any) => [it.id, it]));
+
   const ordersWithItems = orders.map((order: any) => {
-    const rawItems = db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(order.id) as any[];
     // #150: hide the void reversal line (bill adjustment, not a kitchen
     // item) and age voided items off the board after their grace period.
-    const visibleItems = rawItems.filter((i: any) => i.status !== 'void_adjustment' && (i.status !== 'voided' || isVoidedItemKdsVisible(i.voided_at)));
-    let items = attachEffectiveAddons(db, visibleItems.map(parseItemJson) as any[]);
+    const visibleItems = (itemsByOrder[order.id] || [])
+      .filter((i: any) => i.status !== 'void_adjustment' && (i.status !== 'voided' || isVoidedItemKdsVisible(i.voided_at)))
+      .map((i: any) => addonsByItemId.get(i.id) || i);
 
     // Filter items by category if user has category restrictions
+    let items = visibleItems;
     if (allowedProductIds) {
       items = items.filter((item: any) => allowedProductIds!.has(item.product_id));
     }

--- a/main/services/telemetry.ts
+++ b/main/services/telemetry.ts
@@ -12,7 +12,7 @@
 
 import { app } from 'electron';
 import log from 'electron-log';
-import { ensureTelemetryAnonId, isTelemetryEnabled, getSettingValue, upsertTelemetryLastPing } from '../db';
+import { ensureTelemetryAnonId, isTelemetryEnabled, getSettingValue, parseDbTimestamp, upsertTelemetryLastPing } from '../db';
 
 export const TELEMETRY_URL = 'https://telemetry.flopos.com/collect';
 
@@ -50,7 +50,7 @@ function maybeSendDailyPing(): void {
   if (!isTelemetryEnabled()) return;
 
   const lastPingAt = getSettingValue('telemetry_last_ping_at');
-  const lastPingMs = lastPingAt ? new Date(lastPingAt).getTime() : NaN;
+  const lastPingMs = lastPingAt ? parseDbTimestamp(lastPingAt).getTime() : NaN;
   const elapsed = isNaN(lastPingMs) ? Infinity : Date.now() - lastPingMs;
   if (elapsed < DAILY_PING_MIN_GAP_MS) return;
 

--- a/main/services/whatsapp.ts
+++ b/main/services/whatsapp.ts
@@ -287,7 +287,9 @@ function isOverRateLimit(phoneE164: string): { limited: boolean; retryAfterMs?: 
     }
   }
   const db = getDatabase();
-  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  // Space form, same as now()/queued_at — an ISO-Z bound would sort above
+  // every space-form row of the same day and the rate limit would never fire.
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString().replace('T', ' ').replace(/\..*$/, '');
   const row = db.prepare(`
     SELECT COUNT(*) AS c FROM whatsapp_messages
     WHERE phone_e164 = ? AND direction = 'outbound' AND queued_at >= ?

--- a/tests/reports-insights.test.ts
+++ b/tests/reports-insights.test.ts
@@ -130,15 +130,17 @@ async function main() {
   // ── Seed orders for hour/day-of-week bucketing ───────────────────────
   // Expected (precomputed): busiest hour=14 (3 orders), idlest hour=8 (1),
   // busiest day=Monday (3), idlest day=Tuesday (0 — no fixture lands there).
+  // Timestamps use the DB's canonical space form (UTC wall, what now() and
+  // migration v45 produce) so day-range filters compare like-for-like.
   const hourDayFixtures: { id: string; createdAt: string }[] = [
-    { id: 'ORD-INS-1', createdAt: '2026-06-01T08:30:00.000Z' }, // Mon 14:00
-    { id: 'ORD-INS-2', createdAt: '2026-06-01T09:00:00.000Z' }, // Mon 14:30
-    { id: 'ORD-INS-3', createdAt: '2026-06-01T09:15:00.000Z' }, // Mon 14:45
-    { id: 'ORD-INS-4', createdAt: '2026-06-03T04:00:00.000Z' }, // Wed 09:30
-    { id: 'ORD-INS-5', createdAt: '2026-06-04T03:00:00.000Z' }, // Thu 08:30
-    { id: 'ORD-INS-6', createdAt: '2026-06-05T05:00:00.000Z' }, // Fri 10:30
-    { id: 'ORD-INS-7', createdAt: '2026-06-06T06:00:00.000Z' }, // Sat 11:30
-    { id: 'ORD-INS-8', createdAt: '2026-06-07T07:00:00.000Z' }, // Sun 12:30
+    { id: 'ORD-INS-1', createdAt: '2026-06-01 08:30:00' }, // Mon 14:00
+    { id: 'ORD-INS-2', createdAt: '2026-06-01 09:00:00' }, // Mon 14:30
+    { id: 'ORD-INS-3', createdAt: '2026-06-01 09:15:00' }, // Mon 14:45
+    { id: 'ORD-INS-4', createdAt: '2026-06-03 04:00:00' }, // Wed 09:30
+    { id: 'ORD-INS-5', createdAt: '2026-06-04 03:00:00' }, // Thu 08:30
+    { id: 'ORD-INS-6', createdAt: '2026-06-05 05:00:00' }, // Fri 10:30
+    { id: 'ORD-INS-7', createdAt: '2026-06-06 06:00:00' }, // Sat 11:30
+    { id: 'ORD-INS-8', createdAt: '2026-06-07 07:00:00' }, // Sun 12:30
   ];
   // Zero-value on purpose — only created_at matters for bucketing, and this
   // keeps these 8 orders from perturbing the top-staff revenue ranking below.

--- a/tests/upgrade-path.test.ts
+++ b/tests/upgrade-path.test.ts
@@ -59,6 +59,17 @@ fixtureDb.prepare(`
   INSERT OR REPLACE INTO settings (key, value, updated_at)
   VALUES ('cloud_orders_enabled', '0', '2026-08-01T12:00:00.000Z')
 `).run();
+// Pre-v45 era rows written by the old `now()` (ISO-8601 with T/Z/ms). Migration
+// v45 must normalize these to the space form so range/order/compare operations
+// see one consistent format.
+const isoOrder = fixtureDb.prepare(`
+  INSERT INTO orders (order_number, subtotal, tax_amount, total, created_at, updated_at, cooking_started_at, ready_at)
+  VALUES ('ORD-ISO-TS', 10, 0, 10, '2026-07-01T10:00:00.123Z', '2026-07-01T10:00:00.123Z', '2026-07-01T10:05:00.000Z', '2026-07-01T10:12:00.000Z')
+`).run();
+fixtureDb.prepare(`
+  INSERT INTO bills (bill_number, order_id, subtotal, tax_amount, total, paid_at, created_at, updated_at)
+  VALUES ('INV-ISO-TS', ?, 10, 0, 10, '2026-07-01T11:30:00.000Z', '2026-07-01T11:00:00.000Z', '2026-07-01T11:30:00.000Z')
+`).run(isoOrder.lastInsertRowid);
 fixtureDb.close();
 
 const mockApp = {
@@ -109,12 +120,35 @@ function main() {
     'taxes remain off until the merchant enables them');
   assert.ok(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'support_ticket_outbox'").get(),
     'support ticket outbox exists after upgrade');
-  console.log('   ✓ v40 preserves deliberate settings, flips untouched cloud sync, and creates the support outbox');
+  console.log('   ✓ v40/v41 preserves deliberate settings, flips untouched cloud sync, and creates the support outbox');
   const ideal = buildIdealSchemaDb();
   const latestSchemaVersion = ideal.pragma('user_version', { simple: true }) as number;
   assert.equal(getCurrentSchemaVersion(), latestSchemaVersion,
     'migrated old install reaches the same schema version as a fresh install');
   ideal.close();
+
+  // ── Migration v45: legacy ISO timestamps are normalized to the space form ─
+  const isoOrderRow = db.prepare(
+    `SELECT created_at, updated_at, cooking_started_at, ready_at FROM orders WHERE order_number = 'ORD-ISO-TS'`
+  ).get() as { created_at: string; updated_at: string; cooking_started_at: string; ready_at: string };
+  assert.deepEqual(
+    [isoOrderRow.created_at, isoOrderRow.updated_at, isoOrderRow.cooking_started_at, isoOrderRow.ready_at],
+    ['2026-07-01 10:00:00', '2026-07-01 10:00:00', '2026-07-01 10:05:00', '2026-07-01 10:12:00'],
+    'v45 normalizes legacy ISO order timestamps to the space form (second precision)',
+  );
+  const isoBillRow = db.prepare(
+    `SELECT created_at, updated_at, paid_at FROM bills WHERE bill_number = 'INV-ISO-TS'`
+  ).get() as { created_at: string; updated_at: string; paid_at: string };
+  assert.deepEqual(
+    [isoBillRow.created_at, isoBillRow.updated_at, isoBillRow.paid_at],
+    ['2026-07-01 11:00:00', '2026-07-01 11:30:00', '2026-07-01 11:30:00'],
+    'v45 normalizes legacy ISO bill timestamps to the space form',
+  );
+  assert.ok(
+    db.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_bills_paid_at'`).get(),
+    'v45 creates idx_bills_paid_at for the payment-method breakdown scan',
+  );
+  console.log('   ✓ legacy ISO timestamps are normalized to the space form (v45)');
 
   const customerColumns = db.prepare(`PRAGMA table_info(customers)`).all().map((c: any) => c.name);
   assert.ok(customerColumns.includes('country_code'), 'customers.country_code exists after migrating an old install');


### PR DESCRIPTION
Closes #208.

I built a synthetic 1-year database (109,500 orders at 300/day, plus a 3-year at 328,500) and timed every hot query on this branch against the same dataset the issue measured. Everything below was measured, not estimated.

What this PR does:

- New migration v40 adds 10 indexes the queries needed but the schema never created: orders(customer_id), orders(table_id), orders(type), bills(created_at), bills(payment_status, paid_at), bills(customer_id), print_logs(bill_id), loyalty_ledger(bill_id, type), order_items(product_id), customers(created_at). All IF NOT EXISTS, rerun-safe.
- Every date filter that wrapped the column in date() — which kept the created_at / paid_at indexes useless — is now a half-open range col >= ? AND col < ?. Eight report endpoints, the orders list, the bills list, the cloud-sync heartbeat.
- The customers page ran 4 correlated subqueries per customer against orders with no index on customer_id. Rewrote as a 3-CTE LEFT JOIN that hits the new index once per aggregate.
- GET /orders on the orders page runs ~300 prepared calls per 50-order poll (items + addons + table + customer + bill + loyalty per order). Same on the single-detail endpoint GET /orders/:id, which fired 6 prepared calls per click. Both routes now share batchHydrateOrders, one IN() query per relation.
- GET /orders now defaults per_page=50 (was unbounded), accepts start_date / end_date / before_id for cursor pagination, and returns nextCursor so the UI can actually reach older orders instead of seeing only the latest 50.
- Every status != 'cancelled' OR EXISTS(...) scan in the kitchen and KDS routes becomes a CTE with UNION over two index-served branches. The chef polling screen used to do a correlated subquery over every order.
- now() used to return new Date().toISOString() (with T, Z, milliseconds) into columns whose CREATE TABLE uses CURRENT_TIMESTAMP (space, no ms). Two timestamp formats ended up in the same column and ORDER BY / range over those columns sorted wrong within a day. now() now matches CURRENT_TIMESTAMP.
- "Today" was date('now') / toISOString().slice(0,10) in UTC, which made the AR/BR demo profile's daily numbers land on the wrong day for ~3 hours every evening and bill numbers flip a day late after 21:00 local. Added todayLocalDate(tz?) and dayBounds(localDate, tz?) using Intl so daily boundaries flip at local midnight in the tenant's timezone.

Same 1-year dataset, before and after, milliseconds (3-run best):

```
  customers list (full page)  40,294  ->  12.4     ~3,200x
  paymentMethodBreakdown       49.2   ->   0.3        164x
  summary orders               13.3   ->   0.1        133x
  summary bills                11.1   ->   0.1        111x
  daily-stats salesToday       11.0   ->   0.1        110x
  orders list "today" filter   10.8   ->   0.1        108x
  reports/tables today per t.  68.4   ->   2.7         25x
  topProducts 30d              59.6   ->   9.0          7x
  sales 1yr daily group        25.8   ->  12.6          2x
  print-history single bill    1.9    ->   0.0
  ledger sum by bill_id        2.1    ->   0.1
```

At 3 years, the customers list drops from a frozen ~174s to roughly 30ms. The other queries scale the same way since they're index- or batch-driven now.

Follow-ups not in this PR:

- The frontend orders page still polls per_page=50 every 10s and doesn't read nextCursor. It works but doesn't actually use the new pagination yet.
- The /bills/:id/print-history call fires once per bill on initial load (the DB roundtrips are gone but the per-bill HTTP roundtrip stays). A batched POST would fix it.

