### PR TITLE
fix(orders): make held-order restore single-consumer

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -384,6 +384,80 @@ Update order status.
 
 ---
 
+## Held Orders
+
+### GET `/api/held-orders`
+List held orders. Requires an authenticated owner, manager, cashier, or waiter.
+
+**Response (200):**
+```json
+{
+  "orders": [
+    {
+      "id": "ho-abc12345",
+      "tableId": "table-1",
+      "items": [
+        {
+          "id": "line-1",
+          "product": { "id": "prod-1", "name": "Cheeseburger", "price": 250 },
+          "quantity": 1,
+          "addons": [],
+          "special_instructions": ""
+        }
+      ],
+      "customerId": null,
+      "guestCount": 1,
+      "orderNotes": "",
+      "heldAt": "2025-03-31T12:00:00Z"
+    }
+  ],
+  "skippedCount": 0
+}
+```
+
+### POST `/api/held-orders`
+Create or replace the held order for a table. The response `id` identifies the
+specific row returned to the client; replacing an existing held order creates a
+new identity. Requires an authenticated owner, manager, cashier, or waiter.
+
+**Request:**
+```json
+{
+  "tableId": "table-1",
+  "items": [
+    {
+      "id": "line-1",
+      "product": { "id": "prod-1", "name": "Cheeseburger", "price": 250 },
+      "quantity": 1,
+      "addons": [],
+      "special_instructions": ""
+    }
+  ],
+  "customerId": null,
+  "guestCount": 1,
+  "orderNotes": ""
+}
+```
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "id": "ho-abc12345"
+}
+```
+
+### DELETE `/api/held-orders/:tableId?heldOrderId=:id`
+Consume the held order only when `heldOrderId` matches the current row. A
+matching request deletes the row, releases the table, and returns
+`{"success":true,"deleted":true}`. Requests without an identity, for an
+already-consumed row, or for a replacement row return
+`{"success":true,"deleted":false}` without deleting the current row or
+releasing the table. Requires an authenticated owner, manager, cashier, or
+waiter.
+
+---
+
 ## Order Items
 
 ### PATCH `/api/order-items/:id/status`

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -878,12 +878,17 @@ export default function OrdersPage() {
                  </div>
                  <div className="p-4 bg-gray-50 border-t border-gray-100 flex gap-2">
                     <Button onClick={async () => {
-                      const held = await heldOrdersStore.restoreOrder(heldOrder.tableId);
-                      if (held) {
-                        cartStore.loadItems(held.items, heldOrder.tableId, held.customerId, held.guestCount, held.orderNotes);
-                        cartStore.setOrderType('dine_in');
-                        router.push('/pos');
-                      } else {
+                      try {
+                        const held = await heldOrdersStore.restoreOrder(heldOrder.tableId);
+                        if (held) {
+                          cartStore.loadItems(held.items, heldOrder.tableId, held.customerId, held.guestCount, held.orderNotes);
+                          cartStore.setOrderType('dine_in');
+                          router.push('/pos');
+                        } else {
+                          await heldOrdersStore.fetchHeldOrders();
+                          toast.error(t('orders.resumeFailed'));
+                        }
+                      } catch {
                         toast.error(t('orders.resumeFailed'));
                       }
                     }} variant="default" className="flex-1 bg-brand hover:bg-brand/90 text-white">{t('orders.resumeInPos')}</Button>

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -881,7 +881,7 @@ export default function OrdersPage() {
                       try {
                         const held = await heldOrdersStore.restoreOrder(heldOrder.tableId);
                         if (held) {
-                          cartStore.loadItems(held.items, heldOrder.tableId, held.customerId, held.guestCount, held.orderNotes);
+                          cartStore.loadItems(held.items, heldOrder.tableId, held.customerId, held.guestCount, held.orderNotes, held.id);
                           cartStore.setOrderType('dine_in');
                           router.push('/pos');
                         } else {
@@ -895,7 +895,7 @@ export default function OrdersPage() {
                     <Button onClick={async () => {
                       if (await confirm(t('orders.deleteHeldConfirm'), { destructive: true })) {
                         try {
-                          await heldOrdersStore.removeHeldOrder(heldOrder.tableId);
+                          await heldOrdersStore.removeHeldOrder(heldOrder.tableId, heldOrder.id);
                           toast.success(t('orders.heldOrderRemoved'));
                         } catch {
                           toast.error(t('orders.removeHeldOrderFailed'));

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -895,8 +895,13 @@ export default function OrdersPage() {
                     <Button onClick={async () => {
                       if (await confirm(t('orders.deleteHeldConfirm'), { destructive: true })) {
                         try {
-                          await heldOrdersStore.removeHeldOrder(heldOrder.tableId, heldOrder.id);
-                          toast.success(t('orders.heldOrderRemoved'));
+                          const deleted = await heldOrdersStore.removeHeldOrder(heldOrder.tableId, heldOrder.id);
+                          if (deleted) {
+                            toast.success(t('orders.heldOrderRemoved'));
+                          } else {
+                            await heldOrdersStore.fetchHeldOrders();
+                            toast.error(t('orders.removeHeldOrderFailed'));
+                          }
                         } catch {
                           toast.error(t('orders.removeHeldOrderFailed'));
                         }

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -653,13 +653,21 @@ export default function POSPage() {
   };
 
   const handleSelectHeldTable = async (tableId: string) => {
-    const held = await heldOrders.restoreOrder(tableId);
-    if (held) {
-      cart.loadItems(held.items, tableId, held.customerId, held.guestCount, held.orderNotes);
-      cart.setOrderType('dine_in');
+    try {
+      const held = await heldOrders.restoreOrder(tableId);
+      if (held) {
+        cart.loadItems(held.items, tableId, held.customerId, held.guestCount, held.orderNotes);
+        cart.setOrderType('dine_in');
+      } else {
+        await heldOrders.fetchHeldOrders();
+        toast.error(t('pos.loadOrderFailed'));
+      }
+    } catch {
+      toast.error(t('pos.loadOrderFailed'));
+    } finally {
+      setShowTablePicker(false);
+      await refreshTables();
     }
-    setShowTablePicker(false);
-    await refreshTables();
   };
 
   const handleHoldTable = async (tableId: string) => {

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -395,7 +395,8 @@ export default function POSPage() {
 
       if (cart.tableId) {
         try {
-          await heldOrders.removeHeldOrder(cart.tableId, cart.heldOrderId || undefined);
+          const deleted = await heldOrders.removeHeldOrder(cart.tableId, cart.heldOrderId || undefined);
+          if (!deleted) await heldOrders.fetchHeldOrders();
         } catch (heldOrderError) {
           // The order has already been placed. Do not turn a cleanup failure
           // into a failed sale or leave an unhandled promise in the console.
@@ -596,7 +597,8 @@ export default function POSPage() {
       toast.success(successMsg);
       if (cart.tableId) {
         try {
-          await heldOrders.removeHeldOrder(cart.tableId, cart.heldOrderId || undefined);
+          const deleted = await heldOrders.removeHeldOrder(cart.tableId, cart.heldOrderId || undefined);
+          if (!deleted) await heldOrders.fetchHeldOrders();
         } catch (heldOrderError) {
           // The payment is complete; clearing the held-order record is cleanup.
           console.error('Failed to clear held order after payment', heldOrderError);

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -395,7 +395,7 @@ export default function POSPage() {
 
       if (cart.tableId) {
         try {
-          await heldOrders.removeHeldOrder(cart.tableId);
+          await heldOrders.removeHeldOrder(cart.tableId, cart.heldOrderId || undefined);
         } catch (heldOrderError) {
           // The order has already been placed. Do not turn a cleanup failure
           // into a failed sale or leave an unhandled promise in the console.
@@ -596,7 +596,7 @@ export default function POSPage() {
       toast.success(successMsg);
       if (cart.tableId) {
         try {
-          await heldOrders.removeHeldOrder(cart.tableId);
+          await heldOrders.removeHeldOrder(cart.tableId, cart.heldOrderId || undefined);
         } catch (heldOrderError) {
           // The payment is complete; clearing the held-order record is cleanup.
           console.error('Failed to clear held order after payment', heldOrderError);
@@ -656,7 +656,7 @@ export default function POSPage() {
     try {
       const held = await heldOrders.restoreOrder(tableId);
       if (held) {
-        cart.loadItems(held.items, tableId, held.customerId, held.guestCount, held.orderNotes);
+        cart.loadItems(held.items, tableId, held.customerId, held.guestCount, held.orderNotes, held.id);
         cart.setOrderType('dine_in');
       } else {
         await heldOrders.fetchHeldOrders();

--- a/frontend/src/store/cart.ts
+++ b/frontend/src/store/cart.ts
@@ -5,6 +5,7 @@ interface CartState {
   items: CartItem[];
   orderType: 'dine_in' | 'takeaway' | 'delivery';
   tableId: string | null;
+  heldOrderId: string | null;
   customerId: number | string | null;
   customer: Customer | null;
   guestCount: number;
@@ -16,7 +17,7 @@ interface CartState {
   removeItem: (cartItemId: string) => void;
   updateQuantity: (cartItemId: string, quantity: number) => void;
   clearCart: () => void;
-  loadItems: (items: CartItem[], tableId: string | null, customerId: number | string | null, guestCount: number, orderNotes?: string) => void;
+  loadItems: (items: CartItem[], tableId: string | null, customerId: number | string | null, guestCount: number, orderNotes?: string, heldOrderId?: string) => void;
   setOrderType: (type: CartState['orderType']) => void;
   setTableId: (id: string | null) => void;
   setCustomerId: (id: number | string | null) => void;
@@ -48,6 +49,7 @@ export const useCartStore = create<CartState>((set, get) => ({
   items: [],
   orderType: 'dine_in',
   tableId: null,
+  heldOrderId: null,
   customerId: null,
   customer: null,
   guestCount: 1,
@@ -121,15 +123,15 @@ export const useCartStore = create<CartState>((set, get) => ({
   },
 
   clearCart: () => {
-    set({ items: [], tableId: null, customerId: null, customer: null, guestCount: 1, orderType: 'dine_in', deliveryAddress: '', orderNotes: '' });
+    set({ items: [], tableId: null, heldOrderId: null, customerId: null, customer: null, guestCount: 1, orderType: 'dine_in', deliveryAddress: '', orderNotes: '' });
   },
 
-  loadItems: (items, tableId, customerId, guestCount, orderNotes) => {
-    set({ items, tableId, customerId, guestCount, orderNotes: orderNotes || '' });
+  loadItems: (items, tableId, customerId, guestCount, orderNotes, heldOrderId) => {
+    set({ items, tableId, heldOrderId: heldOrderId || null, customerId, guestCount, orderNotes: orderNotes || '' });
   },
 
   setOrderType: (type) => set((state) => ({ orderType: type, deliveryAddress: type !== 'delivery' ? '' : state.deliveryAddress })),
-  setTableId: (id) => set({ tableId: id }),
+  setTableId: (id) => set({ tableId: id, heldOrderId: null }),
   setCustomerId: (id) => set({ customerId: id }),
   setCustomer: (customer) => set({ customer, customerId: customer?.id ?? null }),
   setGuestCount: (count) => set({ guestCount: count }),

--- a/frontend/src/store/held-orders.ts
+++ b/frontend/src/store/held-orders.ts
@@ -24,23 +24,44 @@ interface HeldOrdersState {
   getHeldOrder: (tableId: string) => HeldOrder | undefined;
 }
 
-export const useHeldOrdersStore = create<HeldOrdersState>()((set, get) => {
-  const deleteHeldOrderState = async (tableId: string) => {
-    await api.delete(`${HELD_ORDERS_ENDPOINT}/${tableId}`);
+interface HeldOrderDeleteResponse {
+  success: boolean;
+  deleted: boolean;
+}
+
+interface HeldOrderPostResponse {
+  success: boolean;
+  id?: string;
+}
+
+type HeldOrdersApiClient = Pick<typeof api, 'get' | 'post' | 'delete'>;
+
+export const createHeldOrdersStore = (apiClient: HeldOrdersApiClient = api) => create<HeldOrdersState>()((set, get) => {
+  let mutationVersion = 0;
+  let fetchSequence = 0;
+
+  const deleteHeldOrderState = async (tableId: string, expectedHeldOrderId?: string) => {
+    const query = expectedHeldOrderId ? `?heldOrderId=${encodeURIComponent(expectedHeldOrderId)}` : '';
+    const { data } = await apiClient.delete<HeldOrderDeleteResponse>(`${HELD_ORDERS_ENDPOINT}/${tableId}${query}`);
+    // A successful no-op is a stale consumer, not permission to restore its cache.
+    mutationVersion += 1;
     set((state) => {
       const rest = { ...state.orders };
       delete rest[tableId];
       return { orders: rest };
     });
+    return data?.success === true && data.deleted === true;
   };
 
   return {
     orders: {},
 
     fetchHeldOrders: async () => {
+      const requestSequence = ++fetchSequence;
+      const requestMutationVersion = mutationVersion;
       try {
-        const { data } = await api.get(HELD_ORDERS_ENDPOINT);
-        if (data && data.orders) {
+        const { data } = await apiClient.get(HELD_ORDERS_ENDPOINT);
+        if (data && data.orders && requestSequence === fetchSequence && requestMutationVersion === mutationVersion) {
           const newOrders: Record<string, HeldOrder> = {};
           for (const order of data.orders) {
             newOrders[order.tableId] = order;
@@ -55,11 +76,12 @@ export const useHeldOrdersStore = create<HeldOrdersState>()((set, get) => {
 
     holdOrder: async (tableId, items, customerId, guestCount, orderNotes = '') => {
       try {
-        await api.post(HELD_ORDERS_ENDPOINT, { tableId, items, customerId, guestCount, orderNotes });
+        const { data } = await apiClient.post<HeldOrderPostResponse>(HELD_ORDERS_ENDPOINT, { tableId, items, customerId, guestCount, orderNotes });
+        mutationVersion += 1;
         set((state) => ({
           orders: {
             ...state.orders,
-            [tableId]: { tableId, items, customerId, guestCount, orderNotes, heldAt: new Date().toISOString() },
+            [tableId]: { id: data?.id, tableId, items, customerId, guestCount, orderNotes, heldAt: new Date().toISOString() },
           },
         }));
       } catch (err) {
@@ -72,8 +94,8 @@ export const useHeldOrdersStore = create<HeldOrdersState>()((set, get) => {
       const order = get().orders[tableId];
       if (!order) return null;
       try {
-        await deleteHeldOrderState(tableId);
-        return order;
+        const deleted = await deleteHeldOrderState(tableId, order.id);
+        return deleted ? order : null;
       } catch (err) {
         console.error('Failed to restore order', err);
         throw err;
@@ -82,7 +104,7 @@ export const useHeldOrdersStore = create<HeldOrdersState>()((set, get) => {
 
     removeHeldOrder: async (tableId) => {
       try {
-        await deleteHeldOrderState(tableId);
+        await deleteHeldOrderState(tableId, get().orders[tableId]?.id);
       } catch (err) {
         console.error('Failed to remove held order', err);
         throw err;
@@ -94,3 +116,5 @@ export const useHeldOrdersStore = create<HeldOrdersState>()((set, get) => {
     getHeldOrder: (tableId) => get().orders[tableId],
   };
 });
+
+export const useHeldOrdersStore = createHeldOrdersStore(api);

--- a/frontend/src/store/held-orders.ts
+++ b/frontend/src/store/held-orders.ts
@@ -19,7 +19,7 @@ interface HeldOrdersState {
   fetchHeldOrders: () => Promise<void>;
   holdOrder: (tableId: string, items: CartItem[], customerId: number | string | null, guestCount: number, orderNotes?: string) => Promise<void>;
   restoreOrder: (tableId: string) => Promise<HeldOrder | null>;
-  removeHeldOrder: (tableId: string) => Promise<void>;
+  removeHeldOrder: (tableId: string, expectedHeldOrderId?: string) => Promise<void>;
   hasHeldOrder: (tableId: string) => boolean;
   getHeldOrder: (tableId: string) => HeldOrder | undefined;
 }
@@ -117,9 +117,9 @@ export const createHeldOrdersStore = (apiClient: HeldOrdersApiClient = api) => c
       }
     },
 
-    removeHeldOrder: async (tableId) => {
+    removeHeldOrder: async (tableId, expectedHeldOrderId) => {
       try {
-        await deleteHeldOrderState(tableId, get().orders[tableId]?.id);
+        await deleteHeldOrderState(tableId, expectedHeldOrderId);
       } catch (err) {
         console.error('Failed to remove held order', err);
         throw err;

--- a/frontend/src/store/held-orders.ts
+++ b/frontend/src/store/held-orders.ts
@@ -37,19 +37,27 @@ interface HeldOrderPostResponse {
 type HeldOrdersApiClient = Pick<typeof api, 'get' | 'post' | 'delete'>;
 
 export const createHeldOrdersStore = (apiClient: HeldOrdersApiClient = api) => create<HeldOrdersState>()((set, get) => {
-  let mutationVersion = 0;
+  const tableMutationVersions = new Map<string, number>();
   let fetchSequence = 0;
+
+  const getTableMutationVersion = (tableId: string) => tableMutationVersions.get(tableId) ?? 0;
+  const markTableMutation = (tableId: string) => {
+    tableMutationVersions.set(tableId, getTableMutationVersion(tableId) + 1);
+  };
 
   const deleteHeldOrderState = async (tableId: string, expectedHeldOrderId?: string) => {
     const query = expectedHeldOrderId ? `?heldOrderId=${encodeURIComponent(expectedHeldOrderId)}` : '';
     const { data } = await apiClient.delete<HeldOrderDeleteResponse>(`${HELD_ORDERS_ENDPOINT}/${tableId}${query}`);
-    // A successful no-op is a stale consumer, not permission to restore its cache.
-    mutationVersion += 1;
-    set((state) => {
-      const rest = { ...state.orders };
-      delete rest[tableId];
-      return { orders: rest };
-    });
+    if (expectedHeldOrderId) {
+      markTableMutation(tableId);
+      set((state) => {
+        const current = state.orders[tableId];
+        if (!current || current.id !== expectedHeldOrderId) return state;
+        const rest = { ...state.orders };
+        delete rest[tableId];
+        return { orders: rest };
+      });
+    }
     return data?.success === true && data.deleted === true;
   };
 
@@ -58,15 +66,22 @@ export const createHeldOrdersStore = (apiClient: HeldOrdersApiClient = api) => c
 
     fetchHeldOrders: async () => {
       const requestSequence = ++fetchSequence;
-      const requestMutationVersion = mutationVersion;
+      const requestMutationVersions = new Map(tableMutationVersions);
       try {
         const { data } = await apiClient.get(HELD_ORDERS_ENDPOINT);
-        if (data && data.orders && requestSequence === fetchSequence && requestMutationVersion === mutationVersion) {
-          const newOrders: Record<string, HeldOrder> = {};
-          for (const order of data.orders) {
-            newOrders[order.tableId] = order;
-          }
-          set({ orders: newOrders });
+        if (data && data.orders && requestSequence === fetchSequence) {
+          const fetchedOrders: Record<string, HeldOrder> = {};
+          for (const order of data.orders) fetchedOrders[order.tableId] = order;
+          set((state) => {
+            const newOrders = { ...state.orders };
+            const tableIds = new Set([...Object.keys(state.orders), ...Object.keys(fetchedOrders)]);
+            for (const tableId of tableIds) {
+              if (getTableMutationVersion(tableId) !== (requestMutationVersions.get(tableId) ?? 0)) continue;
+              if (fetchedOrders[tableId]) newOrders[tableId] = fetchedOrders[tableId];
+              else delete newOrders[tableId];
+            }
+            return { orders: newOrders };
+          });
         }
       } catch (err) {
         console.error('Failed to fetch held orders', err);
@@ -77,7 +92,7 @@ export const createHeldOrdersStore = (apiClient: HeldOrdersApiClient = api) => c
     holdOrder: async (tableId, items, customerId, guestCount, orderNotes = '') => {
       try {
         const { data } = await apiClient.post<HeldOrderPostResponse>(HELD_ORDERS_ENDPOINT, { tableId, items, customerId, guestCount, orderNotes });
-        mutationVersion += 1;
+        markTableMutation(tableId);
         set((state) => ({
           orders: {
             ...state.orders,

--- a/frontend/src/store/held-orders.ts
+++ b/frontend/src/store/held-orders.ts
@@ -19,7 +19,7 @@ interface HeldOrdersState {
   fetchHeldOrders: () => Promise<void>;
   holdOrder: (tableId: string, items: CartItem[], customerId: number | string | null, guestCount: number, orderNotes?: string) => Promise<void>;
   restoreOrder: (tableId: string) => Promise<HeldOrder | null>;
-  removeHeldOrder: (tableId: string, expectedHeldOrderId?: string) => Promise<void>;
+  removeHeldOrder: (tableId: string, expectedHeldOrderId?: string) => Promise<boolean>;
   hasHeldOrder: (tableId: string) => boolean;
   getHeldOrder: (tableId: string) => HeldOrder | undefined;
 }
@@ -119,7 +119,7 @@ export const createHeldOrdersStore = (apiClient: HeldOrdersApiClient = api) => c
 
     removeHeldOrder: async (tableId, expectedHeldOrderId) => {
       try {
-        await deleteHeldOrderState(tableId, expectedHeldOrderId);
+        return await deleteHeldOrderState(tableId, expectedHeldOrderId);
       } catch (err) {
         console.error('Failed to remove held order', err);
         throw err;

--- a/main/routes/held-orders.ts
+++ b/main/routes/held-orders.ts
@@ -174,18 +174,21 @@ router.post('/', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Req
 
 router.delete('/:tableId', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Request, res: Response) => {
   try {
-    // New clients provide heldOrderId for compare-and-delete. The optional
-    // query keeps the old idempotent table-only cleanup contract compatible.
     const tableId = req.params.tableId;
     const expectedHeldOrderId = typeof req.query.heldOrderId === 'string' && req.query.heldOrderId.length > 0
       ? req.query.heldOrderId
       : null;
+
+    if (!expectedHeldOrderId) {
+      return res.json({ success: true, deleted: false });
+    }
+
     const db = getDatabase();
     
     let deleted = false;
     withTxn(() => {
       const existing = db.prepare('SELECT id FROM held_orders WHERE table_id = ?').get(tableId) as { id: string } | undefined;
-      if (existing && (!expectedHeldOrderId || existing.id === expectedHeldOrderId)) {
+      if (existing && existing.id === expectedHeldOrderId) {
         db.prepare('DELETE FROM held_orders WHERE table_id = ?').run(tableId);
         db.prepare('UPDATE tables SET status = ?, updated_at = ? WHERE id = ? AND status = ?').run(TABLE_STATUS_AVAILABLE, now(), tableId, TABLE_STATUS_HELD);
         deleted = true;

--- a/main/routes/held-orders.ts
+++ b/main/routes/held-orders.ts
@@ -139,28 +139,33 @@ router.post('/', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Req
       return res.status(400).json({ error: error.message });
     }
     const { tableId, items, customerId, guestCount, orderNotes } = input;
+    let heldOrderId = '';
     
     withTxn(() => {
       const existing = db.prepare('SELECT id FROM held_orders WHERE table_id = ?').get(tableId) as { id: string } | undefined;
+      heldOrderId = `ho-${randomUUID().slice(0, 8)}`;
       
       if (existing) {
         db.prepare(`
           UPDATE held_orders
