### PR TITLE
fix(products): add product description field

### DIFF
--- a/frontend/src/app/(dashboard)/products/page.tsx
+++ b/frontend/src/app/(dashboard)/products/page.tsx
@@ -660,6 +660,11 @@ export default function ProductsPage() {
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" required />
               </div>
               <div>
+                <label htmlFor="product-description" className="block text-sm font-medium text-gray-700 mb-1">{t('products.categoryDescription')}</label>
+                <textarea id="product-description" value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" rows={2} />
+              </div>
+              <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldImage')}</label>
                 <ImageUploader
                   value={form.image_url}


### PR DESCRIPTION
## Summary
- add a Description textarea to the Add/Edit Product modal
- bind it to the existing `form.description` state and API payload
- associate the new textarea with its label for accessibility

Closes #240

## Validation
- `npm run lint` passed with 0 errors (existing warnings remain)
- `npm run build:frontend` passed
- `npm run build` passed
- `npm audit --audit-level=high` passed for root and frontend
- manual E2E QA passed: create a product with a description, save it, reopen it, and verify the description persists

## Out-of-scope test notes
- Existing prepaid-payment E2E tests currently fail because the Confirm Payment button remains disabled; the changed file is unrelated to that POS flow.
- The full suite has shown intermittent unrelated failures; focused reruns of the affected tests passed.