### PR TITLE
fix: make durability fsync portable on Windows

### DIFF
--- a/main/db.ts
+++ b/main/db.ts
@@ -199,7 +199,10 @@ type ReplacementJournal = {
 };
 
 function syncFile(filePath: string): void {
-  const fd = fs.openSync(filePath, 'r');
+  // Windows does not allow fsync on a read-only file handle (it reports
+  // EPERM). All callers pass application-owned database, journal, or backup
+  // files, so use a writable handle for portable durability flushing.
+  const fd = fs.openSync(filePath, 'r+');
   try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
 }
 


### PR DESCRIPTION
## Problem

The post-merge Full Cross-Platform Matrix failed only on Windows during the smoke test. `fs.fsyncSync()` was called on a read-only (`r`) file descriptor and Windows returned `EPERM` while creating the pre-migration backup.

## Fix

Open application-owned database, journal, and backup files with `r+` before fsync. This preserves the fail-closed durability check and avoids weakening recovery guarantees.

## Verification

- `npm run build`
- `npm run test:backup`
- `npm run test:recovery-cloud`
- `tests/smoke-test.test.ts`
- GitHub Windows matrix validation pending

This is a follow-up to merged PR #217 and should be reviewed independently. It addresses the Windows CI failure at run https://github.com/FreeOpenSourcePOS/FloCafe/actions/runs/31290095061.