### PR TITLE
ci: fix Windows uninstaller Pester variable scope

### DIFF
--- a/scripts/uninstallers/uninstall-windows.ps1
+++ b/scripts/uninstallers/uninstall-windows.ps1
@@ -38,7 +38,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $AppName = 'Flo Cafe'
-$AppProcessName = 'Flo Cafe'
+$script:AppProcessName = 'Flo Cafe'
 $RemovalAttempts = 6
 $RemovalRetryDelayMilliseconds = 500
 $AppGracefulCloseTimeoutSeconds = 10


### PR DESCRIPTION
## Intent

Captain-authorized fix for GitHub Actions failure introduced by PR #276: make the smallest consistent-scope correction in scripts/uninstallers/uninstall-windows.ps1 so Get-FloProcesses receives the top-level AppProcessName during dot-sourced Pester execution. Preserve all existing uninstall behavior, add behavioral regression coverage only if needed, and do not alter or rerun/cancel/retry the historical GitHub Actions run. The fix is committed on fm/flocafe-276-ci-scout; validate with the closest available Windows-uninstaller checks plus diff/build checks, drive every no-mistakes gate, and escalate ask-user findings instead of deciding them.

## What Changed

- Made `AppProcessName` script-scoped in `scripts/uninstallers/uninstall-windows.ps1`.
- Ensures `Get-FloProcesses` receives the top-level process name during dot-sourced Pester execution.

## Risk Assessment

✅ Low: The single-line scope correction is narrowly bounded, preserves standalone behavior, and restores the process-name invariant for dot-sourced Pester execution.

## Testing

The targeted Windows-uninstaller entry point was exercised before and after dependency setup but skipped because Windows is unavailable; Pester assertions did not run. After `npm ci`, the build completed successfully, the final diff remained limited to the intended one-line scope correction, and generated `node_modules`/`dist` outputs were removed.

<details>
<summary>Evidence: Targeted Windows-uninstaller test transcript</summary>

```text
npm run test:windows-uninstaller
SKIP windows uninstaller Pester tests: Windows runtime required (this runner is not Windows).
```
</details>
<details>
<summary>Evidence: Build verification</summary>

```text
npm run build
exit code: 0
```
</details>
<details>
<summary>Evidence: Final scoped diff</summary>

```text
scripts/uninstallers/uninstall-windows.ps1: $AppProcessName -> $script:AppProcessName
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (4m12s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"badb998c37490452437d4155cafd111cdd6917d8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/run-windows-uninstaller-tests.cjs:56` - The closest behavioral regression suite could not execute: this host lacks a Windows PowerShell/Pester runtime, so the test runner only reported its supported skip. Windows/Pester evidence is still needed, or the author must explicitly accept this limitation before claiming the intent is fully demonstrated.
- `npm run test:windows-uninstaller`
- <code>`npm ci` to restore missing locked dependencies</code>
- `npm run build`
- `git diff --check 98f09dc1db3eacc144674a23729c07453a74db92 badb998c37490452437d4155cafd111cdd6917d8`
- <code>Final status and diff inspection with `/usr/bin/git`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ Configured ESLint could not run because local dependencies are unavailable (`eslint: command not found`); no PowerShell linter is configured or installed for the changed `.ps1` file.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
