### PR TITLE
feat(i18n): add Persian runtime language support

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useAuthStore } from '@/store/auth';
 import { usePosSettingsStore, type PaperSize, type BillTemplate } from '@/store/pos-settings';
+import type { Language } from '@/lib/i18n';
 import { usePrinterStore, usePrinterStatusSync } from '@/hooks/usePrinter';
 import { Settings, Building2, CreditCard, Monitor, Users, Gift, Printer, Share2, FileText, Lock, Smartphone, RefreshCw, Copy, Check, Wifi, Usb, Trash2, Plus, Star, TestTube2, ChefHat, QrCode, CheckCircle2, Database, Cloud, CloudOff, Zap, Percent, KeyRound, AlertTriangle, Wrench, HardDrive, UploadCloud, Hash, ChevronDown } from 'lucide-react';
 import { Tabs, TabsContent } from '@/components/ui/tabs';
@@ -2357,7 +2358,7 @@ export default function SettingsPage() {
                   <select
                     value={language}
                     onChange={(e) => {
-                      const lang = e.target.value as 'en' | 'es' | 'pt';
+                      const lang = e.target.value as Language;
                       setLanguage(lang);
                       api.put('/settings/business', { language: lang }).catch(() => toast.error(t('settings.saveFailed')));
                     }}

--- a/frontend/src/hooks/useServerKdsInfo.ts
+++ b/frontend/src/hooks/useServerKdsInfo.ts
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { fetchServerInfo } from '@/lib/i18n';
+import type { Language } from '@/lib/i18n';
 import type { KdsViewMode } from '@/hooks/useKdsView';
 
 export interface ServerKdsInfo {
-  language: 'en' | 'es' | 'pt' | null;
+  language: Language | null;
   country: string | null;
   kdsDefaultView: KdsViewMode | null;
 }

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,9 +1,10 @@
-export type Language = 'en' | 'es' | 'pt';
+export type Language = 'en' | 'es' | 'pt' | 'fa';
 import en from './i18n/en.json';
 import es from './i18n/es.json';
 import pt from './i18n/pt.json';
+import fa from './i18n/fa.json';
 
-const translations: Record<Language, Record<string, string>> = { en, es, pt };
+const translations: Record<Language, Record<string, string>> = { en, es, pt, fa };
 
 const PLURAL_RE = /\{(\w+),\s*plural,\s*((?:\s*(?:zero|one|two|few|many|other)\s*\{[^}]*\})+)\s*\}/g;
 const pluralRulesCache = new Map<string, Intl.PluralRules>();
@@ -20,7 +21,7 @@ function getPluralRules(locale: string): Intl.PluralRules {
 function formatIcuPlural(template: string, params: Record<string, string | number>, lang: Language): string {
   return template.replace(PLURAL_RE, (_match, name: string, cases: string) => {
     const raw = Number(params[name] ?? 0);
-    const locale = lang === 'es' ? 'es-AR' : lang === 'pt' ? 'pt-BR' : 'en';
+    const locale = lang === 'es' ? 'es-AR' : lang === 'pt' ? 'pt-BR' : lang === 'fa' ? 'fa-IR' : 'en';
     const pr = getPluralRules(locale).select(raw);
     const ordered = ['zero', 'one', 'two', 'few', 'many', 'other'];
     const seen: Record<string, string> = {};
@@ -112,7 +113,7 @@ export async function fetchServerInfo(baseUrl = '', timeoutMs = 1500): Promise<S
       kds_default_view?: string | null;
     };
     return {
-      language: data.language === 'es' ? 'es' : data.language === 'pt' ? 'pt' : data.language === 'en' ? 'en' : null,
+      language: data.language === 'fa' ? 'fa' : data.language === 'es' ? 'es' : data.language === 'pt' ? 'pt' : data.language === 'en' ? 'en' : null,
       country: data.country || null,
       kdsDefaultView:
         data.kds_default_view === 'kanban' ? 'kanban' : data.kds_default_view === 'tabs' ? 'tabs' : null,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { Language } from '@/lib/i18n';
+
 export interface User {
   id: number;
   name: string;
@@ -20,7 +22,7 @@ export interface Tenant {
   plan: string;
   status: string;
   role?: string;
-  language?: 'en' | 'es' | 'pt';
+  language?: Language;
 }
 
 export interface Category {

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -2,10 +2,13 @@ import { create } from 'zustand';
 import api from '@/lib/api';
 import type { User, Tenant } from '@/lib/types';
 import { usePosSettingsStore } from '@/store/pos-settings';
+import type { Language } from '@/lib/i18n';
+
+const SUPPORTED_LANGUAGES = new Set<Language>(['en', 'es', 'pt', 'fa']);
 
 function syncTenantLanguage(t: Tenant | null | undefined) {
   const lang = t?.language;
-  if (lang === 'en' || lang === 'es' || lang === 'pt') {
+  if (lang && SUPPORTED_LANGUAGES.has(lang)) {
     usePosSettingsStore.getState().setLanguage(lang);
   }
 }

--- a/frontend/src/store/pos-settings.ts
+++ b/frontend/src/store/pos-settings.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import type { Language } from '@/lib/i18n';
 
 export type PaperSize = 'thermal58' | 'thermal80';
 export type PrinterPrintMode = 'escpos' | 'browser';
@@ -17,7 +18,7 @@ export interface PosSettingsState {
   // UI language for i18n routing. Synced from tenant on auth load.
   // Initial value reads the browser locale; persist middleware overrides
   // on reload, so user choices persist across sessions.
-  language: 'en' | 'es' | 'pt';
+  language: Language;
   // Printer settings
   printerPaperSize: PaperSize;
   printerEnabled: boolean;
@@ -57,7 +58,7 @@ export interface PosSettingsState {
   setShowProductImages: (show: boolean) => void;
   setCustomerMandatory: (mandatory: boolean) => void;
   setEnforcePhoneLength: (enabled: boolean) => void;
-  setLanguage: (lang: 'en' | 'es' | 'pt') => void;
+  setLanguage: (lang: Language) => void;
   setPrinterPaperSize: (size: PaperSize) => void;
   setPrinterEnabled: (enabled: boolean) => void;
   setPrinterPrintMode: (mode: PrinterPrintMode) => void;


### PR DESCRIPTION
This PR makes `fa` a recognized runtime language internally but does not yet expose Persian in Setup/Settings or browser auto-detection. User-facing enablement remains gated on translation, RTL, locale and printing work.

- Add `fa` to `Language` type in `i18n.ts` and import `fa.json`
- Add `fa-IR` locale to ICU plural formatter
- Accept `fa` in `fetchServerInfo` language validation
- Update Zustand `pos-settings` store to use canonical `Language` type
- Update `Tenant` type in `types.ts` to use `Language`
- Fix `syncTenantLanguage` in `auth` store to preserve valid `fa` on auth load
- Update `ServerKdsInfo.language` in `useServerKdsInfo`

Refs #241