### PR TITLE
fix(pos): make cart identity and append retries collision-safe

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -494,6 +494,37 @@ Restore a cancelled item (owner or manager only). The item returns to `pending`
 and its recorded inventory deduction is applied again. The request fails when
 the order is terminal, the order is paid, or available stock is insufficient.
 
+### POST `/api/orders/:id/items`
+Append items to an existing order.
+
+**Headers:** `Authorization: Bearer <token>`
+
+For a retry-safe append, send an `Idempotency-Key` header containing 1–128 printable, non-whitespace ASCII characters. Reuse the same key only for the same authenticated user's identical append request (order, items, and order notes) until its response is confirmed. A matching retry returns the original `200` response without adding items again, including if the order has since become non-editable; reusing the key for different data returns `409`.
+
+**Request:**
+```json
+{
+  "items": [
+    {
+      "product_id": "prod-1",
+      "quantity": 2,
+      "addons": [{ "id": "addon-1", "name": "Extra cheese", "price": 20, "quantity": 1 }],
+      "special_instructions": "No onions"
+    }
+  ],
+  "special_instructions": "Add drinks when ready"
+}
+```
+
+**Response (200):**
+```json
+{
+  "order": { "id": "order-1", "items": [ ... ] }
+}
+```
+
+---
+
 ### PATCH `/api/order-items/:id/status`
 Update item status (KDS workflow).
 

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -28,7 +28,6 @@ import {
   buildAppendItemsFingerprint,
   clearAppendAttempt,
   createSafeAppendAttemptStorage,
-  createCookieAppendAttemptStorage,
   getOrCreateAppendAttempt,
   readAppendAttempt,
   type AppendAttempt,
@@ -178,7 +177,6 @@ export default function OrdersPage() {
     appendAttemptStorageRef.current = createSafeAppendAttemptStorage(
       browserStorage,
       sessionStorage,
-      createCookieAppendAttemptStorage(),
     );
     return appendAttemptStorageRef.current;
   };

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -24,6 +24,15 @@ import { useI18n } from '@/hooks/useI18n';
 import { useFormatDate } from '@/hooks/useFormatDate';
 import { useWhatsAppReady } from '@/hooks/useWhatsAppReady';
 import { ORDER_TYPE_LABEL_KEYS } from '@/lib/order-types';
+import {
+  buildAppendItemsFingerprint,
+  clearAppendAttempt,
+  createSafeAppendAttemptStorage,
+  getOrCreateAppendAttempt,
+  readAppendAttempt,
+  type AppendAttempt,
+  type AppendAttemptStorage,
+} from '@/lib/append-attempt';
 
 const itemStatusConfig: Record<string, { dot: string; color: string; labelKey: string }> = {
   pending: { dot: 'bg-yellow-400', color: 'text-yellow-700', labelKey: 'orders.itemStatusWaiting' },
@@ -146,7 +155,22 @@ export default function OrdersPage() {
   const [productSearch, setProductSearch] = useState('');
   const [selectedItems, setSelectedItems] = useState<{ product_id: number; product_name: string; quantity: number; special_instructions: string }[]>([]);
   const [addingItems, setAddingItems] = useState(false);
-  const addItemsAttemptRef = useRef<{ fingerprint: string; key: string } | null>(null);
+  const addItemsAttemptRef = useRef<AppendAttempt | null>(null);
+  const appendAttemptStorageRef = useRef<AppendAttemptStorage | null>(null);
+  const appendRecoveryStartedUsersRef = useRef<Set<string>>(new Set());
+  const activeUserId = user?.id == null ? null : String(user.id);
+
+  const getAppendAttemptStorage = (): AppendAttemptStorage => {
+    if (appendAttemptStorageRef.current) return appendAttemptStorageRef.current;
+    let browserStorage: AppendAttemptStorage | null = null;
+    try {
+      if (typeof window !== 'undefined') browserStorage = window.localStorage;
+    } catch {
+      browserStorage = null;
+    }
+    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(browserStorage);
+    return appendAttemptStorageRef.current;
+  };
 
   // Link Customer states
   const [linkCustomerOrderId, setLinkCustomerOrderId] = useState<number | null>(null);
@@ -186,6 +210,33 @@ export default function OrdersPage() {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (!activeUserId || appendRecoveryStartedUsersRef.current.has(activeUserId)) return;
+    let pendingAttempt: AppendAttempt | null = null;
+    try {
+      pendingAttempt = readAppendAttempt(getAppendAttemptStorage(), { userId: activeUserId });
+    } catch {
+      return;
+    }
+    if (!pendingAttempt) return;
+    appendRecoveryStartedUsersRef.current.add(activeUserId);
+    addItemsAttemptRef.current = pendingAttempt;
+    api.post(`/orders/${pendingAttempt.orderId}/items`, {
+      items: pendingAttempt.items,
+      special_instructions: pendingAttempt.specialInstructions,
+    }, { headers: { 'Idempotency-Key': pendingAttempt.idempotencyKey } }).then(() => {
+      clearAppendAttempt(getAppendAttemptStorage(), pendingAttempt!);
+      if (addItemsAttemptRef.current?.idempotencyKey !== pendingAttempt!.idempotencyKey) return;
+      addItemsAttemptRef.current = null;
+      toast.success(t('orders.itemsAdded', { count: pendingAttempt!.items.length }));
+      fetchOrders();
+    }).catch((err: unknown) => {
+      const axiosErr = err as { response?: { data?: { error?: string } } };
+      toast.error(axiosErr.response?.data?.error || t('orders.addItemsFailed'));
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeUserId]);
 
   useEffect(() => {
     api.get('/settings/kds_enabled')
@@ -706,19 +757,23 @@ export default function OrdersPage() {
         quantity: i.quantity,
         special_instructions: i.special_instructions || undefined,
       }));
-      const fingerprint = JSON.stringify({ user_id: user?.id ?? null, order_id: addItemsOrder.id, items });
-      const attempt = addItemsAttemptRef.current?.fingerprint === fingerprint
-        ? addItemsAttemptRef.current
-        : {
-          fingerprint,
-          key: typeof globalThis.crypto?.randomUUID === 'function'
-            ? globalThis.crypto.randomUUID()
-            : `items-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-        };
+      const fingerprint = buildAppendItemsFingerprint(addItemsOrder.id, items);
+      const storage = getAppendAttemptStorage();
+      const attempt = getOrCreateAppendAttempt(storage, {
+        userId: activeUserId || '',
+        orderId: addItemsOrder.id,
+        fingerprint,
+        createKey: () => typeof globalThis.crypto?.randomUUID === 'function'
+          ? globalThis.crypto.randomUUID()
+          : `items-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        items,
+        orderNumber: addItemsOrder.order_number,
+      });
       addItemsAttemptRef.current = attempt;
       await api.post(`/orders/${addItemsOrder.id}/items`, {
         items,
-      }, { headers: { 'Idempotency-Key': attempt.key } });
+      }, { headers: { 'Idempotency-Key': attempt.idempotencyKey } });
+      clearAppendAttempt(storage, attempt);
       addItemsAttemptRef.current = null;
       toast.success(t('orders.itemsAdded', { count: selectedItems.length }));
       openAddItemsModal(null);

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -237,7 +237,7 @@ export default function OrdersPage() {
       items: pendingAttempt.items,
       special_instructions: pendingAttempt.specialInstructions,
     }, { headers: { 'Idempotency-Key': pendingAttempt.idempotencyKey } }).then(() => {
-      clearAppendAttempt(getAppendAttemptStorage(), pendingAttempt!);
+      if (!clearAppendAttempt(getAppendAttemptStorage(), pendingAttempt!)) throw new Error('Unable to clear append retry state');
       if (addItemsAttemptRef.current?.idempotencyKey !== pendingAttempt!.idempotencyKey) return;
       addItemsAttemptRef.current = null;
       toast.success(t('orders.itemsAdded', { count: pendingAttempt!.items.length }));
@@ -784,7 +784,7 @@ export default function OrdersPage() {
       await api.post(`/orders/${addItemsOrder.id}/items`, {
         items,
       }, { headers: { 'Idempotency-Key': attempt.idempotencyKey } });
-      clearAppendAttempt(storage, attempt);
+      if (!clearAppendAttempt(storage, attempt)) throw new Error('Unable to clear append retry state');
       addItemsAttemptRef.current = null;
       toast.success(t('orders.itemsAdded', { count: selectedItems.length }));
       openAddItemsModal(null);

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -28,6 +28,7 @@ import {
   buildAppendItemsFingerprint,
   clearAppendAttempt,
   createSafeAppendAttemptStorage,
+  createCookieAppendAttemptStorage,
   getOrCreateAppendAttempt,
   readAppendAttempt,
   type AppendAttempt,
@@ -174,7 +175,11 @@ export default function OrdersPage() {
     } catch {
       sessionStorage = null;
     }
-    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(browserStorage, sessionStorage);
+    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(
+      browserStorage,
+      sessionStorage,
+      createCookieAppendAttemptStorage(),
+    );
     return appendAttemptStorageRef.current;
   };
 

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -163,12 +163,18 @@ export default function OrdersPage() {
   const getAppendAttemptStorage = (): AppendAttemptStorage => {
     if (appendAttemptStorageRef.current) return appendAttemptStorageRef.current;
     let browserStorage: AppendAttemptStorage | null = null;
+    let sessionStorage: AppendAttemptStorage | null = null;
     try {
       if (typeof window !== 'undefined') browserStorage = window.localStorage;
     } catch {
       browserStorage = null;
     }
-    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(browserStorage);
+    try {
+      if (typeof window !== 'undefined') sessionStorage = window.sessionStorage;
+    } catch {
+      sessionStorage = null;
+    }
+    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(browserStorage, sessionStorage);
     return appendAttemptStorageRef.current;
   };
 

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -38,6 +38,7 @@ import {
   createSafeAppendAttemptStorage,
   createCookieAppendAttemptStorage,
   getOrCreateAppendAttempt,
+  getPostpaidOrderAttemptStorageKey,
   migrateLegacyAppendAttempt,
   readAppendAttempt,
   type AppendAttempt,
@@ -106,6 +107,8 @@ export default function POSPage() {
   const activeUserId = user?.id == null ? null : String(user.id);
   const prepaidAttemptRef = useRef<PrepaidAttempt | null>(null);
   const postpaidAttemptRef = useRef<PostpaidAttempt | null>(null);
+  const postpaidAttemptKeyRef = useRef<string | null>(null);
+  const postpaidAttemptWasLegacyRef = useRef(false);
   const addItemsAttemptRef = useRef<AppendAttempt | null>(null);
   const appendRecoveryStartedUsersRef = useRef<Set<string>>(new Set());
   const appendAttemptStorageRef = useRef<AppendAttemptStorage | null>(null);
@@ -138,7 +141,9 @@ export default function POSPage() {
       const migratedAppend = migrateLegacyAppendAttempt(getAppendAttemptStorage(), { userId: activeUserId || undefined });
       if (migratedAppend) {
         if (getAppendAttemptStorage().getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY) !== null) {
-          throw new Error('Unable to recover append retry state');
+          postpaidAttemptKeyRef.current = null;
+          postpaidAttemptWasLegacyRef.current = false;
+          return postpaidAttemptRef.current?.userId === activeUserId ? postpaidAttemptRef.current : null;
         }
         return null;
       }
@@ -147,12 +152,29 @@ export default function POSPage() {
     }
     if (postpaidAttemptRef.current?.userId === activeUserId) return postpaidAttemptRef.current;
     postpaidAttemptRef.current = null;
+    postpaidAttemptKeyRef.current = null;
+    postpaidAttemptWasLegacyRef.current = false;
     try {
-      const stored = window.localStorage.getItem(POSTPAID_ATTEMPT_STORAGE_KEY);
+      const userStorageKey = activeUserId ? getPostpaidOrderAttemptStorageKey(activeUserId) : null;
+      const stored = userStorageKey ? window.localStorage.getItem(userStorageKey) : null;
       const parsed = stored ? JSON.parse(stored) as PostpaidAttempt : null;
-      if (parsed && parsed.userId === activeUserId) postpaidAttemptRef.current = parsed;
-      else window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
+      if (parsed && parsed.userId === activeUserId) {
+        postpaidAttemptRef.current = parsed;
+        postpaidAttemptKeyRef.current = userStorageKey;
+        return parsed;
+      }
+      if (userStorageKey && stored !== null) window.localStorage.removeItem(userStorageKey);
+      const legacyStored = window.localStorage.getItem(POSTPAID_ATTEMPT_STORAGE_KEY);
+      const legacyParsed = legacyStored ? JSON.parse(legacyStored) as PostpaidAttempt : null;
+      if (legacyParsed && legacyParsed.userId === activeUserId) {
+        postpaidAttemptRef.current = legacyParsed;
+        postpaidAttemptKeyRef.current = POSTPAID_ATTEMPT_STORAGE_KEY;
+        postpaidAttemptWasLegacyRef.current = true;
+      } else if (legacyStored !== null) {
+        window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
+      }
     } catch {
+      if (activeUserId) window.localStorage.removeItem(getPostpaidOrderAttemptStorageKey(activeUserId));
       window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
       return null;
     }
@@ -161,7 +183,10 @@ export default function POSPage() {
   const savePostpaidAttempt = (attempt: PostpaidAttempt): boolean => {
     postpaidAttemptRef.current = attempt;
     try {
-      window.localStorage.setItem(POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify(attempt));
+      if (!activeUserId) return false;
+      const storageKey = getPostpaidOrderAttemptStorageKey(activeUserId);
+      window.localStorage.setItem(storageKey, JSON.stringify(attempt));
+      postpaidAttemptKeyRef.current = storageKey;
       return true;
     } catch {
       return false;
@@ -170,10 +195,13 @@ export default function POSPage() {
   const clearPostpaidAttempt = () => {
     postpaidAttemptRef.current = null;
     try {
-      window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
+      if (postpaidAttemptKeyRef.current) window.localStorage.removeItem(postpaidAttemptKeyRef.current);
+      if (postpaidAttemptWasLegacyRef.current) window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
     } catch {
       // Ignore storage cleanup failures.
     }
+    postpaidAttemptKeyRef.current = null;
+    postpaidAttemptWasLegacyRef.current = false;
   };
 
   const readPrepaidAttempt = () => {
@@ -314,7 +342,7 @@ export default function POSPage() {
       { headers: { 'Idempotency-Key': pendingAttempt.idempotencyKey } },
     ).then(() => {
       const storage = getAppendAttemptStorage();
-      clearAppendAttempt(storage, pendingAttempt!);
+      if (!clearAppendAttempt(storage, pendingAttempt!)) throw new Error('Unable to clear append retry state');
       if (addItemsAttemptRef.current?.idempotencyKey !== pendingAttempt!.idempotencyKey) return;
       addItemsAttemptRef.current = null;
       // Do not clear cart or checkout state that may have been started while
@@ -460,7 +488,7 @@ export default function POSPage() {
         );
         toast.success(t('pos.itemsAddedToOrder', { number: pendingOrder.order_number }));
         orderForKot = data.order as Order;
-        clearAppendAttempt(storage, itemAttempt);
+        if (!clearAppendAttempt(storage, itemAttempt)) throw new Error('Unable to clear append retry state');
         addItemsAttemptRef.current = null;
         setPendingOrder(null);
       } else {
@@ -836,7 +864,7 @@ export default function POSPage() {
       }, { headers: { 'Idempotency-Key': itemAttempt.idempotencyKey } });
       // A resolved response is the confirmation boundary. Keep the durable
       // attempt through all network errors so a lost response can replay it.
-      clearAppendAttempt(storage, itemAttempt);
+      if (!clearAppendAttempt(storage, itemAttempt)) throw new Error('Unable to clear append retry state');
       addItemsAttemptRef.current = null;
       toast.success(t('pos.itemsAddedToOrder', { number: order.order_number }));
       cart.clearCart();

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -137,7 +137,8 @@ export default function POSPage() {
       if (parsed && parsed.userId === activeUserId) postpaidAttemptRef.current = parsed;
       else window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
     } catch {
-      throw new Error('Unable to read order retry state');
+      window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
+      return null;
     }
     return postpaidAttemptRef.current;
   };

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -122,17 +122,22 @@ export default function POSPage() {
   };
 
   const readPostpaidAttempt = () => {
-    if (postpaidAttemptRef.current?.userId === activeUserId) return postpaidAttemptRef.current;
-    postpaidAttemptRef.current = null;
     if (typeof window === 'undefined') return null;
     try {
-      migrateLegacyAppendAttempt(getAppendAttemptStorage());
+      const migratedAppend = migrateLegacyAppendAttempt(getAppendAttemptStorage());
+      if (migratedAppend) return null;
+    } catch {
+      throw new Error('Unable to recover append retry state');
+    }
+    if (postpaidAttemptRef.current?.userId === activeUserId) return postpaidAttemptRef.current;
+    postpaidAttemptRef.current = null;
+    try {
       const stored = window.localStorage.getItem(POSTPAID_ATTEMPT_STORAGE_KEY);
       const parsed = stored ? JSON.parse(stored) as PostpaidAttempt : null;
       if (parsed && parsed.userId === activeUserId) postpaidAttemptRef.current = parsed;
       else window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
     } catch {
-      return null;
+      throw new Error('Unable to read order retry state');
     }
     return postpaidAttemptRef.current;
   };

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -136,7 +136,12 @@ export default function POSPage() {
     if (typeof window === 'undefined') return null;
     try {
       const migratedAppend = migrateLegacyAppendAttempt(getAppendAttemptStorage(), { userId: activeUserId || undefined });
-      if (migratedAppend) return null;
+      if (migratedAppend) {
+        if (getAppendAttemptStorage().getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY) !== null) {
+          throw new Error('Unable to recover append retry state');
+        }
+        return null;
+      }
     } catch {
       throw new Error('Unable to recover append retry state');
     }

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -37,6 +37,7 @@ import {
   clearAppendAttempt,
   createSafeAppendAttemptStorage,
   getOrCreateAppendAttempt,
+  migrateLegacyAppendAttempt,
   readAppendAttempt,
   type AppendAttempt,
   type AppendAttemptStorage,
@@ -125,12 +126,13 @@ export default function POSPage() {
     postpaidAttemptRef.current = null;
     if (typeof window === 'undefined') return null;
     try {
+      migrateLegacyAppendAttempt(getAppendAttemptStorage());
       const stored = window.localStorage.getItem(POSTPAID_ATTEMPT_STORAGE_KEY);
       const parsed = stored ? JSON.parse(stored) as PostpaidAttempt : null;
       if (parsed && parsed.userId === activeUserId) postpaidAttemptRef.current = parsed;
       else window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
     } catch {
-      window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
+      return null;
     }
     return postpaidAttemptRef.current;
   };

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -37,6 +37,7 @@ import {
   clearAppendAttempt,
   createSafeAppendAttemptStorage,
   getOrCreateAppendAttempt,
+  LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY,
   getPostpaidOrderAttemptStorageKey,
   migrateLegacyAppendAttempt,
   readAppendAttempt,

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -140,7 +140,6 @@ export default function POSPage() {
       const migratedAppend = migrateLegacyAppendAttempt(getAppendAttemptStorage(), { userId: activeUserId || undefined });
       sharedLegacyAppendRetained = migratedAppend !== null
         && getAppendAttemptStorage().getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY) !== null;
-      if (migratedAppend && !sharedLegacyAppendRetained) return null;
     } catch {
       throw new Error('Unable to recover append retry state');
     }

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -112,12 +112,18 @@ export default function POSPage() {
   const getAppendAttemptStorage = (): AppendAttemptStorage => {
     if (appendAttemptStorageRef.current) return appendAttemptStorageRef.current;
     let browserStorage: AppendAttemptStorage | null = null;
+    let sessionStorage: AppendAttemptStorage | null = null;
     try {
       if (typeof window !== 'undefined') browserStorage = window.localStorage;
     } catch {
       // Private/restricted renderers may throw while reading localStorage.
     }
-    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(browserStorage);
+    try {
+      if (typeof window !== 'undefined') sessionStorage = window.sessionStorage;
+    } catch {
+      // Session storage may also be restricted.
+    }
+    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(browserStorage, sessionStorage);
     return appendAttemptStorageRef.current;
   };
 

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -36,6 +36,7 @@ import {
   buildAppendItemsFingerprint,
   clearAppendAttempt,
   createSafeAppendAttemptStorage,
+  createCookieAppendAttemptStorage,
   getOrCreateAppendAttempt,
   migrateLegacyAppendAttempt,
   readAppendAttempt,
@@ -123,14 +124,18 @@ export default function POSPage() {
     } catch {
       // Session storage may also be restricted.
     }
-    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(browserStorage, sessionStorage);
+    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(
+      browserStorage,
+      sessionStorage,
+      createCookieAppendAttemptStorage(),
+    );
     return appendAttemptStorageRef.current;
   };
 
   const readPostpaidAttempt = () => {
     if (typeof window === 'undefined') return null;
     try {
-      const migratedAppend = migrateLegacyAppendAttempt(getAppendAttemptStorage());
+      const migratedAppend = migrateLegacyAppendAttempt(getAppendAttemptStorage(), { userId: activeUserId || undefined });
       if (migratedAppend) return null;
     } catch {
       throw new Error('Unable to recover append retry state');

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -32,6 +32,15 @@ import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useSupportTicketStatus } from '@/hooks/useSupportTicketStatus';
 import { useSupportDiagnosticsPreview } from '@/hooks/useSupportDiagnosticsPreview';
 import { getCurrencySymbol, getCountryByCode } from '@/lib/countries';
+import {
+  buildAppendItemsFingerprint,
+  clearAppendAttempt,
+  createSafeAppendAttemptStorage,
+  getOrCreateAppendAttempt,
+  readAppendAttempt,
+  type AppendAttempt,
+  type AppendAttemptStorage,
+} from '@/lib/append-attempt';
 
 const PREPAID_ATTEMPT_STORAGE_KEY = 'flo.prepaid.checkout.attempt';
 const POSTPAID_ATTEMPT_STORAGE_KEY = 'flo.postpaid.order.attempt';
@@ -95,7 +104,21 @@ export default function POSPage() {
   const activeUserId = user?.id == null ? null : String(user.id);
   const prepaidAttemptRef = useRef<PrepaidAttempt | null>(null);
   const postpaidAttemptRef = useRef<PostpaidAttempt | null>(null);
-  const addItemsAttemptRef = useRef<{ orderId: string; key: string } | null>(null);
+  const addItemsAttemptRef = useRef<AppendAttempt | null>(null);
+  const appendRecoveryStartedUsersRef = useRef<Set<string>>(new Set());
+  const appendAttemptStorageRef = useRef<AppendAttemptStorage | null>(null);
+
+  const getAppendAttemptStorage = (): AppendAttemptStorage => {
+    if (appendAttemptStorageRef.current) return appendAttemptStorageRef.current;
+    let browserStorage: AppendAttemptStorage | null = null;
+    try {
+      if (typeof window !== 'undefined') browserStorage = window.localStorage;
+    } catch {
+      // Private/restricted renderers may throw while reading localStorage.
+    }
+    appendAttemptStorageRef.current = createSafeAppendAttemptStorage(browserStorage);
+    return appendAttemptStorageRef.current;
+  };
 
   const readPostpaidAttempt = () => {
     if (postpaidAttemptRef.current?.userId === activeUserId) return postpaidAttemptRef.current;
@@ -242,6 +265,47 @@ export default function POSPage() {
     } catch { /* ignore */ }
   };
 
+  // A full renderer reload resets the Zustand cart. Recovering the persisted
+  // request here lets a committed-but-response-lost append replay itself even
+  // before the cashier reconstructs the cart or selects the table again.
+  useEffect(() => {
+    if (!activeUserId || appendRecoveryStartedUsersRef.current.has(activeUserId)) return;
+
+    let pendingAttempt: AppendAttempt | null = null;
+    try {
+      pendingAttempt = readAppendAttempt(getAppendAttemptStorage(), { userId: activeUserId });
+    } catch {
+      return;
+    }
+    if (!pendingAttempt) return;
+
+    appendRecoveryStartedUsersRef.current.add(activeUserId);
+    addItemsAttemptRef.current = pendingAttempt;
+    api.post(
+      `/orders/${pendingAttempt.orderId}/items`,
+      {
+        items: pendingAttempt.items,
+        special_instructions: pendingAttempt.specialInstructions,
+      },
+      { headers: { 'Idempotency-Key': pendingAttempt.idempotencyKey } },
+    ).then(() => {
+      const storage = getAppendAttemptStorage();
+      clearAppendAttempt(storage, pendingAttempt!);
+      if (addItemsAttemptRef.current?.idempotencyKey !== pendingAttempt!.idempotencyKey) return;
+      addItemsAttemptRef.current = null;
+      // Do not clear cart or checkout state that may have been started while
+      // recovery was in flight. A reload starts empty; any current UI is newer.
+      toast.success(t('pos.itemsAddedToOrder', { number: pendingAttempt!.orderNumber || pendingAttempt!.orderId }));
+      refreshTables();
+    }).catch((err: unknown) => {
+      const error = err as { response?: { data?: { message?: string } } };
+      toast.error(error.response?.data?.message || t('pos.addItemsFailed'));
+    });
+  // The recovery runs once per authenticated renderer and intentionally uses
+  // the persisted attempt rather than the transient cart state.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeUserId]);
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -352,20 +416,28 @@ export default function POSPage() {
             : null,
           special_instructions: item.special_instructions || null,
         }));
-        const itemFingerprint = JSON.stringify({ order_id: pendingOrder.id, items: newItems, special_instructions: cart.orderNotes || undefined });
-        const priorItemsAttempt = readPostpaidAttempt();
-        const itemAttempt: PostpaidAttempt = priorItemsAttempt?.userId === activeUserId && priorItemsAttempt.fingerprint === itemFingerprint
-          ? priorItemsAttempt
-          : { userId: activeUserId || '', fingerprint: itemFingerprint, idempotencyKey: newIdempotencyKey() };
-        if (!savePostpaidAttempt(itemAttempt)) throw new Error(t('pos.placeOrderFailed'));
+        const specialInstructions = cart.orderNotes || undefined;
+        const itemFingerprint = buildAppendItemsFingerprint(pendingOrder.id, newItems, specialInstructions);
+        const storage = getAppendAttemptStorage();
+        const itemAttempt = getOrCreateAppendAttempt(storage, {
+          userId: activeUserId || '',
+          orderId: pendingOrder.id,
+          fingerprint: itemFingerprint,
+          createKey: newIdempotencyKey,
+          items: newItems,
+          specialInstructions,
+          orderNumber: pendingOrder.order_number,
+        });
+        addItemsAttemptRef.current = itemAttempt;
         const { data } = await api.post(
           `/orders/${pendingOrder.id}/items`,
-          { items: newItems, special_instructions: cart.orderNotes || undefined },
+          { items: newItems, special_instructions: specialInstructions },
           { headers: { 'Idempotency-Key': itemAttempt.idempotencyKey } },
         );
         toast.success(t('pos.itemsAddedToOrder', { number: pendingOrder.order_number }));
         orderForKot = data.order as Order;
-        clearPostpaidAttempt();
+        clearAppendAttempt(storage, itemAttempt);
+        addItemsAttemptRef.current = null;
         setPendingOrder(null);
       } else {
         const orderPayload = {
@@ -713,22 +785,34 @@ export default function POSPage() {
     }
     setSubmitting(true);
     try {
-      const existingAttempt = addItemsAttemptRef.current;
-      const idempotencyKey = existingAttempt?.orderId === String(order.id)
-        ? existingAttempt.key
-        : newIdempotencyKey();
-      addItemsAttemptRef.current = { orderId: String(order.id), key: idempotencyKey };
+      const items = cart.items.map((item) => ({
+        product_id: item.product.id,
+        quantity: item.quantity,
+        addons: item.addons.length > 0
+          ? item.addons.map((a) => ({ id: a.id, name: a.name, price: a.price, quantity: a.quantity || 1 }))
+          : null,
+        special_instructions: item.special_instructions || null,
+      }));
+      const specialInstructions = order.special_instructions || undefined;
+      const fingerprint = buildAppendItemsFingerprint(order.id, items, specialInstructions);
+      const storage = getAppendAttemptStorage();
+      const itemAttempt = getOrCreateAppendAttempt(storage, {
+        userId: activeUserId || '',
+        orderId: order.id,
+        fingerprint,
+        createKey: newIdempotencyKey,
+        items,
+        specialInstructions,
+        orderNumber: order.order_number,
+      });
+      addItemsAttemptRef.current = itemAttempt;
       await api.post(`/orders/${order.id}/items`, {
-        items: cart.items.map((item) => ({
-          product_id: item.product.id,
-          quantity: item.quantity,
-          addons: item.addons.length > 0
-            ? item.addons.map((a) => ({ id: a.id, name: a.name, price: a.price, quantity: a.quantity || 1 }))
-            : null,
-          special_instructions: item.special_instructions || null,
-        })),
-        special_instructions: order.special_instructions || undefined,
-      }, { headers: { 'Idempotency-Key': idempotencyKey } });
+        items,
+        special_instructions: specialInstructions,
+      }, { headers: { 'Idempotency-Key': itemAttempt.idempotencyKey } });
+      // A resolved response is the confirmation boundary. Keep the durable
+      // attempt through all network errors so a lost response can replay it.
+      clearAppendAttempt(storage, itemAttempt);
       addItemsAttemptRef.current = null;
       toast.success(t('pos.itemsAddedToOrder', { number: order.order_number }));
       cart.clearCart();

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -36,7 +36,6 @@ import {
   buildAppendItemsFingerprint,
   clearAppendAttempt,
   createSafeAppendAttemptStorage,
-  createCookieAppendAttemptStorage,
   getOrCreateAppendAttempt,
   getPostpaidOrderAttemptStorageKey,
   migrateLegacyAppendAttempt,
@@ -130,7 +129,6 @@ export default function POSPage() {
     appendAttemptStorageRef.current = createSafeAppendAttemptStorage(
       browserStorage,
       sessionStorage,
-      createCookieAppendAttemptStorage(),
     );
     return appendAttemptStorageRef.current;
   };

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -137,16 +137,12 @@ export default function POSPage() {
 
   const readPostpaidAttempt = () => {
     if (typeof window === 'undefined') return null;
+    let sharedLegacyAppendRetained = false;
     try {
       const migratedAppend = migrateLegacyAppendAttempt(getAppendAttemptStorage(), { userId: activeUserId || undefined });
-      if (migratedAppend) {
-        if (getAppendAttemptStorage().getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY) !== null) {
-          postpaidAttemptKeyRef.current = null;
-          postpaidAttemptWasLegacyRef.current = false;
-          return postpaidAttemptRef.current?.userId === activeUserId ? postpaidAttemptRef.current : null;
-        }
-        return null;
-      }
+      sharedLegacyAppendRetained = migratedAppend !== null
+        && getAppendAttemptStorage().getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY) !== null;
+      if (migratedAppend && !sharedLegacyAppendRetained) return null;
     } catch {
       throw new Error('Unable to recover append retry state');
     }
@@ -164,7 +160,7 @@ export default function POSPage() {
         return parsed;
       }
       if (userStorageKey && stored !== null) window.localStorage.removeItem(userStorageKey);
-      const legacyStored = window.localStorage.getItem(POSTPAID_ATTEMPT_STORAGE_KEY);
+      const legacyStored = sharedLegacyAppendRetained ? null : window.localStorage.getItem(POSTPAID_ATTEMPT_STORAGE_KEY);
       const legacyParsed = legacyStored ? JSON.parse(legacyStored) as PostpaidAttempt : null;
       if (legacyParsed && legacyParsed.userId === activeUserId) {
         postpaidAttemptRef.current = legacyParsed;
@@ -175,7 +171,7 @@ export default function POSPage() {
       }
     } catch {
       if (activeUserId) window.localStorage.removeItem(getPostpaidOrderAttemptStorageKey(activeUserId));
-      window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
+      if (!sharedLegacyAppendRetained) window.localStorage.removeItem(POSTPAID_ATTEMPT_STORAGE_KEY);
       return null;
     }
     return postpaidAttemptRef.current;

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -6,8 +6,18 @@ const APPEND_ATTEMPT_COMPLETION_SUFFIX = '.completion.';
 const APPEND_ATTEMPT_COMPLETION_RETRY_SUFFIX = '.completion-retry.';
 const APPEND_ATTEMPT_COMPLETION_COOKIE_SUFFIX = '.completion-cookie.';
 const CONFIRMED_APPEND_TOMBSTONE_LIMIT = 256;
-const confirmedAppendTombstones = new Map<string, { completedAt: number; fingerprintHash: string }>();
+const confirmedAppendTombstones = new Map<string, { completedAt: number; fingerprint: string }>();
 const APPEND_ATTEMPT_COOKIE_PREFIX = 'flo_append_attempt.';
+const SHA256_CONSTANTS = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
 
 export function getAppendAttemptStorageKey(userId: string): string {
   return `${APPEND_ATTEMPT_STORAGE_KEY}${APPEND_ATTEMPT_USER_SUFFIX}${encodeURIComponent(userId)}`;
@@ -33,13 +43,52 @@ function getConfirmedAppendTombstoneKey(userId: string, idempotencyKey: string):
   return `${userId}\u0000${idempotencyKey}`;
 }
 
-function getFingerprintHash(fingerprint: string): string {
-  let hash = 2166136261;
-  for (let index = 0; index < fingerprint.length; index += 1) {
-    hash ^= fingerprint.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
+function rotateRight(value: number, bits: number): number {
+  return (value >>> bits) | (value << (32 - bits));
+}
+
+function getFingerprintDigest(fingerprint: string): string {
+  const bytes = new TextEncoder().encode(fingerprint);
+  const padded = new Uint8Array(Math.ceil((bytes.length + 9) / 64) * 64);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const bitLength = bytes.length * 8;
+  const view = new DataView(padded.buffer);
+  view.setUint32(padded.length - 8, Math.floor(bitLength / 0x1_0000_0000));
+  view.setUint32(padded.length - 4, bitLength >>> 0);
+  let hash = [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19];
+  const words = new Uint32Array(64);
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let index = 0; index < 16; index += 1) words[index] = view.getUint32(offset + index * 4);
+    for (let index = 16; index < 64; index += 1) {
+      const first = words[index - 15];
+      const second = words[index - 2];
+      words[index] = (words[index - 16]
+        + (rotateRight(first, 7) ^ rotateRight(first, 18) ^ (first >>> 3))
+        + words[index - 7]
+        + (rotateRight(second, 17) ^ rotateRight(second, 19) ^ (second >>> 10))) >>> 0;
+    }
+    let [a, b, c, d, e, f, g, h] = hash;
+    for (let index = 0; index < 64; index += 1) {
+      const first = (h
+        + (rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25))
+        + ((e & f) ^ (~e & g))
+        + SHA256_CONSTANTS[index]
+        + words[index]) >>> 0;
+      const second = ((rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22))
+        + ((a & b) ^ (a & c) ^ (b & c))) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + first) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (first + second) >>> 0;
+    }
+    hash = hash.map((value, index) => (value + [a, b, c, d, e, f, g, h][index]) >>> 0);
   }
-  return (hash >>> 0).toString(16);
+  return hash.map((value) => value.toString(16).padStart(8, '0')).join('');
 }
 
 function pruneConfirmedAppendTombstones(now: number, maxAgeMs: number): void {
@@ -62,7 +111,7 @@ function hasConfirmedAppendTombstone(
 ): boolean {
   pruneConfirmedAppendTombstones(now, maxAgeMs);
   const tombstone = confirmedAppendTombstones.get(getConfirmedAppendTombstoneKey(userId, idempotencyKey));
-  return tombstone?.fingerprintHash === getFingerprintHash(fingerprint);
+  return tombstone?.fingerprint === fingerprint;
 }
 
 export interface AppendAttempt {
@@ -228,7 +277,10 @@ function isExpired(createdAt: number, now: number, maxAgeMs: number): boolean {
 
 function removeAndVerify(storage: AppendAttemptStorage, key: string): boolean {
   const removed = storage.removeItem(key);
-  return removed !== false && storage.getItem(key) === null;
+  return removed !== false
+    && storage.getItem(key) === null
+    && !storage.hasUnverifiedRead?.(key)
+    && !storage.hasUnverifiedRemoval?.(key);
 }
 
 function persistCompletionRecord(
@@ -251,7 +303,7 @@ function persistCompletionRecord(
       completed: completion.completed,
       userId: completion.userId,
       idempotencyKey: completion.idempotencyKey,
-      fingerprintHash: getFingerprintHash(completion.fingerprint || ''),
+      fingerprintDigest: getFingerprintDigest(completion.fingerprint || ''),
       completedAt: completion.completedAt,
     });
     cookieStorage.setItem(cookieKey, cookieValue);
@@ -286,7 +338,7 @@ interface AppendAttemptCompletion {
   userId: string;
   idempotencyKey: string;
   fingerprint?: string;
-  fingerprintHash?: string;
+  fingerprintDigest?: string;
   completedAt: number;
 }
 
@@ -301,7 +353,7 @@ function isCompletionRecord(value: Partial<AppendAttemptCompletion> & { complete
   return value.completed === true
     && typeof value.userId === 'string'
     && typeof value.idempotencyKey === 'string'
-    && (typeof value.fingerprint === 'string' || typeof value.fingerprintHash === 'string')
+    && (typeof value.fingerprint === 'string' || typeof value.fingerprintDigest === 'string')
     && typeof value.completedAt === 'number';
 }
 
@@ -336,7 +388,7 @@ function completedAttemptMatches(
       current.idempotencyKey !== completion.idempotencyKey
       || (typeof completion.fingerprint === 'string'
         ? current.fingerprint !== completion.fingerprint
-        : getFingerprintHash(current.fingerprint || '') !== completion.fingerprintHash)
+        : getFingerprintDigest(current.fingerprint || '') !== completion.fingerprintDigest)
     ) return false;
     const removed = storage.removeItem(attemptKey);
     if (
@@ -373,7 +425,7 @@ function hasCompletedAttempt(
         completion.userId !== userId
         || typeof completion.idempotencyKey !== 'string'
         || !isValidIdempotencyKey(completion.idempotencyKey)
-        || (typeof completion.fingerprint !== 'string' && typeof completion.fingerprintHash !== 'string')
+        || (typeof completion.fingerprint !== 'string' && typeof completion.fingerprintDigest !== 'string')
         || typeof completion.completedAt !== 'number'
         || isExpired(completion.completedAt, now, maxAgeMs)
       ) {
@@ -395,6 +447,9 @@ export function migrateLegacyAppendAttempt(
   const now = options.now ?? Date.now();
   const maxAgeMs = options.maxAgeMs ?? APPEND_ATTEMPT_MAX_AGE_MS;
   const raw = storage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
+  if (storage.hasUnverifiedRead?.(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY)) {
+    throw new Error('Unable to verify append retry state');
+  }
   if (!raw) return null;
 
   let parsed: {
@@ -432,6 +487,9 @@ export function migrateLegacyAppendAttempt(
   }
   const scopedKey = getAppendAttemptStorageKey(parsed.userId);
   const existingRaw = storage.getItem(scopedKey);
+  if (storage.hasUnverifiedRead?.(scopedKey)) {
+    throw new Error('Unable to verify append retry state');
+  }
   const attempt: AppendAttempt = {
     userId: parsed.userId,
     orderId: String(payload.order_id),
@@ -485,6 +543,7 @@ export function migrateLegacyAppendAttempt(
 
 function parseStoredAttempt(storage: AppendAttemptStorage, key: string, now: number, maxAgeMs: number): AppendAttempt | null {
   const raw = storage.getItem(key);
+  if (storage.hasUnverifiedRead?.(key)) throw new Error('Unable to verify append retry state');
   if (!raw) return null;
 
   try {
@@ -530,8 +589,26 @@ function appendAttemptsMatch(first: AppendAttempt, second: AppendAttempt): boole
 function ensureCompletionStorage(storage: AppendAttemptStorage, userId: string): void {
   const markerKey = getAppendAttemptCompletionStorageKey(userId);
   const retryKey = getAppendAttemptCompletionRetryStorageKey(userId);
+  const cookieKey = getAppendAttemptCompletionCookieStorageKey(userId);
   const attemptKey = getAppendAttemptStorageKey(userId);
   const probe = JSON.stringify({ completed: true, userId, idempotencyKey: 'append-storage-probe', fingerprint: '{}', completedAt: Date.now() });
+  const cookieStorage = createCookieCompletionStorage();
+  if (cookieStorage) {
+    try {
+      const cookieProbe = JSON.stringify({
+        completed: true,
+        userId,
+        idempotencyKey: 'append-storage-probe',
+        fingerprintDigest: getFingerprintDigest('{}'),
+        completedAt: Date.now(),
+      });
+      cookieStorage.setItem(cookieKey, cookieProbe);
+      if (cookieStorage.removeItem(cookieKey) === false || cookieStorage.getItem(cookieKey) !== null) {
+        throw new Error('Completion cookie cleanup was not persisted');
+      }
+    } catch {
+    }
+  }
   try {
     storage.setItem(markerKey, probe);
     if (!removeAndVerify(storage, markerKey)) throw new Error('Completion marker cleanup was not persisted');
@@ -552,6 +629,16 @@ function ensureCompletionStorage(storage: AppendAttemptStorage, userId: string):
   }
 }
 
+function assertVerifiedCompletionReads(storage: AppendAttemptStorage, userId: string): void {
+  const keys = [
+    getAppendAttemptCompletionStorageKey(userId),
+    getAppendAttemptCompletionRetryStorageKey(userId),
+  ];
+  if (keys.some((key) => storage.hasUnverifiedRead?.(key))) {
+    throw new Error('Unable to verify append retry state');
+  }
+}
+
 function readUserAttempt(
   storage: AppendAttemptStorage,
   userId: string,
@@ -565,7 +652,9 @@ function readUserAttempt(
   } catch (error) {
     if (!(error instanceof LegacyAppendAttemptConflictError)) throw error;
   }
-  if (hasCompletedAttempt(storage, userId, now, maxAgeMs)) return null;
+  const completed = hasCompletedAttempt(storage, userId, now, maxAgeMs);
+  assertVerifiedCompletionReads(storage, userId);
+  if (completed) return null;
   const scoped = parseStoredAttempt(storage, scopedKey, now, maxAgeMs);
   if (scoped && hasConfirmedAppendTombstone(userId, scoped.idempotencyKey, scoped.fingerprint, now, maxAgeMs)) return null;
   const legacy = parseStoredAttempt(storage, APPEND_ATTEMPT_STORAGE_KEY, now, maxAgeMs);
@@ -672,7 +761,7 @@ export function clearAppendAttempt(
     if (markerPersisted) {
       confirmedAppendTombstones.set(
         getConfirmedAppendTombstoneKey(completedAttempt.userId, completedAttempt.idempotencyKey),
-        { completedAt: Date.now(), fingerprintHash: getFingerprintHash(completedAttempt.fingerprint) },
+        { completedAt: Date.now(), fingerprint: completedAttempt.fingerprint },
       );
       pruneConfirmedAppendTombstones(Date.now(), APPEND_ATTEMPT_MAX_AGE_MS);
     }

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -1,0 +1,226 @@
+export const APPEND_ATTEMPT_STORAGE_KEY = 'flo.pos.append-items.attempt';
+export const APPEND_ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export function getAppendAttemptStorageKey(userId: string): string {
+  return `${APPEND_ATTEMPT_STORAGE_KEY}.${encodeURIComponent(userId)}`;
+}
+
+export interface AppendAttempt {
+  userId: string;
+  orderId: string;
+  fingerprint: string;
+  idempotencyKey: string;
+  items: unknown[];
+  specialInstructions?: string;
+  orderNumber?: string;
+  createdAt: number;
+}
+
+export interface AppendAttemptStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+}
+
+/**
+ * Keep the append path compatible with renderers where localStorage is blocked
+ * or full. The memory layer preserves same-renderer retries; durable storage
+ * is best effort and is used whenever the browser permits it.
+ */
+export function createSafeAppendAttemptStorage(storage: AppendAttemptStorage | null): AppendAttemptStorage {
+  const memory = new Map<string, string | null>();
+  return {
+    getItem: (key) => {
+      if (memory.has(key)) return memory.get(key) ?? null;
+      try {
+        const persisted = storage?.getItem(key);
+        if (persisted !== null && persisted !== undefined) return persisted;
+      } catch {
+        // Fall back to the in-memory copy.
+      }
+      return null;
+    },
+    setItem: (key, value) => {
+      memory.set(key, value);
+      try {
+        storage?.setItem(key, value);
+      } catch {
+        // The request can still proceed with the in-memory retry key.
+      }
+    },
+    removeItem: (key) => {
+      // A tombstone prevents a stale durable value from returning if cleanup
+      // itself is blocked by the browser.
+      memory.set(key, null);
+      try {
+        storage?.removeItem(key);
+      } catch {
+        // Best-effort cleanup; the tombstone keeps same-renderer reads safe.
+      }
+    },
+  };
+}
+
+interface AppendAttemptOptions {
+  userId: string;
+  orderId: number | string;
+  fingerprint: string;
+  createKey: () => string;
+  items: unknown[];
+  specialInstructions?: string;
+  orderNumber?: string;
+  now?: number;
+  maxAgeMs?: number;
+}
+
+/**
+ * Match the request shape used by POST /orders/:id/items. The fingerprint is
+ * local state only; the server still validates the actual request body against
+ * its Idempotency-Key record.
+ */
+export function buildAppendItemsFingerprint(
+  orderId: number | string,
+  items: unknown[],
+  specialInstructions?: string,
+): string {
+  return JSON.stringify({
+    order_id: String(orderId),
+    items,
+    special_instructions: specialInstructions || undefined,
+  });
+}
+
+function isValidIdempotencyKey(key: string): boolean {
+  return key.length > 0 && key.length <= 128 && /^[\x21-\x7e]+$/.test(key);
+}
+
+function isExpired(createdAt: number, now: number, maxAgeMs: number): boolean {
+  return !Number.isFinite(createdAt) || now - createdAt >= maxAgeMs;
+}
+
+function parseStoredAttempt(storage: AppendAttemptStorage, key: string, now: number, maxAgeMs: number): AppendAttempt | null {
+  const raw = storage.getItem(key);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<AppendAttempt>;
+    if (
+      !parsed
+      || typeof parsed.userId !== 'string'
+      || typeof parsed.orderId !== 'string'
+      || typeof parsed.fingerprint !== 'string'
+      || typeof parsed.idempotencyKey !== 'string'
+      || !isValidIdempotencyKey(parsed.idempotencyKey)
+      || !Array.isArray(parsed.items)
+      || (parsed.specialInstructions !== undefined && typeof parsed.specialInstructions !== 'string')
+      || (parsed.orderNumber !== undefined && typeof parsed.orderNumber !== 'string')
+      || typeof parsed.createdAt !== 'number'
+      || isExpired(parsed.createdAt, now, maxAgeMs)
+    ) {
+      storage.removeItem(key);
+      return null;
+    }
+    return parsed as AppendAttempt;
+  } catch {
+    storage.removeItem(key);
+    return null;
+  }
+}
+
+interface StoredAttempt {
+  attempt: AppendAttempt;
+  key: string;
+}
+
+function readUserAttempt(
+  storage: AppendAttemptStorage,
+  userId: string,
+  now: number,
+  maxAgeMs: number,
+): StoredAttempt | null {
+  const scopedKey = getAppendAttemptStorageKey(userId);
+  const scoped = parseStoredAttempt(storage, scopedKey, now, maxAgeMs);
+  if (scoped?.userId === userId) return { attempt: scoped, key: scopedKey };
+
+  // Migrate the pre-user-scoped key only when it belongs to this user. A
+  // different cashier's pending retry is deliberately left intact.
+  const legacy = parseStoredAttempt(storage, APPEND_ATTEMPT_STORAGE_KEY, now, maxAgeMs);
+  if (legacy?.userId !== userId) return null;
+  storage.setItem(scopedKey, JSON.stringify(legacy));
+  storage.removeItem(APPEND_ATTEMPT_STORAGE_KEY);
+  return { attempt: legacy, key: scopedKey };
+}
+
+/** Read a pending attempt for automatic recovery after a renderer reload. */
+export function readAppendAttempt(
+  storage: AppendAttemptStorage,
+  options: { userId: string; now?: number; maxAgeMs?: number },
+): AppendAttempt | null {
+  const now = options.now ?? Date.now();
+  const maxAgeMs = options.maxAgeMs ?? APPEND_ATTEMPT_MAX_AGE_MS;
+  return readUserAttempt(storage, options.userId, now, maxAgeMs)?.attempt || null;
+}
+
+/**
+ * Recover the durable attempt for the same logical append, or replace it with
+ * a new attempt when the order/cart fingerprint no longer matches. The caller
+ * must persist this result before sending the mutating request.
+ */
+export function getOrCreateAppendAttempt(
+  storage: AppendAttemptStorage,
+  options: AppendAttemptOptions,
+): AppendAttempt {
+  const now = options.now ?? Date.now();
+  const maxAgeMs = options.maxAgeMs ?? APPEND_ATTEMPT_MAX_AGE_MS;
+  const orderId = String(options.orderId);
+  const prior = readUserAttempt(storage, options.userId, now, maxAgeMs);
+
+  if (
+    prior
+    && prior.attempt.orderId === orderId
+    && prior.attempt.fingerprint === options.fingerprint
+  ) {
+    return prior.attempt;
+  }
+
+  if (prior) storage.removeItem(prior.key);
+
+  const idempotencyKey = options.createKey();
+  if (!isValidIdempotencyKey(idempotencyKey)) {
+    throw new Error('Unable to create a valid append idempotency key');
+  }
+
+  const attempt: AppendAttempt = {
+    userId: options.userId,
+    orderId,
+    fingerprint: options.fingerprint,
+    idempotencyKey,
+    items: options.items,
+    specialInstructions: options.specialInstructions,
+    orderNumber: options.orderNumber,
+    createdAt: now,
+  };
+  storage.setItem(getAppendAttemptStorageKey(options.userId), JSON.stringify(attempt));
+  return attempt;
+}
+
+/** Clear only after the mutating request has returned a confirmed response. */
+export function clearAppendAttempt(
+  storage: AppendAttemptStorage,
+  completedAttempt: Pick<AppendAttempt, 'userId' | 'idempotencyKey' | 'fingerprint'>,
+): void {
+  const key = getAppendAttemptStorageKey(completedAttempt.userId);
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return;
+    const current = JSON.parse(raw) as Partial<AppendAttempt>;
+    if (
+      current.idempotencyKey !== completedAttempt.idempotencyKey
+      || current.fingerprint !== completedAttempt.fingerprint
+    ) return;
+    storage.removeItem(key);
+  } catch {
+    // Storage cleanup is best effort; leaving the key is safe because a future
+    // matching request replays it and a changed/expired request replaces it.
+  }
+}

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -104,11 +104,40 @@ function isExpired(createdAt: number, now: number, maxAgeMs: number): boolean {
   return !Number.isFinite(createdAt) || now - createdAt >= maxAgeMs;
 }
 
+function normalizeAppendFingerprint(fingerprint: string): string | null {
+  try {
+    const payload = JSON.parse(fingerprint) as {
+      order_id?: unknown;
+      items?: unknown;
+      special_instructions?: unknown;
+    };
+    if (
+      (typeof payload.order_id !== 'string' && typeof payload.order_id !== 'number')
+      || !Array.isArray(payload.items)
+    ) return null;
+    return buildAppendItemsFingerprint(
+      String(payload.order_id),
+      payload.items,
+      typeof payload.special_instructions === 'string' ? payload.special_instructions || undefined : undefined,
+    );
+  } catch {
+    return null;
+  }
+}
+
 interface AppendAttemptCompletion {
   userId: string;
   idempotencyKey: string;
   fingerprint: string;
   completedAt: number;
+}
+
+function isCompletionRecord(value: Partial<AppendAttemptCompletion> & { completed?: unknown }): boolean {
+  return value.completed === true
+    && typeof value.userId === 'string'
+    && typeof value.idempotencyKey === 'string'
+    && typeof value.fingerprint === 'string'
+    && typeof value.completedAt === 'number';
 }
 
 function completedAttemptMatches(
@@ -172,53 +201,65 @@ export function migrateLegacyAppendAttempt(
   const raw = storage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
   if (!raw) return null;
 
+  let parsed: {
+    userId?: unknown;
+    fingerprint?: unknown;
+    idempotencyKey?: unknown;
+    createdAt?: unknown;
+  };
   try {
-    const parsed = JSON.parse(raw) as {
-      userId?: unknown;
-      fingerprint?: unknown;
-      idempotencyKey?: unknown;
-      createdAt?: unknown;
-    };
-    if (typeof parsed.userId !== 'string' || typeof parsed.fingerprint !== 'string') return null;
-    const payload = JSON.parse(parsed.fingerprint) as {
-      order_id?: unknown;
-      items?: unknown;
-      special_instructions?: unknown;
-    };
-    if (
-      (typeof payload.order_id !== 'string' && typeof payload.order_id !== 'number')
-      || !Array.isArray(payload.items)
-    ) return null;
-    if (typeof parsed.idempotencyKey !== 'string' || !isValidIdempotencyKey(parsed.idempotencyKey)) {
-      storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
-      return null;
-    }
-    const createdAt = typeof parsed.createdAt === 'number' ? parsed.createdAt : now;
-    if (isExpired(createdAt, now, maxAgeMs)) {
-      storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
-      return null;
-    }
-    const scopedKey = getAppendAttemptStorageKey(parsed.userId);
-    const existingScoped = storage.getItem(scopedKey);
-    const attempt: AppendAttempt = {
-      userId: parsed.userId,
-      orderId: String(payload.order_id),
-      fingerprint: buildAppendItemsFingerprint(
-        String(payload.order_id),
-        payload.items,
-        typeof payload.special_instructions === 'string' ? payload.special_instructions || undefined : undefined,
-      ),
-      idempotencyKey: parsed.idempotencyKey,
-      items: payload.items,
-      specialInstructions: typeof payload.special_instructions === 'string' ? payload.special_instructions || undefined : undefined,
-      createdAt,
-    };
-    if (!existingScoped) storage.setItem(scopedKey, JSON.stringify(attempt));
-    storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
-    return existingScoped ? null : attempt;
+    parsed = JSON.parse(raw);
   } catch {
     return null;
   }
+  if (typeof parsed.userId !== 'string' || typeof parsed.fingerprint !== 'string') return null;
+  const normalizedFingerprint = normalizeAppendFingerprint(parsed.fingerprint);
+  if (!normalizedFingerprint) return null;
+  if (typeof parsed.idempotencyKey !== 'string' || !isValidIdempotencyKey(parsed.idempotencyKey)) {
+    storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
+    return null;
+  }
+  const payload = JSON.parse(parsed.fingerprint) as {
+    order_id: string | number;
+    items: unknown[];
+    special_instructions?: unknown;
+  };
+  const createdAt = typeof parsed.createdAt === 'number' ? parsed.createdAt : now;
+  if (isExpired(createdAt, now, maxAgeMs)) {
+    storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
+    return null;
+  }
+  const scopedKey = getAppendAttemptStorageKey(parsed.userId);
+  const existingRaw = storage.getItem(scopedKey);
+  const attempt: AppendAttempt = {
+    userId: parsed.userId,
+    orderId: String(payload.order_id),
+    fingerprint: normalizedFingerprint,
+    idempotencyKey: parsed.idempotencyKey,
+    items: payload.items,
+    specialInstructions: typeof payload.special_instructions === 'string' ? payload.special_instructions || undefined : undefined,
+    createdAt,
+  };
+  if (existingRaw !== null) {
+    let existing: Partial<AppendAttempt> | null = null;
+    try { existing = JSON.parse(existingRaw) as Partial<AppendAttempt>; } catch { existing = null; }
+    const equivalent = !!existing
+      && existing.userId === attempt.userId
+      && String(existing.orderId) === attempt.orderId
+      && existing.idempotencyKey === attempt.idempotencyKey
+      && typeof existing.fingerprint === 'string'
+      && normalizeAppendFingerprint(existing.fingerprint) === attempt.fingerprint
+      && Array.isArray(existing.items)
+      && JSON.stringify(existing.items) === JSON.stringify(attempt.items)
+      && (existing.specialInstructions || undefined) === (attempt.specialInstructions || undefined)
+      && typeof existing.createdAt === 'number';
+    if (!equivalent) throw new Error('Unable to migrate legacy append retry state safely');
+  }
+  if (existingRaw === null) storage.setItem(scopedKey, JSON.stringify(attempt));
+  if (storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY) === false) {
+    throw new Error('Unable to complete legacy append retry migration');
+  }
+  return attempt;
 }
 
 function parseStoredAttempt(storage: AppendAttemptStorage, key: string, now: number, maxAgeMs: number): AppendAttempt | null {
@@ -227,6 +268,7 @@ function parseStoredAttempt(storage: AppendAttemptStorage, key: string, now: num
 
   try {
     const parsed = JSON.parse(raw) as Partial<AppendAttempt>;
+    if (isCompletionRecord(parsed as Partial<AppendAttemptCompletion> & { completed?: unknown })) return null;
     if (
       !parsed
       || typeof parsed.userId !== 'string'
@@ -349,17 +391,27 @@ export function clearAppendAttempt(
       || current.fingerprint !== completedAttempt.fingerprint
     ) return;
     const markerKey = getAppendAttemptCompletionStorageKey(completedAttempt.userId);
+    const completionRecord = {
+      completed: true,
+      userId: completedAttempt.userId,
+      idempotencyKey: completedAttempt.idempotencyKey,
+      fingerprint: completedAttempt.fingerprint,
+      completedAt: Date.now(),
+    };
     let markerPersisted = false;
     try {
-      storage.setItem(markerKey, JSON.stringify({
-        userId: completedAttempt.userId,
-        idempotencyKey: completedAttempt.idempotencyKey,
-        fingerprint: completedAttempt.fingerprint,
-        completedAt: Date.now(),
-      }));
+      storage.setItem(markerKey, JSON.stringify(completionRecord));
       markerPersisted = true;
     } catch {
       markerPersisted = false;
+    }
+    if (!markerPersisted) {
+      try {
+        storage.setItem(key, JSON.stringify(completionRecord));
+        markerPersisted = true;
+      } catch {
+        markerPersisted = false;
+      }
     }
     const removed = storage.removeItem(key);
     if (removed !== false && storage.getItem(key) === null && markerPersisted) storage.removeItem(markerKey);

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -80,12 +80,16 @@ export interface AppendAttemptStorage {
   getItem: (key: string) => string | null;
   setItem: (key: string, value: string) => void;
   removeItem: (key: string) => void | boolean;
+  hasUnverifiedRead?: (key: string) => boolean;
+  hasUnverifiedRemoval?: (key: string) => boolean;
 }
 
-export function createCookieAppendAttemptStorage(): AppendAttemptStorage | null {
+function createCookieCompletionStorage(): AppendAttemptStorage | null {
   if (typeof document === 'undefined') return null;
   const cookieName = (key: string) => `${APPEND_ATTEMPT_COOKIE_PREFIX}${encodeURIComponent(key)}`;
+  const isCompletionKey = (key: string) => key.includes(APPEND_ATTEMPT_COMPLETION_COOKIE_SUFFIX);
   const readCookie = (key: string): string | null => {
+    if (!isCompletionKey(key)) return null;
     const name = `${cookieName(key)}=`;
     const entry = document.cookie.split('; ').find((value) => value.startsWith(name));
     return entry ? decodeURIComponent(entry.slice(name.length)) : null;
@@ -93,10 +97,12 @@ export function createCookieAppendAttemptStorage(): AppendAttemptStorage | null 
   return {
     getItem: readCookie,
     setItem: (key, value) => {
+      if (!isCompletionKey(key)) throw new Error('Invalid append completion cookie key');
       document.cookie = `${cookieName(key)}=${encodeURIComponent(value)}; Max-Age=172800; Path=/; SameSite=Strict`;
       if (readCookie(key) !== value) throw new Error('Append retry state was not persisted');
     },
     removeItem: (key) => {
+      if (!isCompletionKey(key)) return false;
       document.cookie = `${cookieName(key)}=; Max-Age=0; Path=/; SameSite=Strict`;
       return readCookie(key) === null;
     },
@@ -109,9 +115,12 @@ export function createSafeAppendAttemptStorage(
   ...fallbackStorages: Array<AppendAttemptStorage | null>
 ): AppendAttemptStorage {
   const memory = new Map<string, string | null>();
+  const unverifiedReads = new Set<string>();
+  const unverifiedRemovals = new Set<string>();
   const stores = [storage, ...fallbackStorages].filter((candidate, index, all) => candidate && all.indexOf(candidate) === index) as AppendAttemptStorage[];
   const readPersisted = (key: string): string | null => {
     let value: string | undefined;
+    let unavailable = false;
     for (const candidate of stores) {
       try {
         const persisted = candidate.getItem(key);
@@ -120,8 +129,11 @@ export function createSafeAppendAttemptStorage(
         value = persisted;
       } catch (error) {
         if (error instanceof Error && error.message === 'Conflicting append retry state') throw error;
+        unavailable = true;
       }
     }
+    if (unavailable) unverifiedReads.add(key);
+    else unverifiedReads.delete(key);
     return value ?? null;
   };
   return {
@@ -144,6 +156,7 @@ export function createSafeAppendAttemptStorage(
         throw new Error('Unable to persist append retry state');
       }
       if (readPersisted(key) !== value) throw new Error('Conflicting append retry state');
+      unverifiedRemovals.delete(key);
       try {
         memory.set(key, value);
       } catch {
@@ -155,17 +168,24 @@ export function createSafeAppendAttemptStorage(
       // itself is blocked by the browser.
       memory.set(key, null);
       if (stores.length === 0) return false;
-      let removed = true;
+      let removed = false;
+      let remaining = false;
+      let unavailable = false;
       for (const candidate of stores) {
         try {
           candidate.removeItem(key);
-          if (candidate.getItem(key) !== null) removed = false;
+          if (candidate.getItem(key) === null) removed = true;
+          else remaining = true;
         } catch {
-          removed = false;
+          unavailable = true;
         }
       }
-      return removed;
+      if (unavailable) unverifiedRemovals.add(key);
+      else unverifiedRemovals.delete(key);
+      return removed && !remaining;
     },
+    hasUnverifiedRead: (key) => unverifiedReads.has(key),
+    hasUnverifiedRemoval: (key) => unverifiedRemovals.has(key),
   };
 }
 
@@ -223,11 +243,19 @@ function persistCompletionRecord(
   } catch (error) {
     void error;
   }
-  const cookieStorage = createCookieAppendAttemptStorage();
+  const cookieStorage = createCookieCompletionStorage();
   if (!cookieStorage) return false;
   try {
-    cookieStorage.setItem(cookieKey, value);
-    return cookieStorage.getItem(cookieKey) === value;
+    const completion = JSON.parse(value) as Partial<AppendAttemptCompletion> & { completed?: boolean };
+    const cookieValue = JSON.stringify({
+      completed: completion.completed,
+      userId: completion.userId,
+      idempotencyKey: completion.idempotencyKey,
+      fingerprintHash: getFingerprintHash(completion.fingerprint || ''),
+      completedAt: completion.completedAt,
+    });
+    cookieStorage.setItem(cookieKey, cookieValue);
+    return cookieStorage.getItem(cookieKey) === cookieValue;
   } catch {
     return false;
   }
@@ -257,7 +285,8 @@ function normalizeAppendFingerprint(fingerprint: string): string | null {
 interface AppendAttemptCompletion {
   userId: string;
   idempotencyKey: string;
-  fingerprint: string;
+  fingerprint?: string;
+  fingerprintHash?: string;
   completedAt: number;
 }
 
@@ -272,8 +301,21 @@ function isCompletionRecord(value: Partial<AppendAttemptCompletion> & { complete
   return value.completed === true
     && typeof value.userId === 'string'
     && typeof value.idempotencyKey === 'string'
-    && typeof value.fingerprint === 'string'
+    && (typeof value.fingerprint === 'string' || typeof value.fingerprintHash === 'string')
     && typeof value.completedAt === 'number';
+}
+
+function readCompletionRecord(storage: AppendAttemptStorage, key: string): string | null {
+  if (key.includes(APPEND_ATTEMPT_COMPLETION_COOKIE_SUFFIX)) return createCookieCompletionStorage()?.getItem(key) ?? null;
+  return storage.getItem(key);
+}
+
+function removeCompletionRecord(storage: AppendAttemptStorage, key: string): void {
+  if (key.includes(APPEND_ATTEMPT_COMPLETION_COOKIE_SUFFIX)) {
+    createCookieCompletionStorage()?.removeItem(key);
+    return;
+  }
+  storage.removeItem(key);
 }
 
 function completedAttemptMatches(
@@ -284,15 +326,25 @@ function completedAttemptMatches(
 ): boolean {
   const raw = storage.getItem(attemptKey);
   if (!raw) {
-    storage.removeItem(completionKey);
+    if (storage.hasUnverifiedRead?.(attemptKey)) return true;
+    removeCompletionRecord(storage, completionKey);
     return true;
   }
   try {
     const current = JSON.parse(raw) as Partial<AppendAttempt>;
-    if (current.idempotencyKey !== completion.idempotencyKey || current.fingerprint !== completion.fingerprint) return false;
+    if (
+      current.idempotencyKey !== completion.idempotencyKey
+      || (typeof completion.fingerprint === 'string'
+        ? current.fingerprint !== completion.fingerprint
+        : getFingerprintHash(current.fingerprint || '') !== completion.fingerprintHash)
+    ) return false;
     const removed = storage.removeItem(attemptKey);
-    if (removed !== false && storage.getItem(attemptKey) === null) {
-      storage.removeItem(completionKey);
+    if (
+      removed !== false
+      && storage.getItem(attemptKey) === null
+      && !storage.hasUnverifiedRemoval?.(attemptKey)
+    ) {
+      removeCompletionRecord(storage, completionKey);
     }
     return true;
   } catch {
@@ -313,7 +365,7 @@ function hasCompletedAttempt(
     getAppendAttemptCompletionCookieStorageKey(userId),
   ];
   for (const completionKey of completionKeys) {
-    const raw = storage.getItem(completionKey);
+    const raw = readCompletionRecord(storage, completionKey);
     if (!raw) continue;
     try {
       const completion = JSON.parse(raw) as Partial<AppendAttemptCompletion>;
@@ -321,16 +373,16 @@ function hasCompletedAttempt(
         completion.userId !== userId
         || typeof completion.idempotencyKey !== 'string'
         || !isValidIdempotencyKey(completion.idempotencyKey)
-        || typeof completion.fingerprint !== 'string'
+        || (typeof completion.fingerprint !== 'string' && typeof completion.fingerprintHash !== 'string')
         || typeof completion.completedAt !== 'number'
         || isExpired(completion.completedAt, now, maxAgeMs)
       ) {
-        storage.removeItem(completionKey);
+        removeCompletionRecord(storage, completionKey);
         continue;
       }
       if (completedAttemptMatches(storage, attemptKey, completionKey, completion as AppendAttemptCompletion)) return true;
     } catch {
-      storage.removeItem(completionKey);
+      removeCompletionRecord(storage, completionKey);
     }
   }
   return false;
@@ -406,8 +458,25 @@ export function migrateLegacyAppendAttempt(
       if (options.userId === parsed.userId) throw new LegacyAppendAttemptConflictError();
       return attempt;
     }
+    const existingCreatedAt = existing?.createdAt as number;
+    const selectedAttempt: AppendAttempt = {
+      ...attempt,
+      createdAt: !isExpired(existingCreatedAt, now, maxAgeMs) && existingCreatedAt > attempt.createdAt
+        ? existingCreatedAt
+        : attempt.createdAt,
+      orderNumber: typeof existing?.orderNumber === 'string' ? existing.orderNumber : attempt.orderNumber,
+    };
+    const serializedSelectedAttempt = JSON.stringify(selectedAttempt);
+    storage.setItem(scopedKey, serializedSelectedAttempt);
+    if (storage.getItem(scopedKey) !== serializedSelectedAttempt) throw new Error('Unable to complete legacy append retry migration');
+    if (!removeAndVerify(storage, LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY)) {
+      throw new Error('Unable to complete legacy append retry migration');
+    }
+    return selectedAttempt;
   }
-  if (existingRaw === null) storage.setItem(scopedKey, JSON.stringify(attempt));
+  const serializedAttempt = JSON.stringify(attempt);
+  storage.setItem(scopedKey, serializedAttempt);
+  if (storage.getItem(scopedKey) !== serializedAttempt) throw new Error('Unable to complete legacy append retry migration');
   if (!removeAndVerify(storage, LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY)) {
     throw new Error('Unable to complete legacy append retry migration');
   }
@@ -608,10 +677,15 @@ export function clearAppendAttempt(
       pruneConfirmedAppendTombstones(Date.now(), APPEND_ATTEMPT_MAX_AGE_MS);
     }
     const removed = storage.removeItem(key);
-    if (removed !== false && storage.getItem(key) === null && markerPersisted) {
+    if (
+      removed !== false
+      && storage.getItem(key) === null
+      && markerPersisted
+      && !storage.hasUnverifiedRemoval?.(key)
+    ) {
       storage.removeItem(markerKey);
       storage.removeItem(retryKey);
-      storage.removeItem(cookieKey);
+      removeCompletionRecord(storage, cookieKey);
     }
     return markerPersisted || (removed !== false && storage.getItem(key) === null);
   } catch {

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -3,19 +3,44 @@ export const LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY = 'flo.postpaid.order.attempt';
 export const APPEND_ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const APPEND_ATTEMPT_USER_SUFFIX = '.user.';
 const APPEND_ATTEMPT_COMPLETION_SUFFIX = '.completion.';
-const confirmedAppendTombstones = new Map<string, number>();
+const CONFIRMED_APPEND_TOMBSTONE_LIMIT = 256;
+const confirmedAppendTombstones = new Map<string, { completedAt: number; fingerprintHash: string }>();
 const APPEND_ATTEMPT_COOKIE_PREFIX = 'flo_append_attempt.';
 
 export function getAppendAttemptStorageKey(userId: string): string {
   return `${APPEND_ATTEMPT_STORAGE_KEY}${APPEND_ATTEMPT_USER_SUFFIX}${encodeURIComponent(userId)}`;
 }
 
+export function getPostpaidOrderAttemptStorageKey(userId: string): string {
+  return `${LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY}${APPEND_ATTEMPT_USER_SUFFIX}${encodeURIComponent(userId)}`;
+}
+
 function getAppendAttemptCompletionStorageKey(userId: string): string {
   return `${APPEND_ATTEMPT_STORAGE_KEY}${APPEND_ATTEMPT_COMPLETION_SUFFIX}${encodeURIComponent(userId)}`;
 }
 
-function getConfirmedAppendTombstoneKey(userId: string, idempotencyKey: string, fingerprint: string): string {
-  return `${userId}\u0000${idempotencyKey}\u0000${fingerprint}`;
+function getConfirmedAppendTombstoneKey(userId: string, idempotencyKey: string): string {
+  return `${userId}\u0000${idempotencyKey}`;
+}
+
+function getFingerprintHash(fingerprint: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < fingerprint.length; index += 1) {
+    hash ^= fingerprint.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+function pruneConfirmedAppendTombstones(now: number, maxAgeMs: number): void {
+  for (const [key, tombstone] of confirmedAppendTombstones) {
+    if (isExpired(tombstone.completedAt, now, maxAgeMs)) confirmedAppendTombstones.delete(key);
+  }
+  while (confirmedAppendTombstones.size > CONFIRMED_APPEND_TOMBSTONE_LIMIT) {
+    const oldest = confirmedAppendTombstones.keys().next().value;
+    if (oldest === undefined) break;
+    confirmedAppendTombstones.delete(oldest);
+  }
 }
 
 function hasConfirmedAppendTombstone(
@@ -25,14 +50,9 @@ function hasConfirmedAppendTombstone(
   now: number,
   maxAgeMs: number,
 ): boolean {
-  const key = getConfirmedAppendTombstoneKey(userId, idempotencyKey, fingerprint);
-  const completedAt = confirmedAppendTombstones.get(key);
-  if (completedAt === undefined) return false;
-  if (isExpired(completedAt, now, maxAgeMs)) {
-    confirmedAppendTombstones.delete(key);
-    return false;
-  }
-  return true;
+  pruneConfirmedAppendTombstones(now, maxAgeMs);
+  const tombstone = confirmedAppendTombstones.get(getConfirmedAppendTombstoneKey(userId, idempotencyKey));
+  return tombstone?.fingerprintHash === getFingerprintHash(fingerprint);
 }
 
 export interface AppendAttempt {
@@ -178,7 +198,8 @@ function persistCompletionRecord(storage: AppendAttemptStorage, key: string, val
   try {
     storage.setItem(key, value);
     if (storage.getItem(key) === value) return true;
-  } catch {
+  } catch (error) {
+    void error;
   }
   const cookieStorage = createCookieAppendAttemptStorage();
   if (!cookieStorage) return false;
@@ -515,16 +536,16 @@ export function getOrCreateAppendAttempt(
 export function clearAppendAttempt(
   storage: AppendAttemptStorage,
   completedAttempt: Pick<AppendAttempt, 'userId' | 'idempotencyKey' | 'fingerprint'>,
-): void {
+): boolean {
   const key = getAppendAttemptStorageKey(completedAttempt.userId);
   try {
     const raw = storage.getItem(key);
-    if (!raw) return;
+    if (!raw) return true;
     const current = JSON.parse(raw) as Partial<AppendAttempt>;
     if (
       current.idempotencyKey !== completedAttempt.idempotencyKey
       || current.fingerprint !== completedAttempt.fingerprint
-    ) return;
+    ) return true;
     const markerKey = getAppendAttemptCompletionStorageKey(completedAttempt.userId);
     const completionRecord = {
       completed: true,
@@ -541,13 +562,15 @@ export function clearAppendAttempt(
     }
     if (markerPersisted) {
       confirmedAppendTombstones.set(
-        getConfirmedAppendTombstoneKey(completedAttempt.userId, completedAttempt.idempotencyKey, completedAttempt.fingerprint),
-        Date.now(),
+        getConfirmedAppendTombstoneKey(completedAttempt.userId, completedAttempt.idempotencyKey),
+        { completedAt: Date.now(), fingerprintHash: getFingerprintHash(completedAttempt.fingerprint) },
       );
+      pruneConfirmedAppendTombstones(Date.now(), APPEND_ATTEMPT_MAX_AGE_MS);
     }
     const removed = storage.removeItem(key);
     if (removed !== false && storage.getItem(key) === null && markerPersisted) storage.removeItem(markerKey);
+    return markerPersisted || (removed !== false && storage.getItem(key) === null);
   } catch {
-    return;
+    return false;
   }
 }

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -22,11 +22,7 @@ export interface AppendAttemptStorage {
   removeItem: (key: string) => void;
 }
 
-/**
- * Keep the append path compatible with renderers where localStorage is blocked
- * or full. The memory layer preserves same-renderer retries; durable storage
- * is best effort and is used whenever the browser permits it.
- */
+/** Wrap browser storage for append-attempt state. */
 export function createSafeAppendAttemptStorage(storage: AppendAttemptStorage | null): AppendAttemptStorage {
   const memory = new Map<string, string | null>();
   return {
@@ -41,11 +37,13 @@ export function createSafeAppendAttemptStorage(storage: AppendAttemptStorage | n
       return null;
     },
     setItem: (key, value) => {
-      memory.set(key, value);
+      if (!storage) throw new Error('Unable to persist append retry state');
       try {
-        storage?.setItem(key, value);
+        storage.setItem(key, value);
+        if (storage.getItem(key) !== value) throw new Error('Append retry state was not persisted');
+        memory.set(key, value);
       } catch {
-        // The request can still proceed with the in-memory retry key.
+        throw new Error('Unable to persist append retry state');
       }
     },
     removeItem: (key) => {

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -1,16 +1,17 @@
 export const APPEND_ATTEMPT_STORAGE_KEY = 'flo.pos.append-items.attempt';
 export const LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY = 'flo.postpaid.order.attempt';
 export const APPEND_ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
-const APPEND_ATTEMPT_COMPLETION_SUFFIX = '.completed';
+const APPEND_ATTEMPT_USER_SUFFIX = '.user.';
+const APPEND_ATTEMPT_COMPLETION_SUFFIX = '.completion.';
 const confirmedAppendTombstones = new Map<string, number>();
 const APPEND_ATTEMPT_COOKIE_PREFIX = 'flo_append_attempt.';
 
 export function getAppendAttemptStorageKey(userId: string): string {
-  return `${APPEND_ATTEMPT_STORAGE_KEY}.${encodeURIComponent(userId)}`;
+  return `${APPEND_ATTEMPT_STORAGE_KEY}${APPEND_ATTEMPT_USER_SUFFIX}${encodeURIComponent(userId)}`;
 }
 
 function getAppendAttemptCompletionStorageKey(userId: string): string {
-  return `${getAppendAttemptStorageKey(userId)}${APPEND_ATTEMPT_COMPLETION_SUFFIX}`;
+  return `${APPEND_ATTEMPT_STORAGE_KEY}${APPEND_ATTEMPT_COMPLETION_SUFFIX}${encodeURIComponent(userId)}`;
 }
 
 function getConfirmedAppendTombstoneKey(userId: string, idempotencyKey: string, fingerprint: string): string {
@@ -171,6 +172,22 @@ function isExpired(createdAt: number, now: number, maxAgeMs: number): boolean {
 function removeAndVerify(storage: AppendAttemptStorage, key: string): boolean {
   const removed = storage.removeItem(key);
   return removed !== false && storage.getItem(key) === null;
+}
+
+function persistCompletionRecord(storage: AppendAttemptStorage, key: string, value: string): boolean {
+  try {
+    storage.setItem(key, value);
+    if (storage.getItem(key) === value) return true;
+  } catch {
+  }
+  const cookieStorage = createCookieAppendAttemptStorage();
+  if (!cookieStorage) return false;
+  try {
+    cookieStorage.setItem(key, value);
+    return cookieStorage.getItem(key) === value;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeAppendFingerprint(fingerprint: string): string | null {
@@ -508,10 +525,6 @@ export function clearAppendAttempt(
       current.idempotencyKey !== completedAttempt.idempotencyKey
       || current.fingerprint !== completedAttempt.fingerprint
     ) return;
-    confirmedAppendTombstones.set(
-      getConfirmedAppendTombstoneKey(completedAttempt.userId, completedAttempt.idempotencyKey, completedAttempt.fingerprint),
-      Date.now(),
-    );
     const markerKey = getAppendAttemptCompletionStorageKey(completedAttempt.userId);
     const completionRecord = {
       completed: true,
@@ -521,19 +534,16 @@ export function clearAppendAttempt(
       completedAt: Date.now(),
     };
     let markerPersisted = false;
-    try {
-      storage.setItem(markerKey, JSON.stringify(completionRecord));
-      markerPersisted = true;
-    } catch {
-      markerPersisted = false;
-    }
+    const serializedCompletion = JSON.stringify(completionRecord);
+    markerPersisted = persistCompletionRecord(storage, markerKey, serializedCompletion);
     if (!markerPersisted) {
-      try {
-        storage.setItem(key, JSON.stringify(completionRecord));
-        markerPersisted = true;
-      } catch {
-        markerPersisted = false;
-      }
+      markerPersisted = persistCompletionRecord(storage, key, serializedCompletion);
+    }
+    if (markerPersisted) {
+      confirmedAppendTombstones.set(
+        getConfirmedAppendTombstoneKey(completedAttempt.userId, completedAttempt.idempotencyKey, completedAttempt.fingerprint),
+        Date.now(),
+      );
     }
     const removed = storage.removeItem(key);
     if (removed !== false && storage.getItem(key) === null && markerPersisted) storage.removeItem(markerKey);

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -3,6 +3,7 @@ export const LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY = 'flo.postpaid.order.attempt';
 export const APPEND_ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const APPEND_ATTEMPT_COMPLETION_SUFFIX = '.completed';
 const confirmedAppendTombstones = new Map<string, number>();
+const APPEND_ATTEMPT_COOKIE_PREFIX = 'flo_append_attempt.';
 
 export function getAppendAttemptStorageKey(userId: string): string {
   return `${APPEND_ATTEMPT_STORAGE_KEY}.${encodeURIComponent(userId)}`;
@@ -50,13 +51,34 @@ export interface AppendAttemptStorage {
   removeItem: (key: string) => void | boolean;
 }
 
+export function createCookieAppendAttemptStorage(): AppendAttemptStorage | null {
+  if (typeof document === 'undefined') return null;
+  const cookieName = (key: string) => `${APPEND_ATTEMPT_COOKIE_PREFIX}${encodeURIComponent(key)}`;
+  const readCookie = (key: string): string | null => {
+    const name = `${cookieName(key)}=`;
+    const entry = document.cookie.split('; ').find((value) => value.startsWith(name));
+    return entry ? decodeURIComponent(entry.slice(name.length)) : null;
+  };
+  return {
+    getItem: readCookie,
+    setItem: (key, value) => {
+      document.cookie = `${cookieName(key)}=${encodeURIComponent(value)}; Max-Age=172800; Path=/; SameSite=Strict`;
+      if (readCookie(key) !== value) throw new Error('Append retry state was not persisted');
+    },
+    removeItem: (key) => {
+      document.cookie = `${cookieName(key)}=; Max-Age=0; Path=/; SameSite=Strict`;
+      return readCookie(key) === null;
+    },
+  };
+}
+
 /** Wrap browser storage for append-attempt state. */
 export function createSafeAppendAttemptStorage(
   storage: AppendAttemptStorage | null,
-  fallbackStorage: AppendAttemptStorage | null = null,
+  ...fallbackStorages: Array<AppendAttemptStorage | null>
 ): AppendAttemptStorage {
   const memory = new Map<string, string | null>();
-  const stores = [storage, fallbackStorage].filter((candidate, index, all) => candidate && all.indexOf(candidate) === index) as AppendAttemptStorage[];
+  const stores = [storage, ...fallbackStorages].filter((candidate, index, all) => candidate && all.indexOf(candidate) === index) as AppendAttemptStorage[];
   return {
     getItem: (key) => {
       if (memory.has(key)) return memory.get(key) ?? null;
@@ -179,6 +201,13 @@ interface AppendAttemptCompletion {
   completedAt: number;
 }
 
+export class LegacyAppendAttemptConflictError extends Error {
+  constructor() {
+    super('A legacy append retry conflicts with the owner-scoped retry');
+    this.name = 'LegacyAppendAttemptConflictError';
+  }
+}
+
 function isCompletionRecord(value: Partial<AppendAttemptCompletion> & { completed?: unknown }): boolean {
   return value.completed === true
     && typeof value.userId === 'string'
@@ -241,7 +270,7 @@ function hasCompletedAttempt(
 
 export function migrateLegacyAppendAttempt(
   storage: AppendAttemptStorage,
-  options: { now?: number; maxAgeMs?: number } = {},
+  options: { now?: number; maxAgeMs?: number; userId?: string } = {},
 ): AppendAttempt | null {
   const now = options.now ?? Date.now();
   const maxAgeMs = options.maxAgeMs ?? APPEND_ATTEMPT_MAX_AGE_MS;
@@ -257,6 +286,11 @@ export function migrateLegacyAppendAttempt(
   try {
     parsed = JSON.parse(raw);
   } catch {
+    storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
     return null;
   }
   if (typeof parsed.userId !== 'string' || typeof parsed.fingerprint !== 'string') return null;
@@ -300,7 +334,10 @@ export function migrateLegacyAppendAttempt(
       && JSON.stringify(existing.items) === JSON.stringify(attempt.items)
       && (existing.specialInstructions || undefined) === (attempt.specialInstructions || undefined)
       && typeof existing.createdAt === 'number';
-    if (!equivalent) return attempt;
+    if (!equivalent) {
+      if (options.userId === parsed.userId) throw new LegacyAppendAttemptConflictError();
+      return attempt;
+    }
   }
   if (existingRaw === null) storage.setItem(scopedKey, JSON.stringify(attempt));
   if (!removeAndVerify(storage, LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY)) {
@@ -378,7 +415,12 @@ function readUserAttempt(
   maxAgeMs: number,
 ): StoredAttempt | null {
   const scopedKey = getAppendAttemptStorageKey(userId);
-  const migrated = migrateLegacyAppendAttempt(storage, { now, maxAgeMs });
+  let migrated: AppendAttempt | null = null;
+  try {
+    migrated = migrateLegacyAppendAttempt(storage, { now, maxAgeMs, userId });
+  } catch (error) {
+    if (!(error instanceof LegacyAppendAttemptConflictError)) throw error;
+  }
   if (hasCompletedAttempt(storage, userId, now, maxAgeMs)) return null;
   const scoped = parseStoredAttempt(storage, scopedKey, now, maxAgeMs);
   if (scoped && hasConfirmedAppendTombstone(userId, scoped.idempotencyKey, scoped.fingerprint, now, maxAgeMs)) return null;

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -162,9 +162,8 @@ export function readAppendAttempt(
 }
 
 /**
- * Recover the durable attempt for the same logical append, or replace it with
- * a new attempt when the order/cart fingerprint no longer matches. The caller
- * must persist this result before sending the mutating request.
+ * Recover the durable attempt for the same logical append. A conflicting
+ * pending attempt is retained until it is completed or expires.
  */
 export function getOrCreateAppendAttempt(
   storage: AppendAttemptStorage,
@@ -183,7 +182,9 @@ export function getOrCreateAppendAttempt(
     return prior.attempt;
   }
 
-  if (prior) storage.removeItem(prior.key);
+  if (prior) {
+    throw new Error('A previous append attempt is still pending');
+  }
 
   const idempotencyKey = options.createKey();
   if (!isValidIdempotencyKey(idempotencyKey)) {

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -163,12 +163,12 @@ function hasCompletedAttempt(
   }
 }
 
-function migrateLegacyPostpaidAppendAttempt(
+export function migrateLegacyAppendAttempt(
   storage: AppendAttemptStorage,
-  userId: string,
-  now: number,
-  maxAgeMs: number,
-): StoredAttempt | null {
+  options: { now?: number; maxAgeMs?: number } = {},
+): AppendAttempt | null {
+  const now = options.now ?? Date.now();
+  const maxAgeMs = options.maxAgeMs ?? APPEND_ATTEMPT_MAX_AGE_MS;
   const raw = storage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
   if (!raw) return null;
 
@@ -179,7 +179,7 @@ function migrateLegacyPostpaidAppendAttempt(
       idempotencyKey?: unknown;
       createdAt?: unknown;
     };
-    if (parsed.userId !== userId || typeof parsed.fingerprint !== 'string') return null;
+    if (typeof parsed.userId !== 'string' || typeof parsed.fingerprint !== 'string') return null;
     const payload = JSON.parse(parsed.fingerprint) as {
       order_id?: unknown;
       items?: unknown;
@@ -198,19 +198,24 @@ function migrateLegacyPostpaidAppendAttempt(
       storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
       return null;
     }
+    const scopedKey = getAppendAttemptStorageKey(parsed.userId);
+    const existingScoped = storage.getItem(scopedKey);
     const attempt: AppendAttempt = {
-      userId,
+      userId: parsed.userId,
       orderId: String(payload.order_id),
-      fingerprint: parsed.fingerprint,
+      fingerprint: buildAppendItemsFingerprint(
+        String(payload.order_id),
+        payload.items,
+        typeof payload.special_instructions === 'string' ? payload.special_instructions || undefined : undefined,
+      ),
       idempotencyKey: parsed.idempotencyKey,
       items: payload.items,
-      specialInstructions: typeof payload.special_instructions === 'string' ? payload.special_instructions : undefined,
+      specialInstructions: typeof payload.special_instructions === 'string' ? payload.special_instructions || undefined : undefined,
       createdAt,
     };
-    const scopedKey = getAppendAttemptStorageKey(userId);
-    storage.setItem(scopedKey, JSON.stringify(attempt));
+    if (!existingScoped) storage.setItem(scopedKey, JSON.stringify(attempt));
     storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
-    return { attempt, key: scopedKey };
+    return existingScoped ? null : attempt;
   } catch {
     return null;
   }
@@ -257,6 +262,7 @@ function readUserAttempt(
   maxAgeMs: number,
 ): StoredAttempt | null {
   const scopedKey = getAppendAttemptStorageKey(userId);
+  const migrated = migrateLegacyAppendAttempt(storage, { now, maxAgeMs });
   if (hasCompletedAttempt(storage, userId, now, maxAgeMs)) return null;
   const scoped = parseStoredAttempt(storage, scopedKey, now, maxAgeMs);
   if (scoped?.userId === userId) return { attempt: scoped, key: scopedKey };
@@ -270,7 +276,8 @@ function readUserAttempt(
     return { attempt: legacy, key: scopedKey };
   }
 
-  return migrateLegacyPostpaidAppendAttempt(storage, userId, now, maxAgeMs);
+  if (migrated?.userId === userId) return { attempt: migrated, key: scopedKey };
+  return null;
 }
 
 /** Read a pending attempt for automatic recovery after a renderer reload. */

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -2,6 +2,7 @@ export const APPEND_ATTEMPT_STORAGE_KEY = 'flo.pos.append-items.attempt';
 export const LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY = 'flo.postpaid.order.attempt';
 export const APPEND_ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const APPEND_ATTEMPT_COMPLETION_SUFFIX = '.completed';
+const confirmedAppendTombstones = new Map<string, number>();
 
 export function getAppendAttemptStorageKey(userId: string): string {
   return `${APPEND_ATTEMPT_STORAGE_KEY}.${encodeURIComponent(userId)}`;
@@ -9,6 +10,27 @@ export function getAppendAttemptStorageKey(userId: string): string {
 
 function getAppendAttemptCompletionStorageKey(userId: string): string {
   return `${getAppendAttemptStorageKey(userId)}${APPEND_ATTEMPT_COMPLETION_SUFFIX}`;
+}
+
+function getConfirmedAppendTombstoneKey(userId: string, idempotencyKey: string, fingerprint: string): string {
+  return `${userId}\u0000${idempotencyKey}\u0000${fingerprint}`;
+}
+
+function hasConfirmedAppendTombstone(
+  userId: string,
+  idempotencyKey: string,
+  fingerprint: string,
+  now: number,
+  maxAgeMs: number,
+): boolean {
+  const key = getConfirmedAppendTombstoneKey(userId, idempotencyKey, fingerprint);
+  const completedAt = confirmedAppendTombstones.get(key);
+  if (completedAt === undefined) return false;
+  if (isExpired(completedAt, now, maxAgeMs)) {
+    confirmedAppendTombstones.delete(key);
+    return false;
+  }
+  return true;
 }
 
 export interface AppendAttempt {
@@ -359,6 +381,7 @@ function readUserAttempt(
   const migrated = migrateLegacyAppendAttempt(storage, { now, maxAgeMs });
   if (hasCompletedAttempt(storage, userId, now, maxAgeMs)) return null;
   const scoped = parseStoredAttempt(storage, scopedKey, now, maxAgeMs);
+  if (scoped && hasConfirmedAppendTombstone(userId, scoped.idempotencyKey, scoped.fingerprint, now, maxAgeMs)) return null;
   const legacy = parseStoredAttempt(storage, APPEND_ATTEMPT_STORAGE_KEY, now, maxAgeMs);
   if (legacy?.userId === userId) {
     if (scoped && scoped.userId === userId && !appendAttemptsMatch(scoped, legacy)) return { attempt: scoped, key: scopedKey };
@@ -443,6 +466,10 @@ export function clearAppendAttempt(
       current.idempotencyKey !== completedAttempt.idempotencyKey
       || current.fingerprint !== completedAttempt.fingerprint
     ) return;
+    confirmedAppendTombstones.set(
+      getConfirmedAppendTombstoneKey(completedAttempt.userId, completedAttempt.idempotencyKey, completedAttempt.fingerprint),
+      Date.now(),
+    );
     const markerKey = getAppendAttemptCompletionStorageKey(completedAttempt.userId);
     const completionRecord = {
       completed: true,

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -1,8 +1,14 @@
 export const APPEND_ATTEMPT_STORAGE_KEY = 'flo.pos.append-items.attempt';
+export const LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY = 'flo.postpaid.order.attempt';
 export const APPEND_ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const APPEND_ATTEMPT_COMPLETION_SUFFIX = '.completed';
 
 export function getAppendAttemptStorageKey(userId: string): string {
   return `${APPEND_ATTEMPT_STORAGE_KEY}.${encodeURIComponent(userId)}`;
+}
+
+function getAppendAttemptCompletionStorageKey(userId: string): string {
+  return `${getAppendAttemptStorageKey(userId)}${APPEND_ATTEMPT_COMPLETION_SUFFIX}`;
 }
 
 export interface AppendAttempt {
@@ -19,7 +25,7 @@ export interface AppendAttempt {
 export interface AppendAttemptStorage {
   getItem: (key: string) => string | null;
   setItem: (key: string, value: string) => void;
-  removeItem: (key: string) => void;
+  removeItem: (key: string) => void | boolean;
 }
 
 /** Wrap browser storage for append-attempt state. */
@@ -50,10 +56,12 @@ export function createSafeAppendAttemptStorage(storage: AppendAttemptStorage | n
       // A tombstone prevents a stale durable value from returning if cleanup
       // itself is blocked by the browser.
       memory.set(key, null);
+      if (!storage) return false;
       try {
-        storage?.removeItem(key);
+        storage.removeItem(key);
+        return storage.getItem(key) === null;
       } catch {
-        // Best-effort cleanup; the tombstone keeps same-renderer reads safe.
+        return false;
       }
     },
   };
@@ -94,6 +102,118 @@ function isValidIdempotencyKey(key: string): boolean {
 
 function isExpired(createdAt: number, now: number, maxAgeMs: number): boolean {
   return !Number.isFinite(createdAt) || now - createdAt >= maxAgeMs;
+}
+
+interface AppendAttemptCompletion {
+  userId: string;
+  idempotencyKey: string;
+  fingerprint: string;
+  completedAt: number;
+}
+
+function completedAttemptMatches(
+  storage: AppendAttemptStorage,
+  attemptKey: string,
+  completion: AppendAttemptCompletion,
+): boolean {
+  const raw = storage.getItem(attemptKey);
+  if (!raw) {
+    storage.removeItem(getAppendAttemptCompletionStorageKey(completion.userId));
+    return true;
+  }
+  try {
+    const current = JSON.parse(raw) as Partial<AppendAttempt>;
+    if (current.idempotencyKey !== completion.idempotencyKey || current.fingerprint !== completion.fingerprint) return false;
+    const removed = storage.removeItem(attemptKey);
+    if (removed !== false && storage.getItem(attemptKey) === null) {
+      storage.removeItem(getAppendAttemptCompletionStorageKey(completion.userId));
+    }
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+function hasCompletedAttempt(
+  storage: AppendAttemptStorage,
+  userId: string,
+  now: number,
+  maxAgeMs: number,
+): boolean {
+  const markerKey = getAppendAttemptCompletionStorageKey(userId);
+  const raw = storage.getItem(markerKey);
+  if (!raw) return false;
+  try {
+    const completion = JSON.parse(raw) as Partial<AppendAttemptCompletion>;
+    if (
+      completion.userId !== userId
+      || typeof completion.idempotencyKey !== 'string'
+      || !isValidIdempotencyKey(completion.idempotencyKey)
+      || typeof completion.fingerprint !== 'string'
+      || typeof completion.completedAt !== 'number'
+      || isExpired(completion.completedAt, now, maxAgeMs)
+    ) {
+      storage.removeItem(markerKey);
+      return false;
+    }
+    return completedAttemptMatches(storage, getAppendAttemptStorageKey(userId), completion as AppendAttemptCompletion);
+  } catch {
+    storage.removeItem(markerKey);
+    return false;
+  }
+}
+
+function migrateLegacyPostpaidAppendAttempt(
+  storage: AppendAttemptStorage,
+  userId: string,
+  now: number,
+  maxAgeMs: number,
+): StoredAttempt | null {
+  const raw = storage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as {
+      userId?: unknown;
+      fingerprint?: unknown;
+      idempotencyKey?: unknown;
+      createdAt?: unknown;
+    };
+    if (parsed.userId !== userId || typeof parsed.fingerprint !== 'string') return null;
+    const payload = JSON.parse(parsed.fingerprint) as {
+      order_id?: unknown;
+      items?: unknown;
+      special_instructions?: unknown;
+    };
+    if (
+      (typeof payload.order_id !== 'string' && typeof payload.order_id !== 'number')
+      || !Array.isArray(payload.items)
+    ) return null;
+    if (typeof parsed.idempotencyKey !== 'string' || !isValidIdempotencyKey(parsed.idempotencyKey)) {
+      storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
+      return null;
+    }
+    const createdAt = typeof parsed.createdAt === 'number' ? parsed.createdAt : now;
+    if (isExpired(createdAt, now, maxAgeMs)) {
+      storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
+      return null;
+    }
+    const attempt: AppendAttempt = {
+      userId,
+      orderId: String(payload.order_id),
+      fingerprint: parsed.fingerprint,
+      idempotencyKey: parsed.idempotencyKey,
+      items: payload.items,
+      specialInstructions: typeof payload.special_instructions === 'string' ? payload.special_instructions : undefined,
+      createdAt,
+    };
+    const scopedKey = getAppendAttemptStorageKey(userId);
+    storage.setItem(scopedKey, JSON.stringify(attempt));
+    storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY);
+    return { attempt, key: scopedKey };
+  } catch {
+    return null;
+  }
 }
 
 function parseStoredAttempt(storage: AppendAttemptStorage, key: string, now: number, maxAgeMs: number): AppendAttempt | null {
@@ -137,16 +257,20 @@ function readUserAttempt(
   maxAgeMs: number,
 ): StoredAttempt | null {
   const scopedKey = getAppendAttemptStorageKey(userId);
+  if (hasCompletedAttempt(storage, userId, now, maxAgeMs)) return null;
   const scoped = parseStoredAttempt(storage, scopedKey, now, maxAgeMs);
   if (scoped?.userId === userId) return { attempt: scoped, key: scopedKey };
 
   // Migrate the pre-user-scoped key only when it belongs to this user. A
   // different cashier's pending retry is deliberately left intact.
   const legacy = parseStoredAttempt(storage, APPEND_ATTEMPT_STORAGE_KEY, now, maxAgeMs);
-  if (legacy?.userId !== userId) return null;
-  storage.setItem(scopedKey, JSON.stringify(legacy));
-  storage.removeItem(APPEND_ATTEMPT_STORAGE_KEY);
-  return { attempt: legacy, key: scopedKey };
+  if (legacy?.userId === userId) {
+    storage.setItem(scopedKey, JSON.stringify(legacy));
+    storage.removeItem(APPEND_ATTEMPT_STORAGE_KEY);
+    return { attempt: legacy, key: scopedKey };
+  }
+
+  return migrateLegacyPostpaidAppendAttempt(storage, userId, now, maxAgeMs);
 }
 
 /** Read a pending attempt for automatic recovery after a renderer reload. */
@@ -217,9 +341,22 @@ export function clearAppendAttempt(
       current.idempotencyKey !== completedAttempt.idempotencyKey
       || current.fingerprint !== completedAttempt.fingerprint
     ) return;
-    storage.removeItem(key);
+    const markerKey = getAppendAttemptCompletionStorageKey(completedAttempt.userId);
+    let markerPersisted = false;
+    try {
+      storage.setItem(markerKey, JSON.stringify({
+        userId: completedAttempt.userId,
+        idempotencyKey: completedAttempt.idempotencyKey,
+        fingerprint: completedAttempt.fingerprint,
+        completedAt: Date.now(),
+      }));
+      markerPersisted = true;
+    } catch {
+      markerPersisted = false;
+    }
+    const removed = storage.removeItem(key);
+    if (removed !== false && storage.getItem(key) === null && markerPersisted) storage.removeItem(markerKey);
   } catch {
-    // Storage cleanup is best effort; leaving the key is safe because a future
-    // matching request replays it and a changed/expired request replaces it.
+    return;
   }
 }

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -3,6 +3,8 @@ export const LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY = 'flo.postpaid.order.attempt';
 export const APPEND_ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const APPEND_ATTEMPT_USER_SUFFIX = '.user.';
 const APPEND_ATTEMPT_COMPLETION_SUFFIX = '.completion.';
+const APPEND_ATTEMPT_COMPLETION_RETRY_SUFFIX = '.completion-retry.';
+const APPEND_ATTEMPT_COMPLETION_COOKIE_SUFFIX = '.completion-cookie.';
 const CONFIRMED_APPEND_TOMBSTONE_LIMIT = 256;
 const confirmedAppendTombstones = new Map<string, { completedAt: number; fingerprintHash: string }>();
 const APPEND_ATTEMPT_COOKIE_PREFIX = 'flo_append_attempt.';
@@ -17,6 +19,14 @@ export function getPostpaidOrderAttemptStorageKey(userId: string): string {
 
 function getAppendAttemptCompletionStorageKey(userId: string): string {
   return `${APPEND_ATTEMPT_STORAGE_KEY}${APPEND_ATTEMPT_COMPLETION_SUFFIX}${encodeURIComponent(userId)}`;
+}
+
+function getAppendAttemptCompletionRetryStorageKey(userId: string): string {
+  return `${APPEND_ATTEMPT_STORAGE_KEY}${APPEND_ATTEMPT_COMPLETION_RETRY_SUFFIX}${encodeURIComponent(userId)}`;
+}
+
+function getAppendAttemptCompletionCookieStorageKey(userId: string): string {
+  return `${APPEND_ATTEMPT_STORAGE_KEY}${APPEND_ATTEMPT_COMPLETION_COOKIE_SUFFIX}${encodeURIComponent(userId)}`;
 }
 
 function getConfirmedAppendTombstoneKey(userId: string, idempotencyKey: string): string {
@@ -100,18 +110,24 @@ export function createSafeAppendAttemptStorage(
 ): AppendAttemptStorage {
   const memory = new Map<string, string | null>();
   const stores = [storage, ...fallbackStorages].filter((candidate, index, all) => candidate && all.indexOf(candidate) === index) as AppendAttemptStorage[];
+  const readPersisted = (key: string): string | null => {
+    let value: string | undefined;
+    for (const candidate of stores) {
+      try {
+        const persisted = candidate.getItem(key);
+        if (persisted === null || persisted === undefined) continue;
+        if (value !== undefined && value !== persisted) throw new Error('Conflicting append retry state');
+        value = persisted;
+      } catch (error) {
+        if (error instanceof Error && error.message === 'Conflicting append retry state') throw error;
+      }
+    }
+    return value ?? null;
+  };
   return {
     getItem: (key) => {
       if (memory.has(key)) return memory.get(key) ?? null;
-      for (const candidate of stores) {
-        try {
-          const persisted = candidate.getItem(key);
-          if (persisted !== null && persisted !== undefined) return persisted;
-        } catch {
-          continue;
-        }
-      }
-      return null;
+      return readPersisted(key);
     },
     setItem: (key, value) => {
       let persisted = false;
@@ -127,6 +143,7 @@ export function createSafeAppendAttemptStorage(
       if (!persisted) {
         throw new Error('Unable to persist append retry state');
       }
+      if (readPersisted(key) !== value) throw new Error('Conflicting append retry state');
       try {
         memory.set(key, value);
       } catch {
@@ -194,7 +211,12 @@ function removeAndVerify(storage: AppendAttemptStorage, key: string): boolean {
   return removed !== false && storage.getItem(key) === null;
 }
 
-function persistCompletionRecord(storage: AppendAttemptStorage, key: string, value: string): boolean {
+function persistCompletionRecord(
+  storage: AppendAttemptStorage,
+  key: string,
+  value: string,
+  cookieKey: string,
+): boolean {
   try {
     storage.setItem(key, value);
     if (storage.getItem(key) === value) return true;
@@ -204,8 +226,8 @@ function persistCompletionRecord(storage: AppendAttemptStorage, key: string, val
   const cookieStorage = createCookieAppendAttemptStorage();
   if (!cookieStorage) return false;
   try {
-    cookieStorage.setItem(key, value);
-    return cookieStorage.getItem(key) === value;
+    cookieStorage.setItem(cookieKey, value);
+    return cookieStorage.getItem(cookieKey) === value;
   } catch {
     return false;
   }
@@ -257,11 +279,12 @@ function isCompletionRecord(value: Partial<AppendAttemptCompletion> & { complete
 function completedAttemptMatches(
   storage: AppendAttemptStorage,
   attemptKey: string,
+  completionKey: string,
   completion: AppendAttemptCompletion,
 ): boolean {
   const raw = storage.getItem(attemptKey);
   if (!raw) {
-    storage.removeItem(getAppendAttemptCompletionStorageKey(completion.userId));
+    storage.removeItem(completionKey);
     return true;
   }
   try {
@@ -269,7 +292,7 @@ function completedAttemptMatches(
     if (current.idempotencyKey !== completion.idempotencyKey || current.fingerprint !== completion.fingerprint) return false;
     const removed = storage.removeItem(attemptKey);
     if (removed !== false && storage.getItem(attemptKey) === null) {
-      storage.removeItem(getAppendAttemptCompletionStorageKey(completion.userId));
+      storage.removeItem(completionKey);
     }
     return true;
   } catch {
@@ -283,27 +306,34 @@ function hasCompletedAttempt(
   now: number,
   maxAgeMs: number,
 ): boolean {
-  const markerKey = getAppendAttemptCompletionStorageKey(userId);
-  const raw = storage.getItem(markerKey);
-  if (!raw) return false;
-  try {
-    const completion = JSON.parse(raw) as Partial<AppendAttemptCompletion>;
-    if (
-      completion.userId !== userId
-      || typeof completion.idempotencyKey !== 'string'
-      || !isValidIdempotencyKey(completion.idempotencyKey)
-      || typeof completion.fingerprint !== 'string'
-      || typeof completion.completedAt !== 'number'
-      || isExpired(completion.completedAt, now, maxAgeMs)
-    ) {
-      storage.removeItem(markerKey);
-      return false;
+  const attemptKey = getAppendAttemptStorageKey(userId);
+  const completionKeys = [
+    getAppendAttemptCompletionStorageKey(userId),
+    getAppendAttemptCompletionRetryStorageKey(userId),
+    getAppendAttemptCompletionCookieStorageKey(userId),
+  ];
+  for (const completionKey of completionKeys) {
+    const raw = storage.getItem(completionKey);
+    if (!raw) continue;
+    try {
+      const completion = JSON.parse(raw) as Partial<AppendAttemptCompletion>;
+      if (
+        completion.userId !== userId
+        || typeof completion.idempotencyKey !== 'string'
+        || !isValidIdempotencyKey(completion.idempotencyKey)
+        || typeof completion.fingerprint !== 'string'
+        || typeof completion.completedAt !== 'number'
+        || isExpired(completion.completedAt, now, maxAgeMs)
+      ) {
+        storage.removeItem(completionKey);
+        continue;
+      }
+      if (completedAttemptMatches(storage, attemptKey, completionKey, completion as AppendAttemptCompletion)) return true;
+    } catch {
+      storage.removeItem(completionKey);
     }
-    return completedAttemptMatches(storage, getAppendAttemptStorageKey(userId), completion as AppendAttemptCompletion);
-  } catch {
-    storage.removeItem(markerKey);
-    return false;
   }
+  return false;
 }
 
 export function migrateLegacyAppendAttempt(
@@ -430,6 +460,7 @@ function appendAttemptsMatch(first: AppendAttempt, second: AppendAttempt): boole
 
 function ensureCompletionStorage(storage: AppendAttemptStorage, userId: string): void {
   const markerKey = getAppendAttemptCompletionStorageKey(userId);
+  const retryKey = getAppendAttemptCompletionRetryStorageKey(userId);
   const attemptKey = getAppendAttemptStorageKey(userId);
   const probe = JSON.stringify({ completed: true, userId, idempotencyKey: 'append-storage-probe', fingerprint: '{}', completedAt: Date.now() });
   try {
@@ -438,10 +469,16 @@ function ensureCompletionStorage(storage: AppendAttemptStorage, userId: string):
     return;
   } catch {
     try {
-      storage.setItem(attemptKey, probe);
-      if (!removeAndVerify(storage, attemptKey)) throw new Error('Completion fallback cleanup was not persisted');
+      storage.setItem(retryKey, probe);
+      if (!removeAndVerify(storage, retryKey)) throw new Error('Completion retry cleanup was not persisted');
+      return;
     } catch {
-      throw new Error('Unable to persist append retry state');
+      try {
+        storage.setItem(attemptKey, probe);
+        if (!removeAndVerify(storage, attemptKey)) throw new Error('Completion fallback cleanup was not persisted');
+      } catch {
+        throw new Error('Unable to persist append retry state');
+      }
     }
   }
 }
@@ -556,9 +593,12 @@ export function clearAppendAttempt(
     };
     let markerPersisted = false;
     const serializedCompletion = JSON.stringify(completionRecord);
-    markerPersisted = persistCompletionRecord(storage, markerKey, serializedCompletion);
+    const retryKey = getAppendAttemptCompletionRetryStorageKey(completedAttempt.userId);
+    const cookieKey = getAppendAttemptCompletionCookieStorageKey(completedAttempt.userId);
+    markerPersisted = persistCompletionRecord(storage, markerKey, serializedCompletion, cookieKey);
+    if (!markerPersisted) markerPersisted = persistCompletionRecord(storage, retryKey, serializedCompletion, cookieKey);
     if (!markerPersisted) {
-      markerPersisted = persistCompletionRecord(storage, key, serializedCompletion);
+      markerPersisted = persistCompletionRecord(storage, key, serializedCompletion, cookieKey);
     }
     if (markerPersisted) {
       confirmedAppendTombstones.set(
@@ -568,7 +608,11 @@ export function clearAppendAttempt(
       pruneConfirmedAppendTombstones(Date.now(), APPEND_ATTEMPT_MAX_AGE_MS);
     }
     const removed = storage.removeItem(key);
-    if (removed !== false && storage.getItem(key) === null && markerPersisted) storage.removeItem(markerKey);
+    if (removed !== false && storage.getItem(key) === null && markerPersisted) {
+      storage.removeItem(markerKey);
+      storage.removeItem(retryKey);
+      storage.removeItem(cookieKey);
+    }
     return markerPersisted || (removed !== false && storage.getItem(key) === null);
   } catch {
     return false;

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -104,6 +104,11 @@ function isExpired(createdAt: number, now: number, maxAgeMs: number): boolean {
   return !Number.isFinite(createdAt) || now - createdAt >= maxAgeMs;
 }
 
+function removeAndVerify(storage: AppendAttemptStorage, key: string): boolean {
+  const removed = storage.removeItem(key);
+  return removed !== false && storage.getItem(key) === null;
+}
+
 function normalizeAppendFingerprint(fingerprint: string): string | null {
   try {
     const payload = JSON.parse(fingerprint) as {
@@ -256,7 +261,7 @@ export function migrateLegacyAppendAttempt(
     if (!equivalent) throw new Error('Unable to migrate legacy append retry state safely');
   }
   if (existingRaw === null) storage.setItem(scopedKey, JSON.stringify(attempt));
-  if (storage.removeItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY) === false) {
+  if (!removeAndVerify(storage, LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY)) {
     throw new Error('Unable to complete legacy append retry migration');
   }
   return attempt;
@@ -297,6 +302,15 @@ interface StoredAttempt {
   key: string;
 }
 
+function appendAttemptsMatch(first: AppendAttempt, second: AppendAttempt): boolean {
+  return first.userId === second.userId
+    && first.orderId === second.orderId
+    && first.fingerprint === second.fingerprint
+    && first.idempotencyKey === second.idempotencyKey
+    && JSON.stringify(first.items) === JSON.stringify(second.items)
+    && (first.specialInstructions || undefined) === (second.specialInstructions || undefined);
+}
+
 function readUserAttempt(
   storage: AppendAttemptStorage,
   userId: string,
@@ -307,17 +321,19 @@ function readUserAttempt(
   const migrated = migrateLegacyAppendAttempt(storage, { now, maxAgeMs });
   if (hasCompletedAttempt(storage, userId, now, maxAgeMs)) return null;
   const scoped = parseStoredAttempt(storage, scopedKey, now, maxAgeMs);
-  if (scoped?.userId === userId) return { attempt: scoped, key: scopedKey };
-
-  // Migrate the pre-user-scoped key only when it belongs to this user. A
-  // different cashier's pending retry is deliberately left intact.
   const legacy = parseStoredAttempt(storage, APPEND_ATTEMPT_STORAGE_KEY, now, maxAgeMs);
   if (legacy?.userId === userId) {
-    storage.setItem(scopedKey, JSON.stringify(legacy));
-    storage.removeItem(APPEND_ATTEMPT_STORAGE_KEY);
-    return { attempt: legacy, key: scopedKey };
+    if (scoped && scoped.userId === userId && !appendAttemptsMatch(scoped, legacy)) {
+      throw new Error('Unable to migrate conflicting append retry state');
+    }
+    if (!scoped) storage.setItem(scopedKey, JSON.stringify(legacy));
+    if (!removeAndVerify(storage, APPEND_ATTEMPT_STORAGE_KEY)) {
+      throw new Error('Unable to complete append retry migration');
+    }
+    return { attempt: scoped || legacy, key: scopedKey };
   }
 
+  if (scoped?.userId === userId) return { attempt: scoped, key: scopedKey };
   if (migrated?.userId === userId) return { attempt: migrated, key: scopedKey };
   return null;
 }

--- a/frontend/src/lib/append-attempt.ts
+++ b/frontend/src/lib/append-attempt.ts
@@ -29,24 +29,40 @@ export interface AppendAttemptStorage {
 }
 
 /** Wrap browser storage for append-attempt state. */
-export function createSafeAppendAttemptStorage(storage: AppendAttemptStorage | null): AppendAttemptStorage {
+export function createSafeAppendAttemptStorage(
+  storage: AppendAttemptStorage | null,
+  fallbackStorage: AppendAttemptStorage | null = null,
+): AppendAttemptStorage {
   const memory = new Map<string, string | null>();
+  const stores = [storage, fallbackStorage].filter((candidate, index, all) => candidate && all.indexOf(candidate) === index) as AppendAttemptStorage[];
   return {
     getItem: (key) => {
       if (memory.has(key)) return memory.get(key) ?? null;
-      try {
-        const persisted = storage?.getItem(key);
-        if (persisted !== null && persisted !== undefined) return persisted;
-      } catch {
-        // Fall back to the in-memory copy.
+      for (const candidate of stores) {
+        try {
+          const persisted = candidate.getItem(key);
+          if (persisted !== null && persisted !== undefined) return persisted;
+        } catch {
+          continue;
+        }
       }
       return null;
     },
     setItem: (key, value) => {
-      if (!storage) throw new Error('Unable to persist append retry state');
+      let persisted = false;
+      for (const candidate of stores) {
+        try {
+          candidate.setItem(key, value);
+          if (candidate.getItem(key) !== value) throw new Error('Append retry state was not persisted');
+          persisted = true;
+        } catch {
+          continue;
+        }
+      }
+      if (!persisted) {
+        throw new Error('Unable to persist append retry state');
+      }
       try {
-        storage.setItem(key, value);
-        if (storage.getItem(key) !== value) throw new Error('Append retry state was not persisted');
         memory.set(key, value);
       } catch {
         throw new Error('Unable to persist append retry state');
@@ -56,13 +72,17 @@ export function createSafeAppendAttemptStorage(storage: AppendAttemptStorage | n
       // A tombstone prevents a stale durable value from returning if cleanup
       // itself is blocked by the browser.
       memory.set(key, null);
-      if (!storage) return false;
-      try {
-        storage.removeItem(key);
-        return storage.getItem(key) === null;
-      } catch {
-        return false;
+      if (stores.length === 0) return false;
+      let removed = true;
+      for (const candidate of stores) {
+        try {
+          candidate.removeItem(key);
+          if (candidate.getItem(key) !== null) removed = false;
+        } catch {
+          removed = false;
+        }
       }
+      return removed;
     },
   };
 }
@@ -258,7 +278,7 @@ export function migrateLegacyAppendAttempt(
       && JSON.stringify(existing.items) === JSON.stringify(attempt.items)
       && (existing.specialInstructions || undefined) === (attempt.specialInstructions || undefined)
       && typeof existing.createdAt === 'number';
-    if (!equivalent) throw new Error('Unable to migrate legacy append retry state safely');
+    if (!equivalent) return attempt;
   }
   if (existingRaw === null) storage.setItem(scopedKey, JSON.stringify(attempt));
   if (!removeAndVerify(storage, LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY)) {
@@ -311,6 +331,24 @@ function appendAttemptsMatch(first: AppendAttempt, second: AppendAttempt): boole
     && (first.specialInstructions || undefined) === (second.specialInstructions || undefined);
 }
 
+function ensureCompletionStorage(storage: AppendAttemptStorage, userId: string): void {
+  const markerKey = getAppendAttemptCompletionStorageKey(userId);
+  const attemptKey = getAppendAttemptStorageKey(userId);
+  const probe = JSON.stringify({ completed: true, userId, idempotencyKey: 'append-storage-probe', fingerprint: '{}', completedAt: Date.now() });
+  try {
+    storage.setItem(markerKey, probe);
+    if (!removeAndVerify(storage, markerKey)) throw new Error('Completion marker cleanup was not persisted');
+    return;
+  } catch {
+    try {
+      storage.setItem(attemptKey, probe);
+      if (!removeAndVerify(storage, attemptKey)) throw new Error('Completion fallback cleanup was not persisted');
+    } catch {
+      throw new Error('Unable to persist append retry state');
+    }
+  }
+}
+
 function readUserAttempt(
   storage: AppendAttemptStorage,
   userId: string,
@@ -323,9 +361,7 @@ function readUserAttempt(
   const scoped = parseStoredAttempt(storage, scopedKey, now, maxAgeMs);
   const legacy = parseStoredAttempt(storage, APPEND_ATTEMPT_STORAGE_KEY, now, maxAgeMs);
   if (legacy?.userId === userId) {
-    if (scoped && scoped.userId === userId && !appendAttemptsMatch(scoped, legacy)) {
-      throw new Error('Unable to migrate conflicting append retry state');
-    }
+    if (scoped && scoped.userId === userId && !appendAttemptsMatch(scoped, legacy)) return { attempt: scoped, key: scopedKey };
     if (!scoped) storage.setItem(scopedKey, JSON.stringify(legacy));
     if (!removeAndVerify(storage, APPEND_ATTEMPT_STORAGE_KEY)) {
       throw new Error('Unable to complete append retry migration');
@@ -377,6 +413,7 @@ export function getOrCreateAppendAttempt(
   if (!isValidIdempotencyKey(idempotencyKey)) {
     throw new Error('Unable to create a valid append idempotency key');
   }
+  ensureCompletionStorage(storage, options.userId);
 
   const attempt: AppendAttempt = {
     userId: options.userId,

--- a/frontend/src/lib/cart-identity.ts
+++ b/frontend/src/lib/cart-identity.ts
@@ -46,7 +46,10 @@ function canonicalize(value: unknown): string {
  * field and the exact note text remain part of the identity.
  */
 export function generateCartItemId(productId: number | string, addons: Addon[], specialInstructions: string): string {
-  const sortedAddons = [...addons].sort((left, right) => {
+  const normalizedAddons = addons.map((addon) => (
+    addon.quantity === undefined ? { ...addon, quantity: 1 } : addon
+  ));
+  const sortedAddons = normalizedAddons.sort((left, right) => {
     const leftKey = canonicalize(left);
     const rightKey = canonicalize(right);
     if (leftKey < rightKey) return -1;

--- a/frontend/src/lib/cart-identity.ts
+++ b/frontend/src/lib/cart-identity.ts
@@ -1,0 +1,73 @@
+import type { Addon, CartItem } from './types';
+
+/**
+ * Serialize the cart identity as typed, sorted structure rather than as a
+ * delimiter-joined string. JSON-like values are escaped and tagged so values
+ * such as `1` and `"001"` cannot become the same identity.
+ */
+function canonicalize(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+
+  switch (typeof value) {
+    case 'string':
+      return `string:${JSON.stringify(value)}`;
+    case 'number':
+      if (Number.isNaN(value)) return 'number:NaN';
+      if (value === Infinity) return 'number:Infinity';
+      if (value === -Infinity) return 'number:-Infinity';
+      if (Object.is(value, -0)) return 'number:-0';
+      return `number:${String(value)}`;
+    case 'boolean':
+      return `boolean:${value ? 'true' : 'false'}`;
+    case 'bigint':
+      return `bigint:${value.toString()}`;
+    case 'symbol':
+      return `symbol:${String(value)}`;
+    case 'function':
+      return `function:${String(value)}`;
+    case 'object': {
+      if (Array.isArray(value)) {
+        return `[${value.map((entry) => canonicalize(entry)).join(',')}]`;
+      }
+      const entries = Object.keys(value as Record<string, unknown>)
+        .sort()
+        .map((key) => `${JSON.stringify(key)}:${canonicalize((value as Record<string, unknown>)[key])}`);
+      return `{${entries.join(',')}}`;
+    }
+    default:
+      return `${typeof value}:${String(value)}`;
+  }
+}
+
+/**
+ * Build the stable identity used by the cart store for merging equivalent
+ * lines. Add-on arrays are order-insensitive, while every selected add-on
+ * field and the exact note text remain part of the identity.
+ */
+export function generateCartItemId(productId: number | string, addons: Addon[], specialInstructions: string): string {
+  const sortedAddons = [...addons].sort((left, right) => {
+    const leftKey = canonicalize(left);
+    const rightKey = canonicalize(right);
+    if (leftKey < rightKey) return -1;
+    if (leftKey > rightKey) return 1;
+    return 0;
+  });
+
+  return `cart-v2:${canonicalize({ productId, addons: sortedAddons, specialInstructions })}`;
+}
+
+/** Normalize persisted/held cart lines to the current identity format. */
+export function normalizeCartItems(items: CartItem[]): CartItem[] {
+  const normalized: CartItem[] = [];
+  for (const item of items) {
+    const id = generateCartItemId(item.product.id, item.addons || [], item.special_instructions || '');
+    const existing = normalized.find((candidate) => candidate.id === id);
+    if (existing) {
+      existing.quantity += item.quantity;
+    } else {
+      normalized.push({ ...item, id });
+    }
+  }
+  return normalized;
+}

--- a/frontend/src/lib/cart-identity.ts
+++ b/frontend/src/lib/cart-identity.ts
@@ -46,9 +46,10 @@ function canonicalize(value: unknown): string {
  * field and the exact note text remain part of the identity.
  */
 export function generateCartItemId(productId: number | string, addons: Addon[], specialInstructions: string): string {
-  const normalizedAddons = addons.map((addon) => (
-    addon.quantity === undefined ? { ...addon, quantity: 1 } : addon
-  ));
+  const normalizedAddons = addons.map((addon) => ({
+    ...addon,
+    quantity: addon.quantity || 1,
+  }));
   const sortedAddons = normalizedAddons.sort((left, right) => {
     const leftKey = canonicalize(left);
     const rightKey = canonicalize(right);

--- a/frontend/src/store/cart.ts
+++ b/frontend/src/store/cart.ts
@@ -1,5 +1,8 @@
 import { create } from 'zustand';
 import type { Customer, Product, Addon, CartItem } from '@/lib/types';
+import { generateCartItemId, normalizeCartItems } from '@/lib/cart-identity';
+
+export { generateCartItemId, normalizeCartItems } from '@/lib/cart-identity';
 
 interface CartState {
   items: CartItem[];
@@ -28,21 +31,6 @@ interface CartState {
 
   subtotal: () => number;
   itemCount: () => number;
-}
-
-function generateCartItemId(productId: number | string, addons: Addon[], specialInstructions: string): string {
-  const parts = [String(productId)];
-  if (addons.length > 0) {
-    const addonStr = [...addons]
-      .sort((a, b) => String(a.id).localeCompare(String(b.id)))
-      .map((a) => `${a.id}:${a.quantity || 1}`)
-      .join(',');
-    parts.push(addonStr);
-  }
-  if (specialInstructions) {
-    parts.push(specialInstructions);
-  }
-  return parts.join('-');
 }
 
 export const useCartStore = create<CartState>((set, get) => ({
@@ -127,7 +115,7 @@ export const useCartStore = create<CartState>((set, get) => ({
   },
 
   loadItems: (items, tableId, customerId, guestCount, orderNotes, heldOrderId) => {
-    set({ items, tableId, heldOrderId: heldOrderId || null, customerId, guestCount, orderNotes: orderNotes || '' });
+    set({ items: normalizeCartItems(items), tableId, heldOrderId: heldOrderId || null, customerId, guestCount, orderNotes: orderNotes || '' });
   },
 
   setOrderType: (type) => set((state) => ({ orderType: type, deliveryAddress: type !== 'delivery' ? '' : state.deliveryAddress })),

--- a/main/routes/orders.ts
+++ b/main/routes/orders.ts
@@ -21,7 +21,8 @@ function orderIdempotencyKey(req: Request): string | null {
   const raw = req.get('Idempotency-Key');
   if (raw === undefined) return null;
   const supplied = raw.trim();
-  if (!supplied || supplied.length > MAX_ORDER_IDEMPOTENCY_KEY_LENGTH || !/^[\x21-\x7e]+$/.test(supplied)) {
+  if (!supplied) return null;
+  if (supplied.length > MAX_ORDER_IDEMPOTENCY_KEY_LENGTH || !/^[\x21-\x7e]+$/.test(supplied)) {
     throw Object.assign(new Error('Idempotency-Key is invalid or too long'), { statusCode: 400 });
   }
   return supplied;
@@ -582,14 +583,6 @@ router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), 
       ? createHash('sha256').update(JSON.stringify({ order_id: req.params.id, items, special_instructions })).digest('hex')
       : null;
 
-    // Replay before any mutable-order guard. A response-loss retry must return
-    // the committed result even if the order was split or its validation state
-    // changed after the original append.
-    if (idempotencyKey && requestHash) {
-      const replayResponse = getStoredOrderReplay(db, idempotencyUserId, idempotencyKey, requestHash);
-      if (replayResponse) return res.json(replayResponse);
-    }
-
     const order = db.prepare('SELECT * FROM orders WHERE id = ?').get(req.params.id) as any;
     if (!order) {
       return res.status(404).json({ error: 'Order not found' });
@@ -598,6 +591,14 @@ router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), 
     const authUser = (req as any).user;
     if (authUser?.role === 'waiter' && order.user_id !== authUser.userId) {
       return res.status(403).json({ error: 'Waiters can only modify their own orders' });
+    }
+
+    // Replay before any mutable-order guard. A response-loss retry must return
+    // the committed result even if the order was split or its validation state
+    // changed after the original append.
+    if (idempotencyKey && requestHash) {
+      const replayResponse = getStoredOrderReplay(db, idempotencyUserId, idempotencyKey, requestHash);
+      if (replayResponse) return res.json(replayResponse);
     }
 
     if (!items || !Array.isArray(items) || items.length === 0) {
@@ -618,6 +619,17 @@ router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), 
     };
 
     const result = withTxn(() => {
+      // Re-fetch and re-validate under the transaction lock: another request (e.g. a
+      // cashier completing/cancelling the order) can race the checks above, which run
+      // before this lock is acquired (#175).
+      const currentOrder = db.prepare('SELECT * FROM orders WHERE id = ?').get(req.params.id) as any;
+      if (!currentOrder) {
+        throw Object.assign(new Error('Order not found'), { statusCode: 404 });
+      }
+      if (authUser?.role === 'waiter' && currentOrder.user_id !== authUser.userId) {
+        throw Object.assign(new Error('Waiters can only modify their own orders'), { statusCode: 403 });
+      }
+
       // Re-check idempotency under the transaction lock in case the early
       // lookup raced the first request. This must remain before mutable-order
       // guards so a committed append always has a replay path.
@@ -626,13 +638,6 @@ router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), 
         if (replayResponse) return { replayResponse };
       }
 
-      // Re-fetch and re-validate under the transaction lock: another request (e.g. a
-      // cashier completing/cancelling the order) can race the checks above, which run
-      // before this lock is acquired (#175).
-      const currentOrder = db.prepare('SELECT * FROM orders WHERE id = ?').get(req.params.id) as any;
-      if (!currentOrder) {
-        throw Object.assign(new Error('Order not found'), { statusCode: 404 });
-      }
       if (db.prepare('SELECT 1 FROM bills WHERE order_id = ? AND split_group_id IS NOT NULL LIMIT 1').get(req.params.id)) {
         throw Object.assign(new Error('Items cannot be changed after a check has been split'), { statusCode: 409 });
       }

--- a/main/routes/orders.ts
+++ b/main/routes/orders.ts
@@ -18,12 +18,32 @@ const router = Router();
 const MAX_ORDER_IDEMPOTENCY_KEY_LENGTH = 128;
 
 function orderIdempotencyKey(req: Request): string | null {
-  const supplied = req.get('Idempotency-Key')?.trim();
-  if (!supplied) return null;
-  if (supplied.length > MAX_ORDER_IDEMPOTENCY_KEY_LENGTH || !/^[\x21-\x7e]+$/.test(supplied)) {
+  const raw = req.get('Idempotency-Key');
+  if (raw === undefined) return null;
+  const supplied = raw.trim();
+  if (!supplied || supplied.length > MAX_ORDER_IDEMPOTENCY_KEY_LENGTH || !/^[\x21-\x7e]+$/.test(supplied)) {
     throw Object.assign(new Error('Idempotency-Key is invalid or too long'), { statusCode: 400 });
   }
   return supplied;
+}
+
+function getStoredOrderReplay(db: any, userId: string, idempotencyKey: string, requestHash: string): any | null {
+  const prior = db.prepare(`
+    SELECT request_hash, response_json
+    FROM order_idempotency
+    WHERE (user_id = ? OR user_id = 'legacy') AND idempotency_key = ?
+    ORDER BY CASE WHEN user_id = ? THEN 0 ELSE 1 END
+    LIMIT 1
+  `).get(userId, idempotencyKey, userId) as { request_hash: string; response_json: string } | undefined;
+  if (!prior) return null;
+  if (prior.request_hash !== requestHash) {
+    throw Object.assign(new Error('Idempotency-Key was already used for a different order request'), { statusCode: 409 });
+  }
+  try {
+    return JSON.parse(prior.response_json);
+  } catch {
+    throw Object.assign(new Error('Stored order response is invalid'), { statusCode: 500 });
+  }
 }
 
 // Rate limiting for PIN validation (simple in-memory)
@@ -554,9 +574,6 @@ router.post('/', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Req
 router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
-    if (db.prepare('SELECT 1 FROM bills WHERE order_id = ? AND split_group_id IS NOT NULL LIMIT 1').get(req.params.id)) {
-      return res.status(409).json({ error: 'Items cannot be changed after a check has been split' });
-    }
     const body = req.body || {};
     const { items, special_instructions } = body;
     const idempotencyKey = orderIdempotencyKey(req);
@@ -564,6 +581,15 @@ router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), 
     const requestHash = idempotencyKey
       ? createHash('sha256').update(JSON.stringify({ order_id: req.params.id, items, special_instructions })).digest('hex')
       : null;
+
+    // Replay before any mutable-order guard. A response-loss retry must return
+    // the committed result even if the order was split or its validation state
+    // changed after the original append.
+    if (idempotencyKey && requestHash) {
+      const replayResponse = getStoredOrderReplay(db, idempotencyUserId, idempotencyKey, requestHash);
+      if (replayResponse) return res.json(replayResponse);
+    }
+
     const order = db.prepare('SELECT * FROM orders WHERE id = ?').get(req.params.id) as any;
     if (!order) {
       return res.status(404).json({ error: 'Order not found' });
@@ -576,18 +602,6 @@ router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), 
 
     if (!items || !Array.isArray(items) || items.length === 0) {
       return res.status(400).json({ error: 'At least one item is required' });
-    }
-
-    try {
-      for (const item of items) {
-        validateItemNotes(db, item.special_instructions);
-        validateItemAddonGroupLimits(db, item.addons);
-      }
-      if (special_instructions !== undefined) {
-        validateOrderNotes(db, special_instructions);
-      }
-    } catch (err: any) {
-      return res.status(400).json({ error: err.message });
     }
 
     // Get settings
@@ -604,6 +618,14 @@ router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), 
     };
 
     const result = withTxn(() => {
+      // Re-check idempotency under the transaction lock in case the early
+      // lookup raced the first request. This must remain before mutable-order
+      // guards so a committed append always has a replay path.
+      if (idempotencyKey && requestHash) {
+        const replayResponse = getStoredOrderReplay(db, idempotencyUserId, idempotencyKey, requestHash);
+        if (replayResponse) return { replayResponse };
+      }
+
       // Re-fetch and re-validate under the transaction lock: another request (e.g. a
       // cashier completing/cancelling the order) can race the checks above, which run
       // before this lock is acquired (#175).
@@ -611,25 +633,23 @@ router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), 
       if (!currentOrder) {
         throw Object.assign(new Error('Order not found'), { statusCode: 404 });
       }
-      if (idempotencyKey) {
-        const prior = db.prepare(`
-          SELECT request_hash, response_json
-          FROM order_idempotency
-          WHERE (user_id = ? OR user_id = 'legacy') AND idempotency_key = ?
-          ORDER BY CASE WHEN user_id = ? THEN 0 ELSE 1 END
-          LIMIT 1
-        `).get(idempotencyUserId, idempotencyKey, idempotencyUserId) as { request_hash: string; response_json: string } | undefined;
-        if (prior) {
-          if (prior.request_hash !== requestHash) throw Object.assign(new Error('Idempotency-Key was already used for a different order request'), { statusCode: 409 });
-          try {
-            return { replayResponse: JSON.parse(prior.response_json) };
-          } catch {
-            throw Object.assign(new Error('Stored order response is invalid'), { statusCode: 500 });
-          }
-        }
+      if (db.prepare('SELECT 1 FROM bills WHERE order_id = ? AND split_group_id IS NOT NULL LIMIT 1').get(req.params.id)) {
+        throw Object.assign(new Error('Items cannot be changed after a check has been split'), { statusCode: 409 });
       }
       if (['completed', 'cancelled'].includes(currentOrder.status)) {
         throw Object.assign(new Error('Cannot add items to a completed or cancelled order'), { statusCode: 400 });
+      }
+
+      try {
+        for (const item of items) {
+          validateItemNotes(db, item.special_instructions);
+          validateItemAddonGroupLimits(db, item.addons);
+        }
+        if (special_instructions !== undefined) {
+          validateOrderNotes(db, special_instructions);
+        }
+      } catch (err: any) {
+        throw Object.assign(new Error(err?.message || 'Invalid order item'), { statusCode: 400 });
       }
 
       const customer = currentOrder.customer_id ? db.prepare('SELECT * FROM customers WHERE id = ?').get(currentOrder.customer_id) as any : null;

--- a/main/routes/orders.ts
+++ b/main/routes/orders.ts
@@ -28,7 +28,12 @@ function orderIdempotencyKey(req: Request): string | null {
   return supplied;
 }
 
-function getStoredOrderReplay(db: any, userId: string, idempotencyKey: string, requestHash: string): any | null {
+function getStoredOrderReplay(
+  db: ReturnType<typeof getDatabase>,
+  userId: string,
+  idempotencyKey: string,
+  requestHash: string,
+): unknown | null {
   const prior = db.prepare(`
     SELECT request_hash, response_json
     FROM order_idempotency
@@ -653,8 +658,8 @@ router.post('/:id/items', requireRole('owner', 'manager', 'cashier', 'waiter'), 
         if (special_instructions !== undefined) {
           validateOrderNotes(db, special_instructions);
         }
-      } catch (err: any) {
-        throw Object.assign(new Error(err?.message || 'Invalid order item'), { statusCode: 400 });
+      } catch (err: unknown) {
+        throw Object.assign(new Error(err instanceof Error ? err.message : 'Invalid order item'), { statusCode: 400 });
       }
 
       const customer = currentOrder.customer_id ? db.prepare('SELECT * FROM customers WHERE id = ?').get(currentOrder.customer_id) as any : null;

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "test:issue-214": "node tests/run-electron-node-test.cjs tests/issue-214-payment-integrity.test.ts",
     "test:issue-214-auth": "node tests/run-electron-node-test.cjs tests/issue-214-auth-migration.test.ts",
     "test:issue-214-migration": "node tests/run-electron-node-test.cjs tests/issue-214-migration-integrity.test.ts",
+    "test:issue-255-cart": "ts-node --transpile-only -P tests/tsconfig.json tests/issue-255-pos-cart-retry.test.ts",
+    "test:issue-255-append": "node tests/run-electron-node-test.cjs tests/issue-255-append-idempotency.test.ts",
     "test:integration-lifecycle": "node tests/run-electron-node-test.cjs tests/integration-order-lifecycle.test.ts",
     "test:integration-reconciliation": "node tests/run-electron-node-test.cjs tests/integration-bill-reconciliation.test.ts",
     "test:integration-loyalty": "node tests/run-electron-node-test.cjs tests/integration-loyalty.test.ts",

--- a/tests/issue-255-append-idempotency.test.ts
+++ b/tests/issue-255-append-idempotency.test.ts
@@ -1,0 +1,119 @@
+/** Issue #255 regression coverage for append idempotency replay and payload mismatch rejection. */
+const Module = require('module');
+const originalLoad = Module._load;
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-issue-255-'));
+Module._load = function (request: string, parent: unknown, isMain: boolean) {
+  if (request === 'electron') return { app: { isPackaged: true, getPath: () => testDir, getVersion: () => 'test' } };
+  return originalLoad.apply(this, arguments as any);
+};
+
+const {
+  initTestDb,
+  createApp,
+  startServer,
+  seedOwnerUser,
+  seedCategory,
+  seedProduct,
+  api,
+  assert,
+  assertEqual,
+  getResults,
+  closeDatabase,
+  getDatabase,
+} = require('./helpers/test-setup');
+const { orderRoutes } = require('../main/routes/orders');
+
+async function main() {
+  console.log('Issue #255 append idempotency contract');
+  const db = initTestDb();
+  const { authHeader } = seedOwnerUser(db);
+  seedCategory(db, 'cat-255', 'Issue 255 menu');
+  seedProduct(db, 'prod-255-base', 'cat-255', 'Issue 255 base', 100);
+  seedProduct(db, '001', 'cat-255', 'Issue 255 append', 25);
+  const app = createApp({ '/api/orders': orderRoutes });
+  const { baseUrl, server } = await startServer(app);
+
+  try {
+    const created = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: { type: 'takeaway', items: [{ product_id: 'prod-255-base', quantity: 1 }] },
+      headers: authHeader,
+    });
+    assertEqual(created.status, 201, 'append replay fixture order is created');
+    const orderId = created.data.order.id;
+    const appendBody = {
+      items: [{
+        product_id: '001',
+        quantity: 1,
+        addons: [{ id: '001', name: 'Extra 001', price: 3, quantity: 1 }],
+        special_instructions: 'response-loss fixture',
+      }],
+      special_instructions: 'append note',
+    };
+    const retryHeaders = { ...authHeader, 'Idempotency-Key': 'issue-255-append-retry' };
+
+    const committedResponse = await api(baseUrl, `/api/orders/${orderId}/items`, {
+      method: 'POST',
+      body: appendBody,
+      headers: retryHeaders,
+    });
+    // Deliberately do not use committedResponse.data below: this models a
+    // renderer losing the response after the transaction committed.
+    const countAfterCommit = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(orderId) as { count: number };
+    const blankKey = await api(baseUrl, `/api/orders/${orderId}/items`, {
+      method: 'POST',
+      body: appendBody,
+      headers: { ...authHeader, 'Idempotency-Key': '   ' },
+    });
+    const countAfterBlankKey = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(orderId) as { count: number };
+    assertEqual(blankKey.status, 400, 'a supplied blank idempotency key is rejected');
+    assertEqual(countAfterBlankKey.count, countAfterCommit.count, 'blank idempotency key rejection does not mutate the order');
+
+    db.prepare('INSERT INTO bills (bill_number, order_id, split_group_id) VALUES (?, ?, ?)').run('BILL-255-SPLIT', orderId, 'split-255');
+    const replayedResponse = await api(baseUrl, `/api/orders/${orderId}/items`, {
+      method: 'POST',
+      body: appendBody,
+      headers: retryHeaders,
+    });
+    const countAfterReplay = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(orderId) as { count: number };
+
+    assertEqual(committedResponse.status, 200, 'first append commits successfully');
+    assertEqual(replayedResponse.status, 200, 'retry with the same key replays the committed append after a later split');
+    assertEqual(countAfterReplay.count, countAfterCommit.count, 'response-loss retry does not duplicate order items');
+    assertEqual(replayedResponse.data.order.items.length, committedResponse.data.order.items.length, 'replay returns the original append response');
+    const addonRow = db.prepare(`
+      SELECT oia.addon_id, oia.addon_name, oia.price, oia.quantity
+      FROM order_item_addons oia
+      JOIN order_items oi ON oi.id = oia.order_item_id
+      WHERE oi.order_id = ? AND oi.product_id = '001'
+    `).get(orderId) as { addon_id: string | null; addon_name: string; price: number; quantity: number };
+    assertEqual(addonRow.addon_name, 'Extra 001', 'append replay fixture preserves the add-on snapshot');
+    assertEqual(addonRow.quantity, 1, 'append replay fixture preserves add-on quantity');
+
+    const mismatched = await api(baseUrl, `/api/orders/${orderId}/items`, {
+      method: 'POST',
+      body: { ...appendBody, items: [{ ...appendBody.items[0], quantity: 2 }] },
+      headers: retryHeaders,
+    });
+    const countAfterMismatch = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(orderId) as { count: number };
+    assertEqual(mismatched.status, 409, 'reusing an append key for a different payload is rejected');
+    assertEqual(countAfterMismatch.count, countAfterReplay.count, 'mismatched append rejection does not mutate the order');
+    assert(
+      String(mismatched.data.error || '').includes('different order request'),
+      'mismatched append response explains the idempotency conflict',
+    );
+  } finally {
+    server.close();
+    closeDatabase();
+    try { fs.rmSync(testDir, { recursive: true }); } catch {}
+  }
+
+  const { passed, failed, total } = getResults();
+  console.log(`${passed}/${total} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((error: any) => { console.error(error); process.exit(1); });

--- a/tests/issue-255-append-idempotency.test.ts
+++ b/tests/issue-255-append-idempotency.test.ts
@@ -4,6 +4,8 @@ const originalLoad = Module._load;
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
 const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-issue-255-'));
 Module._load = function (request: string, parent: unknown, isMain: boolean) {
   if (request === 'electron') return { app: { isPackaged: true, getPath: () => testDir, getVersion: () => 'test' } };
@@ -23,13 +25,26 @@ const {
   getResults,
   closeDatabase,
   getDatabase,
+  now,
 } = require('./helpers/test-setup');
 const { orderRoutes } = require('../main/routes/orders');
+const { getJWTSecret } = require('../main/routes/auth');
+
+function seedWaiterUser(db: any) {
+  const userId = 'waiter-255';
+  db.prepare(`
+    INSERT OR IGNORE INTO users (id, name, email, password, role, is_active, created_at, updated_at)
+    VALUES (?, ?, ?, ?, 'waiter', 1, ?, ?)
+  `).run(userId, 'Issue 255 Waiter', 'waiter-255@test.local', bcrypt.hashSync('testpass123', 10), now(), now());
+  const token = jwt.sign({ userId, email: 'waiter-255@test.local', role: 'waiter' }, getJWTSecret(), { expiresIn: '1h' });
+  return { Authorization: `Bearer ${token}` };
+}
 
 async function main() {
   console.log('Issue #255 append idempotency contract');
   const db = initTestDb();
   const { authHeader } = seedOwnerUser(db);
+  const waiterAuth = seedWaiterUser(db);
   seedCategory(db, 'cat-255', 'Issue 255 menu');
   seedProduct(db, 'prod-255-base', 'cat-255', 'Issue 255 base', 100);
   seedProduct(db, '001', 'cat-255', 'Issue 255 append', 25);
@@ -63,14 +78,46 @@ async function main() {
     // Deliberately do not use committedResponse.data below: this models a
     // renderer losing the response after the transaction committed.
     const countAfterCommit = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(orderId) as { count: number };
-    const blankKey = await api(baseUrl, `/api/orders/${orderId}/items`, {
+
+    db.prepare('UPDATE order_idempotency SET user_id = \'legacy\' WHERE idempotency_key = ?').run('issue-255-append-retry');
+    const unauthorizedReplay = await api(baseUrl, `/api/orders/${orderId}/items`, {
+      method: 'POST',
+      body: appendBody,
+      headers: { ...waiterAuth, 'Idempotency-Key': 'issue-255-append-retry' },
+    });
+    const countAfterUnauthorized = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(orderId) as { count: number };
+    assertEqual(unauthorizedReplay.status, 403, 'a waiter cannot replay a legacy append record for another owner\'s order');
+    assertEqual(countAfterUnauthorized.count, countAfterCommit.count, 'unauthorized replay does not expose or mutate the order');
+
+    const whitespaceOrder = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: { type: 'takeaway', items: [{ product_id: 'prod-255-base', quantity: 1 }] },
+      headers: authHeader,
+    });
+    const whitespaceBefore = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(whitespaceOrder.data.order.id) as { count: number };
+    const blankKey = await api(baseUrl, `/api/orders/${whitespaceOrder.data.order.id}/items`, {
       method: 'POST',
       body: appendBody,
       headers: { ...authHeader, 'Idempotency-Key': '   ' },
     });
-    const countAfterBlankKey = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(orderId) as { count: number };
-    assertEqual(blankKey.status, 400, 'a supplied blank idempotency key is rejected');
-    assertEqual(countAfterBlankKey.count, countAfterCommit.count, 'blank idempotency key rejection does not mutate the order');
+    const countAfterBlankKey = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(whitespaceOrder.data.order.id) as { count: number };
+    assertEqual(blankKey.status, 200, 'a supplied whitespace-only idempotency key is treated as absent');
+    assertEqual(countAfterBlankKey.count, whitespaceBefore.count + 1, 'a whitespace-only key follows the non-idempotent append path');
+
+    const malformedKey = await api(baseUrl, `/api/orders/${whitespaceOrder.data.order.id}/items`, {
+      method: 'POST',
+      body: appendBody,
+      headers: { ...authHeader, 'Idempotency-Key': 'invalid key' },
+    });
+    const tooLongKey = await api(baseUrl, `/api/orders/${whitespaceOrder.data.order.id}/items`, {
+      method: 'POST',
+      body: appendBody,
+      headers: { ...authHeader, 'Idempotency-Key': 'x'.repeat(129) },
+    });
+    const countAfterInvalidKeys = db.prepare('SELECT COUNT(*) AS count FROM order_items WHERE order_id = ?').get(whitespaceOrder.data.order.id) as { count: number };
+    assertEqual(malformedKey.status, 400, 'a non-whitespace invalid idempotency key is rejected');
+    assertEqual(tooLongKey.status, 400, 'an overlong idempotency key is rejected');
+    assertEqual(countAfterInvalidKeys.count, whitespaceBefore.count + 1, 'invalid idempotency keys do not mutate the order');
 
     db.prepare('INSERT INTO bills (bill_number, order_id, split_group_id) VALUES (?, ?, ?)').run('BILL-255-SPLIT', orderId, 'split-255');
     const replayedResponse = await api(baseUrl, `/api/orders/${orderId}/items`, {

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -218,6 +218,11 @@ function main() {
   );
   assert.equal(readAppendAttempt(conflictingMigrationStorage, { userId: 'different-cashier', now: 4_000 }), null, 'foreign callers proceed without consuming a conflicting legacy retry');
   assert.ok(conflictingMigrationStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'foreign callers preserve the conflicting legacy retry');
+  assert.equal(
+    readAppendAttempt(conflictingMigrationStorage, { userId: 'conflict-owner', now: 4_000 })?.idempotencyKey,
+    'scoped-conflict-key',
+    'the owner continues using the scoped retry while the conflicting legacy record remains preserved',
+  );
 
   const blockedMigrationBacking = new MemoryStorage();
   blockedMigrationBacking.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
@@ -296,6 +301,11 @@ function main() {
   }));
   assert.equal(readAppendAttempt(legacyOrderStorage, { userId: 'legacy-cashier', now: 4_000 }), null, 'legacy new-order records are not mistaken for append records');
   assert.ok(legacyOrderStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'legacy new-order records remain available to the order flow');
+
+  const nullLegacyStorage = new MemoryStorage();
+  nullLegacyStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, 'null');
+  assert.equal(readAppendAttempt(nullLegacyStorage, { userId: 'legacy-cashier', now: 4_000 }), null, 'null legacy records follow the cleanup path');
+  assert.equal(nullLegacyStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), null, 'null legacy records are discarded');
 
   // Cleanup is explicit after the caller receives a confirmed response; a
   // failed/lost response leaves the attempt available for retry.
@@ -396,6 +406,7 @@ function main() {
   assert.equal(afterCleanupFailure.idempotencyKey, 'append-key-after-cleanup-failure', 'cleanup failure does not block a later append');
 
   const combinedFailureBacking = new MemoryStorage();
+  const combinedFailureDurable = new MemoryStorage();
   let combinedFailure = false;
   const combinedFailureStorage = createSafeAppendAttemptStorage({
     getItem: combinedFailureBacking.getItem.bind(combinedFailureBacking),
@@ -407,7 +418,7 @@ function main() {
       if (combinedFailure && key === attemptStorageKey) throw new Error('completion removal blocked');
       combinedFailureBacking.removeItem(key);
     },
-  });
+  }, combinedFailureDurable);
   const combinedFailureAttempt = getOrCreateAppendAttempt(combinedFailureStorage, {
     userId: 'cashier-1',
     orderId: '42',
@@ -419,7 +430,8 @@ function main() {
   });
   combinedFailure = true;
   clearAppendAttempt(combinedFailureStorage, combinedFailureAttempt);
-  assert.equal(readAppendAttempt(combinedFailureStorage, { userId: 'cashier-1', now: 21_501 }), null, 'confirmed completion tombstone prevents a combined storage failure from blocking the current renderer');
+  const reloadedCombinedFailureStorage = createSafeAppendAttemptStorage(combinedFailureBacking, combinedFailureDurable);
+  assert.equal(readAppendAttempt(reloadedCombinedFailureStorage, { userId: 'cashier-1', now: 21_501 }), null, 'durable fallback completion state prevents a combined storage failure from blocking after reload');
 
   const fallbackBacking = new MemoryStorage();
   const fallbackDurable = new MemoryStorage();

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -429,15 +429,19 @@ function main() {
     specialInstructions: 'table-note',
     orderNumber: 'K-42',
     now: 20_000,
-  }), /Unable to persist append retry state/, 'blocked storage prevents the append from starting');
-  assert.equal(readAppendAttempt(blockedStorage, { userId: 'cashier-1', now: 20_001 }), null, 'blocked storage does not leave an in-memory-only retry attempt');
+  }), /Unable to verify append retry state/, 'blocked storage prevents the append from starting');
+  assert.throws(
+    () => readAppendAttempt(blockedStorage, { userId: 'cashier-1', now: 20_001 }),
+    /Unable to verify append retry state/,
+    'blocked storage fails closed instead of treating an unreadable retry state as empty',
+  );
 
-  const fallbackStorage = createSafeAppendAttemptStorage({
+  const unverifiedFallbackStorage = createSafeAppendAttemptStorage({
     getItem: () => { throw new Error('primary storage unavailable'); },
     setItem: () => { throw new Error('primary storage unavailable'); },
     removeItem: () => { throw new Error('primary storage unavailable'); },
   }, new MemoryStorage());
-  const fallbackAttempt = getOrCreateAppendAttempt(fallbackStorage, {
+  assert.throws(() => getOrCreateAppendAttempt(unverifiedFallbackStorage, {
     userId: 'cashier-fallback',
     orderId: '42',
     fingerprint,
@@ -445,8 +449,7 @@ function main() {
     items,
     specialInstructions: 'table-note',
     now: 20_500,
-  });
-  assert.equal(fallbackAttempt.idempotencyKey, 'append-key-fallback-only', 'verified fallback storage remains authoritative when primary storage is unavailable');
+  }), /Unable to verify append retry state/, 'an unreadable primary store blocks a new append before a fallback-only key can be sent');
 
   const unavailableStorage = createSafeAppendAttemptStorage(null);
   assert.throws(() => getOrCreateAppendAttempt(unavailableStorage, {
@@ -523,6 +526,69 @@ function main() {
   clearAppendAttempt(combinedFailureStorage, combinedFailureAttempt);
   const reloadedCombinedFailureStorage = createSafeAppendAttemptStorage(combinedFailureBacking, combinedFailureDurable);
   assert.equal(readAppendAttempt(reloadedCombinedFailureStorage, { userId: 'cashier-1', now: 21_501 }), null, 'durable fallback completion state prevents a combined storage failure from blocking after reload');
+
+  const globalWithDocument = globalThis as unknown as { document?: unknown };
+  const originalDocument = globalWithDocument.document;
+  const cookieValues = new Map<string, string>();
+  const cookieDocument = {} as { cookie: string };
+  Object.defineProperty(cookieDocument, 'cookie', {
+    configurable: true,
+    get: () => [...cookieValues.entries()].map(([name, value]) => `${name}=${value}`).join('; '),
+    set: (entry: string) => {
+      const [pair, ...attributes] = entry.split('; ');
+      const separator = pair.indexOf('=');
+      const name = pair.slice(0, separator);
+      const value = pair.slice(separator + 1);
+      if (attributes.includes('Max-Age=0')) cookieValues.delete(name);
+      else cookieValues.set(name, value);
+    },
+  });
+  Object.defineProperty(globalWithDocument, 'document', { configurable: true, value: cookieDocument });
+  try {
+    const cookieCollisionBacking = new MemoryStorage();
+    const cookieCollisionKey = getAppendAttemptStorageKey('cookie-collision');
+    let cookieCompletionBlocked = false;
+    const cookieCollisionStorage = createSafeAppendAttemptStorage({
+      getItem: cookieCollisionBacking.getItem.bind(cookieCollisionBacking),
+      setItem: (key, value) => {
+        if (cookieCompletionBlocked && (key.includes('.completion') || key === cookieCollisionKey)) {
+          throw new Error('completion storage blocked');
+        }
+        cookieCollisionBacking.setItem(key, value);
+      },
+      removeItem: (key) => {
+        if (cookieCompletionBlocked && key === cookieCollisionKey) throw new Error('completion cleanup blocked');
+        cookieCollisionBacking.removeItem(key);
+      },
+    });
+    const collisionFirstFingerprint = buildAppendItemsFingerprint('42', items, 'note-512789');
+    const collisionSecondFingerprint = buildAppendItemsFingerprint('42', items, 'note-749192');
+    const cookieCollisionAttempt = getOrCreateAppendAttempt(cookieCollisionStorage, {
+      userId: 'cookie-collision',
+      orderId: '42',
+      fingerprint: collisionFirstFingerprint,
+      createKey: () => 'append-key-cookie-collision',
+      items,
+      specialInstructions: 'note-512789',
+      now: 21_750,
+    });
+    cookieCompletionBlocked = true;
+    assert.equal(clearAppendAttempt(cookieCollisionStorage, cookieCollisionAttempt), true, 'a preflighted completion cookie recovers when storage cleanup fails');
+    cookieCollisionBacking.setItem(cookieCollisionKey, JSON.stringify({
+      ...cookieCollisionAttempt,
+      fingerprint: collisionSecondFingerprint,
+      specialInstructions: 'note-749192',
+    }));
+    const cookieCollisionReload = createSafeAppendAttemptStorage(cookieCollisionBacking);
+    assert.equal(
+      readAppendAttempt(cookieCollisionReload, { userId: 'cookie-collision', now: 21_751 })?.fingerprint,
+      collisionSecondFingerprint,
+      'collision-resistant completion identity does not suppress a mismatched retry with the same key',
+    );
+  } finally {
+    if (originalDocument === undefined) delete globalWithDocument.document;
+    else Object.defineProperty(globalWithDocument, 'document', { configurable: true, value: originalDocument });
+  }
 
   const fallbackBacking = new MemoryStorage();
   const fallbackDurable = new MemoryStorage();

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -253,6 +253,36 @@ function main() {
     'scoped-conflict-key',
     'conflicting scoped retry is not overwritten during migration',
   );
+
+  const freshnessMigrationStorage = new MemoryStorage();
+  freshnessMigrationStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
+    userId: 'fresh-owner',
+    fingerprint,
+    idempotencyKey: 'fresh-legacy-key',
+    createdAt: 49_999,
+  }));
+  freshnessMigrationStorage.setItem(getAppendAttemptStorageKey('fresh-owner'), JSON.stringify({
+    userId: 'fresh-owner',
+    orderId: '42',
+    fingerprint,
+    idempotencyKey: 'fresh-legacy-key',
+    items,
+    specialInstructions: 'table-note',
+    createdAt: 40_000,
+  }));
+  const freshMigration = migrateLegacyAppendAttempt(freshnessMigrationStorage, { now: 50_000, maxAgeMs: 5_000 });
+  assert.equal(freshMigration?.createdAt, 49_999, 'fresh shared retry replaces an expired equivalent scoped copy');
+  assert.equal(
+    JSON.parse(freshnessMigrationStorage.getItem(getAppendAttemptStorageKey('fresh-owner'))).createdAt,
+    49_999,
+    'fresh migrated retry remains durable in the scoped slot',
+  );
+  assert.equal(
+    readAppendAttempt(freshnessMigrationStorage, { userId: 'fresh-owner', now: 50_001, maxAgeMs: 5_000 })?.idempotencyKey,
+    'fresh-legacy-key',
+    'fresh migrated retry survives a reload after migration',
+  );
+
   assert.equal(readAppendAttempt(conflictingMigrationStorage, { userId: 'different-cashier', now: 4_000 }), null, 'foreign callers proceed without consuming a conflicting legacy retry');
   assert.ok(conflictingMigrationStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'foreign callers preserve the conflicting legacy retry');
   assert.equal(
@@ -401,6 +431,22 @@ function main() {
     now: 20_000,
   }), /Unable to persist append retry state/, 'blocked storage prevents the append from starting');
   assert.equal(readAppendAttempt(blockedStorage, { userId: 'cashier-1', now: 20_001 }), null, 'blocked storage does not leave an in-memory-only retry attempt');
+
+  const fallbackStorage = createSafeAppendAttemptStorage({
+    getItem: () => { throw new Error('primary storage unavailable'); },
+    setItem: () => { throw new Error('primary storage unavailable'); },
+    removeItem: () => { throw new Error('primary storage unavailable'); },
+  }, new MemoryStorage());
+  const fallbackAttempt = getOrCreateAppendAttempt(fallbackStorage, {
+    userId: 'cashier-fallback',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-fallback-only',
+    items,
+    specialInstructions: 'table-note',
+    now: 20_500,
+  });
+  assert.equal(fallbackAttempt.idempotencyKey, 'append-key-fallback-only', 'verified fallback storage remains authoritative when primary storage is unavailable');
 
   const unavailableStorage = createSafeAppendAttemptStorage(null);
   assert.throws(() => getOrCreateAppendAttempt(unavailableStorage, {

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -176,7 +176,7 @@ function main() {
     setItem: () => { throw new Error('storage blocked'); },
     removeItem: () => { throw new Error('storage blocked'); },
   });
-  const fallbackAttempt = getOrCreateAppendAttempt(blockedStorage, {
+  assert.throws(() => getOrCreateAppendAttempt(blockedStorage, {
     userId: 'cashier-1',
     orderId: '42',
     fingerprint,
@@ -185,18 +185,20 @@ function main() {
     specialInstructions: 'table-note',
     orderNumber: 'K-42',
     now: 20_000,
-  });
-  const fallbackRetry = getOrCreateAppendAttempt(blockedStorage, {
+  }), /Unable to persist append retry state/, 'blocked storage prevents the append from starting');
+  assert.equal(readAppendAttempt(blockedStorage, { userId: 'cashier-1', now: 20_001 }), null, 'blocked storage does not leave an in-memory-only retry attempt');
+
+  const unavailableStorage = createSafeAppendAttemptStorage(null);
+  assert.throws(() => getOrCreateAppendAttempt(unavailableStorage, {
     userId: 'cashier-1',
     orderId: '42',
     fingerprint,
-    createKey: () => 'append-key-memory-2',
+    createKey: () => 'append-key-unavailable',
     items,
     specialInstructions: 'table-note',
     orderNumber: 'K-42',
-    now: 20_001,
-  });
-  assert.equal(fallbackRetry.idempotencyKey, fallbackAttempt.idempotencyKey, 'blocked storage keeps same-renderer retries safe');
+    now: 20_000,
+  }), /Unable to persist append retry state/, 'unavailable storage prevents the append from starting');
 
   const invalidStorage = new MemoryStorage();
   invalidStorage.setItem(attemptStorageKey, JSON.stringify({ ...first, idempotencyKey: ' ' }));

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -126,7 +126,7 @@ function main() {
   assert.deepEqual(reloaded?.items, items, 'reload recovery retains the exact append payload');
   assert.equal(reloaded?.orderNumber, 'K-42', 'reload recovery retains the order display identity');
 
-  const mismatched = getOrCreateAppendAttempt(storage, {
+  assert.throws(() => getOrCreateAppendAttempt(storage, {
     userId: 'cashier-1',
     orderId: '42',
     fingerprint: buildAppendItemsFingerprint('42', [{ product_id: '001', quantity: 2 }], 'table-note'),
@@ -135,13 +135,12 @@ function main() {
     specialInstructions: 'table-note',
     orderNumber: 'K-42',
     now: 3_000,
-  });
-  assert.equal(mismatched.idempotencyKey, 'append-key-3', 'a mismatched payload never reuses the old append key');
-  assert.notEqual(mismatched.fingerprint, first.fingerprint, 'mismatched append payload is represented separately');
+  }), /previous append attempt is still pending/, 'a mismatched payload is rejected without replacing the pending attempt');
+  assert.equal(readAppendAttempt(storage, { userId: 'cashier-1', now: 3_000 })?.idempotencyKey, first.idempotencyKey, 'a mismatched append preserves the original retry key');
 
   // Cleanup is explicit after the caller receives a confirmed response; a
   // failed/lost response leaves the attempt available for retry.
-  clearAppendAttempt(storage, mismatched);
+  clearAppendAttempt(storage, first);
   assert.equal(storage.getItem(attemptStorageKey), null, 'confirmed completion cleanup removes the durable attempt');
 
   const stale = getOrCreateAppendAttempt(storage, {

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -205,10 +205,10 @@ function main() {
     items: [{ product_id: '002', quantity: 1 }],
     createdAt: 4_000,
   }));
-  assert.throws(
-    () => migrateLegacyAppendAttempt(conflictingMigrationStorage, { now: 4_000 }),
-    /Unable to migrate legacy append retry state safely/,
-    'a conflicting scoped attempt does not consume the legacy retry record',
+  assert.equal(
+    migrateLegacyAppendAttempt(conflictingMigrationStorage, { now: 4_000 })?.idempotencyKey,
+    'legacy-conflict-key',
+    'a conflicting scoped attempt preserves the legacy retry record',
   );
   assert.ok(conflictingMigrationStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'conflicting legacy retry remains available');
   assert.equal(
@@ -216,6 +216,8 @@ function main() {
     'scoped-conflict-key',
     'conflicting scoped retry is not overwritten during migration',
   );
+  assert.equal(readAppendAttempt(conflictingMigrationStorage, { userId: 'different-cashier', now: 4_000 }), null, 'foreign callers proceed without consuming a conflicting legacy retry');
+  assert.ok(conflictingMigrationStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'foreign callers preserve the conflicting legacy retry');
 
   const blockedMigrationBacking = new MemoryStorage();
   blockedMigrationBacking.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
@@ -279,10 +281,10 @@ function main() {
     items,
     createdAt: 4_000,
   }));
-  assert.throws(
-    () => readAppendAttempt(conflictingUnscopedStorage, { userId: 'unscoped-owner', now: 4_000 }),
-    /Unable to migrate conflicting append retry state/,
-    'a conflicting unscoped retry is not discarded beside a scoped attempt',
+  assert.equal(
+    readAppendAttempt(conflictingUnscopedStorage, { userId: 'unscoped-owner', now: 4_000 })?.idempotencyKey,
+    'scoped-append-key',
+    'a conflicting unscoped retry does not replace the scoped attempt',
   );
   assert.ok(conflictingUnscopedStorage.getItem(APPEND_ATTEMPT_STORAGE_KEY), 'conflicting unscoped retry remains available');
 
@@ -358,10 +360,14 @@ function main() {
   }), /Unable to persist append retry state/, 'unavailable storage prevents the append from starting');
 
   const cleanupBacking = new MemoryStorage();
+  let cleanupBlocked = false;
   const cleanupFailureStorage = createSafeAppendAttemptStorage({
     getItem: cleanupBacking.getItem.bind(cleanupBacking),
     setItem: cleanupBacking.setItem.bind(cleanupBacking),
-    removeItem: () => { throw new Error('cleanup blocked'); },
+    removeItem: (key) => {
+      if (cleanupBlocked && key === attemptStorageKey) throw new Error('cleanup blocked');
+      cleanupBacking.removeItem(key);
+    },
   });
   const completed = getOrCreateAppendAttempt(cleanupFailureStorage, {
     userId: 'cashier-1',
@@ -373,6 +379,7 @@ function main() {
     orderNumber: 'K-42',
     now: 21_000,
   });
+  cleanupBlocked = true;
   clearAppendAttempt(cleanupFailureStorage, completed);
   const reloadedCleanupStorage = createSafeAppendAttemptStorage(cleanupBacking);
   assert.equal(readAppendAttempt(reloadedCleanupStorage, { userId: 'cashier-1', now: 21_001 }), null, 'a durable completion marker suppresses a stale attempt after cleanup failure');
@@ -389,17 +396,19 @@ function main() {
   assert.equal(afterCleanupFailure.idempotencyKey, 'append-key-after-cleanup-failure', 'cleanup failure does not block a later append');
 
   const fallbackBacking = new MemoryStorage();
+  const fallbackDurable = new MemoryStorage();
+  let fallbackCleanupBlocked = false;
   const fallbackStorage = createSafeAppendAttemptStorage({
     getItem: fallbackBacking.getItem.bind(fallbackBacking),
     setItem: (key, value) => {
-      if (key.endsWith('.completed')) throw new Error('marker storage blocked');
+      if (fallbackCleanupBlocked && (key.endsWith('.completed') || key === getAppendAttemptStorageKey('cashier-1'))) throw new Error('primary cleanup blocked');
       fallbackBacking.setItem(key, value);
     },
     removeItem: (key) => {
-      if (key === getAppendAttemptStorageKey('cashier-1')) throw new Error('cleanup blocked');
+      if (fallbackCleanupBlocked && key === getAppendAttemptStorageKey('cashier-1')) throw new Error('cleanup blocked');
       fallbackBacking.removeItem(key);
     },
-  });
+  }, fallbackDurable);
   const fallbackCompleted = getOrCreateAppendAttempt(fallbackStorage, {
     userId: 'cashier-1',
     orderId: '42',
@@ -409,8 +418,9 @@ function main() {
     specialInstructions: 'table-note',
     now: 22_000,
   });
+  fallbackCleanupBlocked = true;
   clearAppendAttempt(fallbackStorage, fallbackCompleted);
-  const fallbackReload = createSafeAppendAttemptStorage(fallbackBacking);
+  const fallbackReload = createSafeAppendAttemptStorage(fallbackBacking, fallbackDurable);
   assert.equal(readAppendAttempt(fallbackReload, { userId: 'cashier-1', now: 22_001 }), null, 'fallback completion state suppresses a stale attempt after marker failure');
   assert.equal(
     getOrCreateAppendAttempt(fallbackReload, {

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -83,6 +83,31 @@ function main() {
     'falsy add-on quantity matches the existing default quantity of one',
   );
 
+  const namespaceStorage = new MemoryStorage();
+  const namespaceItems = [{ product_id: 'namespace-item', quantity: 1 }];
+  const namespaceFirst = getOrCreateAppendAttempt(namespaceStorage, {
+    userId: 'cashier',
+    orderId: '42',
+    fingerprint: buildAppendItemsFingerprint('42', namespaceItems),
+    createKey: () => 'namespace-first-key',
+    items: namespaceItems,
+    now: 500,
+  });
+  const namespaceSecond = getOrCreateAppendAttempt(namespaceStorage, {
+    userId: 'cashier.completed',
+    orderId: '43',
+    fingerprint: buildAppendItemsFingerprint('43', namespaceItems),
+    createKey: () => 'namespace-second-key',
+    items: namespaceItems,
+    now: 500,
+  });
+  clearAppendAttempt(namespaceStorage, namespaceFirst);
+  assert.equal(
+    readAppendAttempt(namespaceStorage, { userId: 'cashier.completed', now: 501 })?.idempotencyKey,
+    namespaceSecond.idempotencyKey,
+    'completion state cannot collide with another user\'s pending retry key',
+  );
+
   const normal = generateCartItemId('burger', [addon('cheese'), addon('sauce')], 'no onions');
   assert.equal(
     normal,
@@ -411,7 +436,7 @@ function main() {
   const combinedFailureStorage = createSafeAppendAttemptStorage({
     getItem: combinedFailureBacking.getItem.bind(combinedFailureBacking),
     setItem: (key, value) => {
-      if (combinedFailure && (key.endsWith('.completed') || key === attemptStorageKey)) throw new Error('completion writes blocked');
+      if (combinedFailure && (key.includes('.completion.') || key === attemptStorageKey)) throw new Error('completion writes blocked');
       combinedFailureBacking.setItem(key, value);
     },
     removeItem: (key) => {
@@ -439,7 +464,7 @@ function main() {
   const fallbackStorage = createSafeAppendAttemptStorage({
     getItem: fallbackBacking.getItem.bind(fallbackBacking),
     setItem: (key, value) => {
-      if (fallbackCleanupBlocked && (key.endsWith('.completed') || key === getAppendAttemptStorageKey('cashier-1'))) throw new Error('primary cleanup blocked');
+      if (fallbackCleanupBlocked && (key.includes('.completion.') || key === getAppendAttemptStorageKey('cashier-1'))) throw new Error('primary cleanup blocked');
       fallbackBacking.setItem(key, value);
     },
     removeItem: (key) => {

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -11,6 +11,7 @@ const {
   buildAppendItemsFingerprint,
   createSafeAppendAttemptStorage,
   getOrCreateAppendAttempt,
+  migrateLegacyAppendAttempt,
   readAppendAttempt,
   clearAppendAttempt,
 } = require('../frontend/src/lib/append-attempt');
@@ -152,7 +153,7 @@ function main() {
   const legacyStorage = new MemoryStorage();
   legacyStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
     userId: 'legacy-cashier',
-    fingerprint: buildAppendItemsFingerprint('42', items, 'table-note'),
+    fingerprint: JSON.stringify({ order_id: 42, items, special_instructions: 'table-note' }),
     idempotencyKey: 'legacy-append-key',
   }));
   const migrated = readAppendAttempt(legacyStorage, { userId: 'legacy-cashier', now: 4_000 });
@@ -160,6 +161,34 @@ function main() {
   assert.equal(migrated?.orderId, '42', 'legacy migration preserves the appended order');
   assert.deepEqual(migrated?.items, items, 'legacy migration preserves the append payload');
   assert.equal(legacyStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), null, 'legacy append storage is removed after migration');
+  const migratedRetry = getOrCreateAppendAttempt(legacyStorage, {
+    userId: 'legacy-cashier',
+    orderId: '42',
+    fingerprint: buildAppendItemsFingerprint('42', items, 'table-note'),
+    createKey: () => 'new-key-after-migration',
+    items,
+    specialInstructions: 'table-note',
+    now: 4_001,
+  });
+  assert.equal(migratedRetry.idempotencyKey, 'legacy-append-key', 'migrated append reuses its key for the normalized logical payload');
+
+  const foreignLegacyStorage = new MemoryStorage();
+  foreignLegacyStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
+    userId: 'legacy-owner',
+    fingerprint: JSON.stringify({ order_id: 42, items }),
+    idempotencyKey: 'foreign-legacy-key',
+  }));
+  assert.equal(readAppendAttempt(foreignLegacyStorage, { userId: 'different-cashier', now: 4_000 }), null, 'foreign cashier cannot read a migrated append');
+  assert.equal(foreignLegacyStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), null, 'recognized foreign append is removed from the shared legacy slot');
+  assert.equal(readAppendAttempt(foreignLegacyStorage, { userId: 'legacy-owner', now: 4_001 })?.idempotencyKey, 'foreign-legacy-key', 'recognized foreign append remains recoverable in its owner-scoped slot');
+
+  const directMigrationStorage = new MemoryStorage();
+  directMigrationStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
+    userId: 'direct-owner',
+    fingerprint: JSON.stringify({ order_id: 42, items }),
+    idempotencyKey: 'direct-legacy-key',
+  }));
+  assert.equal(migrateLegacyAppendAttempt(directMigrationStorage, { now: 4_000 })?.userId, 'direct-owner', 'legacy append migration identifies the recorded owner');
 
   const legacyOrderStorage = new MemoryStorage();
   legacyOrderStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -1,0 +1,224 @@
+/** Issue #255 regression coverage for collision-safe cart identity and durable append attempts. */
+const assert = require('node:assert/strict');
+const {
+  generateCartItemId,
+  normalizeCartItems,
+} = require('../frontend/src/lib/cart-identity');
+const {
+  APPEND_ATTEMPT_MAX_AGE_MS,
+  getAppendAttemptStorageKey,
+  buildAppendItemsFingerprint,
+  createSafeAppendAttemptStorage,
+  getOrCreateAppendAttempt,
+  readAppendAttempt,
+  clearAppendAttempt,
+} = require('../frontend/src/lib/append-attempt');
+
+class MemoryStorage {
+  values = new Map();
+
+  getItem(key: string) {
+    return this.values.has(key) ? this.values.get(key) : null;
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+}
+
+function addon(id: number | string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    addon_group_id: 'group-1',
+    name: 'Extra',
+    price: 10,
+    quantity: 1,
+    is_active: 1,
+    sort_order: 1,
+    ...overrides,
+  };
+}
+
+function main() {
+  // The old delimiter-joined identity made these two different configurations
+  // produce the same string: "burger-a-b-c".
+  const delimiterFirst = generateCartItemId('burger-a', [], 'b-c');
+  const delimiterSecond = generateCartItemId('burger', [], 'a-b-c');
+  assert.notEqual(delimiterFirst, delimiterSecond, 'delimiter-bearing product/note values keep distinct cart lines');
+
+  const addonDelimiterFirst = generateCartItemId('burger', [addon('extra-a')], 'b-c');
+  const addonDelimiterSecond = generateCartItemId('burger', [addon('extra')], 'a-b-c');
+  assert.notEqual(addonDelimiterFirst, addonDelimiterSecond, 'delimiter-bearing add-on/note values keep distinct cart lines');
+
+  assert.notEqual(
+    generateCartItemId('001', [], ''),
+    generateCartItemId(1, [], ''),
+    'leading-zero product IDs are not coerced into numeric IDs',
+  );
+  assert.notEqual(
+    generateCartItemId('burger', [addon('001')], ''),
+    generateCartItemId('burger', [addon(1)], ''),
+    'leading-zero add-on IDs are not coerced into numeric IDs',
+  );
+  assert.notEqual(
+    generateCartItemId('burger', [addon('extra', { name: 'No onions' })], ''),
+    generateCartItemId('burger', [addon('extra', { name: 'Extra onions' })], ''),
+    'add-on option fields participate in cart identity',
+  );
+
+  const normal = generateCartItemId('burger', [addon('cheese'), addon('sauce')], 'no onions');
+  assert.equal(
+    normal,
+    generateCartItemId('burger', [addon('sauce'), addon('cheese')], 'no onions'),
+    'normal cart identity is stable when selected add-ons arrive in a different order',
+  );
+  assert.notEqual(
+    normal,
+    generateCartItemId('burger', [addon('cheese'), addon('sauce')], 'extra hot'),
+    'normal carts with different notes remain distinct',
+  );
+
+  const loadedProduct = { id: 'burger', name: 'Burger', price: 100 };
+  const normalizedLoaded = normalizeCartItems([
+    { id: 'legacy-burger-no-onions', product: loadedProduct, quantity: 1, addons: [], special_instructions: 'no onions' },
+    { id: 'legacy-burger-extra-hot', product: loadedProduct, quantity: 2, addons: [], special_instructions: 'extra hot' },
+    { id: 'legacy-burger-no-onions-2', product: loadedProduct, quantity: 3, addons: [], special_instructions: 'no onions' },
+  ]);
+  assert.equal(normalizedLoaded.length, 2, 'loaded carts preserve distinct configurations while merging equivalent lines');
+  assert.equal(normalizedLoaded.find((item: any) => item.special_instructions === 'no onions')?.quantity, 4, 'loaded equivalent lines use canonical identity and combine quantities');
+  assert.equal(normalizedLoaded.find((item: any) => item.special_instructions === 'no onions')?.id, generateCartItemId('burger', [], 'no onions'), 'loaded lines receive canonical IDs');
+
+  const storage = new MemoryStorage();
+  const attemptStorageKey = getAppendAttemptStorageKey('cashier-1');
+  const items = [{ product_id: '001', quantity: 1, special_instructions: 'no-onions' }];
+  const fingerprint = buildAppendItemsFingerprint('42', items, 'table-note');
+  const first = getOrCreateAppendAttempt(storage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-1',
+    items,
+    specialInstructions: 'table-note',
+    orderNumber: 'K-42',
+    now: 1_000,
+  });
+  assert.equal(first.idempotencyKey, 'append-key-1', 'first append attempt creates and persists a key');
+  assert.ok(storage.getItem(attemptStorageKey), 'append attempt is durable before the request is sent');
+
+  // Simulate a committed request whose response was lost, then a renderer
+  // reload. The same logical payload must recover the original key.
+  const recovered = getOrCreateAppendAttempt(storage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-2',
+    items,
+    specialInstructions: 'table-note',
+    orderNumber: 'K-42',
+    now: 2_000,
+  });
+  assert.equal(recovered.idempotencyKey, first.idempotencyKey, 'response-loss/reload recovery reuses the original append key');
+  const reloaded = readAppendAttempt(storage, { userId: 'cashier-1', now: 2_000 });
+  assert.deepEqual(reloaded?.items, items, 'reload recovery retains the exact append payload');
+  assert.equal(reloaded?.orderNumber, 'K-42', 'reload recovery retains the order display identity');
+
+  const mismatched = getOrCreateAppendAttempt(storage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint: buildAppendItemsFingerprint('42', [{ product_id: '001', quantity: 2 }], 'table-note'),
+    createKey: () => 'append-key-3',
+    items: [{ product_id: '001', quantity: 2 }],
+    specialInstructions: 'table-note',
+    orderNumber: 'K-42',
+    now: 3_000,
+  });
+  assert.equal(mismatched.idempotencyKey, 'append-key-3', 'a mismatched payload never reuses the old append key');
+  assert.notEqual(mismatched.fingerprint, first.fingerprint, 'mismatched append payload is represented separately');
+
+  // Cleanup is explicit after the caller receives a confirmed response; a
+  // failed/lost response leaves the attempt available for retry.
+  clearAppendAttempt(storage, mismatched);
+  assert.equal(storage.getItem(attemptStorageKey), null, 'confirmed completion cleanup removes the durable attempt');
+
+  const stale = getOrCreateAppendAttempt(storage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-stale',
+    items,
+    specialInstructions: 'table-note',
+    orderNumber: 'K-42',
+    now: 10_000,
+  });
+  const expired = getOrCreateAppendAttempt(storage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-fresh',
+    items,
+    specialInstructions: 'table-note',
+    orderNumber: 'K-42',
+    now: 10_000 + APPEND_ATTEMPT_MAX_AGE_MS + 1,
+  });
+  assert.equal(stale.idempotencyKey, 'append-key-stale', 'expiry fixture starts with a stale key');
+  assert.equal(expired.idempotencyKey, 'append-key-fresh', 'expired attempts are replaced with a fresh key');
+  assert.equal(JSON.parse(storage.getItem(attemptStorageKey)).idempotencyKey, 'append-key-fresh', 'expiry cleanup persists only the fresh attempt');
+  clearAppendAttempt(storage, stale);
+  assert.equal(JSON.parse(storage.getItem(attemptStorageKey)).idempotencyKey, 'append-key-fresh', 'late cleanup cannot remove a newer append attempt');
+  clearAppendAttempt(storage, expired);
+  assert.equal(storage.getItem(attemptStorageKey), null, 'matching confirmed completion cleanup removes the current attempt');
+
+  const blockedStorage = createSafeAppendAttemptStorage({
+    getItem: () => { throw new Error('storage blocked'); },
+    setItem: () => { throw new Error('storage blocked'); },
+    removeItem: () => { throw new Error('storage blocked'); },
+  });
+  const fallbackAttempt = getOrCreateAppendAttempt(blockedStorage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-memory',
+    items,
+    specialInstructions: 'table-note',
+    orderNumber: 'K-42',
+    now: 20_000,
+  });
+  const fallbackRetry = getOrCreateAppendAttempt(blockedStorage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-memory-2',
+    items,
+    specialInstructions: 'table-note',
+    orderNumber: 'K-42',
+    now: 20_001,
+  });
+  assert.equal(fallbackRetry.idempotencyKey, fallbackAttempt.idempotencyKey, 'blocked storage keeps same-renderer retries safe');
+
+  const invalidStorage = new MemoryStorage();
+  invalidStorage.setItem(attemptStorageKey, JSON.stringify({ ...first, idempotencyKey: ' ' }));
+  assert.equal(readAppendAttempt(invalidStorage, { userId: 'cashier-1', now: 2_000 }), null, 'invalid persisted keys are discarded before recovery');
+  assert.equal(invalidStorage.getItem(attemptStorageKey), null, 'invalid persisted key cleanup is safe');
+
+  const foreignStorage = new MemoryStorage();
+  const foreignAttempt = getOrCreateAppendAttempt(foreignStorage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-foreign',
+    items,
+    specialInstructions: 'table-note',
+    orderNumber: 'K-42',
+    now: 30_000,
+  });
+  assert.equal(readAppendAttempt(foreignStorage, { userId: 'cashier-2', now: 30_001 }), null, 'another cashier does not recover a foreign append attempt');
+  assert.equal(readAppendAttempt(foreignStorage, { userId: 'cashier-1', now: 30_001 })?.idempotencyKey, foreignAttempt.idempotencyKey, 'the original cashier retains its pending append retry');
+
+  console.log('Issue #255 cart identity and append-attempt tests passed');
+}
+
+main();

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -75,6 +75,11 @@ function main() {
     generateCartItemId('burger', [addon('extra', { quantity: 1 })], ''),
     'missing add-on quantity matches the default quantity of one',
   );
+  assert.equal(
+    generateCartItemId('burger', [addon('extra', { quantity: 0 })], ''),
+    generateCartItemId('burger', [addon('extra', { quantity: 1 })], ''),
+    'falsy add-on quantity matches the existing default quantity of one',
+  );
 
   const normal = generateCartItemId('burger', [addon('cheese'), addon('sauce')], 'no onions');
   assert.equal(

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -9,6 +9,7 @@ const {
   APPEND_ATTEMPT_STORAGE_KEY,
   LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY,
   getAppendAttemptStorageKey,
+  getPostpaidOrderAttemptStorageKey,
   buildAppendItemsFingerprint,
   createSafeAppendAttemptStorage,
   getOrCreateAppendAttempt,
@@ -248,6 +249,14 @@ function main() {
     'scoped-conflict-key',
     'the owner continues using the scoped retry while the conflicting legacy record remains preserved',
   );
+  const foreignOrder = { userId: 'different-cashier', fingerprint: 'order-fingerprint', idempotencyKey: 'foreign-order-key' };
+  conflictingMigrationStorage.setItem(getPostpaidOrderAttemptStorageKey(foreignOrder.userId), JSON.stringify(foreignOrder));
+  assert.equal(
+    JSON.parse(conflictingMigrationStorage.getItem(getPostpaidOrderAttemptStorageKey(foreignOrder.userId))).idempotencyKey,
+    foreignOrder.idempotencyKey,
+    'a foreign order uses a user-scoped key without overwriting the conflicting shared append retry',
+  );
+  assert.ok(conflictingMigrationStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'user-scoped order storage preserves the shared append retry');
 
   const blockedMigrationBacking = new MemoryStorage();
   blockedMigrationBacking.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -6,6 +6,7 @@ const {
 } = require('../frontend/src/lib/cart-identity');
 const {
   APPEND_ATTEMPT_MAX_AGE_MS,
+  LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY,
   getAppendAttemptStorageKey,
   buildAppendItemsFingerprint,
   createSafeAppendAttemptStorage,
@@ -68,6 +69,11 @@ function main() {
     generateCartItemId('burger', [addon('extra', { name: 'No onions' })], ''),
     generateCartItemId('burger', [addon('extra', { name: 'Extra onions' })], ''),
     'add-on option fields participate in cart identity',
+  );
+  assert.equal(
+    generateCartItemId('burger', [addon('extra', { quantity: undefined })], ''),
+    generateCartItemId('burger', [addon('extra', { quantity: 1 })], ''),
+    'missing add-on quantity matches the default quantity of one',
   );
 
   const normal = generateCartItemId('burger', [addon('cheese'), addon('sauce')], 'no onions');
@@ -138,6 +144,27 @@ function main() {
   }), /previous append attempt is still pending/, 'a mismatched payload is rejected without replacing the pending attempt');
   assert.equal(readAppendAttempt(storage, { userId: 'cashier-1', now: 3_000 })?.idempotencyKey, first.idempotencyKey, 'a mismatched append preserves the original retry key');
 
+  const legacyStorage = new MemoryStorage();
+  legacyStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
+    userId: 'legacy-cashier',
+    fingerprint: buildAppendItemsFingerprint('42', items, 'table-note'),
+    idempotencyKey: 'legacy-append-key',
+  }));
+  const migrated = readAppendAttempt(legacyStorage, { userId: 'legacy-cashier', now: 4_000 });
+  assert.equal(migrated?.idempotencyKey, 'legacy-append-key', 'legacy append records migrate before new attempts are created');
+  assert.equal(migrated?.orderId, '42', 'legacy migration preserves the appended order');
+  assert.deepEqual(migrated?.items, items, 'legacy migration preserves the append payload');
+  assert.equal(legacyStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), null, 'legacy append storage is removed after migration');
+
+  const legacyOrderStorage = new MemoryStorage();
+  legacyOrderStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
+    userId: 'legacy-cashier',
+    fingerprint: JSON.stringify({ table_id: 'table-1', items }),
+    idempotencyKey: 'legacy-order-key',
+  }));
+  assert.equal(readAppendAttempt(legacyOrderStorage, { userId: 'legacy-cashier', now: 4_000 }), null, 'legacy new-order records are not mistaken for append records');
+  assert.ok(legacyOrderStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'legacy new-order records remain available to the order flow');
+
   // Cleanup is explicit after the caller receives a confirmed response; a
   // failed/lost response leaves the attempt available for retry.
   clearAppendAttempt(storage, first);
@@ -199,6 +226,37 @@ function main() {
     orderNumber: 'K-42',
     now: 20_000,
   }), /Unable to persist append retry state/, 'unavailable storage prevents the append from starting');
+
+  const cleanupBacking = new MemoryStorage();
+  const cleanupFailureStorage = createSafeAppendAttemptStorage({
+    getItem: cleanupBacking.getItem.bind(cleanupBacking),
+    setItem: cleanupBacking.setItem.bind(cleanupBacking),
+    removeItem: () => { throw new Error('cleanup blocked'); },
+  });
+  const completed = getOrCreateAppendAttempt(cleanupFailureStorage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-cleanup-failure',
+    items,
+    specialInstructions: 'table-note',
+    orderNumber: 'K-42',
+    now: 21_000,
+  });
+  clearAppendAttempt(cleanupFailureStorage, completed);
+  const reloadedCleanupStorage = createSafeAppendAttemptStorage(cleanupBacking);
+  assert.equal(readAppendAttempt(reloadedCleanupStorage, { userId: 'cashier-1', now: 21_001 }), null, 'a durable completion marker suppresses a stale attempt after cleanup failure');
+  const afterCleanupFailure = getOrCreateAppendAttempt(reloadedCleanupStorage, {
+    userId: 'cashier-1',
+    orderId: '43',
+    fingerprint: buildAppendItemsFingerprint('43', items, 'table-note'),
+    createKey: () => 'append-key-after-cleanup-failure',
+    items,
+    specialInstructions: 'table-note',
+    orderNumber: 'K-43',
+    now: 21_002,
+  });
+  assert.equal(afterCleanupFailure.idempotencyKey, 'append-key-after-cleanup-failure', 'cleanup failure does not block a later append');
 
   const invalidStorage = new MemoryStorage();
   invalidStorage.setItem(attemptStorageKey, JSON.stringify({ ...first, idempotencyKey: ' ' }));

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -165,6 +165,17 @@ function main() {
   assert.deepEqual(reloaded?.items, items, 'reload recovery retains the exact append payload');
   assert.equal(reloaded?.orderNumber, 'K-42', 'reload recovery retains the order display identity');
 
+  const stalePrimary = new MemoryStorage();
+  const freshFallback = new MemoryStorage();
+  stalePrimary.setItem(attemptStorageKey, JSON.stringify({ ...first, idempotencyKey: 'stale-primary-key' }));
+  freshFallback.setItem(attemptStorageKey, JSON.stringify({ ...first, idempotencyKey: 'fresh-fallback-key' }));
+  const conflictingStorage = createSafeAppendAttemptStorage(stalePrimary, freshFallback);
+  assert.throws(
+    () => readAppendAttempt(conflictingStorage, { userId: 'cashier-1', now: 2_001 }),
+    /Conflicting append retry state/,
+    'stale primary and fresh fallback retry values fail closed instead of selecting an ambiguous key',
+  );
+
   assert.throws(() => getOrCreateAppendAttempt(storage, {
     userId: 'cashier-1',
     orderId: '42',

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -6,6 +6,7 @@ const {
 } = require('../frontend/src/lib/cart-identity');
 const {
   APPEND_ATTEMPT_MAX_AGE_MS,
+  APPEND_ATTEMPT_STORAGE_KEY,
   LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY,
   getAppendAttemptStorageKey,
   buildAppendItemsFingerprint,
@@ -236,6 +237,54 @@ function main() {
     'a failed scoped migration blocks recovery instead of using the shared record',
   );
   assert.ok(blockedMigrationBacking.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'failed migration preserves the shared retry record');
+
+  const unscopedMigrationBacking = new MemoryStorage();
+  unscopedMigrationBacking.setItem(APPEND_ATTEMPT_STORAGE_KEY, JSON.stringify({
+    userId: 'unscoped-owner',
+    orderId: '42',
+    fingerprint,
+    idempotencyKey: 'unscoped-append-key',
+    items,
+    createdAt: 4_000,
+  }));
+  const unscopedMigrationStorage = createSafeAppendAttemptStorage({
+    getItem: unscopedMigrationBacking.getItem.bind(unscopedMigrationBacking),
+    setItem: unscopedMigrationBacking.setItem.bind(unscopedMigrationBacking),
+    removeItem: (key) => {
+      if (key === APPEND_ATTEMPT_STORAGE_KEY) return;
+      unscopedMigrationBacking.removeItem(key);
+    },
+  });
+  assert.throws(
+    () => readAppendAttempt(unscopedMigrationStorage, { userId: 'unscoped-owner', now: 4_000 }),
+    /Unable to complete append retry migration/,
+    'a failed unscoped-key removal blocks migration instead of leaving a duplicate recovery source',
+  );
+  assert.ok(unscopedMigrationBacking.getItem(APPEND_ATTEMPT_STORAGE_KEY), 'failed unscoped migration preserves the original retry record');
+
+  const conflictingUnscopedStorage = new MemoryStorage();
+  conflictingUnscopedStorage.setItem(getAppendAttemptStorageKey('unscoped-owner'), JSON.stringify({
+    userId: 'unscoped-owner',
+    orderId: '42',
+    fingerprint,
+    idempotencyKey: 'scoped-append-key',
+    items,
+    createdAt: 4_000,
+  }));
+  conflictingUnscopedStorage.setItem(APPEND_ATTEMPT_STORAGE_KEY, JSON.stringify({
+    userId: 'unscoped-owner',
+    orderId: '43',
+    fingerprint: buildAppendItemsFingerprint('43', items),
+    idempotencyKey: 'unscoped-append-key',
+    items,
+    createdAt: 4_000,
+  }));
+  assert.throws(
+    () => readAppendAttempt(conflictingUnscopedStorage, { userId: 'unscoped-owner', now: 4_000 }),
+    /Unable to migrate conflicting append retry state/,
+    'a conflicting unscoped retry is not discarded beside a scoped attempt',
+  );
+  assert.ok(conflictingUnscopedStorage.getItem(APPEND_ATTEMPT_STORAGE_KEY), 'conflicting unscoped retry remains available');
 
   const legacyOrderStorage = new MemoryStorage();
   legacyOrderStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -190,6 +190,53 @@ function main() {
   }));
   assert.equal(migrateLegacyAppendAttempt(directMigrationStorage, { now: 4_000 })?.userId, 'direct-owner', 'legacy append migration identifies the recorded owner');
 
+  const conflictingMigrationStorage = new MemoryStorage();
+  conflictingMigrationStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
+    userId: 'conflict-owner',
+    fingerprint: JSON.stringify({ order_id: 42, items }),
+    idempotencyKey: 'legacy-conflict-key',
+  }));
+  conflictingMigrationStorage.setItem(getAppendAttemptStorageKey('conflict-owner'), JSON.stringify({
+    userId: 'conflict-owner',
+    orderId: '42',
+    fingerprint: buildAppendItemsFingerprint('42', [{ product_id: '002', quantity: 1 }]),
+    idempotencyKey: 'scoped-conflict-key',
+    items: [{ product_id: '002', quantity: 1 }],
+    createdAt: 4_000,
+  }));
+  assert.throws(
+    () => migrateLegacyAppendAttempt(conflictingMigrationStorage, { now: 4_000 }),
+    /Unable to migrate legacy append retry state safely/,
+    'a conflicting scoped attempt does not consume the legacy retry record',
+  );
+  assert.ok(conflictingMigrationStorage.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'conflicting legacy retry remains available');
+  assert.equal(
+    JSON.parse(conflictingMigrationStorage.getItem(getAppendAttemptStorageKey('conflict-owner'))).idempotencyKey,
+    'scoped-conflict-key',
+    'conflicting scoped retry is not overwritten during migration',
+  );
+
+  const blockedMigrationBacking = new MemoryStorage();
+  blockedMigrationBacking.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
+    userId: 'blocked-owner',
+    fingerprint: JSON.stringify({ order_id: 42, items }),
+    idempotencyKey: 'blocked-legacy-key',
+  }));
+  const blockedMigrationStorage = createSafeAppendAttemptStorage({
+    getItem: blockedMigrationBacking.getItem.bind(blockedMigrationBacking),
+    setItem: (key, value) => {
+      if (key === getAppendAttemptStorageKey('blocked-owner')) throw new Error('scoped storage blocked');
+      blockedMigrationBacking.setItem(key, value);
+    },
+    removeItem: blockedMigrationBacking.removeItem.bind(blockedMigrationBacking),
+  });
+  assert.throws(
+    () => readAppendAttempt(blockedMigrationStorage, { userId: 'blocked-owner', now: 4_000 }),
+    /Unable to persist append retry state/,
+    'a failed scoped migration blocks recovery instead of using the shared record',
+  );
+  assert.ok(blockedMigrationBacking.getItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY), 'failed migration preserves the shared retry record');
+
   const legacyOrderStorage = new MemoryStorage();
   legacyOrderStorage.setItem(LEGACY_POSTPAID_ATTEMPT_STORAGE_KEY, JSON.stringify({
     userId: 'legacy-cashier',
@@ -291,6 +338,44 @@ function main() {
     now: 21_002,
   });
   assert.equal(afterCleanupFailure.idempotencyKey, 'append-key-after-cleanup-failure', 'cleanup failure does not block a later append');
+
+  const fallbackBacking = new MemoryStorage();
+  const fallbackStorage = createSafeAppendAttemptStorage({
+    getItem: fallbackBacking.getItem.bind(fallbackBacking),
+    setItem: (key, value) => {
+      if (key.endsWith('.completed')) throw new Error('marker storage blocked');
+      fallbackBacking.setItem(key, value);
+    },
+    removeItem: (key) => {
+      if (key === getAppendAttemptStorageKey('cashier-1')) throw new Error('cleanup blocked');
+      fallbackBacking.removeItem(key);
+    },
+  });
+  const fallbackCompleted = getOrCreateAppendAttempt(fallbackStorage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-fallback-completion',
+    items,
+    specialInstructions: 'table-note',
+    now: 22_000,
+  });
+  clearAppendAttempt(fallbackStorage, fallbackCompleted);
+  const fallbackReload = createSafeAppendAttemptStorage(fallbackBacking);
+  assert.equal(readAppendAttempt(fallbackReload, { userId: 'cashier-1', now: 22_001 }), null, 'fallback completion state suppresses a stale attempt after marker failure');
+  assert.equal(
+    getOrCreateAppendAttempt(fallbackReload, {
+      userId: 'cashier-1',
+      orderId: '43',
+      fingerprint: buildAppendItemsFingerprint('43', items, 'table-note'),
+      createKey: () => 'append-key-after-fallback-completion',
+      items,
+      specialInstructions: 'table-note',
+      now: 22_002,
+    }).idempotencyKey,
+    'append-key-after-fallback-completion',
+    'fallback completion state does not block a later append',
+  );
 
   const invalidStorage = new MemoryStorage();
   invalidStorage.setItem(attemptStorageKey, JSON.stringify({ ...first, idempotencyKey: ' ' }));

--- a/tests/issue-255-pos-cart-retry.test.ts
+++ b/tests/issue-255-pos-cart-retry.test.ts
@@ -53,8 +53,8 @@ function main() {
   const delimiterSecond = generateCartItemId('burger', [], 'a-b-c');
   assert.notEqual(delimiterFirst, delimiterSecond, 'delimiter-bearing product/note values keep distinct cart lines');
 
-  const addonDelimiterFirst = generateCartItemId('burger', [addon('extra-a')], 'b-c');
-  const addonDelimiterSecond = generateCartItemId('burger', [addon('extra')], 'a-b-c');
+  const addonDelimiterFirst = generateCartItemId('burger', [addon('extra')], 'a:1-b-c');
+  const addonDelimiterSecond = generateCartItemId('burger-extra:1-a:1', [], 'b-c');
   assert.notEqual(addonDelimiterFirst, addonDelimiterSecond, 'delimiter-bearing add-on/note values keep distinct cart lines');
 
   assert.notEqual(
@@ -394,6 +394,32 @@ function main() {
     now: 21_002,
   });
   assert.equal(afterCleanupFailure.idempotencyKey, 'append-key-after-cleanup-failure', 'cleanup failure does not block a later append');
+
+  const combinedFailureBacking = new MemoryStorage();
+  let combinedFailure = false;
+  const combinedFailureStorage = createSafeAppendAttemptStorage({
+    getItem: combinedFailureBacking.getItem.bind(combinedFailureBacking),
+    setItem: (key, value) => {
+      if (combinedFailure && (key.endsWith('.completed') || key === attemptStorageKey)) throw new Error('completion writes blocked');
+      combinedFailureBacking.setItem(key, value);
+    },
+    removeItem: (key) => {
+      if (combinedFailure && key === attemptStorageKey) throw new Error('completion removal blocked');
+      combinedFailureBacking.removeItem(key);
+    },
+  });
+  const combinedFailureAttempt = getOrCreateAppendAttempt(combinedFailureStorage, {
+    userId: 'cashier-1',
+    orderId: '42',
+    fingerprint,
+    createKey: () => 'append-key-combined-failure',
+    items,
+    specialInstructions: 'table-note',
+    now: 21_500,
+  });
+  combinedFailure = true;
+  clearAppendAttempt(combinedFailureStorage, combinedFailureAttempt);
+  assert.equal(readAppendAttempt(combinedFailureStorage, { userId: 'cashier-1', now: 21_501 }), null, 'confirmed completion tombstone prevents a combined storage failure from blocking the current renderer');
 
   const fallbackBacking = new MemoryStorage();
   const fallbackDurable = new MemoryStorage();


### PR DESCRIPTION
## Intent

Implement only FloCafe issue #255, fix(pos): make cart identity and append retries collision-safe, from the current main baseline. Do not touch issue #241/Iran work or unrelated open issues. Reproduce and fix delimiter-joined cart identity collisions between distinct configurations, preserving every relevant product/add-on/option/note field and leading-zero semantics using a canonical unambiguous identity. Reproduce and fix the renderer reload/response-loss path where an append actually committed but a new idempotency key caused duplicate order items. Inspect and preserve the existing backend idempotency contract. Make the logical append retry key durable across the renderer reload/response-loss boundary, reuse it for the same logical attempt, reject mismatched payload reuse safely, and clear it only after confirmed completion while preserving API compatibility and cleanup behavior. Add behavioral regression tests for delimiter collisions, normal distinct carts, response loss after committed append followed by reload/retry, mismatched reuse, and cleanup/expiry, preferring non-Electron route/store tests and documenting any known Electron installation race if blocked. Keep the PR narrowly scoped to #255. Commit on the task branch. Run complete no-mistakes validation and, after checks-passed, publish a new PR without merging using a conventional title and body covering the full #255 delta, with bug and appropriate area labels. Keep #241/Iran untouched.

## What Changed

- Replaced delimiter-joined cart IDs with typed canonical identities that preserve product IDs, all selected add-on fields, notes, and leading-zero distinctions while normalizing equivalent cart lines.
- Added durable, user-scoped append retry recovery across renderer reloads, with payload fingerprints, key reuse, legacy migration, expiry handling, and completion-safe cleanup; backend replays committed appends before mutable-order guards and rejects mismatched key reuse with `409`.
- Documented the append endpoint contract and added issue #255 regression coverage for cart collisions, response-loss retries, mismatches, cleanup, expiry, and storage failures.

## Risk Assessment

⚠️ Medium: The change is scoped to #255 and preserves the reviewed replay and ownership invariants, but it introduces a substantial client-side persistent retry state machine that warrants the pipeline's dedicated validation.

## Testing

After restoring local dependencies, both focused #255 behavioral suites and a live API/database response-loss replay scenario passed; evidence is saved above, the final diff is clean and scoped to #255 files, and no renderer screenshot was possible because this isolated environment had no available browser session.

<details>
<summary>Evidence: Issue #255 live replay result</summary>

`Live replay evidence: canonical delimiter/leading-zero identities remain distinct; renderer recovery reused its key; replay after a split kept rows at 2; changed payload returned HTTP 409.`

```text
{
  "cartIdentity": {
    "delimiterConfigurationsAreDistinct": true,
    "leadingZeroProductIsDistinctFromNumeric": true
  },
  "rendererReload": {
    "initialKey": "renderer-retry-key",
    "recoveredKey": "renderer-retry-key",
    "sameLogicalAttemptReused": true
  },
  "appendResponseLossReplay": {
    "firstAppendStatus": 200,
    "retryAfterSplitStatus": 200,
    "responseItemCountsMatch": true,
    "orderItemRows": {
      "afterCommit": 2,
      "afterRetry": 2,
      "afterMismatchedRetry": 2
    },
    "mismatchedRetry": {
      "status": 409,
      "error": "Idempotency-Key was already used for a different order request"
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7132296a7ad16d5c0adfaa960ca42468310af5ad","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (15) ✅</summary>

- 🚨 `main/routes/orders.ts:589` - The replay lookup runs before the waiter ownership check at line 599. A waiter presenting a matching key can therefore replay an append response for an order they do not own, including legacy records permitted by the existing compatibility query. Perform order lookup and authorization first, while keeping replay ahead of split/status guards.
- ⚠️ `main/routes/orders.ts:24` - The required intent says “preserving API compatibility,” but lines 21–25 change a supplied whitespace-only Idempotency-Key from the baseline’s “treat as absent” behavior to HTTP 400; the new regression test codifies this change. Confirm whether this intentional API break is allowed.
- 🚨 `frontend/src/lib/append-attempt.ts:186` - The required intent says to “clear it only after confirmed completion,” but a pending attempt is deleted whenever a different order or fingerprint is started, before any successful response. If the original append committed and its response was lost, changing the cart removes its only durable retry key and prevents later reconciliation. Retain/refuse unresolved attempts unless this abandonment behavior is explicitly authorized.

🔧 Fix: Fix auth, blank-key compatibility, pending retry retention (tests blocked)
1 error still open:
- 🚨 `frontend/src/lib/append-attempt.ts:48` - The required criterion says “Make the logical append retry key durable across the renderer reload/response-loss boundary,” but lines 43–49 continue after a failed localStorage write using only a per-renderer in-memory key. If the append commits and the response is lost while storage is unavailable/full, reload loses the key and a new retry can duplicate items. Persist durably or block the mutation when persistence fails.

🔧 Fix: Require durable retry storage; focused test blocked by missing ts-node
3 issues (1 error, 2 warnings) still open:
- 🚨 `frontend/src/app/(dashboard)/pos/page.tsx:272` - The criterion “Make the logical append retry key durable across the renderer reload/response-loss boundary” is not met for existing records: recovery reads only the new storage key, while the baseline stored pending appends under `flo.postpaid.order.attempt`. An upgrade/reload can therefore ignore and overwrite the old key, allowing duplicate items. Migrate old append records before creating new attempts.
- ⚠️ `frontend/src/lib/cart-identity.ts:50` - Raw add-on canonicalization distinguishes `quantity: undefined` from `quantity: 1`, although POS paths treat missing quantity as one. Held or legacy cart data can therefore create duplicate lines instead of merging equivalent add-ons. Normalize the default quantity before canonicalizing.
- ⚠️ `frontend/src/lib/append-attempt.ts:220` - If durable cleanup fails after a successful append, the in-memory tombstone disappears on reload and the old completed attempt blocks every different append until expiry because mismatches are rejected. Persist a completion marker or otherwise prevent cleanup failures from becoming unresolved blockers.

🔧 Fix: Migrate legacy retries, normalize addons, persist completion markers
2 issues (1 error, 1 warning) still open:
- 🚨 `frontend/src/lib/append-attempt.ts:182` - The legacy migration returns without moving records owned by another user, but the old append and new-order flows share `flo.postpaid.order.attempt`; `POSPage.readPostpaidAttempt` deletes records whose user differs. Cashier A’s committed response-loss append can therefore be deleted when cashier B starts a new order, defeating the required durable retry guarantee. Migrate recognized legacy append records to the recorded owner’s scoped key before other flows can remove them.
- ⚠️ `frontend/src/lib/cart-identity.ts:50` - Only `undefined` add-on quantities are normalized to one. Existing POS and backend paths coerce other falsy quantities such as `0` with `|| 1`, so held/legacy data can create separate cart lines for configurations that serialize and price identically. Normalize the same default before canonicalization.

🔧 Fix: Normalize falsy add-on quantities in cart identity
1 error still open:
- 🚨 `frontend/src/lib/append-attempt.ts:203` - The required intent says “reuse it for the same logical attempt.” Legacy append records store numeric `order_id` in their fingerprint, but migration preserves that raw fingerprint while current fingerprints stringify the order ID. After automatic recovery fails once, retrying the same migrated payload reaches the mismatch check and throws instead of reusing the durable key. Normalize migrated fingerprints or compare normalized payloads.

🔧 Fix: Migrate legacy append retries and normalize retry fingerprints
4 issues (3 errors, 1 warning) still open:
- 🚨 `frontend/src/app/(dashboard)/orders/page.tsx:710` - The new durable helper is used by POSPage, but the sibling dashboard append flow still keeps its key only in a renderer ref. The criterion “Make the logical append retry key durable across the renderer reload/response-loss boundary” remains unmet: reload clears the ref, the retry creates a new key, and items can duplicate.
- 🚨 `frontend/src/lib/append-attempt.ts:217` - Migration removes the legacy record whenever any owner-scoped value exists, without verifying it is the same logical attempt. A stale, corrupt, or different-payload scoped record can therefore discard an unresolved legacy retry key, violating “clear it only after confirmed completion.” Preserve the legacy record unless the scoped copy is validated as equivalent.
- 🚨 `frontend/src/app/(dashboard)/pos/page.tsx:125` - If writing the scoped migration copy fails, the caller ignores that failure and reads the old shared slot directly. Another user can then delete it, or the new-order flow can overwrite it, losing the only retry key for a committed response-loss append. Fail closed until migration succeeds or preserve the legacy append record from other writers.
- ⚠️ `frontend/src/lib/append-attempt.ts:352` - The completion tombstone is only persisted when marker storage succeeds. If marker persistence and removal both fail, a confirmed append remains pending after reload and blocks different appends until expiry. Add a retryable/equivalent durable completion state or prevent this blocker.

🔧 Fix: Harden append migration and cleanup durability
2 warnings still open:
- ⚠️ `frontend/src/app/(dashboard)/pos/page.tsx:136` - The new catch throws on malformed/unreadable `flo.postpaid.order.attempt` instead of discarding it as the baseline did. A corrupt legacy order-attempt record can now make every postpaid checkout fail indefinitely, changing unrelated cleanup behavior. Preserve the prior discard path or explicitly confirm this fail-closed behavior.
- ⚠️ `frontend/src/lib/append-attempt.ts:317` - Migration of the pre-user-scoped append key ignores a failed `removeItem`. If the scoped copy is later confirmed and cleared, the durable unscoped copy remains; after reload it is migrated and replayed again, repeatedly blocking or reprocessing stale recovery. Verify/remove the source or persist equivalent completion state for both keys.

🔧 Fix: Preserve malformed cleanup and verify append migration removals
2 warnings still open:
- ⚠️ `frontend/src/lib/append-attempt.ts:321` - `migrateLegacyAppendAttempt` throws when the shared legacy append belongs to user A but A already has a non-equivalent scoped attempt. `readUserAttempt` invokes migration before checking the requested user, so an unrelated user B’s append/new-order path also fails until the conflict expires. Preserve both A records while allowing foreign callers to proceed safely.
- ⚠️ `frontend/src/lib/append-attempt.ts:432` - If writing both completion states fails and `removeItem` also fails, the confirmed attempt remains durable without a tombstone. Reload then treats it as pending and blocks mismatched appends until expiry. Ensure this combined storage-failure path has durable completion state or cannot become a retry blocker.

🔧 Fix: Preserve retry conflicts and harden completion durability
2 warnings still open:
- ⚠️ `frontend/src/lib/append-attempt.ts:469` - The required criterion is to “clear it only after confirmed completion.” If both completion writes fail and `removeItem` also fails, lines 454–470 leave the original pending record without a durable completion marker. After reload, a different append is blocked for up to 24 hours. Preserve a durable completion state or prevent this confirmed attempt from remaining a retry blocker.
- ⚠️ `tests/issue-255-pos-cart-retry.test.ts:56` - This new assertion does not reproduce the old delimiter collision: the baseline IDs for `extra-a`/`b-c` and `extra`/`a-b-c` are different. Use a genuinely colliding pair, such as the second note `a:1-b-c`, so the regression fails before the fix.

🔧 Fix: Harden completion fallback and delimiter collision coverage
3 issues (2 errors, 1 warning) still open:
- 🚨 `frontend/src/lib/append-attempt.ts:496` - The required durable-retry/cleanup criterion is still violated. If both completion writes fail at lines 483–493, line 496 can return `false` while the in-memory tombstone hides the pending record only in the current renderer; after reload, the durable attempt is read as pending and blocks every different append until expiry despite the append having completed. Persist and verify a durable completion state, or make cleanup retryable before allowing this state.
- 🚨 `frontend/src/app/(dashboard)/pos/page.tsx:129` - The requirement to keep the append retry key durable across reloads remains reachable through the legacy conflict path. When a shared legacy append belongs to a user who already has a non-equivalent scoped attempt, migration returns the legacy record without moving/removing it (helper line 303). `readPostpaidAttempt` then returns `null` at line 130, and the postpaid new-order flow can overwrite the shared `flo.postpaid.order.attempt` at line 150, destroying the unresolved legacy retry key for that user. Preserve the legacy record at the shared boundary or prevent this writer until migration is resolved.
- ⚠️ `frontend/src/lib/append-attempt.ts:262` - This contradicts the required preservation of cleanup behavior for legacy state. A corrupt shared record containing JSON `null` parses successfully, then line 262 dereferences `parsed.userId` and throws; the POS caller converts that into `Unable to recover append retry state` instead of reaching the prior cleanup path. Every postpaid checkout can therefore fail indefinitely until the corrupt storage entry is manually removed. Guard non-object parsed values and preserve the baseline discard behavior.

🔧 Fix: Harden completion recovery and legacy conflict handling
3 errors still open:
- 🚨 `frontend/src/lib/append-attempt.ts:532` - If both durable completion writes fail and removal also fails, the in-memory tombstone hides the original attempt only until reload. The durable pending record then blocks different appends until expiry and may be retried despite confirmed completion, violating the required durable reload boundary and cleanup criterion. Persist a retryable durable completion state or prevent this state.
- 🚨 `frontend/src/app/(dashboard)/pos/page.tsx:135` - When user A has a conflicting shared legacy append and scoped retry, migration returns A’s legacy record unchanged for unrelated user B. `readPostpaidAttempt` treats that as null, after which B’s new-order flow writes the same shared key and overwrites A’s unresolved retry before confirmed completion. Protect the shared record at this writer boundary or migrate it safely first.
- 🚨 `frontend/src/lib/append-attempt.ts:13` - Appending `.completed` to the encoded attempt key creates a namespace collision: user IDs `cashier` and `cashier.completed` produce one user’s completion key as the other user’s attempt key because periods remain unescaped. Completing one append can overwrite or suppress another user’s pending retry. Use disjoint key namespaces.

🔧 Fix: Isolated completion keys and protected legacy retries
3 issues (2 errors, 1 warning) still open:
- 🚨 `frontend/src/app/(dashboard)/pos/page.tsx:135` - When a shared append record for user A conflicts with A’s scoped retry, migration returns it unchanged for user B; `readPostpaidAttempt` then throws because the shared slot remains. User B’s normal postpaid order flow is blocked until expiry. Preserve A’s records while allowing B to proceed safely.
- 🚨 `frontend/src/lib/append-attempt.ts:539` - If the completion marker write, fallback write, and attempt removal all fail, `clearAppendAttempt` leaves the confirmed append without durable completion state. After reload, the old key is recovered as pending, so a different append is rejected or the old request is retried. This violates the required durable cleanup/recovery behavior.
- ⚠️ `frontend/src/lib/append-attempt.ts:543` - `confirmedAppendTombstones` retains full fingerprints, including item and note payloads, in a module-level map. Successful cleanup removes the durable attempt, so these entries are never queried and deleted; a long-running POS renderer accumulates completed append payloads. Bound or independently expire this map, or store a compact bounded key.

🔧 Fix: Isolated completion state and protected legacy order retries
2 errors still open:
- 🚨 `frontend/src/lib/append-attempt.ts:103` - The required criterion is “Make the logical append retry key durable across the renderer reload/response-loss boundary.” `setItem` accepts success from any fallback store, but `getItem` always prefers the first non-null store. If localStorage retains an older value while its write fails, sessionStorage/cookie receives the new attempt but a reload reads the stale localStorage value, losing or blocking recovery. Use an authoritative verified store or fail closed before sending.
- 🚨 `frontend/src/lib/append-attempt.ts:570` - The required criterion is to “clear it only after confirmed completion while preserving API compatibility and cleanup behavior.” If completion-marker writes and attempt removal all fail, `clearAppendAttempt` returns false and leaves the confirmed attempt durable without a marker. After reload, it is treated as pending and can block different appends for 24 hours or replay the already-committed request. Establish durable completion state or otherwise make this confirmed-completion failure recoverable.

🔧 Fix: Hardened retry storage authority and completion recovery
3 issues (2 errors, 1 warning) still open:
- 🚨 `frontend/src/lib/append-attempt.ts:404` - Legacy migration treats any numeric scoped `createdAt` as equivalent. If a fresh shared retry coexists with an expired scoped copy, line 411 removes the fresh source; parsing then removes the expired scoped copy, leaving only an in-memory attempt and allowing a reload to generate a duplicate-prone key. Validate freshness/equivalent timestamps or persist the fresh copy before removal.
- 🚨 `frontend/src/lib/append-attempt.ts:160` - An unavailable primary storage can make `removeItem` return false even when session/cookie fallback storage durably holds the completion marker. `ensureCompletionStorage` then rejects every later different append during probe cleanup, so a confirmed append can block sales until storage recovers or expiry. Make the verified fallback authoritative or exclude unavailable stores from cleanup verification.
- ⚠️ `frontend/src/lib/append-attempt.ts:96` - The cookie fallback stores the full append payload, including item names and notes, at `Path=/`; because `setItem` writes every configured store, this payload is sent in Cookie headers on every same-origin API request, increasing header size and exposing order data to server/proxy logs. Use the cookie only when other durable stores fail and scope/minimize its contents.

🔧 Fix: Hardened migration freshness, fallback cleanup, and cookie privacy
4 issues (2 errors, 2 warnings) still open:
- 🚨 `frontend/src/lib/append-attempt.ts:137` - The required criterion “Make the logical append retry key durable across the renderer reload/response-loss boundary” is still violated when the primary store is unreadable: `readPersisted` records an unverified read but returns the fallback value, and `getOrCreateAppendAttempt` proceeds with a new fallback-only key. If localStorage hides an older committed attempt while sessionStorage is empty, the new request can duplicate items. Fail closed on an unverified attempt read or establish an authoritative store before sending.
- 🚨 `frontend/src/lib/append-attempt.ts:690` - The criterion “clear it only after confirmed completion” remains violated when completion-marker writes and attempt removal all fail. `clearAppendAttempt` returns `false` while leaving the durable pending attempt unchanged; after reload it is treated as unresolved, blocking different appends or replaying a confirmed append until expiry. Provide durable retryable completion state or prevent this post-confirmation state.
- ⚠️ `frontend/src/app/(dashboard)/pos/page.tsx:139` - After migrating any legacy append owned by another user, this early return skips reading the current user&#39;s scoped postpaid-order retry. A user with a committed-but-response-lost new-order attempt can therefore generate a new idempotency key and create a duplicate order when an unrelated legacy append is migrated. Continue loading the current user&#39;s postpaid attempt after append migration.
- ⚠️ `frontend/src/lib/append-attempt.ts:254` - The collision-safety requirement is weakened by storing only a 32-bit FNV hash in the cookie completion marker and in-memory tombstone. Two distinct fingerprints with the same hash are treated as the same completed attempt when the same idempotency key is present, allowing mismatched reuse to be suppressed instead of rejected. Use an exact fingerprint or a collision-resistant representation for this fallback path.

🔧 Fix: Fail closed on uncertain retry recovery
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm run test:issue-255-cart` (initially blocked by absent local dependencies)</code>
- <code>`npm ci` (lockfile-pinned local test setup; removed `node_modules` afterward)</code>
- `npm run test:issue-255-cart`
- `npm run test:issue-255-append`
- <code>`node - &lt;&lt;&#39;NODE&#39;` live Express/SQLite reproduction: cart identity, reload key reuse, committed append replay after split, and mismatched retry rejection</code>
- <code>`git diff --check ae4c31e...2a029049` and final targeted-diff inspection</code>
- `Attempted in-app browser renderer capture; no browser session was available.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