-          SET items = ?, customer_id = ?, guest_count = ?, order_notes = ?, updated_at = ?
+          SET id = ?, items = ?, customer_id = ?, guest_count = ?, order_notes = ?, updated_at = ?
           WHERE id = ?
-        `).run(JSON.stringify(items), customerId || null, guestCount || 1, orderNotes || '', now(), existing.id);
+        `).run(heldOrderId, JSON.stringify(items), customerId || null, guestCount || 1, orderNotes || '', now(), existing.id);
       } else {
-        const id = `ho-${randomUUID().slice(0, 8)}`;
         db.prepare(`
           INSERT INTO held_orders (id, table_id, items, customer_id, guest_count, order_notes, created_at, updated_at)
           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        `).run(id, tableId, JSON.stringify(items), customerId || null, guestCount || 1, orderNotes || '', now(), now());
+        `).run(heldOrderId, tableId, JSON.stringify(items), customerId || null, guestCount || 1, orderNotes || '', now(), now());
       }
 
       db.prepare('UPDATE tables SET status = ?, updated_at = ? WHERE id = ?').run(TABLE_STATUS_HELD, now(), tableId);
     });
 
-    res.json({ success: true });
+    // Returning the current row identity lets a client prove that its cached
+    // snapshot is still the row it is consuming. Replacing a held order gets
+    // a new identity, so an older terminal receives deleted:false instead of
+    // deleting the replacement.
+    res.json({ success: true, id: heldOrderId });
   } catch (error: any) {
     console.error("[API] Hold order error:", error);
     res.status(500).json({ error: "Could not hold order" });
@@ -169,13 +174,18 @@ router.post('/', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Req
 
 router.delete('/:tableId', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Request, res: Response) => {
   try {
+    // New clients provide heldOrderId for compare-and-delete. The optional
+    // query keeps the old idempotent table-only cleanup contract compatible.
     const tableId = req.params.tableId;
+    const expectedHeldOrderId = typeof req.query.heldOrderId === 'string' && req.query.heldOrderId.length > 0
+      ? req.query.heldOrderId
+      : null;
     const db = getDatabase();
     
     let deleted = false;
     withTxn(() => {
-      const existing = db.prepare('SELECT id FROM held_orders WHERE table_id = ?').get(tableId);
-      if (existing) {
+      const existing = db.prepare('SELECT id FROM held_orders WHERE table_id = ?').get(tableId) as { id: string } | undefined;
+      if (existing && (!expectedHeldOrderId || existing.id === expectedHeldOrderId)) {
         db.prepare('DELETE FROM held_orders WHERE table_id = ?').run(tableId);
         db.prepare('UPDATE tables SET status = ?, updated_at = ? WHERE id = ? AND status = ?').run(TABLE_STATUS_AVAILABLE, now(), tableId, TABLE_STATUS_HELD);
         deleted = true;

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test:issue-133-kds-kot-toggles": "node tests/run-electron-node-test.cjs tests/issue-133-kds-kot-toggles.test.ts",
     "test:issue-137-barcode": "node tests/run-electron-node-test.cjs tests/issue-137-barcode.test.ts",
     "test:tables-string-ids": "node tests/run-electron-node-test.cjs tests/tables-string-ids.test.ts",
-    "test:held-orders": "node tests/run-electron-node-test.cjs tests/held-orders.test.ts",
+    "test:held-orders": "node tests/run-electron-node-test.cjs tests/held-orders.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/held-orders-store.test.ts",
     "test:product-images": "node tests/run-electron-node-test.cjs tests/product-images.test.ts",
     "test:schema-health": "node tests/run-electron-node-test.cjs tests/schema-health.test.ts",
     "test:upgrade-path": "node tests/run-electron-node-test.cjs tests/upgrade-path.test.ts",

--- a/tests/held-orders-store.test.ts
+++ b/tests/held-orders-store.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Behavioral regression coverage for the held-order client store.
+ * Run: ts-node --transpile-only -P tests/tsconfig.json tests/held-orders-store.test.ts
+ */
+
+const assert = require('node:assert/strict');
+const Module = require('module');
+const path = require('node:path');
+const frontendRequire = Module.createRequire(path.join(process.cwd(), 'frontend/package.json'));
+const originalLoad = Module._load;
+
+type HeldOrder = {
+  id: string;
+  tableId: string;
+  items: Array<Record<string, unknown>>;
+  customerId: number | string | null;
+  guestCount: number;
+  orderNotes: string;
+  heldAt: string;
+};
+
+const serverOrders = new Map<string, HeldOrder>();
+let nextOrderId = 0;
+let deleteError: Error | null = null;
+let deferNextGet = false;
+let releaseDeferredGet: (() => void) | null = null;
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+const serverApi = {
+  get: async (url: string) => {
+    assert.equal(url, '/held-orders');
+    const response = { data: { orders: Array.from(serverOrders.values()).map(clone) } };
+    if (deferNextGet) {
+      deferNextGet = false;
+      return new Promise((resolve) => {
+        releaseDeferredGet = () => resolve(response);
+      });
+    }
+    return response;
+  },
+  post: async (url: string, body: { tableId: string; items: HeldOrder['items']; customerId: HeldOrder['customerId']; guestCount: number; orderNotes: string }) => {
+    assert.equal(url, '/held-orders');
+    const id = `ho-${body.tableId}-${++nextOrderId}`;
+    serverOrders.set(body.tableId, {
+      id,
+      tableId: body.tableId,
+      items: clone(body.items),
+      customerId: body.customerId,
+      guestCount: body.guestCount,
+      orderNotes: body.orderNotes,
+      heldAt: '2026-08-01T00:00:00.000Z',
+    });
+    return { data: { success: true, id } };
+  },
+  delete: async (url: string) => {
+    assert.match(url, /^\/held-orders\//);
+    if (deleteError) {
+      const error = deleteError;
+      deleteError = null;
+      throw error;
+    }
+
+    const parsed = new URL(url, 'http://localhost');
+    const tableId = parsed.pathname.slice('/held-orders/'.length);
+    const expectedHeldOrderId = parsed.searchParams.get('heldOrderId');
+    const current = serverOrders.get(tableId);
+    const deleted = !!current && (!expectedHeldOrderId || current.id === expectedHeldOrderId);
+    if (deleted) serverOrders.delete(tableId);
+    return { data: { success: true, deleted } };
+  },
+};
+
+// The store uses the production alias import. Keep this test a direct store
+// behavior test without requiring a browser or a Next.js runtime.
+Module._load = function (request: string, parent: unknown, isMain: boolean) {
+  if (request === '@/lib/api') return serverApi;
+  if (request === 'zustand') return originalLoad.call(this, frontendRequire.resolve('zustand'), parent, isMain);
+  return originalLoad.apply(this, arguments as any);
+};
+
+const { createHeldOrdersStore } = require('../frontend/src/store/held-orders');
+
+function makeHeldOrder(tableId: string): HeldOrder {
+  return {
+    id: `ho-${tableId}`,
+    tableId,
+    items: [{
+      id: `item-${tableId}`,
+      product: { id: `product-${tableId}`, name: 'Latte', price: 100 },
+      quantity: 1,
+      addons: [],
+      special_instructions: '',
+    }],
+    customerId: null,
+    guestCount: 1,
+    orderNotes: '',
+    heldAt: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+async function main() {
+  console.log('Held-order client store regression tests (#256)');
+  console.log('='.repeat(60));
+
+  serverOrders.clear();
+  nextOrderId = 0;
+  serverOrders.set('table-a', makeHeldOrder('table-a'));
+  serverOrders.set('table-b', makeHeldOrder('table-b'));
+
+  const firstTerminal = createHeldOrdersStore(serverApi);
+  const secondTerminal = createHeldOrdersStore(serverApi);
+
+  await firstTerminal.getState().fetchHeldOrders();
+  await secondTerminal.getState().fetchHeldOrders();
+  assert.equal(firstTerminal.getState().hasHeldOrder('table-a'), true, 'first terminal caches the held order');
+  assert.equal(secondTerminal.getState().hasHeldOrder('table-a'), true, 'second terminal retains the same held-order snapshot');
+
+  const restored = await firstTerminal.getState().restoreOrder('table-a');
+  assert.equal(restored?.tableId, 'table-a', 'first consumer receives the held order');
+  assert.equal(firstTerminal.getState().hasHeldOrder('table-a'), false, 'first consumer clears its cache after consumption');
+  assert.equal(serverOrders.has('table-a'), false, 'first consumer removes the server row');
+
+  const staleRestore = await secondTerminal.getState().restoreOrder('table-a');
+  assert.equal(staleRestore, null, 'second consumer does not restore an already-consumed snapshot');
+  assert.equal(secondTerminal.getState().hasHeldOrder('table-a'), false, 'second consumer clears its stale cache');
+
+  await secondTerminal.getState().fetchHeldOrders();
+  assert.equal(secondTerminal.getState().hasHeldOrder('table-a'), false, 'reloading does not resurrect the consumed order');
+  assert.equal(secondTerminal.getState().hasHeldOrder('table-b'), true, 'reloading preserves still-held orders');
+
+  const replacement = makeHeldOrder('table-b');
+  replacement.id = 'ho-table-b-replacement';
+  replacement.items[0].product = { id: 'product-new', name: 'Cappuccino', price: 120 };
+  serverOrders.set('table-b', replacement);
+  const staleReplacementRestore = await secondTerminal.getState().restoreOrder('table-b');
+  assert.equal(staleReplacementRestore, null, 'a stale snapshot cannot delete and restore a replacement row');
+  assert.deepEqual(serverOrders.get('table-b'), replacement, 'replacement row remains after stale restore');
+  assert.equal(secondTerminal.getState().hasHeldOrder('table-b'), false, 'replacement conflict clears the stale cache');
+
+  await secondTerminal.getState().fetchHeldOrders();
+  assert.equal(secondTerminal.getState().getHeldOrder('table-b')?.id, replacement.id, 'reload picks up the replacement row');
+
+  deferNextGet = true;
+  const staleReload = secondTerminal.getState().fetchHeldOrders();
+  const currentReplacementRestore = await secondTerminal.getState().restoreOrder('table-b');
+  assert.equal(currentReplacementRestore?.id, replacement.id, 'current replacement identity can still be consumed');
+  assert.equal(typeof releaseDeferredGet, 'function', 'older reload remains pending while deletion completes');
+  releaseDeferredGet?.();
+  releaseDeferredGet = null;
+  await staleReload;
+  assert.equal(secondTerminal.getState().hasHeldOrder('table-b'), false, 'an older reload cannot resurrect a locally consumed order');
+
+  await secondTerminal.getState().removeHeldOrder('table-a');
+  assert.equal(secondTerminal.getState().hasHeldOrder('table-a'), false, 'repeated deletion remains safe after stale cleanup');
+
+  serverOrders.set('table-c', makeHeldOrder('table-c'));
+  await secondTerminal.getState().fetchHeldOrders();
+  assert.equal(secondTerminal.getState().hasHeldOrder('table-c'), true, 'reload caches a new held order before retrying an error');
+  deleteError = new Error('unauthorized');
+  await assert.rejects(
+    () => secondTerminal.getState().restoreOrder('table-c'),
+    /unauthorized/,
+    'delete errors are surfaced to the caller',
+  );
+  assert.equal(secondTerminal.getState().hasHeldOrder('table-c'), true, 'delete errors retain the cached order for retry');
+  assert.equal(serverOrders.has('table-c'), true, 'delete errors do not consume the server row');
+
+  console.log('\n✅ Held-order client store regression tests passed');
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error('\n❌ Test failed:');
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    Module._load = originalLoad;
+  });

--- a/tests/held-orders-store.test.ts
+++ b/tests/held-orders-store.test.ts
@@ -24,6 +24,8 @@ let nextOrderId = 0;
 let deleteError: Error | null = null;
 let deferNextGet = false;
 let releaseDeferredGet: (() => void) | null = null;
+let deferAllGets = false;
+const deferredGets: Array<{ response: { data: { orders: HeldOrder[] } }; resolve: (response: { data: { orders: HeldOrder[] } }) => void }> = [];
 let deferNextDelete = false;
 let releaseDeferredDelete: (() => void) | null = null;
 
@@ -39,6 +41,11 @@ const serverApi = {
       deferNextGet = false;
       return new Promise((resolve) => {
         releaseDeferredGet = () => resolve(response);
+      });
+    }
+    if (deferAllGets) {
+      return new Promise((resolve) => {
+        deferredGets.push({ response, resolve });
       });
     }
     return response;
@@ -167,6 +174,24 @@ async function main() {
   await secondTerminal.getState().fetchHeldOrders();
   assert.equal(secondTerminal.getState().getHeldOrder('table-b')?.id, replacement.id, 'reload picks up the replacement row');
 
+  const cleanupTableId = 'table-cleanup';
+  const cleanupInitial = makeHeldOrder(cleanupTableId);
+  serverOrders.set(cleanupTableId, cleanupInitial);
+  const replacementStore = createHeldOrdersStore(serverApi);
+  await replacementStore.getState().fetchHeldOrders();
+  const consumedReplacement = await replacementStore.getState().restoreOrder(cleanupTableId);
+  assert.equal(consumedReplacement?.id, cleanupInitial.id, 'cleanup scenario captures the consumed identity');
+  const cleanupReplacement = makeHeldOrder(cleanupTableId);
+  cleanupReplacement.id = 'ho-table-cleanup-replacement';
+  cleanupReplacement.orderNotes = 'cleanup replacement';
+  serverOrders.set(cleanupTableId, cleanupReplacement);
+  await replacementStore.getState().fetchHeldOrders();
+  await replacementStore.getState().removeHeldOrder(cleanupTableId, consumedReplacement?.id);
+  assert.equal(replacementStore.getState().getHeldOrder(cleanupTableId)?.id, cleanupReplacement.id, 'cleanup with the consumed identity preserves the replacement cache');
+  assert.equal(serverOrders.get(cleanupTableId)?.id, cleanupReplacement.id, 'cleanup with the consumed identity preserves the replacement row');
+  await replacementStore.getState().removeHeldOrder(cleanupTableId);
+  assert.equal(replacementStore.getState().getHeldOrder(cleanupTableId)?.id, cleanupReplacement.id, 'cleanup without an identity is a non-consuming no-op');
+
   deferNextGet = true;
   const staleReload = secondTerminal.getState().fetchHeldOrders();
   const currentReplacementRestore = await secondTerminal.getState().restoreOrder('table-b');
@@ -189,6 +214,25 @@ async function main() {
   await pendingInitialLoad;
   assert.equal(mergeStore.getState().hasHeldOrder('table-a'), true, 'unrelated local holds survive an in-flight reload');
   assert.equal(mergeStore.getState().hasHeldOrder('table-b'), true, 'in-flight reload still caches unaffected held orders');
+
+  const outOfOrderStore = createHeldOrdersStore(serverApi);
+  serverOrders.clear();
+  serverOrders.set('table-old', makeHeldOrder('table-old'));
+  deferAllGets = true;
+  const olderFetch = outOfOrderStore.getState().fetchHeldOrders();
+  serverOrders.clear();
+  serverOrders.set('table-new', makeHeldOrder('table-new'));
+  const newerFetch = outOfOrderStore.getState().fetchHeldOrders();
+  deferAllGets = false;
+  assert.equal(deferredGets.length, 2, 'two reloads remain pending for out-of-order resolution');
+  const olderResponse = deferredGets.shift();
+  const newerResponse = deferredGets.shift();
+  newerResponse?.resolve(newerResponse.response);
+  await newerFetch;
+  olderResponse?.resolve(olderResponse.response);
+  await olderFetch;
+  assert.equal(outOfOrderStore.getState().hasHeldOrder('table-new'), true, 'newer reload result remains cached');
+  assert.equal(outOfOrderStore.getState().hasHeldOrder('table-old'), false, 'older reload result cannot overwrite newer data');
 
   await secondTerminal.getState().removeHeldOrder('table-a');
   assert.equal(secondTerminal.getState().hasHeldOrder('table-a'), false, 'repeated deletion remains safe after stale cleanup');

--- a/tests/held-orders-store.test.ts
+++ b/tests/held-orders-store.test.ts
@@ -186,10 +186,12 @@ async function main() {
   cleanupReplacement.orderNotes = 'cleanup replacement';
   serverOrders.set(cleanupTableId, cleanupReplacement);
   await replacementStore.getState().fetchHeldOrders();
-  await replacementStore.getState().removeHeldOrder(cleanupTableId, consumedReplacement?.id);
+  const staleCleanupDeleted = await replacementStore.getState().removeHeldOrder(cleanupTableId, consumedReplacement?.id);
+  assert.equal(staleCleanupDeleted, false, 'stale cleanup reports that no row was deleted');
   assert.equal(replacementStore.getState().getHeldOrder(cleanupTableId)?.id, cleanupReplacement.id, 'cleanup with the consumed identity preserves the replacement cache');
   assert.equal(serverOrders.get(cleanupTableId)?.id, cleanupReplacement.id, 'cleanup with the consumed identity preserves the replacement row');
-  await replacementStore.getState().removeHeldOrder(cleanupTableId);
+  const idlessCleanupDeleted = await replacementStore.getState().removeHeldOrder(cleanupTableId);
+  assert.equal(idlessCleanupDeleted, false, 'ID-less cleanup reports that no row was deleted');
   assert.equal(replacementStore.getState().getHeldOrder(cleanupTableId)?.id, cleanupReplacement.id, 'cleanup without an identity is a non-consuming no-op');
 
   deferNextGet = true;

--- a/tests/held-orders-store.test.ts
+++ b/tests/held-orders-store.test.ts
@@ -24,6 +24,8 @@ let nextOrderId = 0;
 let deleteError: Error | null = null;
 let deferNextGet = false;
 let releaseDeferredGet: (() => void) | null = null;
+let deferNextDelete = false;
+let releaseDeferredDelete: (() => void) | null = null;
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value));
@@ -66,10 +68,19 @@ const serverApi = {
     const parsed = new URL(url, 'http://localhost');
     const tableId = parsed.pathname.slice('/held-orders/'.length);
     const expectedHeldOrderId = parsed.searchParams.get('heldOrderId');
-    const current = serverOrders.get(tableId);
-    const deleted = !!current && (!expectedHeldOrderId || current.id === expectedHeldOrderId);
-    if (deleted) serverOrders.delete(tableId);
-    return { data: { success: true, deleted } };
+    const deleteCurrent = () => {
+      const current = serverOrders.get(tableId);
+      const deleted = !!current && !!expectedHeldOrderId && current.id === expectedHeldOrderId;
+      if (deleted) serverOrders.delete(tableId);
+      return { data: { success: true, deleted } };
+    };
+    if (deferNextDelete) {
+      deferNextDelete = false;
+      return new Promise((resolve) => {
+        releaseDeferredDelete = () => resolve(deleteCurrent());
+      });
+    }
+    return deleteCurrent();
   },
 };
 
@@ -131,6 +142,19 @@ async function main() {
   assert.equal(secondTerminal.getState().hasHeldOrder('table-a'), false, 'reloading does not resurrect the consumed order');
   assert.equal(secondTerminal.getState().hasHeldOrder('table-b'), true, 'reloading preserves still-held orders');
 
+  const replacementBeforeDelete = makeHeldOrder('table-race');
+  serverOrders.set('table-race', replacementBeforeDelete);
+  await secondTerminal.getState().fetchHeldOrders();
+  deferNextDelete = true;
+  const staleDelete = secondTerminal.getState().restoreOrder('table-race');
+  await secondTerminal.getState().holdOrder('table-race', replacementBeforeDelete.items, null, 1, 'replacement');
+  assert.equal(typeof releaseDeferredDelete, 'function', 'older delete remains pending while a replacement is held');
+  releaseDeferredDelete?.();
+  releaseDeferredDelete = null;
+  assert.equal(await staleDelete, null, 'late deletion of an older snapshot reports a stale restore');
+  assert.equal(secondTerminal.getState().getHeldOrder('table-race')?.orderNotes, 'replacement', 'late deletion cannot clear a newer cached replacement');
+  assert.equal(serverOrders.get('table-race')?.orderNotes, 'replacement', 'late deletion cannot remove the replacement row');
+
   const replacement = makeHeldOrder('table-b');
   replacement.id = 'ho-table-b-replacement';
   replacement.items[0].product = { id: 'product-new', name: 'Cappuccino', price: 120 };
@@ -152,6 +176,19 @@ async function main() {
   releaseDeferredGet = null;
   await staleReload;
   assert.equal(secondTerminal.getState().hasHeldOrder('table-b'), false, 'an older reload cannot resurrect a locally consumed order');
+
+  serverOrders.clear();
+  serverOrders.set('table-b', makeHeldOrder('table-b'));
+  const mergeStore = createHeldOrdersStore(serverApi);
+  deferNextGet = true;
+  const pendingInitialLoad = mergeStore.getState().fetchHeldOrders();
+  await mergeStore.getState().holdOrder('table-a', makeHeldOrder('table-a').items, null, 1);
+  assert.equal(typeof releaseDeferredGet, 'function', 'initial reload remains pending during an unrelated hold');
+  releaseDeferredGet?.();
+  releaseDeferredGet = null;
+  await pendingInitialLoad;
+  assert.equal(mergeStore.getState().hasHeldOrder('table-a'), true, 'unrelated local holds survive an in-flight reload');
+  assert.equal(mergeStore.getState().hasHeldOrder('table-b'), true, 'in-flight reload still caches unaffected held orders');
 
   await secondTerminal.getState().removeHeldOrder('table-a');
   assert.equal(secondTerminal.getState().hasHeldOrder('table-a'), false, 'repeated deletion remains safe after stale cleanup');

--- a/tests/held-orders.test.ts
+++ b/tests/held-orders.test.ts
@@ -108,8 +108,15 @@ async function main() {
 
     // ═══════════════════════════════════════════════════════════════════
     console.log('\n─── Scenario D: DELETE /held-orders/:tableId removes order ───');
+
+    const noIdDeleteRes = await api(baseUrl, `/api/held-orders/${tableId}`, { method: 'DELETE', headers: authHeader });
+    assertEqual(noIdDeleteRes.status, 200, 'ID-less DELETE returns 200');
+    assertEqual(noIdDeleteRes.data.success, true, 'ID-less DELETE returns success');
+    assertEqual(noIdDeleteRes.data.deleted, false, 'ID-less DELETE is a non-consuming no-op');
+    assertEqual((db.prepare('SELECT status FROM tables WHERE id = ?').get(tableId) as any).status, 'held', 'ID-less DELETE preserves the held table');
+    assertEqual((await api(baseUrl, '/api/held-orders', { headers: authHeader })).data.orders.length, 1, 'ID-less DELETE preserves the held order');
     
-    const delRes = await api(baseUrl, `/api/held-orders/${tableId}`, { method: 'DELETE', headers: authHeader });
+    const delRes = await api(baseUrl, `/api/held-orders/${tableId}?heldOrderId=${encodeURIComponent(postRes.data.id)}`, { method: 'DELETE', headers: authHeader });
     assertEqual(delRes.status, 200, 'DELETE /held-orders returns 200');
     assertEqual(delRes.data.success, true, 'First DELETE returns success');
     assertEqual(delRes.data.deleted, true, 'First DELETE reports that the row was consumed');

--- a/tests/held-orders.test.ts
+++ b/tests/held-orders.test.ts
@@ -4,7 +4,7 @@
  * Tests that:
  * A) POST /held-orders creates a held order for a table
  * B) GET /held-orders returns a list of held orders
- * C) DELETE /held-orders/:tableId removes the held order
+ * C) DELETE /held-orders/:tableId consumes matching rows and safely handles stale rows
  *
  * Usage: node tests/run-electron-node-test.cjs tests/held-orders.test.ts
  */

--- a/tests/held-orders.test.ts
+++ b/tests/held-orders.test.ts
@@ -23,7 +23,7 @@ Module._load = function (request: string, parent: unknown, isMain: boolean) {
 
 const {
   initTestDb, createApp, startServer,
-  seedOwnerUser,
+  seedOwnerUser, seedTable,
   api, assert, assertEqual,
   closeDatabase, getDatabase, now,
 } = require('./helpers/test-setup');
@@ -44,6 +44,7 @@ async function main() {
 
   try {
     const tableId = 'tbl-test-123';
+    seedTable(db, tableId, 1);
     const mockItems = [{
       id: 'latte-line',
       product: { id: 'product-latte', name: 'Latte', price: 100 },
@@ -69,6 +70,7 @@ async function main() {
     
     assertEqual(postRes.status, 200, 'POST /held-orders returns 200');
     assertEqual(postRes.data.success, true, 'Returns success: true');
+    assert(typeof postRes.data.id === 'string' && postRes.data.id.length > 0, 'POST returns the current held-order identity');
     console.log('  ✓ POST /held-orders creates successfully');
 
     // ═══════════════════════════════════════════════════════════════════
@@ -109,21 +111,70 @@ async function main() {
     
     const delRes = await api(baseUrl, `/api/held-orders/${tableId}`, { method: 'DELETE', headers: authHeader });
     assertEqual(delRes.status, 200, 'DELETE /held-orders returns 200');
+    assertEqual(delRes.data.success, true, 'First DELETE returns success');
+    assertEqual(delRes.data.deleted, true, 'First DELETE reports that the row was consumed');
+    assertEqual((db.prepare('SELECT status FROM tables WHERE id = ?').get(tableId) as any).status, 'available', 'First DELETE releases the table');
     
     const verifyRes = await api(baseUrl, '/api/held-orders', { headers: authHeader });
     assertEqual(verifyRes.data.orders.length, 0, 'Held orders list is empty after deletion');
-    console.log('  ✓ DELETE /held-orders removes order correctly');
+    console.log('  ✓ DELETE /held-orders consumes the held order and releases the table');
 
-    // A stale screen or another terminal may send the same delete after the
-    // record is already gone. That must be safe to retry.
-    const repeatDeleteRes = await api(baseUrl, `/api/held-orders/${tableId}`, { method: 'DELETE', headers: authHeader });
-    assertEqual(repeatDeleteRes.status, 200, 'Repeated DELETE is a successful no-op');
-    assertEqual(repeatDeleteRes.data.success, true, 'Repeated DELETE returns success');
-    assertEqual(repeatDeleteRes.data.deleted, false, 'Repeated DELETE reports that nothing remained to delete');
-    console.log('  ✓ DELETE /held-orders is idempotent');
+    // A second terminal can retain the same held-order snapshot and race the
+    // first terminal. It must get an explicit no-op result, not a second
+    // consumption signal.
+    const staleDeleteRes = await api(baseUrl, `/api/held-orders/${tableId}`, { method: 'DELETE', headers: authHeader });
+    assertEqual(staleDeleteRes.status, 200, 'Stale DELETE is a successful no-op');
+    assertEqual(staleDeleteRes.data.success, true, 'Stale DELETE returns success');
+    assertEqual(staleDeleteRes.data.deleted, false, 'Stale DELETE reports that no row was consumed');
+    assertEqual((db.prepare('SELECT status FROM tables WHERE id = ?').get(tableId) as any).status, 'available', 'Stale DELETE preserves the released table');
+    console.log('  ✓ Stale DELETE cannot consume the same held order twice');
 
-    // ─── Scenario E: malformed legacy rows do not hide valid rows ───
-    console.log('\n─── Scenario E: malformed legacy rows are isolated ───');
+    // Missing credentials must still be rejected before the idempotent
+    // deletion path is reached.
+    const unauthorizedDeleteRes = await api(baseUrl, `/api/held-orders/${tableId}`, { method: 'DELETE' });
+    assertEqual(unauthorizedDeleteRes.status, 401, 'DELETE /held-orders requires authentication');
+    console.log('  ✓ DELETE /held-orders keeps its authorization boundary');
+
+    // Replacing a held order for the same table creates a new identity. A
+    // terminal retaining the old identity must not delete the replacement.
+    console.log('\n─── Scenario E: replacement rows remain single-consumer ───');
+    const replacementTableId = 'tbl-replacement-256';
+    seedTable(db, replacementTableId, 2);
+    const firstReplacement = await api(baseUrl, '/api/held-orders', {
+      method: 'POST',
+      body: { tableId: replacementTableId, items: mockItems },
+      headers: authHeader,
+    });
+    const firstReplacementId = firstReplacement.data.id;
+    const replacementItems = [{ ...mockItems[0], product: { ...mockItems[0].product, name: 'Cappuccino' } }];
+    const secondReplacement = await api(baseUrl, '/api/held-orders', {
+      method: 'POST',
+      body: { tableId: replacementTableId, items: replacementItems },
+      headers: authHeader,
+    });
+    const secondReplacementId = secondReplacement.data.id;
+    assert(firstReplacementId !== secondReplacementId, 'Replacing a held order changes its identity');
+
+    const staleReplacementDelete = await api(
+      baseUrl,
+      `/api/held-orders/${replacementTableId}?heldOrderId=${encodeURIComponent(firstReplacementId)}`,
+      { method: 'DELETE', headers: authHeader },
+    );
+    assertEqual(staleReplacementDelete.data.deleted, false, 'Stale identity cannot delete a replacement row');
+    const replacementList = await api(baseUrl, '/api/held-orders', { headers: authHeader });
+    const replacement = replacementList.data.orders.find((order: any) => order.tableId === replacementTableId);
+    assertEqual(replacement?.id, secondReplacementId, 'Replacement row remains listed after stale deletion');
+    assertEqual(replacement?.items[0].product.name, 'Cappuccino', 'Replacement contents remain intact');
+
+    const currentReplacementDelete = await api(
+      baseUrl,
+      `/api/held-orders/${replacementTableId}?heldOrderId=${encodeURIComponent(secondReplacementId)}`,
+      { method: 'DELETE', headers: authHeader },
+    );
+    assertEqual(currentReplacementDelete.data.deleted, true, 'Current identity can consume the replacement row');
+
+    // ─── Scenario F: malformed legacy rows do not hide valid rows ───
+    console.log('\n─── Scenario F: malformed legacy rows are isolated ───');
     db.prepare(`
       INSERT INTO held_orders (id, table_id, items, customer_id, guest_count, order_notes, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
## Intent

Implement only FloCafe issue #256, fix(orders): make held-order restore single-consumer, from the current main baseline. Do not touch issue #241/Iran work or unrelated open issues. Reproduce the stale/two-terminal restore path: two clients retain the same held order, one consumes it, and the other must not restore its cached copy as a new local cart when the backend reports that the row was already consumed. Use the existing DELETE response contract {success:true, deleted:false}; make the server/client contract unambiguous for a second consumer, protect replacements from stale deletes, clear or refresh stale client state, and preserve held-order listing and floor/table behavior. Do not turn a stale restore into a duplicate order or silently claim consumption when no row was deleted. Add behavioral regression coverage for first-consumer success, second/stale-consumer behavior, repeated deletion, replacement protection, cache cleanup/reload including out-of-order reloads, and relevant authorization/error paths. Prefer non-Electron route/store tests where possible; if an Electron runner is blocked by the known installation race, document it and retain the closest executable coverage. Keep the PR narrowly scoped to #256. Keep restore failures visible to the UI and refresh held-order data after a stale restore so a replacement remains accessible.

## What Changed

- Added held-order row identities to the API and client flow so deletes consume only the matching cached order and cannot remove replacements.
- Updated POS and Orders restore/removal flows to track held-order IDs, surface stale-operation failures, and refresh held-order state.
- Documented the held-order API contract and added regression coverage for stale consumers, repeated deletion, replacements, reload ordering, cache cleanup, and authorization.

## Risk Assessment

✅ Low: The scoped implementation satisfies the reviewed single-consumer, stale-delete, replacement-protection, cache-ordering, authorization, and UI-refresh paths without a substantiated source defect.

## Testing

After restoring locked local dependencies, the focused API and client-store regression target passed end-to-end. The API transcript provides product-level evidence for first/stale consumers, repeated/id-less deletion, table state, replacement protection, listing, malformed-row isolation, and authorization; visual UI evidence was attempted but unavailable because the environment exposed no browser target.

<details>
<summary>Evidence: Held-order API evidence</summary>

`First DELETE consumed and released the table; stale DELETE returned success with deleted:false; replacement identity protection and authorization checks passed; all held-order API scenarios passed.`

```text

> flo-desktop@3.0.5 test:held-orders
> node tests/run-electron-node-test.cjs tests/held-orders.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/held-orders-store.test.ts

Integration Test: Held Orders API
==================================================
[DB] Opening database at: /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-held-orders-3ckmsw/flo.db
[DB] Schema: v0 → v66
[DB] Triggering auto-backup before migrating v0 → v66...
[DB] Auto-backup before migrating v0 → v66 created at /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-held-orders-3ckmsw/backups/flo-backup-2026-08-13T05-58-16-000Z-pre-v0-to-v66.db
[DB] Applying migration v1: initial_schema
[DB] Install defaults loaded; first-run setup pending
[DB] Migration v1 complete
[DB] Applying migration v2: hash_plaintext_pins
[DB] Migration v2 complete
[DB] Applying migration v3: cloud_identity_and_outbox
[DB] Migration v3 complete
[DB] Applying migration v4: add_notes_limits_settings
[DB] Migration v4 complete
[DB] Applying migration v5: add_print_logs_table
[DB] Migration v5 complete
[DB] Applying migration v6: add_loyalty_settings
[DB] Migration v6 complete
[DB] Applying migration v7: add_discount_settings
[DB] Migration v7 complete
[DB] Applying migration v8: add_loyalty_index
[DB] Migration v8 complete
[DB] Applying migration v9: add_sequences_table
[DB] Migration v9 complete
[DB] Applying migration v10: fix_sequences_composite_key
[DB] Migration v10 complete
[DB] Applying migration v11: first_run_setup_uses_welcome_form
[DB] Migration v11 complete
[DB] Applying migration v12: fix_table_integer_ids
[DB] Migration v12 complete
[DB] Applying migration v13: fix_null_table_ids
[DB] Migration v13 complete
[DB] Applying migration v14: simplify_loyalty_settings
[DB] Migration v14 complete
[DB] Applying migration v15: add_instagram_handle_setting
[DB] Migration v15 complete
[DB] Applying migration v16: add_terms_accepted_at_to_users
[DB] Migration v16 complete
[DB] Applying migration v17: add_held_orders_table
[DB] Migration v17 complete
[DB] Applying migration v18: fix_null_category_ids
[DB] Migration v18 complete
[DB] Applying migration v19: backfill_product_cb_percent_and_tags
[DB] Migration v19 complete
[DB] Applying migration v20: add_tables_is_active
[DB] Migration v20 complete
[DB] Applying migration v21: clear_legacy_loyalty_expiry
[DB] Migration v21 complete
[DB] Applying migration v22: add_customers_phone_digits
[DB] Migration v22 complete
[DB] Applying migration v23: normalize_customer_phones
[MIGRATION v23] normalized: 0, unparseable: 0
[MIGRATION v23] merged 0 duplicate customer(s)
[MIGRATION v23] verification: 0 customers, 0 still non-E.164
[DB] Migration v23 complete
[DB] Applying migration v24: normalize_customer_phones_retry
[MIGRATION v24] normalized: 0, unparseable: 0
[DB] Migration v24 complete
[DB] Applying migration v25: add_order_item_addons_table
[MIGRATION v25] backfilled addons for 0 order items (0 unparseable, skipped)
[DB] Migration v25 complete
[DB] Applying migration v26: add_kds_default_view
[DB] Migration v26 complete
[DB] Applying migration v27: add_station_printer_link_and_user_stations
[DB] Migration v27 complete
[DB] Applying migration v28: seed_telemetry_settings
[DB] Migration v28 complete
[DB] Applying migration v29: whatsapp_messaging
[DB] Migration v29 complete
[DB] Applying migration v30: drop_order_items_addons_json_column
[MIGRATION v30] backfilled 0 order_item(s) still missing a normalized addons snapshot
[MIGRATION v30] Dropped order_items.addons — order_item_addons is now the only place selected addons live.
[DB] Migration v30 complete
[DB] Applying migration v31: add_customers_tag_counts_column
[DB] Migration v31 complete
[DB] Applying migration v32: add_kds_and_kot_printing_toggles
[DB] Migration v32 complete
[DB] Applying migration v33: add_addon_groups_allow_multiple_quantities
[DB] Migration v33 complete
[DB] Applying migration v34: add_order_items_voided_at
[DB] Migration v34 complete
[DB] Applying migration v35: add_tax_pack_configuration_tables
[DB] Migration v35 complete
[DB] Applying migration v36: add_product_and_addon_tax_categories
[DB] Migration v36 complete
[DB] Applying migration v37: add_transaction_tax_snapshots_and_charge_categories
[DB] Migration v37 complete
[DB] Applying migration v38: register_bundled_tax_pack_versions
[DB] Migration v38 complete
[DB] Applying migration v39: add_users_tokens_valid_after
[DB] Migration v39 complete
[DB] Applying migration v40: v2_cloud_defaults_and_tax_toggle
[DB] Migration v40 complete
[DB] Applying migration v41: support_ticket_outbox
[DB] Migration v41 complete
[DB] Applying migration v42: add_global_cashback_percent
[DB] Migration v42 complete
[DB] Applying migration v43: telemetry_default_on_for_new_installs
[DB] Migration v43 complete
[DB] Applying migration v44: store_diagnostics_outbox
[DB] Migration v44 complete
[DB] Applying migration v45: add_performance_indexes_and_normalize_timestamps
[DB] Migration v45 complete
[DB] Applying migration v46: normalize_cloud_enabled_flags_to_01
[DB] Migration v46 complete
[DB] Applying migration v47: store_diagnostics_enabled_by_default
[DB] Migration v47 complete
[DB] Applying migration v48: deactivate_reusable_demo_credentials
[DB] Migration v48 complete
[DB] Applying migration v49: add_payment_idempotency_records
[DB] Migration v49 complete
[DB] Applying migration v50: add_order_idempotency_records
[DB] Migration v50 complete
[DB] Applying migration v51: enforce_global_payment_transaction_refs
[DB] Migration v51 complete
[DB] Applying migration v52: restore_method_scoped_transaction_refs
[DB] Migration v52 complete
[DB] Applying migration v53: scope_idempotency_records_to_user
[DB] Migration v53 complete
[DB] Applying migration v54: repair_retry_ownership_and_payment_reference_history
[DB] Migration v54 complete
[DB] Applying migration v55: durable_token_revocations
[DB] Migration v55 complete
[DB] Applying migration v56: persist_station_assignment_scope
[DB] Migration v56 complete
[DB] Applying migration v57: rename_gstin_to_generic_tax_registration_number
[DB] Migration v57 complete
[DB] Applying migration v58: configurable_manual_payment_methods
[DB] Migration v58 complete
[DB] Applying migration v59: split_checks_by_item_quantity
[DB] Migration v59 complete
[DB] Applying migration v60: seed_split_checks_disabled_setting
[DB] Migration v60 complete
[DB] Applying migration v61: seed_server_app_enabled_setting
[DB] Migration v61 complete
[DB] Applying migration v62: normalize_cloud_last_error
[DB] Migration v62 complete
[DB] Applying migration v63: seed_printer_trim_decimals_setting
[DB] Migration v63 complete
[DB] Applying migration v64: drop_unused_printer_usb_device_path
[DB] Migration v64 complete
[DB] Applying migration v65: seed_bill_content_visibility_settings
[DB] Migration v65 complete
[DB] Applying migration v66: seed_bill_template_settings
[DB] Migration v66 complete
[DB] integrity_check: ok
[DB] foreign_key_check: clean
[Auth] Generated new JWT secret for this install

─── Scenario A: POST /held-orders creates a held order ───
  ✓ POST /held-orders returns 200
  ✓ Returns success: true
  ✓ POST returns the current held-order identity
  ✓ POST /held-orders creates successfully

─── Scenario B: GET /held-orders returns held orders ───
  ✓ GET /held-orders returns 200
  ✓ Returns an array of orders
  ✓ Array contains one order
  ✓ Table ID matches
  ✓ Guest count matches
  ✓ Notes match
  ✓ Items is an array
  ✓ Items parsed correctly
  ✓ GET /held-orders retrieves held order

─── Scenario C: POST /held-orders validates request data ───
  ✓ Invalid held-order input returns 400
  ✓ Invalid held-order input returns 400
  ✓ Invalid held-order input returns 400
  ✓ Invalid held-order input returns 400
  ✓ Invalid held-order input returns 400
  ✓ POST /held-orders rejects malformed input

─── Scenario D: DELETE /held-orders/:tableId removes order ───
  ✓ ID-less DELETE returns 200
  ✓ ID-less DELETE returns success
  ✓ ID-less DELETE is a non-consuming no-op
  ✓ ID-less DELETE preserves the held table
  ✓ ID-less DELETE preserves the held order
  ✓ DELETE /held-orders returns 200
  ✓ First DELETE returns success
  ✓ First DELETE reports that the row was consumed
  ✓ First DELETE releases the table
  ✓ Held orders list is empty after deletion
  ✓ DELETE /held-orders consumes the held order and releases the table
  ✓ Stale DELETE is a successful no-op
  ✓ Stale DELETE returns success
  ✓ Stale DELETE reports that no row was consumed
  ✓ Stale DELETE preserves the released table
  ✓ Stale DELETE cannot consume the same held order twice
  ✓ DELETE /held-orders requires authentication
  ✓ DELETE /held-orders keeps its authorization boundary

─── Scenario E: replacement rows remain single-consumer ───
  ✓ Replacing a held order changes its identity
  ✓ Stale identity cannot delete a replacement row
  ✓ Replacement row remains listed after stale deletion
  ✓ Replacement contents remain intact
  ✓ Current identity can consume the replacement row

─── Scenario F: malformed legacy rows are isolated ───
[API] Skipping malformed held order ho-malformed
  ✓ GET /held-orders succeeds with malformed stored data
  ✓ Valid stored rows remain visible
  ✓ Valid legacy row is returned
  ✓ Malformed row count is reported
  ✓ Parser details are not exposed
  ✓ Malformed held orders are isolated

✅ All held orders tests passed
[DB] Database closed
Held-order client store regression tests (#256)
============================================================
Failed to restore order Error: unauthorized
    at main (/Users/gurkiratkhaira/.no-mistakes/worktrees/de2296f2e6f8/01KZWNVACE1KP8NPZQF14WRSZF/tests/held-orders-store.test.ts:245:17)
    at processTicksAndRejections (node:internal/process/task_queues:104:5)

✅ Held-order client store regression tests passed
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (5m20s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b7ebd0a77c63f8c2dbbcc40cb3a5f099439be2c9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (4) ✅</summary>

- 🚨 `main/routes/held-orders.ts:188` - The requirement to “protect replacements from stale deletes” is still violated: `removeHeldOrder` can send no `heldOrderId` (store line 107), while this route treats an omitted ID as a wildcard. After one terminal restores H1 and another creates replacement H2, checkout cleanup can delete H2. Carry the original ID through cleanup/UI actions or make table-only deletion a non-consuming no-op.
- ⚠️ `frontend/src/store/held-orders.ts:48` - This response handler unconditionally removes the current cached row. If restore(H1) overlaps with a local hold(H2), a late DELETE response can clear H2 from the store even though the server still retains it, hiding the replacement until a later reload. Only clear state when the cached ID still matches the request’s expected ID.
- ⚠️ `frontend/src/store/held-orders.ts:64` - The global mutation version discards any in-flight GET after an unrelated mutation, but no follow-up fetch occurs. A pending initial load containing existing held order B can be dropped after successfully holding table A, leaving B absent from the held-order list and table picker. Merge unaffected rows, use per-table versions, or refetch after mutation.

🔧 Fix: Guard ID-less deletes and preserve concurrent held-order cache state
2 issues (1 error, 1 warning) still open:
- 🚨 `frontend/src/store/held-orders.ts:122` - Contradicts the required criterion to “protect replacements from stale deletes.” `removeHeldOrder` re-reads the current cached ID at line 122 instead of retaining the ID consumed into the cart. If A restores H1, B creates H2, POS refreshes and caches H2, then A pays H1, cleanup can send H2 and delete B’s replacement. Carry H1 through restore/cart cleanup, or make cleanup without a captured identity a no-op.
- ⚠️ `tests/held-orders-store.test.ts:170` - The required behavioral coverage for “cache cleanup/reload including out-of-order reloads” is missing. The added tests defer only one GET while racing a delete or hold; none start two fetches and resolve them out of order, so the request-sequence guard can regress undetected.

🔧 Fix: Carry held-order identity through cleanup; add reload race coverage
1 warning still open:
- ⚠️ `frontend/src/app/(dashboard)/orders/page.tsx:898` - Contradicts the required criterion “Do not ... silently claim consumption when no row was deleted.” When DELETE returns `{success:true, deleted:false}`, `removeHeldOrder` discards the result and this handler always shows the success toast. A stale delete can hide the old card while leaving a replacement on the server. Return/branch on `deleted`, refresh on false, and show stale/no-op feedback.

🔧 Fix: Handle stale deletes without false success claims
1 warning still open:
- ⚠️ `frontend/src/app/(dashboard)/pos/page.tsx:398` - The checkout cleanup calls ignore `deleted:false`. If terminal A restores H1, terminal B replaces it with H2, and A later completes checkout, DELETE(H1) correctly preserves H2 but POS only refreshes `/tables`, not held-order data. The table then shows `held` while the local store lacks H2, so the replacement is not selectable until reload, contradicting the requirement to “protect replacements from stale deletes” and keep replacements accessible.

🔧 Fix: Refresh held orders after stale POS cleanup
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ No reviewer-visible UI screenshot could be captured because no browser target/session was available (`agent.browsers.list()` returned `[]`). Route and client-store behavioral coverage passed instead.
- `npm run test:held-orders`
- `git diff --check ae4c31e429b898ae54c3a34743d9241ab6dbb906 ac655cd525b65428386bacd04279327473dfa9c3`
- <code>Browser availability check: `agent.browsers.list()`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ Targeted ESLint checks could not run because required packages are missing: @typescript-eslint/eslint-plugin in the root and eslint in frontend.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
