### PR TITLE
test(e2e): align prepaid checkout with configurable payment methods

### DIFF
--- a/frontend/e2e/prepaid-payment-reconciliation.spec.ts
+++ b/frontend/e2e/prepaid-payment-reconciliation.spec.ts
@@ -13,6 +13,8 @@ test('prepaid checkout uses the authoritative decimal bill total and settles in 
   await expect(page.getByRole('button', { name: 'Tax ฿4.20' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Confirm Payment · ฿64.20' })).toBeVisible();
   await expect(page.getByText('Round off', { exact: true })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Cash' }).click();
+  await expect(page.getByRole('button', { name: 'Confirm Payment · ฿64.20' })).toBeEnabled();
 
   const orderResponse = page.waitForResponse((response) => {
     const url = new URL(response.url());
@@ -53,6 +55,8 @@ test('prepaid checkout never reports success when the payment response is partia
   await page.getByRole('button', { name: 'Add to Cart - ฿60.00' }).click();
   await page.getByRole('button', { name: 'Place Order' }).click();
   await expect(page.getByRole('button', { name: 'Confirm Payment · ฿64.20' })).toBeVisible();
+  await page.getByRole('button', { name: 'Cash' }).click();
+  await expect(page.getByRole('button', { name: 'Confirm Payment · ฿64.20' })).toBeEnabled();
 
   let paymentBatchRequests = 0;
   await page.route('**/api/bills/*/payments', async (route) => {


### PR DESCRIPTION
## Summary
- update prepaid checkout E2E coverage for the configurable payment-method UI
- select Cash before confirming payment in both prepaid scenarios
- assert the Confirm Payment action is enabled before exercising the API flow

The application intentionally starts payment amounts empty after configurable payment methods were introduced; clicking a payment-method button allocates the remaining balance. The previous tests assumed the old auto-filled behavior.

## Validation
- `npm run test:e2e` — 4 passed
- `npm test` — passed
- `npm run lint` — passed with existing warnings
- `npm run test:customer-auth` — passed in 10 consecutive runs

No application code was changed. The intermittent customer-auth result was not reproduced and does not need a fix in this PR.