### PR TITLE
ci: automate macOS TestFlight and App Store promotion

### DIFF
--- a/.github/workflows/macos-app-store-submit.yml
+++ b/.github/workflows/macos-app-store-submit.yml
@@ -1,0 +1,111 @@
+name: macOS App Store submission
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: App Store marketing version already uploaded to TestFlight (X.Y.Z)
+        required: true
+        type: string
+      build_number:
+        description: Exact processed TestFlight build number to submit
+        required: true
+        type: string
+      release_mode:
+        description: Release after Apple approval automatically, in phases, or manually
+        required: true
+        type: choice
+        options:
+          - manual
+          - automatic
+          - phased
+        default: manual
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-app-store-submit-${{ inputs.version }}-${{ inputs.build_number }}
+  cancel-in-progress: false
+
+jobs:
+  submit:
+    # The workflow file must be selected from the default branch. It promotes
+    # an already-processed App Store Connect build and never builds arbitrary
+    # workflow-dispatch source code.
+    if: github.ref == 'refs/heads/main'
+    runs-on: macos-14
+    environment:
+      name: production-release
+    timeout-minutes: 45
+    env:
+      MAS_BUNDLE_ID: com.flo.desktop
+      MAS_VERSION: ${{ inputs.version }}
+      MAS_BUILD_NUMBER: ${{ inputs.build_number }}
+      MACOS_STORE_RELEASE_MODE: ${{ inputs.release_mode }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Only the committed Fastfile is needed; do not checkout an
+          # arbitrary input ref for this production submission.
+          ref: main
+
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+        with:
+          ruby-version: '3.3'
+          bundler: none
+
+      - name: Install pinned Fastlane
+        run: gem install fastlane --version 2.237.0 --no-document
+
+      - name: Validate production submission inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$MAS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::version must be strict X.Y.Z; received '$MAS_VERSION'."
+            exit 1
+          }
+          [[ "$MAS_BUILD_NUMBER" =~ ^[0-9]+(\.[0-9]+)*$ ]] || {
+            echo "::error::build_number must be a numeric CFBundleVersion; received '$MAS_BUILD_NUMBER'."
+            exit 1
+          }
+          case "$MACOS_STORE_RELEASE_MODE" in
+            manual|automatic|phased) ;;
+            *) echo "::error::release_mode must be manual, automatic, or phased."; exit 1 ;;
+          esac
+
+      - name: Check App Store Connect credentials
+        shell: bash
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+          ASC_API_PRIVATE_KEY: ${{ secrets.ASC_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "$ASC_API_KEY_ID" ]] && missing+=(ASC_API_KEY_ID)
+          [[ -z "$ASC_API_ISSUER_ID" ]] && missing+=(ASC_API_ISSUER_ID)
+          [[ -z "$ASC_API_PRIVATE_KEY" ]] && missing+=(ASC_API_PRIVATE_KEY)
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing required App Store Connect secret(s): ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Write App Store Connect API key
+        shell: bash
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_PRIVATE_KEY: ${{ secrets.ASC_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          key_path="$RUNNER_TEMP/AuthKey_${ASC_API_KEY_ID}.p8"
+          echo "$ASC_API_PRIVATE_KEY" | base64 --decode > "$key_path"
+          chmod 600 "$key_path"
+          echo "ASC_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
+      - name: Submit exact build to Mac App Store review
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+        run: fastlane submit_store

--- a/.github/workflows/macos-testflight.yml
+++ b/.github/workflows/macos-testflight.yml
@@ -1,0 +1,204 @@
+name: macOS TestFlight
+
+on:
+  schedule:
+    - cron: '30 0 * * *' # Nightly after the full nightly matrix starts.
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: TestFlight destination for a manually selected source
+        required: true
+        type: choice
+        options:
+          - internal
+          - external
+        default: internal
+      source_ref:
+        description: main for internal testing, or a protected release/* branch/strict X.Y.Z-rc.N tag for external testing
+        required: true
+        type: string
+        default: main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-testflight-${{ github.event_name == 'schedule' && 'nightly' || inputs.source_ref }}
+  cancel-in-progress: false
+
+jobs:
+  upload-testflight:
+    # Manual runs must execute the workflow definition from the default branch;
+    # source_ref is validated below and is only the code being tested.
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: macos-14
+    # Scheduled nightlies use a non-approval environment. Any manual run,
+    # including internal or external beta testing, uses the reviewer-protected
+    # beta environment and cannot access credentials until approved.
+    environment:
+      name: ${{ github.event_name == 'schedule' && 'macos-testflight-nightly' || 'macos-testflight-beta' }}
+    timeout-minutes: 100
+    env:
+      TESTFLIGHT_CHANNEL: ${{ github.event_name == 'schedule' && 'internal' || inputs.channel }}
+      SOURCE_REF: ${{ github.event_name == 'schedule' && 'main' || inputs.source_ref }}
+      MAS_BUNDLE_ID: com.flo.desktop
+    steps:
+      - name: Validate TestFlight source policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$TESTFLIGHT_CHANNEL" == "internal" && "$SOURCE_REF" != "main" ]]; then
+            echo "::error::Internal TestFlight runs must build main; received '$SOURCE_REF'."
+            exit 1
+          fi
+          if [[ "$TESTFLIGHT_CHANNEL" == "external" ]] &&
+             [[ ! "$SOURCE_REF" =~ ^release/ ]] &&
+             [[ ! "$SOURCE_REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+            echo "::error::External TestFlight runs require a release/* branch or strict X.Y.Z-rc.N tag; received '$SOURCE_REF'."
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+        with:
+          ruby-version: '3.3'
+          bundler: none
+
+      - name: Install npm dependencies
+        run: npm ci
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Install pinned Fastlane
+        run: gem install fastlane --version 2.237.0 --no-document
+
+      - name: Check MAS signing credentials
+        shell: bash
+        env:
+          CSC_LINK: ${{ secrets.MAS_MAC_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAS_MAC_CERTS_PASSWORD }}
+          MAS_PROVISIONING_PROFILE: ${{ secrets.MAS_PROVISIONING_PROFILE }}
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+          ASC_API_PRIVATE_KEY: ${{ secrets.ASC_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "$CSC_LINK" ]] && missing+=(MAS_MAC_CERTS)
+          [[ -z "$CSC_KEY_PASSWORD" ]] && missing+=(MAS_MAC_CERTS_PASSWORD)
+          [[ -z "$MAS_PROVISIONING_PROFILE" ]] && missing+=(MAS_PROVISIONING_PROFILE)
+          [[ -z "$ASC_API_KEY_ID" ]] && missing+=(ASC_API_KEY_ID)
+          [[ -z "$ASC_API_ISSUER_ID" ]] && missing+=(ASC_API_ISSUER_ID)
+          [[ -z "$ASC_API_PRIVATE_KEY" ]] && missing+=(ASC_API_PRIVATE_KEY)
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing required macOS TestFlight secret(s): ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Install MAS provisioning profile
+        shell: bash
+        env:
+          MAS_PROVISIONING_PROFILE: ${{ secrets.MAS_PROVISIONING_PROFILE }}
+        run: |
+          set -euo pipefail
+          echo "$MAS_PROVISIONING_PROFILE" | base64 --decode > build/flo.provisionprofile
+          security cms -D -i build/flo.provisionprofile >/dev/null
+          chmod 600 build/flo.provisionprofile
+
+      - name: Build signed MAS package
+        run: npm run build:mas
+        env:
+          MAS_BUILD: 1
+          BUILD_NUMBER: ${{ github.run_number }}
+          CSC_LINK: ${{ secrets.MAS_MAC_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAS_MAC_CERTS_PASSWORD }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+          APPLE_TEAM_ID: BKDY677XJA
+
+      - name: Verify MAS package
+        id: verify
+        shell: bash
+        run: |
+          set -euo pipefail
+          packages=(release/*.pkg)
+          if (( ${#packages[@]} != 1 )); then
+            echo "::error::Expected exactly one MAS .pkg, found ${#packages[@]}."
+            exit 1
+          fi
+          pkg="${packages[0]}"
+          pkgutil --check-signature "$pkg"
+          expanded="$RUNNER_TEMP/flo-mas-expanded"
+          pkgutil --expand-full "$pkg" "$expanded"
+          app=$(find "$expanded" -type d -name '*.app' -print -quit)
+          [[ -n "$app" ]] || { echo "::error::MAS package contains no .app bundle"; exit 1; }
+          codesign --verify --deep --strict --verbose=2 "$app"
+          bundle_id=$(plutil -extract CFBundleIdentifier raw -o - "$app/Contents/Info.plist")
+          version=$(plutil -extract CFBundleShortVersionString raw -o - "$app/Contents/Info.plist")
+          build_version=$(plutil -extract CFBundleVersion raw -o - "$app/Contents/Info.plist")
+          expected_version=$(node -p "require('./package.json').version")
+          [[ "$bundle_id" == "$MAS_BUNDLE_ID" ]] || { echo "::error::Bundle ID '$bundle_id' does not match '$MAS_BUNDLE_ID'."; exit 1; }
+          [[ "$version" == "$expected_version" ]] || { echo "::error::Marketing version '$version' does not match '$expected_version'."; exit 1; }
+          [[ "$build_version" == *".${GITHUB_RUN_NUMBER}" ]] || { echo "::error::Build version '$build_version' does not contain CI build number '${GITHUB_RUN_NUMBER}'."; exit 1; }
+          echo "MAS_PKG=$pkg" >> "$GITHUB_OUTPUT"
+          echo "MAS_VERSION=$version" >> "$GITHUB_OUTPUT"
+          echo "MAS_BUILD_NUMBER=$build_version" >> "$GITHUB_OUTPUT"
+          echo "Verified $pkg: bundle=$bundle_id version=$version build=$build_version"
+
+      - name: Prepare App Store Connect API key
+        shell: bash
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_PRIVATE_KEY: ${{ secrets.ASC_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          key_path="$RUNNER_TEMP/AuthKey_${ASC_API_KEY_ID}.p8"
+          echo "$ASC_API_PRIVATE_KEY" | base64 --decode > "$key_path"
+          chmod 600 "$key_path"
+          echo "ASC_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
+      - name: Upload package to TestFlight
+        env:
+          MAS_PKG: ${{ steps.verify.outputs.MAS_PKG }}
+          TESTFLIGHT_GROUP: ${{ vars.TESTFLIGHT_GROUP }}
+          TESTFLIGHT_CHANGELOG: ${{ vars.TESTFLIGHT_CHANGELOG }}
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+          MAS_BUNDLE_ID: com.flo.desktop
+        run: fastlane upload_testflight
+
+      - name: Write TestFlight promotion manifest
+        shell: bash
+        env:
+          MAS_VERSION: ${{ steps.verify.outputs.MAS_VERSION }}
+          MAS_BUILD_NUMBER: ${{ steps.verify.outputs.MAS_BUILD_NUMBER }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/macos-testflight-manifest.json" <<EOF
+          {
+            "bundleId": "com.flo.desktop",
+            "marketingVersion": "$MAS_VERSION",
+            "buildNumber": "$MAS_BUILD_NUMBER",
+            "sourceRef": "$SOURCE_REF",
+            "sourceSha": "$SOURCE_SHA",
+            "testflightChannel": "$TESTFLIGHT_CHANNEL"
+          }
+          EOF
+
+      - name: Upload TestFlight promotion manifest
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: macos-testflight-manifest-${{ github.run_id }}
+          path: ${{ runner.temp }}/macos-testflight-manifest.json
+          if-no-files-found: error
+          retention-days: 90

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,60 @@
+# Flo Cafe App Store Connect lanes.
+# Authentication is supplied by the workflow through an App Store Connect API key;
+# no Apple ID password or interactive 2FA is used in CI.
+
+def asc_api_key
+  app_store_connect_api_key(
+    key_id: ENV.fetch("ASC_API_KEY_ID"),
+    issuer_id: ENV.fetch("ASC_API_ISSUER_ID"),
+    key_filepath: ENV.fetch("ASC_API_KEY_PATH"),
+    duration: 1200,
+    in_house: false
+  )
+end
+
+platform :mac do
+  desc "Upload a signed macOS MAS package to TestFlight"
+  lane :upload_testflight do
+    channel = ENV.fetch("TESTFLIGHT_CHANNEL")
+    group = ENV.fetch("TESTFLIGHT_GROUP", "").strip
+    if channel == "external" && group.empty?
+      UI.user_error!("TESTFLIGHT_GROUP is required for external TestFlight distribution")
+    end
+
+    upload_to_testflight(
+      api_key: asc_api_key,
+      pkg: ENV.fetch("MAS_PKG"),
+      app_identifier: ENV.fetch("MAS_BUNDLE_ID"),
+      changelog: ENV.fetch("TESTFLIGHT_CHANGELOG", ""),
+      groups: group.empty? ? nil : [group],
+      distribute_external: channel == "external",
+      notify_external_testers: false,
+      # Submit the processed build to TestFlight for both channels. Internal
+      # distribution does not require external beta review; external
+      # distribution may trigger Apple's first-build beta review.
+      skip_submission: false,
+      skip_waiting_for_build_processing: false
+    )
+  end
+
+  desc "Submit an already-processed TestFlight build to the Mac App Store"
+  lane :submit_store do
+    mode = ENV.fetch("MACOS_STORE_RELEASE_MODE", "manual")
+    unless %w[manual automatic phased].include?(mode)
+      UI.user_error!("MACOS_STORE_RELEASE_MODE must be manual, automatic, or phased")
+    end
+
+    deliver(
+      api_key: asc_api_key,
+      app_identifier: ENV.fetch("MAS_BUNDLE_ID"),
+      app_version: ENV.fetch("MAS_VERSION"),
+      build_number: ENV.fetch("MAS_BUILD_NUMBER"),
+      skip_binary_upload: true,
+      skip_metadata: true,
+      submit_for_review: true,
+      automatic_release: mode != "manual",
+      phased_release: mode == "phased",
+      force: true
+    )
+  end
+end

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:win": "npm run build:frontend && npm run build && electron-builder --win",
     "build:appx": "npm run build:frontend && npm run build && electron-builder --win appx --config.npmRebuild=false",
     "build:mac": "npm run build:frontend && npm run build && electron-builder --mac",
-    "build:mas": "MAS_BUILD=1 npm run build:frontend && MAS_BUILD=1 npm run build && MAS_BUILD=1 electron-builder --mac mas --universal",
+    "build:mas": "MAS_BUILD=1 npm run build:frontend && MAS_BUILD=1 npm run build && MAS_BUILD=1 electron-builder --mac mas --universal --publish never",
     "build:mas-dev": "MAS_BUILD=1 npm run build:frontend && MAS_BUILD=1 npm run build && MAS_BUILD=1 electron-builder --mac masDev",
     "build:linux": "npm run build:frontend && npm run build && electron-builder --linux",
     "release:linux": "npm run build:frontend && npm run build && electron-builder --linux --publish always",

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -19,6 +19,7 @@ function run() {
 
   assert.equal(pkg.engines?.node, '>=22.12.0', 'root Node engine must match Electron 43 minimum');
   assert.equal(pkg.scripts?.['verify:electron'], 'node scripts/verify-electron-runtime.cjs', 'Electron runtime verification must be cross-platform');
+  assert.ok(pkg.scripts?.['build:mas']?.includes('--publish never'), 'MAS builds must never implicitly publish from the build command');
   assert.ok(fs.existsSync(path.join(__dirname, '../scripts/verify-electron-runtime.cjs')), 'cross-platform Electron runtime verifier must exist');
 
   // ── electron-builder config ──────────────────────────────────────────
@@ -200,6 +201,38 @@ function run() {
   for (const secret of ['AZURE_AD_TENANT_ID', 'AZURE_AD_APPLICATION_CLIENT_ID', 'AZURE_AD_APPLICATION_SECRET', 'SELLER_ID']) {
     assert.ok(storePublishJob.includes(`secrets.${secret}`), `Store publishing must read ${secret} from GitHub secrets`);
   }
+
+  // ── macOS Store: MAS/TestFlight and production promotion paths ───────
+  const testflightWorkflow = fs.readFileSync(path.join(__dirname, '../.github/workflows/macos-testflight.yml'), 'utf8');
+  assert.ok(testflightWorkflow.includes("github.event_name == 'schedule'"), 'macOS TestFlight must have a scheduled nightly path');
+  assert.ok(testflightWorkflow.includes("github.ref == 'refs/heads/main'"), 'manual TestFlight dispatch must use the workflow definition from main');
+  assert.ok(testflightWorkflow.includes('release/* branch or strict X.Y.Z-rc.N tag'), 'external TestFlight runs must be restricted to release candidates');
+  assert.ok(testflightWorkflow.includes('environment:\n      name: ${{ github.event_name == \'schedule\' && \'macos-testflight-nightly\' || \'macos-testflight-beta\' }}'), 'manual TestFlight runs must use the reviewer-protected beta environment');
+  assert.ok(testflightWorkflow.includes('npm run build:mas'), 'TestFlight must build the MAS target, not direct-distribution DMG/ZIP artifacts');
+  assert.ok(testflightWorkflow.includes('BUILD_NUMBER: ${{ github.run_number }}'), 'TestFlight builds must receive a unique CI build number');
+  assert.ok(testflightWorkflow.includes('pkgutil --check-signature'), 'TestFlight must verify the MAS package signature before upload');
+  assert.ok(testflightWorkflow.includes('gem install fastlane --version 2.237.0'), 'TestFlight must install a pinned Fastlane version');
+  assert.ok(testflightWorkflow.includes('fastlane upload_testflight'), 'TestFlight must upload through the pinned Fastlane lane');
+  for (const secret of ['MAS_MAC_CERTS', 'MAS_MAC_CERTS_PASSWORD', 'MAS_PROVISIONING_PROFILE', 'ASC_API_KEY_ID', 'ASC_API_ISSUER_ID', 'ASC_API_PRIVATE_KEY']) {
+    assert.ok(testflightWorkflow.includes(`secrets.${secret}`), `TestFlight must read ${secret} from the protected environment`);
+  }
+
+  const appStoreSubmitWorkflow = fs.readFileSync(path.join(__dirname, '../.github/workflows/macos-app-store-submit.yml'), 'utf8');
+  assert.ok(appStoreSubmitWorkflow.includes('workflow_dispatch:'), 'Mac App Store promotion must be explicitly dispatched');
+  assert.ok(appStoreSubmitWorkflow.includes("github.ref == 'refs/heads/main'"), 'Mac App Store promotion must use the workflow definition from main');
+  assert.ok(appStoreSubmitWorkflow.includes('environment:\n      name: production-release'), 'Mac App Store promotion must use the protected production-release environment');
+  assert.ok(appStoreSubmitWorkflow.includes('version:'), 'Mac App Store promotion must require an explicit marketing version');
+  assert.ok(appStoreSubmitWorkflow.includes('build_number:'), 'Mac App Store promotion must require the exact processed build number');
+  assert.ok(appStoreSubmitWorkflow.includes('release_mode:'), 'Mac App Store promotion must make manual/automatic/phased release explicit');
+  assert.ok(appStoreSubmitWorkflow.includes('gem install fastlane --version 2.237.0'), 'Mac App Store promotion must install a pinned Fastlane version');
+  assert.ok(appStoreSubmitWorkflow.includes('fastlane submit_store'), 'Mac App Store promotion must submit the selected build through Fastlane');
+  assert.ok(appStoreSubmitWorkflow.includes('MACOS_STORE_RELEASE_MODE'), 'Mac App Store promotion must pass the release mode to Fastlane');
+
+  const fastfile = fs.readFileSync(path.join(__dirname, '../fastlane/Fastfile'), 'utf8');
+  assert.ok(fastfile.includes('upload_to_testflight'), 'Fastlane must define the TestFlight upload lane');
+  assert.ok(fastfile.includes('deliver('), 'Fastlane must define the App Store submission lane');
+  assert.ok(fastfile.includes('automatic_release: mode != "manual"'), 'Fastlane must keep manual release as the safe default');
+  assert.ok(fastfile.includes('phased_release: mode == "phased"'), 'Fastlane must support an explicit phased release mode');
 
   console.log('✅ Release config + workflow integrity checks passed');
 }


### PR DESCRIPTION
## Summary

- Add a MAS-signed macOS TestFlight workflow for scheduled internal nightlies and reviewer-gated external beta candidates.
- Use a unique CI build number and emit a promotion manifest so the exact processed TestFlight build can be promoted later.
- Add a reviewer-gated production workflow that submits an already-processed build to Mac App Store review.
- Support manual, automatic-after-review, and seven-day phased release modes.
- Pin Ruby setup and Fastlane, use separate MAS signing/provisioning credentials from direct-distribution notarization credentials, and keep production submission separate from the nightly lane.
- Prevent `build:mas` from implicitly publishing through electron-builder.

This PR is intentionally stacked on `feat/microsoft-store-publishing` and should be merged after PR #260, or retargeted to `main` once that PR lands.

## Required setup

- `macos-testflight-nightly` Environment: MAS signing/API secrets, no approval for scheduled nightlies.
- `macos-testflight-beta` Environment: same secrets, required maintainer approval for manual beta runs.
- `production-release` Environment: App Store Connect API secrets and required maintainers.
- App Store Connect bundle ID `com.flo.desktop`, Mac App Distribution certificate, MAS provisioning profile, TestFlight groups, and prepared version metadata.

See the workflow comments and `fastlane/Fastfile` for the lane behavior. The first production mode should be `manual`; switch to `automatic` or `phased` only after a successful review cycle.

## Verification

- `npm run test:release-config`
- YAML parsing for all release workflows
- `git diff --check`

Apple signing, TestFlight processing, and App Store review require the maintainer's Apple/GitHub credentials and cannot be validated locally.
