### PR TITLE
feat(i18n): sync html lang and dir attributes on language change

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Toaster } from "react-hot-toast";
 import "./globals.css";
 import MenuActionHandler from "@/components/layout/MenuActionHandler";
 import AuthGuard from "@/components/layout/AuthGuard";
+import { HtmlLangSync } from "@/components/layout/HtmlLangSync";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -47,11 +48,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <MenuActionHandler />
+        <HtmlLangSync />
         <AuthGuard>{children}</AuthGuard>
         <Toaster position="top-right" />
         <script

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -48,7 +48,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/frontend/src/components/kds/KdsHtmlLang.tsx
+++ b/frontend/src/components/kds/KdsHtmlLang.tsx
@@ -7,7 +7,14 @@ export function KdsHtmlLang() {
   const language = usePosSettingsStore((s) => s.language);
   useEffect(() => {
     if (typeof document !== 'undefined') {
-      document.documentElement.lang = language === 'es' ? 'es' : language === 'pt' ? 'pt-BR' : 'en';
+      const el = document.documentElement;
+      if (language === 'fa') {
+        el.lang = 'fa-IR';
+        el.dir = 'rtl';
+      } else {
+        el.lang = language === 'es' ? 'es' : language === 'pt' ? 'pt-BR' : 'en';
+        el.dir = 'ltr';
+      }
     }
   }, [language]);
   return null;

--- a/frontend/src/components/layout/HtmlLangSync.tsx
+++ b/frontend/src/components/layout/HtmlLangSync.tsx
@@ -11,10 +11,8 @@ import { usePosSettingsStore } from '@/store/pos-settings';
  * readers always have the correct BCP 47 locale and text-direction cues,
  * even though the root layout is a static Next.js export.
  *
- * Used in every layout subtree that can switch languages (main app, KDS
- * standalone).  Server-standalone keeps lang="en" hardcoded because the
- * customer-facing ordering UI is in the tenant language, not the operator
- * language, and no i18n switching is wired there yet.
+ * HtmlLangSync handles the main application document.
+ * KDS performs equivalent synchronization separately through KdsHtmlLang.
  */
 export function HtmlLangSync() {
   const language = usePosSettingsStore((s) => s.language);

--- a/frontend/src/components/layout/HtmlLangSync.tsx
+++ b/frontend/src/components/layout/HtmlLangSync.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePosSettingsStore } from '@/store/pos-settings';
+
+/**
+ * Syncs `<html lang>` and `<html dir>` with the active UI language.
+ *
+ * Persian (fa) is RTL; all other supported languages are LTR.
+ * This runs client-side on every language change so the browser and screen
+ * readers always have the correct BCP 47 locale and text-direction cues,
+ * even though the root layout is a static Next.js export.
+ *
+ * Used in every layout subtree that can switch languages (main app, KDS
+ * standalone).  Server-standalone keeps lang="en" hardcoded because the
+ * customer-facing ordering UI is in the tenant language, not the operator
+ * language, and no i18n switching is wired there yet.
+ */
+export function HtmlLangSync() {
+  const language = usePosSettingsStore((s) => s.language);
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const el = document.documentElement;
+    switch (language) {
+      case 'fa':
+        el.lang = 'fa-IR';
+        el.dir = 'rtl';
+        break;
+      case 'es':
+        el.lang = 'es';
+        el.dir = 'ltr';
+        break;
+      case 'pt':
+        el.lang = 'pt-BR';
+        el.dir = 'ltr';
+        break;
+      default:
+        el.lang = 'en';
+        el.dir = 'ltr';
+    }
+  }, [language]);
+  return null;
+}


### PR DESCRIPTION
## Summary
Synchronizes `<html lang>` and `<html dir>` attributes dynamically with the active UI language selected in `pos-settings`.

- Adds shared `HtmlLangSync` client component setting `lang` and `dir` attributes (`fa` -> `lang="fa-IR"` and `dir="rtl"`; others -> `ltr`)
- Mounts `HtmlLangSync` in root layout
- Updates `KdsHtmlLang` component in KDS standalone layout to handle `fa` and `dir` attributes

## Testing
- `npm run build:frontend`: PASS (clean static export)
- `npm run lint`: PASS (0 errors)

Refs #241