### PR TITLE
test: make Windows maintenance concurrency deterministic

### DIFF
--- a/tests/database-maintenance-lock.test.ts
+++ b/tests/database-maintenance-lock.test.ts
@@ -89,17 +89,27 @@ async function run() {
   let authTouched = false;
   app.use((_req, _res, next) => { authTouched = true; next(); });
   app.post('/api/db/backup', (_req, res) => res.json({ reached: true }));
-  let activeRouteMaintenanceStarted = false;
-  const unregisterMaintenanceStart = registerDatabaseMaintenanceStartListener(() => {
-    activeRouteMaintenanceStarted = true;
+  let routeMaintenanceStarted!: () => void;
+  const routeMaintenanceStartedSignal = new Promise<void>((resolve) => {
+    routeMaintenanceStarted = resolve;
   });
-  const activeRouteMaintenance = withDatabaseMaintenanceLock(async () => { await delay(20); });
-  while (!activeRouteMaintenanceStarted) await delay(1);
+  const unregisterMaintenanceStart = registerDatabaseMaintenanceStartListener(() => {
+    routeMaintenanceStarted();
+  });
+  let releaseMaintenance!: () => void;
+  const maintenanceHold = new Promise<void>((resolve) => {
+    releaseMaintenance = resolve;
+  });
+  const activeRouteMaintenance = withDatabaseMaintenanceLock(async () => {
+    await maintenanceHold;
+  });
+  await routeMaintenanceStartedSignal;
   try {
     const concurrentRoute = await request(app).post('/api/db/backup');
     assert.equal(concurrentRoute.status, 503, 'concurrent maintenance route receives 503 before auth/route middleware');
     assert.equal(authTouched, false, 'concurrent maintenance route does not reach later middleware');
   } finally {
+    releaseMaintenance();
     await activeRouteMaintenance;
     unregisterMaintenanceStart();
   }


### PR DESCRIPTION
## Summary
- replace the fixed 20 ms maintenance delay with an explicit promise gate
- keep maintenance active until the concurrent route assertion completes
- preserve the 503-before-auth regression coverage without changing production code

## Validation
- `npm run test:database-tools-api`
- `npm test`
- `npm run build`
- `npm run lint`
- focused maintenance test repeated 20 times

Fixes the Windows-only `200 !== 503` flake in `database-maintenance-lock.test.ts`.