### PR TITLE
fix(bills): preserve split-check tax attribution

### DIFF
--- a/docs/tax-engine-v2-spec.md
+++ b/docs/tax-engine-v2-spec.md
@@ -326,6 +326,15 @@ Each finalized transaction needs a tax snapshot containing:
 - Rounding
 - Final component amounts
 
+When a bill is split, each child bill stores its own copy of the relevant
+snapshots. These copies are marked with `splitAllocation: "minor-unit-v1"` and
+allocate snapshot bases and tax components in integer minor units, preserving
+signed reconciliation and the item-versus-charge attribution for that child.
+Receipt, thermal-print, and tax-report resolvers must consume the marked child
+copy rather than the shared source-order item snapshots. Existing nested and
+flat `tax_breakdown` values remain readable for legacy rows; they contribute
+only residual components that are not already represented by a snapshot.
+
 Later pack updates must never alter existing orders, bills, refunds or reports.
 
 Refunds must use the original transaction snapshot—not current tax rules.

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -33,6 +33,7 @@ import {
   type AppendAttempt,
   type AppendAttemptStorage,
 } from '@/lib/append-attempt';
+import { preferChildScopedBill } from '@/lib/printer/tax-components';
 
 const itemStatusConfig: Record<string, { dot: string; color: string; labelKey: string }> = {
   pending: { dot: 'bg-yellow-400', color: 'text-yellow-700', labelKey: 'orders.itemStatusWaiting' },
@@ -489,24 +490,22 @@ export default function OrdersPage() {
     fetchOrders();
 
     if (bill && autoPrintBill) {
-      const order = orders.find((o) => o.bill?.id === bill.id);
-      if (order) {
-        try {
-          const { data } = await api.get(`/bills/${bill.id}`);
-          const latestBill = data.bill as Bill;
-          await printBill(
-            { ...latestBill, order },
-            {
-              business_name: currentTenant?.business_name || t('common.businessNameFallback'),
-              currency,
-              country: currentTenant?.country || 'IN',
-            },
-            { isReprint: false }
-          );
-          await api.post(`/bills/${bill.id}/print`, { print_type: 'receipt' });
-        } catch {
-          toast.error(t('orders.receiptPrintFailedHint'));
-        }
+      try {
+        const fallbackOrder = orders.find((o) => o.bill?.id === bill.id);
+        const { data } = await api.get(`/bills/${bill.id}`);
+        const latestBill = preferChildScopedBill(data.bill as Bill, fallbackOrder);
+        await printBill(
+          latestBill,
+          {
+            business_name: currentTenant?.business_name || t('common.businessNameFallback'),
+            currency,
+            country: currentTenant?.country || 'IN',
+          },
+          { isReprint: false }
+        );
+        await api.post(`/bills/${bill.id}/print`, { print_type: 'receipt' });
+      } catch {
+        toast.error(t('orders.receiptPrintFailedHint'));
       }
     }
   };
@@ -520,10 +519,12 @@ export default function OrdersPage() {
     const isReprint = (printHistory[billId]?.length ?? 0) > 0;
     setPrintingBillId(billId);
     try {
+      const { data } = await api.get(`/bills/${billId}`);
+      const latestBill = preferChildScopedBill(data.bill as Bill, order);
       // Actually attempt the print first — only log/report success if the printer accepted the job,
       // otherwise a disconnected printer would silently report "success" (it was only logging before).
       const printWarnings = await printBill(
-        { ...order.bill, order },
+        latestBill,
         {
           business_name: currentTenant?.business_name || t('common.businessNameFallback'),
           currency,

--- a/frontend/src/components/pos/PaymentModal.tsx
+++ b/frontend/src/components/pos/PaymentModal.tsx
@@ -7,6 +7,7 @@ import api from '@/lib/api';
 import toast from 'react-hot-toast';
 import type { Bill } from '@/lib/types';
 import TaxBreakdown from '@/components/pos/TaxBreakdown';
+import { resolveTaxComponents } from '@/lib/printer/tax-components';
 import { useCartStore } from '@/store/cart';
 import { useConfirm } from '@/hooks/use-confirm';
 import { useI18n } from '@/hooks/useI18n';
@@ -368,7 +369,10 @@ export default function PaymentModal({ bill, currency, onClose, onPaid, onBillUp
                   <span>− {currencyFmt(Number(bill.discount_amount))}</span>
                 </div>
               )}
-              <TaxBreakdown taxAmount={Number(bill.tax_amount)} taxBreakdown={bill.tax_breakdown} />
+              <TaxBreakdown taxAmount={Number(bill.tax_amount)} taxBreakdown={resolveTaxComponents(bill).map((component) => ({
+                ...component,
+                rate: component.rate ?? 0,
+              }))} />
               {Number(bill.delivery_charge) > 0 && (
                 <div className="flex justify-between text-slate-300">
                   <span>{t('pos.delivery')}</span>

--- a/frontend/src/components/pos/SplitCheckModal.tsx
+++ b/frontend/src/components/pos/SplitCheckModal.tsx
@@ -12,7 +12,7 @@ import type { Bill, Order, OrderItem } from '@/lib/types';
 export function SplitCheckModal({ bill, order, onClose, onSplit }: { bill: Bill; order: Order; onClose: () => void; onSplit: (bills: Bill[]) => void }) {
   const { t } = useI18n();
   const fmt = useFormatCurrency();
-  const items = (order.items || []).filter((item) => !['cancelled', 'voided'].includes(item.status));
+  const items = (order.items || []).filter((item) => !['cancelled', 'voided', 'void_adjustment'].includes(item.status));
   const initialCount = Math.min(8, Math.max(2, order.guest_count || 2));
   const [count, setCount] = useState(initialCount);
   const [labels, setLabels] = useState(() => Array.from({ length: initialCount }, (_, i) => `Guest ${i + 1}`));

--- a/frontend/src/lib/printer/tax-components.ts
+++ b/frontend/src/lib/printer/tax-components.ts
@@ -1,3 +1,5 @@
+import type { Bill, Order } from '@/lib/types';
+
 export interface DisplayTaxComponent {
   title: string;
   rate: number | null;
@@ -16,6 +18,11 @@ interface TaxDocument extends TaxSource {
 }
 
 const SPLIT_TAX_SNAPSHOT_VERSION = 'minor-unit-v1';
+
+export function preferChildScopedBill(bill: Bill, fallbackOrder?: Order): Bill {
+  if (bill.order || !fallbackOrder) return bill;
+  return { ...bill, order: fallbackOrder };
+}
 
 function parseJson(value: unknown): unknown {
   if (typeof value !== 'string') return value;
@@ -132,7 +139,7 @@ function reconcileSplitSnapshotComponents(
 
 function legacyItemComponents(items: Array<TaxSource & { status?: string | null }> | undefined): DisplayTaxComponent[] {
   return (items || []).filter(
-    (item) => item.status !== 'cancelled' && item.status !== 'voided',
+    (item) => item.status !== 'cancelled' && item.status !== 'voided' && item.status !== 'void_adjustment',
   ).flatMap((item) => {
     const snapshot = snapshotComponents(item.tax_snapshot);
     return snapshot.present ? [] : legacyComponents(item.tax_breakdown);
@@ -159,7 +166,7 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
 
   const items = document.order?.items ?? document.items;
   const activeItems = items?.filter(
-    (item) => item.status !== 'cancelled' && item.status !== 'voided',
+    (item) => item.status !== 'cancelled' && item.status !== 'voided' && item.status !== 'void_adjustment',
   );
   const components: DisplayTaxComponent[] = [];
   let usedSnapshot = false;

--- a/frontend/src/lib/printer/tax-components.ts
+++ b/frontend/src/lib/printer/tax-components.ts
@@ -201,12 +201,14 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
 
   if (activeItems && activeItems.length > 0) {
     let hasItemTaxEvidence = false;
+    const itemSnapshotComponents: DisplayTaxComponent[] = [];
     for (const item of activeItems) {
       const snapshot = snapshotComponents(item.tax_snapshot);
       const legacy = snapshot.present ? [] : legacyComponents(item.tax_breakdown);
       usedSnapshot ||= snapshot.present;
       hasItemTaxEvidence ||= snapshot.present || legacy.length > 0;
       components.push(...(snapshot.present ? snapshot.components : legacy));
+      if (snapshot.present) itemSnapshotComponents.push(...snapshot.components);
     }
     if (!hasItemTaxEvidence) {
       const snapshot = snapshotComponents(document.tax_snapshot);
@@ -234,8 +236,14 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
           ) / 1_000_000;
         }
         components.push(...chargeSnapshot.components);
+        components.push(...documentLegacyComponents(document, [
+          ...itemSnapshotComponents,
+          ...chargeSnapshot.components,
+        ]));
         chargeReconciledSeparately = true;
-      } else if (!usedSnapshot) {
+      } else if (usedSnapshot) {
+        components.push(...documentLegacyComponents(document, itemSnapshotComponents));
+      } else {
         const documentLegacy = legacyComponents(document.tax_breakdown);
         if (documentLegacy.length > 0) components.splice(0, components.length, ...documentLegacy);
       }

--- a/frontend/src/lib/printer/tax-components.ts
+++ b/frontend/src/lib/printer/tax-components.ts
@@ -130,6 +130,15 @@ function reconcileSplitSnapshotComponents(
   return result;
 }
 
+function legacyItemComponents(items: Array<TaxSource & { status?: string | null }> | undefined): DisplayTaxComponent[] {
+  return (items || []).filter(
+    (item) => item.status !== 'cancelled' && item.status !== 'voided',
+  ).flatMap((item) => {
+    const snapshot = snapshotComponents(item.tax_snapshot);
+    return snapshot.present ? [] : legacyComponents(item.tax_breakdown);
+  });
+}
+
 export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent[] {
   // A split bill carries child-specific snapshot amounts. The order-item rows
   // are shared by every child and retain source-order amounts, so using them
@@ -138,7 +147,7 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
     const splitSnapshot = snapshotComponents(document.tax_snapshot);
     if (splitSnapshot.present) {
       const merged = new Map<string, DisplayTaxComponent>();
-      for (const component of splitSnapshot.components) {
+      for (const component of [...splitSnapshot.components, ...legacyItemComponents(document.order?.items ?? document.items)]) {
         const key = `${component.title}\u0000${component.rate ?? ''}`;
         const current = merged.get(key);
         if (current) current.amount += component.amount;

--- a/frontend/src/lib/printer/tax-components.ts
+++ b/frontend/src/lib/printer/tax-components.ts
@@ -15,6 +15,8 @@ interface TaxDocument extends TaxSource {
   items?: Array<TaxSource & { status?: string | null }>;
 }
 
+const SPLIT_TAX_SNAPSHOT_VERSION = 'minor-unit-v1';
+
 function parseJson(value: unknown): unknown {
   if (typeof value !== 'string') return value;
   try {
@@ -22,6 +24,15 @@ function parseJson(value: unknown): unknown {
   } catch {
     return value;
   }
+}
+
+function hasSplitAllocatedSnapshot(value: unknown): boolean {
+  const parsed = parseJson(value);
+  if (Array.isArray(parsed)) return parsed.some(hasSplitAllocatedSnapshot);
+  if (!parsed || typeof parsed !== 'object') return false;
+  const snapshot = parsed as Record<string, unknown>;
+  return snapshot.splitAllocation === SPLIT_TAX_SNAPSHOT_VERSION
+    && Array.isArray(snapshot.lines);
 }
 
 function finiteNumber(value: unknown): number | null {
@@ -91,7 +102,52 @@ function legacyComponents(value: unknown): DisplayTaxComponent[] {
   return components;
 }
 
+function reconcileSplitSnapshotComponents(
+  components: DisplayTaxComponent[],
+  targetValue: unknown,
+): DisplayTaxComponent[] {
+  const target = finiteNumber(targetValue);
+  let result = components.map((component) => ({
+    ...component,
+    amount: Math.round(component.amount * 1_000_000) / 1_000_000,
+  }));
+  if (target === null) return result;
+  if (result.length === 0) return target === 0 ? [] : [{ title: 'Tax', rate: null, amount: target }];
+
+  const current = result.reduce((sum, component) => sum + component.amount, 0);
+  if (Math.abs(current - target) > 0.0000001) {
+    if (current === 0) return target === 0 ? result : [{ title: 'Tax', rate: null, amount: target }];
+    const ratio = target / current;
+    result = result.map((component) => ({
+      ...component,
+      amount: Math.round(component.amount * ratio * 1_000_000) / 1_000_000,
+    }));
+    const allocated = result.reduce((sum, component) => sum + component.amount, 0);
+    result[result.length - 1].amount = Math.round(
+      (result[result.length - 1].amount + target - allocated) * 1_000_000,
+    ) / 1_000_000;
+  }
+  return result;
+}
+
 export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent[] {
+  // A split bill carries child-specific snapshot amounts. The order-item rows
+  // are shared by every child and retain source-order amounts, so using them
+  // here would misattribute item tax against the full charge-tax snapshot.
+  if (hasSplitAllocatedSnapshot(document.tax_snapshot)) {
+    const splitSnapshot = snapshotComponents(document.tax_snapshot);
+    if (splitSnapshot.present) {
+      const merged = new Map<string, DisplayTaxComponent>();
+      for (const component of splitSnapshot.components) {
+        const key = `${component.title}\u0000${component.rate ?? ''}`;
+        const current = merged.get(key);
+        if (current) current.amount += component.amount;
+        else merged.set(key, { ...component });
+      }
+      return reconcileSplitSnapshotComponents(Array.from(merged.values()), document.tax_amount);
+    }
+  }
+
   const items = document.order?.items ?? document.items;
   const activeItems = items?.filter(
     (item) => item.status !== 'cancelled' && item.status !== 'voided',

--- a/frontend/src/lib/printer/tax-components.ts
+++ b/frontend/src/lib/printer/tax-components.ts
@@ -176,18 +176,32 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
   if (hasSplitAllocatedSnapshot(document.tax_snapshot)) {
     const splitSnapshot = snapshotComponents(document.tax_snapshot);
     if (splitSnapshot.present) {
+      const represented = new Map<string, DisplayTaxComponent>();
       const merged = new Map<string, DisplayTaxComponent>();
       for (const component of [
         ...splitSnapshot.components,
         ...legacyItemComponents(document.order?.items ?? document.items),
-        ...documentLegacyComponents(document, splitSnapshot.components),
       ]) {
         const key = `${component.title}\u0000${component.rate ?? ''}`;
         const current = merged.get(key);
         if (current) current.amount += component.amount;
         else merged.set(key, { ...component });
       }
-      return reconcileSplitSnapshotComponents(Array.from(merged.values()), document.tax_amount);
+      for (const [key, component] of merged) represented.set(key, component);
+      const target = finiteNumber(document.tax_amount);
+      const representedTotal = Array.from(represented.values()).reduce((sum, component) => sum + component.amount, 0);
+      const needsDocumentResidual = target === null
+        || (target !== 0 && (target < 0 ? representedTotal > target : representedTotal < target));
+      const residual = needsDocumentResidual
+        ? documentLegacyComponents(document, splitSnapshot.components)
+        : [];
+      for (const component of residual) {
+        const key = `${component.title}\u0000${component.rate ?? ''}`;
+        const current = represented.get(key);
+        if (current) current.amount += component.amount;
+        else represented.set(key, { ...component });
+      }
+      return reconcileSplitSnapshotComponents(Array.from(represented.values()), document.tax_amount);
     }
   }
 

--- a/frontend/src/lib/printer/tax-components.ts
+++ b/frontend/src/lib/printer/tax-components.ts
@@ -146,6 +146,23 @@ function legacyItemComponents(items: Array<TaxSource & { status?: string | null 
   });
 }
 
+function documentLegacyComponents(document: TaxDocument): DisplayTaxComponent[] {
+  const remainingItems = new Map<string, number>();
+  for (const component of legacyItemComponents(document.order?.items ?? document.items)) {
+    const key = `${component.title}\u0000${component.rate ?? ''}`;
+    remainingItems.set(key, (remainingItems.get(key) || 0) + component.amount);
+  }
+  return legacyComponents(document.tax_breakdown).flatMap((component) => {
+    const key = `${component.title}\u0000${component.rate ?? ''}`;
+    const itemAmount = remainingItems.get(key) || 0;
+    const sameSign = itemAmount === 0 || component.amount === 0 || Math.sign(itemAmount) === Math.sign(component.amount);
+    const consumed = sameSign ? Math.min(Math.abs(itemAmount), Math.abs(component.amount)) * Math.sign(component.amount) : 0;
+    const residual = component.amount - consumed;
+    remainingItems.set(key, itemAmount - consumed);
+    return Math.abs(residual) < 0.0000001 ? [] : [{ ...component, amount: residual }];
+  });
+}
+
 export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent[] {
   // A split bill carries child-specific snapshot amounts. The order-item rows
   // are shared by every child and retain source-order amounts, so using them
@@ -154,7 +171,11 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
     const splitSnapshot = snapshotComponents(document.tax_snapshot);
     if (splitSnapshot.present) {
       const merged = new Map<string, DisplayTaxComponent>();
-      for (const component of [...splitSnapshot.components, ...legacyItemComponents(document.order?.items ?? document.items)]) {
+      for (const component of [
+        ...splitSnapshot.components,
+        ...legacyItemComponents(document.order?.items ?? document.items),
+        ...documentLegacyComponents(document),
+      ]) {
         const key = `${component.title}\u0000${component.rate ?? ''}`;
         const current = merged.get(key);
         if (current) current.amount += component.amount;

--- a/frontend/src/lib/printer/tax-components.ts
+++ b/frontend/src/lib/printer/tax-components.ts
@@ -99,7 +99,7 @@ function legacyComponents(value: unknown): DisplayTaxComponent[] {
     if (!entry || typeof entry !== 'object') continue;
     const raw = entry as Record<string, unknown>;
     const amount = finiteNumber(raw.amount);
-    if (amount === null) continue;
+    if (amount === null || amount === 0) continue;
     components.push({
       title: String(raw.title || raw.name || 'Tax'),
       rate: finiteNumber(raw.rate),
@@ -176,11 +176,16 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
   if (hasSplitAllocatedSnapshot(document.tax_snapshot)) {
     const splitSnapshot = snapshotComponents(document.tax_snapshot);
     if (splitSnapshot.present) {
+      const items = document.order?.items ?? document.items;
+      const hasItemSnapshot = items?.some((item) => snapshotComponents(item.tax_snapshot).present) ?? false;
+      const snapshotComponentsForDocument = hasItemSnapshot
+        ? splitSnapshot.components
+        : splitSnapshot.components.filter((component) => component.amount !== 0);
       const represented = new Map<string, DisplayTaxComponent>();
       const merged = new Map<string, DisplayTaxComponent>();
       for (const component of [
-        ...splitSnapshot.components,
-        ...legacyItemComponents(document.order?.items ?? document.items),
+        ...snapshotComponentsForDocument,
+        ...legacyItemComponents(items),
       ]) {
         const key = `${component.title}\u0000${component.rate ?? ''}`;
         const current = merged.get(key);
@@ -193,7 +198,7 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
       const needsDocumentResidual = target === null
         || (target !== 0 && (target < 0 ? representedTotal > target : representedTotal < target));
       const residual = needsDocumentResidual
-        ? documentLegacyComponents(document, splitSnapshot.components)
+        ? documentLegacyComponents(document, snapshotComponentsForDocument)
         : [];
       for (const component of residual) {
         const key = `${component.title}\u0000${component.rate ?? ''}`;
@@ -256,7 +261,10 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
         ]));
         chargeReconciledSeparately = true;
       } else if (usedSnapshot) {
-        components.push(...documentLegacyComponents(document, itemSnapshotComponents));
+        const legacyItems = legacyItemComponents(document.order?.items ?? document.items);
+        if ((document.tax_amount !== undefined && document.tax_amount !== null) || legacyItems.length > 0) {
+          components.push(...documentLegacyComponents(document, itemSnapshotComponents));
+        }
       } else {
         const documentLegacy = legacyComponents(document.tax_breakdown);
         if (documentLegacy.length > 0) components.splice(0, components.length, ...documentLegacy);

--- a/frontend/src/lib/printer/tax-components.ts
+++ b/frontend/src/lib/printer/tax-components.ts
@@ -146,9 +146,15 @@ function legacyItemComponents(items: Array<TaxSource & { status?: string | null 
   });
 }
 
-function documentLegacyComponents(document: TaxDocument): DisplayTaxComponent[] {
+function documentLegacyComponents(
+  document: TaxDocument,
+  coveredComponents: DisplayTaxComponent[] = [],
+): DisplayTaxComponent[] {
   const remainingItems = new Map<string, number>();
-  for (const component of legacyItemComponents(document.order?.items ?? document.items)) {
+  for (const component of [
+    ...legacyItemComponents(document.order?.items ?? document.items),
+    ...coveredComponents,
+  ]) {
     const key = `${component.title}\u0000${component.rate ?? ''}`;
     remainingItems.set(key, (remainingItems.get(key) || 0) + component.amount);
   }
@@ -174,7 +180,7 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
       for (const component of [
         ...splitSnapshot.components,
         ...legacyItemComponents(document.order?.items ?? document.items),
-        ...documentLegacyComponents(document),
+        ...documentLegacyComponents(document, splitSnapshot.components),
       ]) {
         const key = `${component.title}\u0000${component.rate ?? ''}`;
         const current = merged.get(key);

--- a/frontend/src/lib/printer/tax-components.ts
+++ b/frontend/src/lib/printer/tax-components.ts
@@ -244,7 +244,12 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
     const snapshot = snapshotComponents(document.tax_snapshot);
     usedSnapshot = snapshot.present;
     components.push(
-      ...(snapshot.present ? snapshot.components : legacyComponents(document.tax_breakdown)),
+      ...(snapshot.present
+        ? [
+          ...snapshot.components,
+          ...documentLegacyComponents(document, snapshot.components),
+        ]
+        : legacyComponents(document.tax_breakdown)),
     );
   }
 

--- a/main/db.ts
+++ b/main/db.ts
@@ -4647,7 +4647,7 @@ export function parseRowJson(row: any): any {
         merged[key].amount += line.amount;
       }
     }
-    taxBreakdown = Object.values(merged).map((line) => ({
+    taxBreakdown = Object.values(merged).filter((line) => line.amount !== 0).map((line) => ({
       ...line,
       amount: Math.round(line.amount * 100) / 100,
     }));

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -319,6 +319,106 @@ function allocateMinorUnits(sourceMinor: number, weights: number[]): number[] {
   return base;
 }
 
+// Tax snapshots may contain signed evidence for a historical adjustment. Keep
+// allocateMinorUnits' non-negative contract unchanged and allocate the
+// magnitude with the same largest-remainder ordering before restoring the sign.
+function allocateSignedMinorUnits(sourceMinor: number, weights: number[]): number[] {
+  const sign = sourceMinor < 0 ? -1 : 1;
+  return allocateMinorUnits(Math.abs(sourceMinor), weights).map((minor) => minor * sign);
+}
+
+const SPLIT_TAX_SNAPSHOT_VERSION = 'minor-unit-v1';
+
+function parseTaxSnapshot(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw;
+  try { return JSON.parse(raw); } catch { return null; }
+}
+
+function snapshotMinorAmount(value: unknown): number | null {
+  if (typeof value !== 'string' && typeof value !== 'number') return null;
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return null;
+  return Math.round(amount * 100);
+}
+
+function formatSnapshotMinorAmount(original: unknown, minor: number): string | number {
+  const amount = minor / 100;
+  return typeof original === 'string' ? amount.toFixed(2) : amount;
+}
+
+/**
+ * Persist a child-specific copy of every tax snapshot. Snapshot amounts are
+ * tax evidence, so allocate each component in integer minor units with the
+ * same non-negative largest-remainder allocator used for bill totals.
+ */
+export function allocateTaxSnapshots(sourceRaw: unknown, weights: number[]): (string | null)[] {
+  const parsed = parseTaxSnapshot(sourceRaw);
+  const sourceText = typeof sourceRaw === 'string'
+    ? sourceRaw
+    : parsed === null || parsed === undefined ? null : JSON.stringify(parsed);
+  const snapshots = Array.isArray(parsed) ? parsed : [parsed];
+  const hasTaxSnapshots = snapshots.some((snapshot) => (
+    snapshot && typeof snapshot === 'object' && Array.isArray((snapshot as any).lines)
+  ));
+  if (!hasTaxSnapshots) return new Array(weights.length).fill(sourceText);
+
+  return weights.map((_, childIndex) => {
+    const child = JSON.parse(JSON.stringify(parsed));
+    const childSnapshots = Array.isArray(child) ? child : [child];
+
+    for (const snapshot of childSnapshots) {
+      if (!snapshot || typeof snapshot !== 'object' || !Array.isArray(snapshot.lines)) continue;
+      snapshot.splitAllocation = SPLIT_TAX_SNAPSHOT_VERSION;
+      snapshot.lines = snapshot.lines.map((line: any) => {
+        if (!line || typeof line !== 'object') return line;
+        const nextLine = { ...line };
+        for (const field of ['grossAmount', 'taxableBase'] as const) {
+          const sourceMinor = snapshotMinorAmount(line[field]);
+          if (sourceMinor !== null) {
+            nextLine[field] = formatSnapshotMinorAmount(
+              line[field],
+              allocateSignedMinorUnits(sourceMinor, weights)[childIndex],
+            );
+          }
+        }
+
+        if (Array.isArray(line.components)) {
+          const nextComponents = line.components.map((component: any) => {
+            if (!component || typeof component !== 'object') return component;
+            const sourceMinor = snapshotMinorAmount(component.amount);
+            if (sourceMinor === null) return { ...component };
+            return {
+              ...component,
+              amount: formatSnapshotMinorAmount(
+                component.amount,
+                allocateSignedMinorUnits(sourceMinor, weights)[childIndex],
+              ),
+            };
+          });
+          nextLine.components = nextComponents;
+
+          const componentMinors = nextComponents.map((component: any) => snapshotMinorAmount(component?.amount));
+          if (componentMinors.every((minor: number | null): minor is number => minor !== null)) {
+            const componentTotal = componentMinors.reduce((sum: number, minor: number) => sum + minor, 0);
+            nextLine.taxAmount = formatSnapshotMinorAmount(line.taxAmount, componentTotal);
+          }
+        } else {
+          const sourceMinor = snapshotMinorAmount(line.taxAmount);
+          if (sourceMinor !== null) {
+            nextLine.taxAmount = formatSnapshotMinorAmount(
+              line.taxAmount,
+              allocateSignedMinorUnits(sourceMinor, weights)[childIndex],
+            );
+          }
+        }
+        return nextLine;
+      });
+    }
+
+    return JSON.stringify(child);
+  });
+}
+
 function allocateTaxBreakdown(
   sourceBreakdownRaw: any,
   checkTaxMinors: number[],
@@ -504,18 +604,20 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
 
       const checkTaxMinors = allocations.tax_amount.map((amt) => Math.round(amt * 100));
       const checkTaxBreakdowns = allocateTaxBreakdown(txnSource.tax_breakdown, checkTaxMinors, weights);
+      const checkTaxSnapshots = allocateTaxSnapshots(txnSource.tax_snapshot, weights);
 
       const billIds: number[] = [];
       txnNormalized.forEach((check, index) => {
         let billId: number;
         const splitBk = checkTaxBreakdowns[index];
+        const splitSnapshot = checkTaxSnapshots[index];
         if (index === 0) {
-          db.prepare(`UPDATE bills SET split_group_id = ?, split_label = ?, subtotal = ?, tax_amount = ?, tax_breakdown = ?, discount_amount = ?, delivery_charge = ?, packaging_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ? WHERE id = ?`)
-            .run(groupId, check.label, allocations.subtotal[index], allocations.tax_amount[index], splitBk, allocations.discount_amount[index], allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], now(), txnSource.id);
+          db.prepare(`UPDATE bills SET split_group_id = ?, split_label = ?, subtotal = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, delivery_charge = ?, packaging_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ? WHERE id = ?`)
+            .run(groupId, check.label, allocations.subtotal[index], allocations.tax_amount[index], splitBk, splitSnapshot, allocations.discount_amount[index], allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], now(), txnSource.id);
           billId = Number(txnSource.id);
         } else {
           const inserted = db.prepare(`INSERT INTO bills (bill_number, order_id, customer_id, subtotal, tax_amount, tax_breakdown, tax_snapshot, discount_amount, discount_type, discount_value, discount_reason, delivery_charge, packaging_charge, round_off, total, paid_amount, balance, payment_status, split_group_id, split_label, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 'unpaid', ?, ?, ?, ?)`)
-            .run(generateBillNumber(), txnSource.order_id, txnSource.customer_id, allocations.subtotal[index], allocations.tax_amount[index], splitBk, txnSource.tax_snapshot, allocations.discount_amount[index], txnSource.discount_type, txnSource.discount_value, txnSource.discount_reason, allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], groupId, check.label, now(), now());
+            .run(generateBillNumber(), txnSource.order_id, txnSource.customer_id, allocations.subtotal[index], allocations.tax_amount[index], splitBk, splitSnapshot, allocations.discount_amount[index], txnSource.discount_type, txnSource.discount_value, txnSource.discount_reason, allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], groupId, check.label, now(), now());
           billId = Number(inserted.lastInsertRowid);
         }
         billIds.push(billId);

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -997,6 +997,10 @@ interface OrderBillSyncValues {
 interface LegacyTaxContribution {
   taxWeights: number[];
   exclusiveWeights: number[];
+  ownerTaxMinors: number[] | null;
+  ownerExclusiveTaxMinors: number[] | null;
+  ownerTaxSourceMinor: number | null;
+  ownerExclusiveTaxSourceMinor: number | null;
   exclusiveSourceMinor: number;
   allExclusive: boolean;
   hasLegacyTaxEvidence: boolean;
@@ -1011,6 +1015,11 @@ function collectLegacyTaxContribution(
 ): LegacyTaxContribution {
   const taxWeights = new Array(weights.length).fill(0);
   const exclusiveWeights = new Array(weights.length).fill(0);
+  const ownerTaxMinors = new Array(weights.length).fill(0);
+  const ownerExclusiveTaxMinors = new Array(weights.length).fill(0);
+  let ownerTaxSourceMinor = 0;
+  let ownerExclusiveTaxSourceMinor = 0;
+  let hasCompleteOwnerMinorAllocations = true;
   let exclusiveSourceMinor = 0;
   let allExclusive = true;
   let hasLegacyItems = false;
@@ -1027,6 +1036,18 @@ function collectLegacyTaxContribution(
     const effectiveWeights = ownerWeights.some((weight) => weight > 0) ? ownerWeights : weights;
     const totalWeight = effectiveWeights.reduce((sum, weight) => sum + weight, 0);
     if (totalWeight <= 0) continue;
+    if (persistedBreakdowns.has(Number(item.id))) {
+      const sourceMinor = Math.round(sourceCents);
+      const ownerAllocation = allocateSignedMinorUnits(sourceMinor, effectiveWeights);
+      for (let index = 0; index < weights.length; index += 1) {
+        ownerTaxMinors[index] += ownerAllocation[index];
+        if (item.tax_type !== 'inclusive') ownerExclusiveTaxMinors[index] += ownerAllocation[index];
+      }
+      ownerTaxSourceMinor += sourceMinor;
+      if (item.tax_type !== 'inclusive') ownerExclusiveTaxSourceMinor += sourceMinor;
+    } else {
+      hasCompleteOwnerMinorAllocations = false;
+    }
     const magnitude = Math.abs(sourceCents);
     for (let index = 0; index < weights.length; index += 1) {
       const contribution = magnitude * effectiveWeights[index] / totalWeight;
@@ -1041,6 +1062,12 @@ function collectLegacyTaxContribution(
   return {
     taxWeights,
     exclusiveWeights,
+    ownerTaxMinors: hasLegacyItems && hasCompleteOwnerMinorAllocations ? ownerTaxMinors : null,
+    ownerExclusiveTaxMinors: hasLegacyItems && hasCompleteOwnerMinorAllocations ? ownerExclusiveTaxMinors : null,
+    ownerTaxSourceMinor: hasLegacyItems && hasCompleteOwnerMinorAllocations ? ownerTaxSourceMinor : null,
+    ownerExclusiveTaxSourceMinor: hasLegacyItems && hasCompleteOwnerMinorAllocations
+      ? ownerExclusiveTaxSourceMinor
+      : null,
     exclusiveSourceMinor: Math.round(exclusiveSourceMinor),
     allExclusive,
     hasLegacyTaxEvidence: hasLegacyItems || hasDocumentLegacyTax,
@@ -1060,7 +1087,10 @@ function allocateLegacyTaxContribution(
     ? sourceTaxMinor
     : sourceTaxMinor - snapshotSourceTaxMinor;
   const taxWeights = contribution.taxWeights.some((weight) => weight > 0) ? contribution.taxWeights : fallbackWeights;
-  const legacyTaxMinors = allocateSignedMinorUnits(legacySourceTaxMinor, taxWeights);
+  const legacyTaxMinors = contribution.ownerTaxMinors !== null
+    && contribution.ownerTaxSourceMinor === legacySourceTaxMinor
+    ? contribution.ownerTaxMinors
+    : allocateSignedMinorUnits(legacySourceTaxMinor, taxWeights);
   const exclusiveSourceMinor = contribution.allExclusive
     ? legacySourceTaxMinor
     : contribution.exclusiveSourceMinor;
@@ -1068,7 +1098,10 @@ function allocateLegacyTaxContribution(
     ? contribution.exclusiveWeights
     : fallbackWeights;
   const legacyExclusiveTaxMinors = contribution.hasLegacyTaxEvidence || legacySourceTaxMinor !== 0
-    ? allocateSignedMinorUnits(exclusiveSourceMinor, exclusiveWeights)
+    ? contribution.ownerExclusiveTaxMinors !== null
+      && contribution.ownerExclusiveTaxSourceMinor === exclusiveSourceMinor
+      ? contribution.ownerExclusiveTaxMinors
+      : allocateSignedMinorUnits(exclusiveSourceMinor, exclusiveWeights)
     : new Array(fallbackWeights.length).fill(0);
   return { legacySourceTaxMinor, legacyTaxMinors, legacyExclusiveTaxMinors };
 }

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -396,7 +396,8 @@ function reconcileSnapshotAllocations(
 function allocateTaxSnapshotsWithTax(
   sourceRaw: unknown,
   weights: number[],
-  snapshotWeights?: number[][],
+  snapshotWeights?: Array<number[] | null>,
+  snapshotExclusions?: boolean[],
 ): TaxSnapshotAllocationResult {
   const parsed = parseTaxSnapshot(sourceRaw);
   const sourceText = typeof sourceRaw === 'string'
@@ -416,9 +417,11 @@ function allocateTaxSnapshotsWithTax(
 
   sourceSnapshots.forEach((sourceSnapshot: any, snapshotIndex: number) => {
     if (!sourceSnapshot || typeof sourceSnapshot !== 'object' || !Array.isArray(sourceSnapshot.lines)) return;
-    const localWeights = Array.isArray(snapshotWeights?.[snapshotIndex])
-      && snapshotWeights[snapshotIndex].length === weights.length
-      ? snapshotWeights[snapshotIndex]
+    if (snapshotExclusions?.[snapshotIndex]) return;
+    const candidateWeights = snapshotWeights?.[snapshotIndex];
+    const localWeights = Array.isArray(candidateWeights)
+      && candidateWeights.length === weights.length
+      ? candidateWeights
       : weights;
     const snapshotEntries: SnapshotTaxAllocation[] = [];
 
@@ -471,12 +474,17 @@ function allocateTaxSnapshotsWithTax(
     const childResult = JSON.parse(JSON.stringify(parsed));
     const childResultSnapshots = Array.isArray(childResult) ? childResult : [childResult];
     sourceSnapshots.forEach((sourceSnapshot: any, snapshotIndex: number) => {
+      if (snapshotExclusions?.[snapshotIndex]) {
+        childResultSnapshots[snapshotIndex] = null;
+        return;
+      }
       const childSnapshot = childResultSnapshots[snapshotIndex];
       if (!sourceSnapshot || !childSnapshot || !Array.isArray(sourceSnapshot.lines)) return;
       childSnapshot.splitAllocation = SPLIT_TAX_SNAPSHOT_VERSION;
-      const localWeights = Array.isArray(snapshotWeights?.[snapshotIndex])
-        && snapshotWeights[snapshotIndex].length === weights.length
-        ? snapshotWeights[snapshotIndex]
+      const candidateWeights = snapshotWeights?.[snapshotIndex];
+      const localWeights = Array.isArray(candidateWeights)
+        && candidateWeights.length === weights.length
+        ? candidateWeights
         : weights;
       sourceSnapshot.lines.forEach((sourceLine: any, lineIndex: number) => {
         const line = childSnapshot.lines?.[lineIndex];
@@ -529,7 +537,7 @@ function allocateTaxSnapshotsWithTax(
 export function allocateTaxSnapshots(
   sourceRaw: unknown,
   weights: number[],
-  snapshotWeights?: number[][],
+  snapshotWeights?: Array<number[] | null>,
 ): (string | null)[] {
   return allocateTaxSnapshotsWithTax(sourceRaw, weights, snapshotWeights).snapshots;
 }
@@ -674,11 +682,19 @@ function hasSnapshotLines(raw: unknown): boolean {
   ));
 }
 
+function hasSplitAllocatedSnapshot(raw: unknown): boolean {
+  const parsed = parseTaxSnapshot(raw);
+  if (Array.isArray(parsed)) return parsed.some(hasSplitAllocatedSnapshot);
+  if (!parsed || typeof parsed !== 'object') return false;
+  return (parsed as any).splitAllocation === SPLIT_TAX_SNAPSHOT_VERSION
+    && Array.isArray((parsed as any).lines);
+}
+
 function getSplitBillAllocationWeights(
   db: ReturnType<typeof getDatabase>,
   orderId: number | string,
   bills: any[],
-): { weights: number[]; snapshotWeights: number[][] } {
+): { weights: number[]; snapshotWeights: Array<number[] | null>; snapshotExclusions: boolean[] } {
   const items = db.prepare('SELECT * FROM order_items WHERE order_id = ? ORDER BY id').all(orderId) as any[];
   const billIds = bills.map((bill) => Number(bill.id));
   const billItems = billIds.length === 0
@@ -702,16 +718,18 @@ function getSplitBillAllocationWeights(
       }, 0);
   });
 
-  const snapshotWeights = items
+  const snapshotItems = items
     .filter((item) => item.status !== 'cancelled' && hasSnapshotLines(item.tax_snapshot))
-    .map((item) => {
-      const itemWeights = bills.map((bill) => (
-        quantities.get(Number(bill.id))?.get(Number(item.id)) || 0
-      ));
-      return itemWeights.some((weight) => weight > 0) ? itemWeights : weights;
-    });
+  const snapshotWeights = snapshotItems.map((item) => {
+    if (['voided', 'void_adjustment'].includes(item.status)) return null;
+    const itemWeights = bills.map((bill) => (
+      quantities.get(Number(bill.id))?.get(Number(item.id)) || 0
+    ));
+    return itemWeights.some((weight) => weight > 0) ? itemWeights : weights;
+  });
+  const snapshotExclusions = snapshotItems.map((item) => ['voided', 'void_adjustment'].includes(item.status));
 
-  return { weights, snapshotWeights };
+  return { weights, snapshotWeights, snapshotExclusions };
 }
 
 export function syncUnpaidBillsForOrder(
@@ -744,7 +762,7 @@ export function syncUnpaidBillsForOrder(
     return;
   }
 
-  const { weights, snapshotWeights } = getSplitBillAllocationWeights(db, orderId, bills);
+  const { weights, snapshotWeights, snapshotExclusions } = getSplitBillAllocationWeights(db, orderId, bills);
   const fields = {
     subtotal: Math.round(source.subtotal * 100),
     taxAmount: Math.round(source.taxAmount * 100),
@@ -759,7 +777,7 @@ export function syncUnpaidBillsForOrder(
     allocateMinorUnits(value, weights).map((minor) => minor / 100),
   ])) as Record<keyof typeof fields, number[]>;
   const allocatedTaxMinors = allocations.taxAmount.map((amount) => Math.round(amount * 100));
-  const snapshotAllocation = allocateTaxSnapshotsWithTax(source.taxSnapshot, weights, snapshotWeights);
+  const snapshotAllocation = allocateTaxSnapshotsWithTax(source.taxSnapshot, weights, snapshotWeights, snapshotExclusions);
   const sourceTaxMinor = Math.round(Number(source.taxAmount || 0) * 100);
   const snapshotTaxMinors = snapshotAllocation.taxMinors;
   const snapshotTaxMatches = snapshotTaxMinors !== null
@@ -847,12 +865,16 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
       }
 
       const checkTaxMinors = allocations.tax_amount.map((amt) => Math.round(amt * 100));
-      const snapshotWeights = txnActiveItems
-        .filter((item) => hasSnapshotLines(item.tax_snapshot))
-        .map((item) => txnNormalized.map((check: { items: { item: any; quantity: number }[] }) => (
+      const txnSnapshotItems = db.prepare("SELECT * FROM order_items WHERE order_id = ? AND status != 'cancelled' ORDER BY id").all(txnSource.order_id) as any[];
+      const snapshotItems = txnSnapshotItems.filter((item) => hasSnapshotLines(item.tax_snapshot));
+      const snapshotWeights = snapshotItems.map((item) => {
+        if (['voided', 'void_adjustment'].includes(item.status)) return null;
+        return txnNormalized.map((check: { items: { item: any; quantity: number }[] }) => (
           check.items.find((entry) => Number(entry.item.id) === Number(item.id))?.quantity || 0
-        )));
-      const snapshotAllocation = allocateTaxSnapshotsWithTax(txnSource.tax_snapshot, weights, snapshotWeights);
+        ));
+      });
+      const snapshotExclusions = snapshotItems.map((item) => ['voided', 'void_adjustment'].includes(item.status));
+      const snapshotAllocation = allocateTaxSnapshotsWithTax(txnSource.tax_snapshot, weights, snapshotWeights, snapshotExclusions);
       const sourceTaxMinor = Math.round(Number(txnSource.tax_amount || 0) * 100);
       const snapshotTaxMinors = snapshotAllocation.taxMinors;
       const snapshotTaxMatches = snapshotTaxMinors !== null
@@ -1333,6 +1355,9 @@ router.post('/:id/applyDiscount', requireRole('owner', 'manager'), (req: Request
 
     if (bill.payment_status === 'paid') {
       return res.status(400).json({ error: 'Cannot apply discount to a paid bill' });
+    }
+    if (bill.split_group_id) {
+      return res.status(409).json({ error: 'Apply discounts before splitting a bill' });
     }
     const order = db.prepare('SELECT * FROM orders WHERE id = ?').get(bill.order_id) as any;
     if (!order) {

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -354,11 +354,13 @@ function formatSnapshotMinorAmount(original: unknown, minor: number): string | n
 interface SnapshotTaxAllocation {
   original: unknown;
   allocations: number[];
+  exclusive: boolean;
 }
 
 interface TaxSnapshotAllocationResult {
   snapshots: (string | null)[];
   taxMinors: number[] | null;
+  exclusiveTaxMinors: number[] | null;
 }
 
 function reconcileSnapshotAllocations(
@@ -408,12 +410,13 @@ function allocateTaxSnapshotsWithTax(
     snapshot && typeof snapshot === 'object' && Array.isArray((snapshot as any).lines)
   ));
   if (!hasTaxSnapshots) {
-    return { snapshots: new Array(weights.length).fill(sourceText), taxMinors: null };
+    return { snapshots: new Array(weights.length).fill(sourceText), taxMinors: null, exclusiveTaxMinors: null };
   }
 
   const sourceSnapshots = Array.isArray(parsed) ? parsed : [parsed];
   const entryByKey = new Map<string, SnapshotTaxAllocation>();
   const snapshotTaxMinors = new Array(weights.length).fill(0);
+  const exclusiveTaxMinors = new Array(weights.length).fill(0);
 
   sourceSnapshots.forEach((sourceSnapshot: any, snapshotIndex: number) => {
     if (!sourceSnapshot || typeof sourceSnapshot !== 'object' || !Array.isArray(sourceSnapshot.lines)) return;
@@ -428,6 +431,7 @@ function allocateTaxSnapshotsWithTax(
     sourceSnapshot.lines.forEach((sourceLine: any, lineIndex: number) => {
       if (!sourceLine || typeof sourceLine !== 'object') return;
       if (Array.isArray(sourceLine.components)) {
+        const exclusive = sourceLine.taxBehavior !== 'inclusive' && sourceLine.taxBehavior !== 'exempt';
         sourceLine.components.forEach((sourceComponent: any, componentIndex: number) => {
           if (!sourceComponent || typeof sourceComponent !== 'object') return;
           const sourceMinor = snapshotMinorAmount(sourceComponent.amount);
@@ -435,6 +439,7 @@ function allocateTaxSnapshotsWithTax(
           const entry: SnapshotTaxAllocation = {
             original: sourceComponent.amount,
             allocations: allocateSignedMinorUnits(sourceMinor, localWeights),
+            exclusive,
           };
           snapshotEntries.push(entry);
           entryByKey.set(`${snapshotIndex}:${lineIndex}:${componentIndex}`, entry);
@@ -445,6 +450,7 @@ function allocateTaxSnapshotsWithTax(
           const entry: SnapshotTaxAllocation = {
             original: sourceLine.taxAmount,
             allocations: allocateSignedMinorUnits(sourceMinor, localWeights),
+            exclusive: sourceLine.taxBehavior !== 'inclusive' && sourceLine.taxBehavior !== 'exempt',
           };
           snapshotEntries.push(entry);
           entryByKey.set(`${snapshotIndex}:${lineIndex}:taxAmount`, entry);
@@ -464,6 +470,10 @@ function allocateTaxSnapshotsWithTax(
       for (let childIndex = 0; childIndex < weights.length; childIndex += 1) {
         snapshotTaxMinors[childIndex] += snapshotEntries.reduce(
           (sum, entry) => sum + entry.allocations[childIndex],
+          0,
+        );
+        exclusiveTaxMinors[childIndex] += snapshotEntries.reduce(
+          (sum, entry) => sum + (entry.exclusive ? entry.allocations[childIndex] : 0),
           0,
         );
       }
@@ -531,7 +541,7 @@ function allocateTaxSnapshotsWithTax(
     return JSON.stringify(childResult);
   });
 
-  return { snapshots: childSnapshots, taxMinors: snapshotTaxMinors };
+  return { snapshots: childSnapshots, taxMinors: snapshotTaxMinors, exclusiveTaxMinors };
 }
 
 export function allocateTaxSnapshots(
@@ -540,6 +550,20 @@ export function allocateTaxSnapshots(
   snapshotWeights?: Array<number[] | null>,
 ): (string | null)[] {
   return allocateTaxSnapshotsWithTax(sourceRaw, weights, snapshotWeights).snapshots;
+}
+
+function composeSplitTotals(
+  allocations: Record<string, number[]>,
+  exclusiveTaxMinors: number[],
+): number[] {
+  return allocations.subtotal.map((subtotal, index) => Number((
+    subtotal
+    - allocations.discountAmount[index]
+    + exclusiveTaxMinors[index] / 100
+    + allocations.deliveryCharge[index]
+    + allocations.packagingCharge[index]
+    + allocations.roundOff[index]
+  ).toFixed(2)));
 }
 
 function allocateTaxBreakdown(
@@ -783,7 +807,12 @@ export function syncUnpaidBillsForOrder(
   const snapshotTaxMatches = snapshotTaxMinors !== null
     && snapshotTaxMinors.reduce((sum, minor) => sum + minor, 0) === sourceTaxMinor;
   const taxMinors = snapshotTaxMatches ? snapshotTaxMinors : allocatedTaxMinors;
-  if (snapshotTaxMatches) allocations.taxAmount = taxMinors.map((minor) => minor / 100);
+  if (snapshotTaxMatches) {
+    allocations.taxAmount = taxMinors.map((minor) => minor / 100);
+    if (snapshotAllocation.exclusiveTaxMinors) {
+      allocations.total = composeSplitTotals(allocations, snapshotAllocation.exclusiveTaxMinors);
+    }
+  }
   const breakdowns = allocateTaxBreakdown(source.taxBreakdown, taxMinors, weights);
   const snapshots = snapshotAllocation.snapshots;
   const update = db.prepare(`
@@ -880,7 +909,12 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
       const snapshotTaxMatches = snapshotTaxMinors !== null
         && snapshotTaxMinors.reduce((sum, minor) => sum + minor, 0) === sourceTaxMinor;
       const resolvedTaxMinors = snapshotTaxMatches ? snapshotTaxMinors : checkTaxMinors;
-      if (snapshotTaxMatches) allocations.tax_amount = resolvedTaxMinors.map((minor) => minor / 100);
+      if (snapshotTaxMatches) {
+        allocations.tax_amount = resolvedTaxMinors.map((minor) => minor / 100);
+        if (snapshotAllocation.exclusiveTaxMinors) {
+          allocations.total = composeSplitTotals(allocations, snapshotAllocation.exclusiveTaxMinors);
+        }
+      }
       const resolvedTaxBreakdowns = allocateTaxBreakdown(txnSource.tax_breakdown, resolvedTaxMinors, weights);
       const checkTaxSnapshots = snapshotAllocation.snapshots;
 

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -285,6 +285,40 @@ router.post('/generate', requireRole('owner', 'manager', 'cashier'), (req: Reque
   }
 });
 
+function allocateMinorUnits(sourceMinor: number, weights: number[]): number[] {
+  const n = weights.length;
+  if (n === 0) return [];
+  const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+  const effectiveWeights = totalWeight === 0 ? Array(n).fill(1) : weights;
+  const effectiveTotalWeight = effectiveWeights.reduce((sum, w) => sum + w, 0);
+
+  const base: number[] = new Array(n);
+  const remainders: { index: number; remainder: number }[] = new Array(n);
+  let used = 0;
+
+  for (let i = 0; i < n; i++) {
+    const exact = (sourceMinor * effectiveWeights[i]) / effectiveTotalWeight;
+    const b = Math.floor(exact);
+    base[i] = b;
+    used += b;
+    remainders[i] = { index: i, remainder: exact - b };
+  }
+
+  let left = sourceMinor - used;
+  remainders.sort((a, b) => {
+    if (Math.abs(b.remainder - a.remainder) > 1e-9) {
+      return b.remainder - a.remainder;
+    }
+    return a.index - b.index;
+  });
+
+  for (let i = 0; i < left; i++) {
+    base[remainders[i].index] += 1;
+  }
+
+  return base;
+}
+
 // Divide one unpaid dine-in bill into independently payable guest checks.
 // The kitchen order and inventory rows remain singular; bill_items stores only
 // the whole-unit quantity allocated to each resulting check.
@@ -304,7 +338,7 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
     }
     const checks = req.body?.checks;
     if (!Array.isArray(checks) || checks.length < 2 || checks.length > 20) return res.status(400).json({ error: 'Create between 2 and 20 guest checks' });
-    const activeItems = db.prepare("SELECT * FROM order_items WHERE order_id = ? AND status NOT IN ('cancelled', 'voided') ORDER BY id").all(source.order_id) as any[];
+    const activeItems = db.prepare("SELECT * FROM order_items WHERE order_id = ? AND status NOT IN ('cancelled', 'voided', 'void_adjustment') ORDER BY id").all(source.order_id) as any[];
     const itemById = new Map(activeItems.map((item) => [Number(item.id), item]));
     const assigned = new Map<number, number>();
     const normalized = checks.map((check: any, index: number) => {
@@ -328,35 +362,69 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
     }
 
     const result = withTxn(() => {
+      const txnSource = db.prepare('SELECT * FROM bills WHERE id = ?').get(req.params.id) as any;
+      if (!txnSource) throw Object.assign(new Error('Bill not found'), { statusCode: 404 });
+      const txnOrder = db.prepare('SELECT * FROM orders WHERE id = ?').get(txnSource.order_id) as any;
+      if (txnOrder?.type !== 'dine_in') throw Object.assign(new Error('Only dine-in checks can be split'), { statusCode: 400 });
+      if (txnSource.payment_status !== 'unpaid' || Number(txnSource.paid_amount || 0) !== 0 || txnSource.payment_details) {
+        throw Object.assign(new Error('A check can only be split before any payment is recorded'), { statusCode: 409 });
+      }
+      if (txnSource.split_group_id || Number((db.prepare('SELECT COUNT(*) AS n FROM bills WHERE order_id = ?').get(txnSource.order_id) as any).n) > 1) {
+        throw Object.assign(new Error('This check has already been split'), { statusCode: 409 });
+      }
+      const txnActiveItems = db.prepare("SELECT * FROM order_items WHERE order_id = ? AND status NOT IN ('cancelled', 'voided', 'void_adjustment') ORDER BY id").all(txnSource.order_id) as any[];
+      if (txnActiveItems.length !== activeItems.length) {
+        throw Object.assign(new Error('Order items changed during request'), { statusCode: 400 });
+      }
+      for (const item of txnActiveItems) {
+        if ((assigned.get(Number(item.id)) || 0) !== Number(item.quantity)) {
+          throw Object.assign(new Error(`Allocate all ${item.quantity} × ${item.product_name}`), { statusCode: 400 });
+        }
+      }
+
       const groupId = randomUUID();
-      const weights = normalized.map((check: { items: { item: any; quantity: number }[] }) => check.items.reduce((sum: number, entry: { item: any; quantity: number }) => sum + Number(entry.item.total || entry.item.subtotal || 0) * entry.quantity / Number(entry.item.quantity), 0));
-      const totalWeight = weights.reduce((sum, value) => sum + value, 0) || normalized.length;
+      const weights = normalized.map((check: { items: { item: any; quantity: number }[] }) =>
+        check.items.reduce((sum: number, entry: { item: any; quantity: number }) => sum + Number(entry.item.total || entry.item.subtotal || 0) * entry.quantity / Number(entry.item.quantity), 0)
+      );
       const fields = ['subtotal', 'tax_amount', 'discount_amount', 'delivery_charge', 'packaging_charge', 'round_off', 'total'] as const;
       const allocations: Record<string, number[]> = {};
       for (const field of fields) {
-        const totalMinor = Math.round(Number(source[field] || 0) * 100);
-        let used = 0;
-        allocations[field] = normalized.map((_check, index) => {
-          const minor = index === normalized.length - 1 ? totalMinor - used : Math.round(totalMinor * weights[index] / totalWeight);
-          used += minor;
-          return minor / 100;
-        });
+        const totalMinor = Math.round(Number(txnSource[field] || 0) * 100);
+        const allocatedMinors = allocateMinorUnits(totalMinor, weights);
+        allocations[field] = allocatedMinors.map((minor) => minor / 100);
       }
-      const splitBreakdown = (index: number) => {
-        const breakdown = typeof source.tax_breakdown === 'string' ? (() => { try { return JSON.parse(source.tax_breakdown); } catch { return null; } })() : source.tax_breakdown;
-        if (!Array.isArray(breakdown)) return source.tax_breakdown;
-        return JSON.stringify(breakdown.map((line: any) => ({ ...line, amount: Number((Number(line.amount || 0) * weights[index] / totalWeight).toFixed(2)) })));
-      };
+
+      const parsedBreakdown = typeof txnSource.tax_breakdown === 'string'
+        ? (() => { try { return JSON.parse(txnSource.tax_breakdown); } catch { return null; } })()
+        : txnSource.tax_breakdown;
+
+      let checkTaxBreakdowns: (string | null)[] = normalized.map(() => (typeof txnSource.tax_breakdown === 'string' ? txnSource.tax_breakdown : JSON.stringify(txnSource.tax_breakdown || null)));
+      if (Array.isArray(parsedBreakdown)) {
+        const linesPerCheck: any[][] = normalized.map(() => []);
+        for (const line of parsedBreakdown) {
+          const lineMinor = Math.round(Number(line?.amount || 0) * 100);
+          const lineMinors = allocateMinorUnits(lineMinor, weights);
+          lineMinors.forEach((minor, checkIdx) => {
+            linesPerCheck[checkIdx].push({
+              ...line,
+              amount: minor / 100,
+            });
+          });
+        }
+        checkTaxBreakdowns = linesPerCheck.map((lines) => JSON.stringify(lines));
+      }
+
       const billIds: number[] = [];
       normalized.forEach((check, index) => {
         let billId: number;
+        const splitBk = checkTaxBreakdowns[index];
         if (index === 0) {
           db.prepare(`UPDATE bills SET split_group_id = ?, split_label = ?, subtotal = ?, tax_amount = ?, tax_breakdown = ?, discount_amount = ?, delivery_charge = ?, packaging_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ? WHERE id = ?`)
-            .run(groupId, check.label, allocations.subtotal[index], allocations.tax_amount[index], splitBreakdown(index), allocations.discount_amount[index], allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], now(), source.id);
-          billId = Number(source.id);
+            .run(groupId, check.label, allocations.subtotal[index], allocations.tax_amount[index], splitBk, allocations.discount_amount[index], allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], now(), txnSource.id);
+          billId = Number(txnSource.id);
         } else {
           const inserted = db.prepare(`INSERT INTO bills (bill_number, order_id, customer_id, subtotal, tax_amount, tax_breakdown, tax_snapshot, discount_amount, discount_type, discount_value, discount_reason, delivery_charge, packaging_charge, round_off, total, paid_amount, balance, payment_status, split_group_id, split_label, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 'unpaid', ?, ?, ?, ?)`)
-            .run(generateBillNumber(), source.order_id, source.customer_id, allocations.subtotal[index], allocations.tax_amount[index], splitBreakdown(index), source.tax_snapshot, allocations.discount_amount[index], source.discount_type, source.discount_value, source.discount_reason, allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], groupId, check.label, now(), now());
+            .run(generateBillNumber(), txnSource.order_id, txnSource.customer_id, allocations.subtotal[index], allocations.tax_amount[index], splitBk, txnSource.tax_snapshot, allocations.discount_amount[index], txnSource.discount_type, txnSource.discount_value, txnSource.discount_reason, allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], groupId, check.label, now(), now());
           billId = Number(inserted.lastInsertRowid);
         }
         billIds.push(billId);

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -356,6 +356,11 @@ interface SnapshotTaxAllocation {
   allocations: number[];
 }
 
+interface TaxSnapshotAllocationResult {
+  snapshots: (string | null)[];
+  taxMinors: number[] | null;
+}
+
 function reconcileSnapshotAllocations(
   entries: SnapshotTaxAllocation[],
   targets: number[],
@@ -388,12 +393,11 @@ function reconcileSnapshotAllocations(
   }
 }
 
-export function allocateTaxSnapshots(
+function allocateTaxSnapshotsWithTax(
   sourceRaw: unknown,
   weights: number[],
-  targetTaxMinors?: number[],
   snapshotWeights?: number[][],
-): (string | null)[] {
+): TaxSnapshotAllocationResult {
   const parsed = parseTaxSnapshot(sourceRaw);
   const sourceText = typeof sourceRaw === 'string'
     ? sourceRaw
@@ -402,11 +406,13 @@ export function allocateTaxSnapshots(
   const hasTaxSnapshots = snapshots.some((snapshot) => (
     snapshot && typeof snapshot === 'object' && Array.isArray((snapshot as any).lines)
   ));
-  if (!hasTaxSnapshots) return new Array(weights.length).fill(sourceText);
+  if (!hasTaxSnapshots) {
+    return { snapshots: new Array(weights.length).fill(sourceText), taxMinors: null };
+  }
 
   const sourceSnapshots = Array.isArray(parsed) ? parsed : [parsed];
-  const allocations: SnapshotTaxAllocation[] = [];
   const entryByKey = new Map<string, SnapshotTaxAllocation>();
+  const snapshotTaxMinors = new Array(weights.length).fill(0);
 
   sourceSnapshots.forEach((sourceSnapshot: any, snapshotIndex: number) => {
     if (!sourceSnapshot || typeof sourceSnapshot !== 'object' || !Array.isArray(sourceSnapshot.lines)) return;
@@ -427,7 +433,6 @@ export function allocateTaxSnapshots(
             original: sourceComponent.amount,
             allocations: allocateSignedMinorUnits(sourceMinor, localWeights),
           };
-          allocations.push(entry);
           snapshotEntries.push(entry);
           entryByKey.set(`${snapshotIndex}:${lineIndex}:${componentIndex}`, entry);
         });
@@ -438,7 +443,6 @@ export function allocateTaxSnapshots(
             original: sourceLine.taxAmount,
             allocations: allocateSignedMinorUnits(sourceMinor, localWeights),
           };
-          allocations.push(entry);
           snapshotEntries.push(entry);
           entryByKey.set(`${snapshotIndex}:${lineIndex}:taxAmount`, entry);
         }
@@ -454,20 +458,26 @@ export function allocateTaxSnapshots(
         snapshotEntries,
         allocateSignedMinorUnits(snapshotTotal, localWeights),
       );
+      for (let childIndex = 0; childIndex < weights.length; childIndex += 1) {
+        snapshotTaxMinors[childIndex] += snapshotEntries.reduce(
+          (sum, entry) => sum + entry.allocations[childIndex],
+          0,
+        );
+      }
     }
   });
 
-  if (targetTaxMinors && targetTaxMinors.length === weights.length) {
-    reconcileSnapshotAllocations(allocations, targetTaxMinors);
-  }
-
-  return weights.map((_, childIndex) => {
+  const childSnapshots = weights.map((_, childIndex) => {
     const childResult = JSON.parse(JSON.stringify(parsed));
     const childResultSnapshots = Array.isArray(childResult) ? childResult : [childResult];
     sourceSnapshots.forEach((sourceSnapshot: any, snapshotIndex: number) => {
       const childSnapshot = childResultSnapshots[snapshotIndex];
       if (!sourceSnapshot || !childSnapshot || !Array.isArray(sourceSnapshot.lines)) return;
       childSnapshot.splitAllocation = SPLIT_TAX_SNAPSHOT_VERSION;
+      const localWeights = Array.isArray(snapshotWeights?.[snapshotIndex])
+        && snapshotWeights[snapshotIndex].length === weights.length
+        ? snapshotWeights[snapshotIndex]
+        : weights;
       sourceSnapshot.lines.forEach((sourceLine: any, lineIndex: number) => {
         const line = childSnapshot.lines?.[lineIndex];
         if (!sourceLine || !line || typeof line !== 'object') return;
@@ -476,7 +486,7 @@ export function allocateTaxSnapshots(
           if (sourceMinor !== null) {
             line[field] = formatSnapshotMinorAmount(
               sourceLine[field],
-              allocateSignedMinorUnits(sourceMinor, weights)[childIndex],
+              allocateSignedMinorUnits(sourceMinor, localWeights)[childIndex],
             );
           }
         }
@@ -512,6 +522,16 @@ export function allocateTaxSnapshots(
     });
     return JSON.stringify(childResult);
   });
+
+  return { snapshots: childSnapshots, taxMinors: snapshotTaxMinors };
+}
+
+export function allocateTaxSnapshots(
+  sourceRaw: unknown,
+  weights: number[],
+  snapshotWeights?: number[][],
+): (string | null)[] {
+  return allocateTaxSnapshotsWithTax(sourceRaw, weights, snapshotWeights).snapshots;
 }
 
 function allocateTaxBreakdown(
@@ -738,9 +758,16 @@ export function syncUnpaidBillsForOrder(
     field,
     allocateMinorUnits(value, weights).map((minor) => minor / 100),
   ])) as Record<keyof typeof fields, number[]>;
-  const taxMinors = allocations.taxAmount.map((amount) => Math.round(amount * 100));
+  const allocatedTaxMinors = allocations.taxAmount.map((amount) => Math.round(amount * 100));
+  const snapshotAllocation = allocateTaxSnapshotsWithTax(source.taxSnapshot, weights, snapshotWeights);
+  const sourceTaxMinor = Math.round(Number(source.taxAmount || 0) * 100);
+  const snapshotTaxMinors = snapshotAllocation.taxMinors;
+  const snapshotTaxMatches = snapshotTaxMinors !== null
+    && snapshotTaxMinors.reduce((sum, minor) => sum + minor, 0) === sourceTaxMinor;
+  const taxMinors = snapshotTaxMatches ? snapshotTaxMinors : allocatedTaxMinors;
+  if (snapshotTaxMatches) allocations.taxAmount = taxMinors.map((minor) => minor / 100);
   const breakdowns = allocateTaxBreakdown(source.taxBreakdown, taxMinors, weights);
-  const snapshots = allocateTaxSnapshots(source.taxSnapshot, weights, taxMinors, snapshotWeights);
+  const snapshots = snapshotAllocation.snapshots;
   const update = db.prepare(`
     UPDATE bills SET subtotal = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?,
       delivery_charge = ?, packaging_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ?
@@ -820,18 +847,25 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
       }
 
       const checkTaxMinors = allocations.tax_amount.map((amt) => Math.round(amt * 100));
-      const checkTaxBreakdowns = allocateTaxBreakdown(txnSource.tax_breakdown, checkTaxMinors, weights);
       const snapshotWeights = txnActiveItems
         .filter((item) => hasSnapshotLines(item.tax_snapshot))
         .map((item) => txnNormalized.map((check: { items: { item: any; quantity: number }[] }) => (
           check.items.find((entry) => Number(entry.item.id) === Number(item.id))?.quantity || 0
         )));
-      const checkTaxSnapshots = allocateTaxSnapshots(txnSource.tax_snapshot, weights, checkTaxMinors, snapshotWeights);
+      const snapshotAllocation = allocateTaxSnapshotsWithTax(txnSource.tax_snapshot, weights, snapshotWeights);
+      const sourceTaxMinor = Math.round(Number(txnSource.tax_amount || 0) * 100);
+      const snapshotTaxMinors = snapshotAllocation.taxMinors;
+      const snapshotTaxMatches = snapshotTaxMinors !== null
+        && snapshotTaxMinors.reduce((sum, minor) => sum + minor, 0) === sourceTaxMinor;
+      const resolvedTaxMinors = snapshotTaxMatches ? snapshotTaxMinors : checkTaxMinors;
+      if (snapshotTaxMatches) allocations.tax_amount = resolvedTaxMinors.map((minor) => minor / 100);
+      const resolvedTaxBreakdowns = allocateTaxBreakdown(txnSource.tax_breakdown, resolvedTaxMinors, weights);
+      const checkTaxSnapshots = snapshotAllocation.snapshots;
 
       const billIds: number[] = [];
       txnNormalized.forEach((check, index) => {
         let billId: number;
-        const splitBk = checkTaxBreakdowns[index];
+        const splitBk = resolvedTaxBreakdowns[index];
         const splitSnapshot = checkTaxSnapshots[index];
         if (index === 0) {
           db.prepare(`UPDATE bills SET split_group_id = ?, split_label = ?, subtotal = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, delivery_charge = ?, packaging_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ? WHERE id = ?`)

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -186,7 +186,7 @@ function applyPersistedChildTaxBreakdowns(
     if (hasSnapshotLines(item.tax_snapshot)) return item;
     const breakdown = childBreakdowns.get(Number(item.id));
     if (breakdown === undefined) return item;
-    return { ...item, tax_breakdown: breakdown, tax_amount: taxBreakdownMinorTotal(breakdown) / 100 };
+    return { ...item, tax_breakdown: [breakdown], tax_amount: taxBreakdownMinorTotal(breakdown) / 100 };
   });
 }
 
@@ -857,13 +857,17 @@ function composeSplitTotals(
   allocations: Record<string, number[]>,
   exclusiveTaxMinors: number[],
 ): number[] {
+  const discountAmount = allocations.discount_amount ?? allocations.discountAmount;
+  const deliveryCharge = allocations.delivery_charge ?? allocations.deliveryCharge;
+  const packagingCharge = allocations.packaging_charge ?? allocations.packagingCharge;
+  const roundOff = allocations.round_off ?? allocations.roundOff;
   return allocations.subtotal.map((subtotal, index) => Number((
     subtotal
-    - allocations.discountAmount[index]
+    - discountAmount[index]
     + exclusiveTaxMinors[index] / 100
-    + allocations.deliveryCharge[index]
-    + allocations.packagingCharge[index]
-    + allocations.roundOff[index]
+    + deliveryCharge[index]
+    + packagingCharge[index]
+    + roundOff[index]
   ).toFixed(2)));
 }
 

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -155,7 +155,7 @@ function getPersistedChildTaxBreakdowns(
   for (const breakdown of parsed) {
     while (itemIndex < sourceItems.length) {
       const item = sourceItems[itemIndex++];
-      if (item.status === 'cancelled') continue;
+      if (['cancelled', 'voided', 'void_adjustment'].includes(item.status)) continue;
       const itemBreakdown = parseTaxSnapshot(item.tax_breakdown);
       if (!Array.isArray(itemBreakdown) || itemBreakdown.length === 0) continue;
       result.set(Number(item.id), breakdown);
@@ -1182,7 +1182,7 @@ function getSplitBillAllocationWeights(
   });
 
   const snapshotItems = items
-    .filter((item) => item.status !== 'cancelled' && hasSnapshotLines(item.tax_snapshot))
+    .filter((item) => !['cancelled', 'voided', 'void_adjustment'].includes(item.status) && hasSnapshotLines(item.tax_snapshot))
   const snapshotWeights = snapshotItems.map((item) => {
     if (['voided', 'void_adjustment'].includes(item.status)) return null;
     const itemWeights = bills.map((bill) => (
@@ -1282,26 +1282,13 @@ function getTaxBreakdownWeights(
       component && typeof component === 'object' ? ownerWeightsByKey.get(componentKey(component)) || null : null
     ));
   }
-  const voidedByKey = new Map<string, any[]>();
-  for (const item of items) {
-    if (item.status !== 'voided') continue;
-    const key = `${item.product_id}:${item.quantity}`;
-    const matches = voidedByKey.get(key) || [];
-    matches.push(item);
-    voidedByKey.set(key, matches);
-  }
   let itemIndex = 0;
   return parsed.map(() => {
     while (itemIndex < items.length) {
       const item = items[itemIndex++];
-      if (item.status === 'cancelled') continue;
+      if (['cancelled', 'voided', 'void_adjustment'].includes(item.status)) continue;
       const breakdown = parseTaxSnapshot(item.tax_breakdown);
       if (Array.isArray(breakdown) && breakdown.length > 0) {
-        if (item.status === 'void_adjustment') {
-          const key = `${item.product_id}:${item.quantity}`;
-          const original = voidedByKey.get(key)?.shift();
-          return original ? itemWeights(original) : null;
-        }
         return itemWeights(item);
       }
     }

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -20,6 +20,7 @@ import {
   calculateConfiguredChargeTaxes,
   combineItemAndChargeTaxes,
   getActiveCountryPack,
+  scaleTaxSnapshots,
 } from '../services/tax';
 import { applyPayableRounding } from '../services/tax-engine';
 import { sendEvent } from '../services/telemetry';
@@ -33,10 +34,10 @@ function scaleTaxBreakdown(
   childIndex = 0,
   sourceTaxMinor?: number,
 ): unknown {
-  if (raw === null || raw === undefined || ratio === 1) return raw;
   if (ownerWeights && ownerWeights.length > 0) {
     return allocateTaxBreakdownForChild(raw, ownerWeights, childIndex, sourceTaxMinor);
   }
+  if (raw === null || raw === undefined || ratio === 1) return raw;
   const wasString = typeof raw === 'string';
   let parsed = raw;
   if (wasString) {
@@ -65,12 +66,102 @@ function scaleTaxBreakdown(
   return wasString ? JSON.stringify(scaled) : scaled;
 }
 
+type ChildItemAllocation = { weights: number[]; index: number };
+
+function getTaxDiscountRatio(subtotal: unknown, discountAmount: unknown): number {
+  const base = Number(subtotal || 0);
+  if (!Number.isFinite(base) || base <= 0) return 1;
+  const discount = Math.max(0, Number(discountAmount || 0));
+  return Math.max(0, Math.min(1, (base - discount) / base));
+}
+
+export function projectOrderItems(
+  order: any,
+  rawItemRows: any[],
+  allocations: any[] = [],
+  childItemAllocations = new Map<number, ChildItemAllocation>(),
+): any[] {
+  const allocated = new Map(allocations.map((row) => [Number(row.order_item_id), Number(row.quantity)]));
+  const taxDiscountRatio = getTaxDiscountRatio(order.subtotal, order.discount_amount);
+  return rawItemRows
+    .filter((item) => allocations.length === 0 || allocated.has(Number(item.id)))
+    .map((item) => {
+      const quantity = allocated.get(Number(item.id));
+      const originalQuantity = Number(item.quantity);
+      const quantityRatio = quantity === undefined || originalQuantity <= 0
+        ? 1
+        : quantity / originalQuantity;
+      const ownerAllocation = childItemAllocations.get(Number(item.id));
+      const sourceTaxMinor = Math.round(Number(item.tax_amount || 0) * taxDiscountRatio * 100);
+      const taxMinor = ownerAllocation
+        ? allocateSignedMinorUnits(sourceTaxMinor, ownerAllocation.weights)[ownerAllocation.index]
+        : Math.round(sourceTaxMinor * quantityRatio);
+      const hasSnapshot = hasSnapshotLines(item.tax_snapshot);
+      const scaledBreakdown = hasSnapshot
+        ? item.tax_breakdown
+        : scaleTaxBreakdown(item.tax_breakdown, taxDiscountRatio);
+      const taxBreakdown = ownerAllocation
+        ? scaleTaxBreakdown(
+          scaledBreakdown,
+          1,
+          ownerAllocation.weights,
+          ownerAllocation.index,
+          sourceTaxMinor,
+        )
+        : scaleTaxBreakdown(scaledBreakdown, quantityRatio);
+      const taxSnapshot = ownerAllocation || !hasSnapshot || (taxDiscountRatio === 1 && quantityRatio === 1)
+        ? item.tax_snapshot
+        : scaleTaxSnapshots([item.tax_snapshot], taxDiscountRatio * quantityRatio)[0] || null;
+      if (quantity === undefined && taxDiscountRatio === 1 && !ownerAllocation) return item;
+      return {
+        ...item,
+        ...(quantity === undefined ? {} : { quantity }),
+        subtotal: Number((Number(item.subtotal) * quantityRatio).toFixed(2)),
+        tax_amount: taxMinor / 100,
+        tax_breakdown: taxBreakdown,
+        tax_snapshot: taxSnapshot,
+        total: Number((Number(item.total) * quantityRatio).toFixed(2)),
+      };
+    });
+}
+
+function childAllocationsForBills(
+  bills: any[],
+  billItems: any[],
+  billId: number,
+): Map<number, ChildItemAllocation> {
+  const childIds = bills.map((bill) => Number(bill.id));
+  const childIdSet = new Set(childIds);
+  const index = childIds.indexOf(billId);
+  if (index === -1) return new Map();
+  const quantities = new Map<number, number[]>();
+  for (const row of billItems.filter((row) => childIdSet.has(Number(row.bill_id)))) {
+    const itemId = Number(row.order_item_id);
+    const weights = quantities.get(itemId) || new Array(childIds.length).fill(0);
+    weights[childIds.indexOf(Number(row.bill_id))] = Number(row.quantity);
+    quantities.set(itemId, weights);
+  }
+  return new Map(Array.from(quantities.entries()).map(([itemId, weights]) => [itemId, { weights, index }]));
+}
+
+function selectRowsByIds<T>(
+  db: ReturnType<typeof getDatabase>,
+  ids: any[],
+  queryForCount: (count: number) => string,
+): T[] {
+  const rows: T[] = [];
+  for (let offset = 0; offset < ids.length; offset += 400) {
+    const chunk = ids.slice(offset, offset + 400);
+    rows.push(...db.prepare(queryForCount(chunk.length)).all(...chunk) as T[]);
+  }
+  return rows;
+}
+
 export function getOrderWithItems(db: ReturnType<typeof getDatabase>, orderId: number, billId?: number): any {
   const order = parseRowJson(db.prepare('SELECT * FROM orders WHERE id = ?').get(orderId));
   if (!order) return order;
   const allocations = billId === undefined ? [] : db.prepare('SELECT order_item_id, quantity FROM bill_items WHERE bill_id = ?').all(billId) as any[];
-  const allocated = new Map(allocations.map((row) => [Number(row.order_item_id), Number(row.quantity)]));
-  const childItemAllocations = new Map<number, { weights: number[]; index: number }>();
+  let childItemAllocations = new Map<number, ChildItemAllocation>();
   if (billId !== undefined) {
     const bill = db.prepare('SELECT split_group_id FROM bills WHERE id = ?').get(billId) as any;
     if (bill?.split_group_id) {
@@ -79,46 +170,76 @@ export function getOrderWithItems(db: ReturnType<typeof getDatabase>, orderId: n
       const childRows = childIds.length === 0
         ? []
         : db.prepare(`SELECT bill_id, order_item_id, quantity FROM bill_items WHERE bill_id IN (${childIds.map(() => '?').join(',')})`).all(...childIds) as any[];
-      const quantities = new Map<number, number[]>();
-      for (const row of childRows) {
-        const itemId = Number(row.order_item_id);
-        const weights = quantities.get(itemId) || new Array(childIds.length).fill(0);
-        weights[childIds.indexOf(Number(row.bill_id))] = Number(row.quantity);
-        quantities.set(itemId, weights);
-      }
-      for (const [itemId, weights] of quantities) {
-        const index = childIds.indexOf(Number(billId));
-        if (index !== -1) childItemAllocations.set(itemId, { weights, index });
-      }
+      childItemAllocations = childAllocationsForBills(childBills, childRows, Number(billId));
     }
   }
-  const itemRows = (db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(orderId) as any[])
-    .filter((item) => allocations.length === 0 || allocated.has(Number(item.id)))
-    .map((item) => {
-      const quantity = allocated.get(Number(item.id));
-      if (quantity === undefined || quantity === Number(item.quantity)) return item;
-      const originalQuantity = Number(item.quantity);
-      if (originalQuantity <= 0) return item;
-      const ratio = quantity / originalQuantity;
-      return {
-        ...item,
-        quantity,
-        subtotal: Number((Number(item.subtotal) * ratio).toFixed(2)),
-        tax_amount: Number((Number(item.tax_amount || 0) * ratio).toFixed(2)),
-        tax_breakdown: scaleTaxBreakdown(
-          item.tax_breakdown,
-          ratio,
-          childItemAllocations.get(Number(item.id))?.weights,
-          childItemAllocations.get(Number(item.id))?.index,
-          Math.round(Number(item.tax_amount || 0) * 100),
-        ),
-        total: Number((Number(item.total) * ratio).toFixed(2)),
-      };
-    });
+  const itemRows = db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(orderId) as any[];
   return {
     ...order,
-    items: attachEffectiveAddons(db, itemRows.map(parseItemJson)),
+    items: attachEffectiveAddons(db, projectOrderItems(order, itemRows, allocations, childItemAllocations).map(parseItemJson)),
   };
+}
+
+export function getOrdersWithItemsForBills(
+  db: ReturnType<typeof getDatabase>,
+  bills: any[],
+): Map<number, any> {
+  const result = new Map<number, any>();
+  if (bills.length === 0) return result;
+  const orderIds = Array.from(new Set(bills.map((bill) => Number(bill.order_id))));
+  const orderRows = selectRowsByIds<any>(db, orderIds, (count) => `SELECT * FROM orders WHERE id IN (${new Array(count).fill('?').join(',')})`);
+  const orders = new Map(orderRows.map((row) => [Number(row.id), parseRowJson(row)]));
+  const itemRows = selectRowsByIds<any>(db, orderIds, (count) => `SELECT * FROM order_items WHERE order_id IN (${new Array(count).fill('?').join(',')}) ORDER BY id`);
+  const itemsByOrder = new Map<number, any[]>();
+  for (const item of itemRows) {
+    const items = itemsByOrder.get(Number(item.order_id)) || [];
+    items.push(item);
+    itemsByOrder.set(Number(item.order_id), items);
+  }
+
+  const billIds = bills.map((bill) => Number(bill.id));
+  const reportBillItems = selectRowsByIds<any>(db, billIds, (count) => `SELECT bill_id, order_item_id, quantity FROM bill_items WHERE bill_id IN (${new Array(count).fill('?').join(',')})`);
+  const splitGroupIds = Array.from(new Set(bills.map((bill) => bill.split_group_id).filter(Boolean)));
+  const siblingBills = splitGroupIds.length === 0
+    ? []
+    : selectRowsByIds<any>(db, splitGroupIds, (count) => `SELECT id, order_id, split_group_id FROM bills WHERE split_group_id IN (${new Array(count).fill('?').join(',')}) ORDER BY split_group_id, id`);
+  const allBillIds = Array.from(new Set([...billIds, ...siblingBills.map((bill) => Number(bill.id))]));
+  const allBillItems = selectRowsByIds<any>(db, allBillIds, (count) => `SELECT bill_id, order_item_id, quantity FROM bill_items WHERE bill_id IN (${new Array(count).fill('?').join(',')})`);
+  const billItemsByBill = new Map<number, any[]>();
+  for (const row of reportBillItems) {
+    const rows = billItemsByBill.get(Number(row.bill_id)) || [];
+    rows.push(row);
+    billItemsByBill.set(Number(row.bill_id), rows);
+  }
+  const siblingsByGroup = new Map<string, any[]>();
+  for (const bill of siblingBills) {
+    const groupBills = siblingsByGroup.get(String(bill.split_group_id)) || [];
+    groupBills.push(bill);
+    siblingsByGroup.set(String(bill.split_group_id), groupBills);
+  }
+
+  const projected = new Map<number, any>();
+  const addonItems = new Map<number, any>();
+  for (const bill of bills) {
+    const order = orders.get(Number(bill.order_id));
+    if (!order) continue;
+    const groupBills = bill.split_group_id ? siblingsByGroup.get(String(bill.split_group_id)) || [] : [];
+    const allocations = billItemsByBill.get(Number(bill.id)) || [];
+    const itemAllocations = groupBills.length > 0
+      ? childAllocationsForBills(groupBills, allBillItems, Number(bill.id))
+      : new Map<number, ChildItemAllocation>();
+    const items = projectOrderItems(order, itemsByOrder.get(Number(bill.order_id)) || [], allocations, itemAllocations)
+      .map(parseItemJson);
+    items.forEach((item) => addonItems.set(Number(item.id), item));
+    projected.set(Number(bill.id), { ...order, items });
+  }
+  const hydratedAddons = attachEffectiveAddons(db, Array.from(addonItems.values()));
+  const addonsByItem = new Map(hydratedAddons.map((item) => [Number(item.id), item.addons]));
+  for (const [billId, order] of projected) {
+    order.items = order.items.map((item: any) => ({ ...item, addons: addonsByItem.get(Number(item.id)) || [] }));
+    result.set(billId, order);
+  }
+  return result;
 }
 
 // Fixed conversion rate for redeeming loyalty wallet points as payment (points per 1 currency unit).
@@ -816,6 +937,7 @@ function getSplitBillAllocationWeights(
   db: ReturnType<typeof getDatabase>,
   orderId: number | string,
   bills: any[],
+  legacyTaxRatio = 1,
 ): {
   weights: number[];
   snapshotWeights: Array<number[] | null>;
@@ -862,7 +984,7 @@ function getSplitBillAllocationWeights(
   let legacySourceTaxMinor = 0;
   for (const item of items) {
     if (['cancelled', 'voided', 'void_adjustment'].includes(item.status) || hasSnapshotLines(item.tax_snapshot)) continue;
-    const itemTaxMinor = Math.round(Number(item.tax_amount || 0) * 100);
+    const itemTaxMinor = Math.round(Number(item.tax_amount || 0) * legacyTaxRatio * 100);
     if (itemTaxMinor === 0) continue;
     const itemWeights = bills.map((bill) => quantities.get(Number(bill.id))?.get(Number(item.id)) || 0);
     const allocations = allocateSignedMinorUnits(itemTaxMinor, itemWeights.some((weight) => weight > 0) ? itemWeights : weights);
@@ -988,7 +1110,12 @@ export function syncUnpaidBillsForOrder(
     legacyTaxMinors,
     legacyExclusiveTaxMinors,
     legacySourceTaxMinor,
-  } = getSplitBillAllocationWeights(db, orderId, bills);
+  } = getSplitBillAllocationWeights(
+    db,
+    orderId,
+    bills,
+    getTaxDiscountRatio(source.subtotal, source.discountAmount),
+  );
   const fields = {
     subtotal: Math.round(source.subtotal * 100),
     taxAmount: Math.round(source.taxAmount * 100),
@@ -1120,12 +1247,13 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
       const snapshotExclusions = snapshotItems.map((item) => ['voided', 'void_adjustment'].includes(item.status));
       const snapshotAllocation = allocateTaxSnapshotsWithTax(txnSource.tax_snapshot, weights, snapshotWeights, snapshotExclusions);
       const sourceTaxMinor = Math.round(Number(txnSource.tax_amount || 0) * 100);
+      const legacyTaxRatio = getTaxDiscountRatio(txnSource.subtotal, txnSource.discount_amount);
       const legacyTaxMinors = new Array(txnNormalized.length).fill(0);
       const legacyExclusiveTaxMinors = new Array(txnNormalized.length).fill(0);
       let legacySourceTaxMinor = 0;
       for (const item of txnSnapshotItems) {
         if (['cancelled', 'voided', 'void_adjustment'].includes(item.status) || hasSnapshotLines(item.tax_snapshot)) continue;
-        const itemTaxMinor = Math.round(Number(item.tax_amount || 0) * 100);
+        const itemTaxMinor = Math.round(Number(item.tax_amount || 0) * legacyTaxRatio * 100);
         if (itemTaxMinor === 0) continue;
         const itemWeights = txnNormalized.map((check: { items: { item: any; quantity: number }[] }) => (
           check.items.find((entry) => Number(entry.item.id) === Number(item.id))?.quantity || 0

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -448,40 +448,8 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
   try {
     const db = getDatabase();
     if (getSettingValue('split_checks_enabled') !== 'true') return res.status(403).json({ error: 'Split checks are not enabled' });
-    const source = db.prepare('SELECT * FROM bills WHERE id = ?').get(req.params.id) as any;
-    if (!source) return res.status(404).json({ error: 'Bill not found' });
-    const order = db.prepare('SELECT * FROM orders WHERE id = ?').get(source.order_id) as any;
-    if (order?.type !== 'dine_in') return res.status(400).json({ error: 'Only dine-in checks can be split' });
-    if (source.payment_status !== 'unpaid' || Number(source.paid_amount || 0) !== 0 || source.payment_details) {
-      return res.status(409).json({ error: 'A check can only be split before any payment is recorded' });
-    }
-    if (source.split_group_id || Number((db.prepare('SELECT COUNT(*) AS n FROM bills WHERE order_id = ?').get(source.order_id) as any).n) > 1) {
-      return res.status(409).json({ error: 'This check has already been split' });
-    }
     const checks = req.body?.checks;
     if (!Array.isArray(checks) || checks.length < 2 || checks.length > 20) return res.status(400).json({ error: 'Create between 2 and 20 guest checks' });
-    const activeItems = db.prepare("SELECT * FROM order_items WHERE order_id = ? AND status NOT IN ('cancelled', 'voided', 'void_adjustment') ORDER BY id").all(source.order_id) as any[];
-    const itemById = new Map(activeItems.map((item) => [Number(item.id), item]));
-    const assigned = new Map<number, number>();
-    const normalized = checks.map((check: any, index: number) => {
-      const label = String(check?.label || `Guest ${index + 1}`).trim().slice(0, 40) || `Guest ${index + 1}`;
-      if (!Array.isArray(check?.items) || check.items.length === 0) throw Object.assign(new Error(`${label} must contain at least one item`), { statusCode: 400 });
-      const seenItems = new Set<number>();
-      const items = check.items.map((entry: any) => {
-        const itemId = Number(entry?.order_item_id);
-        const quantity = Number(entry?.quantity);
-        const item = itemById.get(itemId);
-        if (!item || !Number.isSafeInteger(quantity) || quantity < 1) throw Object.assign(new Error(`Invalid item allocation in ${label}`), { statusCode: 400 });
-        if (seenItems.has(itemId)) throw Object.assign(new Error(`${label} contains the same item more than once`), { statusCode: 400 });
-        seenItems.add(itemId);
-        assigned.set(itemId, (assigned.get(itemId) || 0) + quantity);
-        return { item, quantity };
-      });
-      return { label, items };
-    });
-    for (const item of activeItems) {
-      if ((assigned.get(Number(item.id)) || 0) !== Number(item.quantity)) return res.status(400).json({ error: `Allocate all ${item.quantity} × ${item.product_name}` });
-    }
 
     const result = withTxn(() => {
       const txnSource = db.prepare('SELECT * FROM bills WHERE id = ?').get(req.params.id) as any;

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -144,6 +144,52 @@ function childAllocationsForBills(
   return new Map(Array.from(quantities.entries()).map(([itemId, weights]) => [itemId, { weights, index }]));
 }
 
+function getPersistedChildTaxBreakdowns(
+  sourceRaw: unknown,
+  sourceItems: any[],
+): Map<number, any> {
+  const parsed = parseTaxSnapshot(sourceRaw);
+  if (!Array.isArray(parsed) || !Array.isArray(parsed[0])) return new Map();
+  const result = new Map<number, any>();
+  let itemIndex = 0;
+  for (const breakdown of parsed) {
+    while (itemIndex < sourceItems.length) {
+      const item = sourceItems[itemIndex++];
+      if (item.status === 'cancelled') continue;
+      const itemBreakdown = parseTaxSnapshot(item.tax_breakdown);
+      if (!Array.isArray(itemBreakdown) || itemBreakdown.length === 0) continue;
+      result.set(Number(item.id), breakdown);
+      break;
+    }
+  }
+  return result;
+}
+
+function taxBreakdownMinorTotal(raw: unknown): number {
+  const parsed = parseTaxSnapshot(raw);
+  const entries = Array.isArray(parsed) ? parsed : [parsed];
+  return entries.reduce((sum, entry) => {
+    if (Array.isArray(entry)) return sum + taxBreakdownMinorTotal(entry);
+    const amount = Number((entry as any)?.amount);
+    return Number.isFinite(amount) ? sum + Math.round(amount * 100) : sum;
+  }, 0);
+}
+
+function applyPersistedChildTaxBreakdowns(
+  projectedItems: any[],
+  sourceItems: any[],
+  sourceRaw: unknown,
+): any[] {
+  const childBreakdowns = getPersistedChildTaxBreakdowns(sourceRaw, sourceItems);
+  if (childBreakdowns.size === 0) return projectedItems;
+  return projectedItems.map((item) => {
+    if (hasSnapshotLines(item.tax_snapshot)) return item;
+    const breakdown = childBreakdowns.get(Number(item.id));
+    if (breakdown === undefined) return item;
+    return { ...item, tax_breakdown: breakdown, tax_amount: taxBreakdownMinorTotal(breakdown) / 100 };
+  });
+}
+
 function selectRowsByIds<T>(
   db: ReturnType<typeof getDatabase>,
   ids: any[],
@@ -162,8 +208,10 @@ export function getOrderWithItems(db: ReturnType<typeof getDatabase>, orderId: n
   if (!order) return order;
   const allocations = billId === undefined ? [] : db.prepare('SELECT order_item_id, quantity FROM bill_items WHERE bill_id = ?').all(billId) as any[];
   let childItemAllocations = new Map<number, ChildItemAllocation>();
+  let persistedTaxBreakdown: unknown = null;
   if (billId !== undefined) {
-    const bill = db.prepare('SELECT split_group_id FROM bills WHERE id = ?').get(billId) as any;
+    const bill = db.prepare('SELECT split_group_id, tax_breakdown FROM bills WHERE id = ?').get(billId) as any;
+    persistedTaxBreakdown = bill?.tax_breakdown;
     if (bill?.split_group_id) {
       const childBills = db.prepare('SELECT id FROM bills WHERE split_group_id = ? ORDER BY id').all(bill.split_group_id) as any[];
       const childIds = childBills.map((child) => Number(child.id));
@@ -174,9 +222,13 @@ export function getOrderWithItems(db: ReturnType<typeof getDatabase>, orderId: n
     }
   }
   const itemRows = db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(orderId) as any[];
+  const projectedItems = projectOrderItems(order, itemRows, allocations, childItemAllocations);
+  const childScopedItems = billId === undefined
+    ? projectedItems
+    : applyPersistedChildTaxBreakdowns(projectedItems, itemRows, persistedTaxBreakdown);
   return {
     ...order,
-    items: attachEffectiveAddons(db, projectOrderItems(order, itemRows, allocations, childItemAllocations).map(parseItemJson)),
+    items: attachEffectiveAddons(db, childScopedItems.map(parseItemJson)),
   };
 }
 
@@ -228,7 +280,9 @@ export function getOrdersWithItemsForBills(
     const itemAllocations = groupBills.length > 0
       ? childAllocationsForBills(groupBills, allBillItems, Number(bill.id))
       : new Map<number, ChildItemAllocation>();
-    const items = projectOrderItems(order, itemsByOrder.get(Number(bill.order_id)) || [], allocations, itemAllocations)
+    const rawItems = itemsByOrder.get(Number(bill.order_id)) || [];
+    const projectedItems = projectOrderItems(order, rawItems, allocations, itemAllocations);
+    const items = applyPersistedChildTaxBreakdowns(projectedItems, rawItems, bill.tax_breakdown)
       .map(parseItemJson);
     items.forEach((item) => addonItems.set(Number(item.id), item));
     projected.set(Number(bill.id), { ...order, items });
@@ -878,10 +932,24 @@ function allocateTaxBreakdown(
     return allocateSignedMinorUnits(comp.minorAmount, allocationWeights);
   });
 
-  reconcileSnapshotAllocations(
-    compAllocations.map((allocations) => ({ allocations })),
-    checkTaxMinors,
-  );
+  const allocationGroups = new Map<string, { entries: Array<{ allocations: number[] }>; weights: number[]; sourceMinor: number }>();
+  components.forEach((comp, index) => {
+    const ownerWeights = comp.outerIndex === undefined ? null : componentWeights?.[comp.outerIndex];
+    const allocationWeights = ownerWeights && ownerWeights.length === weights.length && ownerWeights.some((weight) => weight > 0)
+      ? ownerWeights
+      : weights;
+    const groupKey = comp.outerIndex === undefined ? 'flat' : `outer:${comp.outerIndex}`;
+    const group = allocationGroups.get(groupKey) || { entries: [], weights: allocationWeights, sourceMinor: 0 };
+    group.entries.push({ allocations: compAllocations[index] });
+    group.sourceMinor += comp.minorAmount;
+    allocationGroups.set(groupKey, group);
+  });
+  for (const [groupKey, group] of allocationGroups) {
+    const target = groupKey === 'flat'
+      ? checkTaxMinors
+      : allocateSignedMinorUnits(group.sourceMinor, group.weights);
+    reconcileSnapshotAllocations(group.entries, target);
+  }
 
   const result: (string | null)[] = [];
 
@@ -926,6 +994,78 @@ interface OrderBillSyncValues {
   total: number;
 }
 
+interface LegacyTaxContribution {
+  taxWeights: number[];
+  exclusiveWeights: number[];
+  exclusiveSourceMinor: number;
+  allExclusive: boolean;
+  hasLegacyItems: boolean;
+}
+
+function collectLegacyTaxContribution(
+  items: any[],
+  weights: number[],
+  itemWeights: (item: any) => number[],
+  taxRatio: number,
+  sourceBreakdownRaw?: unknown,
+): LegacyTaxContribution {
+  const taxWeights = new Array(weights.length).fill(0);
+  const exclusiveWeights = new Array(weights.length).fill(0);
+  let exclusiveSourceMinor = 0;
+  let allExclusive = true;
+  let hasLegacyItems = false;
+  const persistedBreakdowns = sourceBreakdownRaw === undefined
+    ? new Map<number, any>()
+    : getPersistedChildTaxBreakdowns(sourceBreakdownRaw, items);
+  for (const item of items) {
+    if (['cancelled', 'voided', 'void_adjustment'].includes(item.status) || hasSnapshotLines(item.tax_snapshot)) continue;
+    const sourceCents = persistedBreakdowns.has(Number(item.id))
+      ? taxBreakdownMinorTotal(persistedBreakdowns.get(Number(item.id)))
+      : Number(item.tax_amount || 0) * taxRatio * 100;
+    if (!Number.isFinite(sourceCents) || sourceCents === 0) continue;
+    const ownerWeights = itemWeights(item);
+    const effectiveWeights = ownerWeights.some((weight) => weight > 0) ? ownerWeights : weights;
+    const totalWeight = effectiveWeights.reduce((sum, weight) => sum + weight, 0);
+    if (totalWeight <= 0) continue;
+    const magnitude = Math.abs(sourceCents);
+    for (let index = 0; index < weights.length; index += 1) {
+      const contribution = magnitude * effectiveWeights[index] / totalWeight;
+      taxWeights[index] += contribution;
+      if (item.tax_type !== 'inclusive') exclusiveWeights[index] += contribution;
+    }
+    if (item.tax_type !== 'inclusive') exclusiveSourceMinor += sourceCents;
+    else allExclusive = false;
+    hasLegacyItems = true;
+  }
+  return { taxWeights, exclusiveWeights, exclusiveSourceMinor: Math.round(exclusiveSourceMinor), allExclusive, hasLegacyItems };
+}
+
+function allocateLegacyTaxContribution(
+  sourceTaxMinor: number,
+  snapshotAllocation: TaxSnapshotAllocationResult,
+  contribution: LegacyTaxContribution,
+  fallbackWeights: number[],
+): { legacySourceTaxMinor: number; legacyTaxMinors: number[]; legacyExclusiveTaxMinors: number[] } {
+  const snapshotSourceTaxMinor = snapshotAllocation.taxMinors === null
+    ? 0
+    : snapshotAllocation.taxMinors.reduce((sum, minor) => sum + minor, 0);
+  const legacySourceTaxMinor = snapshotAllocation.taxMinors === null
+    ? sourceTaxMinor
+    : sourceTaxMinor - snapshotSourceTaxMinor;
+  const taxWeights = contribution.taxWeights.some((weight) => weight > 0) ? contribution.taxWeights : fallbackWeights;
+  const legacyTaxMinors = allocateSignedMinorUnits(legacySourceTaxMinor, taxWeights);
+  const exclusiveSourceMinor = contribution.allExclusive
+    ? legacySourceTaxMinor
+    : contribution.exclusiveSourceMinor;
+  const exclusiveWeights = contribution.exclusiveWeights.some((weight) => weight > 0)
+    ? contribution.exclusiveWeights
+    : fallbackWeights;
+  const legacyExclusiveTaxMinors = contribution.hasLegacyItems
+    ? allocateSignedMinorUnits(exclusiveSourceMinor, exclusiveWeights)
+    : new Array(fallbackWeights.length).fill(0);
+  return { legacySourceTaxMinor, legacyTaxMinors, legacyExclusiveTaxMinors };
+}
+
 function hasSnapshotLines(raw: unknown): boolean {
   const parsed = parseTaxSnapshot(raw);
   return (Array.isArray(parsed) ? parsed : [parsed]).some((snapshot) => (
@@ -938,13 +1078,12 @@ function getSplitBillAllocationWeights(
   orderId: number | string,
   bills: any[],
   legacyTaxRatio = 1,
+  legacyBreakdownRaw?: unknown,
 ): {
   weights: number[];
   snapshotWeights: Array<number[] | null>;
   snapshotExclusions: boolean[];
-  legacyTaxMinors: number[];
-  legacyExclusiveTaxMinors: number[];
-  legacySourceTaxMinor: number;
+  legacyContribution: LegacyTaxContribution;
 } {
   const items = db.prepare('SELECT * FROM order_items WHERE order_id = ? ORDER BY id').all(orderId) as any[];
   const billIds = bills.map((bill) => Number(bill.id));
@@ -979,29 +1118,19 @@ function getSplitBillAllocationWeights(
     return itemWeights.some((weight) => weight > 0) ? itemWeights : weights;
   });
   const snapshotExclusions = snapshotItems.map((item) => ['voided', 'void_adjustment'].includes(item.status));
-  const legacyTaxMinors = new Array(bills.length).fill(0);
-  const legacyExclusiveTaxMinors = new Array(bills.length).fill(0);
-  let legacySourceTaxMinor = 0;
-  for (const item of items) {
-    if (['cancelled', 'voided', 'void_adjustment'].includes(item.status) || hasSnapshotLines(item.tax_snapshot)) continue;
-    const itemTaxMinor = Math.round(Number(item.tax_amount || 0) * legacyTaxRatio * 100);
-    if (itemTaxMinor === 0) continue;
-    const itemWeights = bills.map((bill) => quantities.get(Number(bill.id))?.get(Number(item.id)) || 0);
-    const allocations = allocateSignedMinorUnits(itemTaxMinor, itemWeights.some((weight) => weight > 0) ? itemWeights : weights);
-    legacySourceTaxMinor += itemTaxMinor;
-    allocations.forEach((minor, index) => {
-      legacyTaxMinors[index] += minor;
-      if (item.tax_type !== 'inclusive') legacyExclusiveTaxMinors[index] += minor;
-    });
-  }
+  const legacyContribution = collectLegacyTaxContribution(
+    items,
+    weights,
+    (item) => bills.map((bill) => quantities.get(Number(bill.id))?.get(Number(item.id)) || 0),
+    legacyTaxRatio,
+    legacyBreakdownRaw,
+  );
 
   return {
     weights,
     snapshotWeights,
     snapshotExclusions,
-    legacyTaxMinors,
-    legacyExclusiveTaxMinors,
-    legacySourceTaxMinor,
+    legacyContribution,
   };
 }
 
@@ -1058,13 +1187,28 @@ function getTaxBreakdownWeights(
 ): Array<number[] | null> | undefined {
   const parsed = parseTaxSnapshot(sourceRaw);
   if (!Array.isArray(parsed) || !Array.isArray(parsed[0])) return undefined;
+  const voidedByKey = new Map<string, any[]>();
+  for (const item of items) {
+    if (item.status !== 'voided') continue;
+    const key = `${item.product_id}:${item.quantity}`;
+    const matches = voidedByKey.get(key) || [];
+    matches.push(item);
+    voidedByKey.set(key, matches);
+  }
   let itemIndex = 0;
   return parsed.map(() => {
     while (itemIndex < items.length) {
       const item = items[itemIndex++];
       if (item.status === 'cancelled') continue;
       const breakdown = parseTaxSnapshot(item.tax_breakdown);
-      if (Array.isArray(breakdown) && breakdown.length > 0) return itemWeights(item);
+      if (Array.isArray(breakdown) && breakdown.length > 0) {
+        if (item.status === 'void_adjustment') {
+          const key = `${item.product_id}:${item.quantity}`;
+          const original = voidedByKey.get(key)?.shift();
+          return original ? itemWeights(original) : null;
+        }
+        return itemWeights(item);
+      }
     }
     return null;
   });
@@ -1107,14 +1251,13 @@ export function syncUnpaidBillsForOrder(
     weights,
     snapshotWeights,
     snapshotExclusions,
-    legacyTaxMinors,
-    legacyExclusiveTaxMinors,
-    legacySourceTaxMinor,
+    legacyContribution,
   } = getSplitBillAllocationWeights(
     db,
     orderId,
     bills,
     getTaxDiscountRatio(source.subtotal, source.discountAmount),
+    source.taxBreakdown,
   );
   const fields = {
     subtotal: Math.round(source.subtotal * 100),
@@ -1132,13 +1275,19 @@ export function syncUnpaidBillsForOrder(
   const allocatedTaxMinors = allocations.taxAmount.map((amount) => Math.round(amount * 100));
   const snapshotAllocation = allocateTaxSnapshotsWithTax(source.taxSnapshot, weights, snapshotWeights, snapshotExclusions);
   const sourceTaxMinor = Math.round(Number(source.taxAmount || 0) * 100);
+  const legacyAllocation = allocateLegacyTaxContribution(
+    sourceTaxMinor,
+    snapshotAllocation,
+    legacyContribution,
+    weights,
+  );
   const resolvedTax = resolveSplitTaxAllocations(
     sourceTaxMinor,
     allocatedTaxMinors,
     snapshotAllocation,
-    legacySourceTaxMinor,
-    legacyTaxMinors,
-    legacyExclusiveTaxMinors,
+    legacyAllocation.legacySourceTaxMinor,
+    legacyAllocation.legacyTaxMinors,
+    legacyAllocation.legacyExclusiveTaxMinors,
   );
   const taxMinors = resolvedTax.taxMinors;
   if (resolvedTax.exclusiveTaxMinors) {
@@ -1248,33 +1397,28 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
       const snapshotAllocation = allocateTaxSnapshotsWithTax(txnSource.tax_snapshot, weights, snapshotWeights, snapshotExclusions);
       const sourceTaxMinor = Math.round(Number(txnSource.tax_amount || 0) * 100);
       const legacyTaxRatio = getTaxDiscountRatio(txnSource.subtotal, txnSource.discount_amount);
-      const legacyTaxMinors = new Array(txnNormalized.length).fill(0);
-      const legacyExclusiveTaxMinors = new Array(txnNormalized.length).fill(0);
-      let legacySourceTaxMinor = 0;
-      for (const item of txnSnapshotItems) {
-        if (['cancelled', 'voided', 'void_adjustment'].includes(item.status) || hasSnapshotLines(item.tax_snapshot)) continue;
-        const itemTaxMinor = Math.round(Number(item.tax_amount || 0) * legacyTaxRatio * 100);
-        if (itemTaxMinor === 0) continue;
-        const itemWeights = txnNormalized.map((check: { items: { item: any; quantity: number }[] }) => (
+      const legacyContribution = collectLegacyTaxContribution(
+        txnSnapshotItems,
+        weights,
+        (item) => txnNormalized.map((check: { items: { item: any; quantity: number }[] }) => (
           check.items.find((entry) => Number(entry.item.id) === Number(item.id))?.quantity || 0
-        ));
-        const allocationsForItem = allocateSignedMinorUnits(
-          itemTaxMinor,
-          itemWeights.some((weight) => weight > 0) ? itemWeights : weights,
-        );
-        legacySourceTaxMinor += itemTaxMinor;
-        allocationsForItem.forEach((minor, index) => {
-          legacyTaxMinors[index] += minor;
-          if (item.tax_type !== 'inclusive') legacyExclusiveTaxMinors[index] += minor;
-        });
-      }
+        )),
+        legacyTaxRatio,
+        txnSource.tax_breakdown,
+      );
+      const legacyAllocation = allocateLegacyTaxContribution(
+        sourceTaxMinor,
+        snapshotAllocation,
+        legacyContribution,
+        weights,
+      );
       const resolvedTax = resolveSplitTaxAllocations(
         sourceTaxMinor,
         checkTaxMinors,
         snapshotAllocation,
-        legacySourceTaxMinor,
-        legacyTaxMinors,
-        legacyExclusiveTaxMinors,
+        legacyAllocation.legacySourceTaxMinor,
+        legacyAllocation.legacyTaxMinors,
+        legacyAllocation.legacyExclusiveTaxMinors,
       );
       const resolvedTaxMinors = resolvedTax.taxMinors;
       if (resolvedTax.exclusiveTaxMinors) {

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -319,6 +319,128 @@ function allocateMinorUnits(sourceMinor: number, weights: number[]): number[] {
   return base;
 }
 
+function allocateTaxBreakdown(
+  sourceBreakdownRaw: any,
+  checkTaxMinors: number[],
+  weights: number[],
+): (string | null)[] {
+  const numChecks = weights.length;
+  const parsed = typeof sourceBreakdownRaw === 'string'
+    ? (() => { try { return JSON.parse(sourceBreakdownRaw); } catch { return null; } })()
+    : sourceBreakdownRaw;
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    return new Array(numChecks).fill(typeof sourceBreakdownRaw === 'string' ? sourceBreakdownRaw : JSON.stringify(sourceBreakdownRaw || null));
+  }
+
+  const isNested = Array.isArray(parsed[0]);
+
+  interface TaxCompRef {
+    outerIndex?: number;
+    innerIndex: number;
+    component: any;
+    minorAmount: number;
+  }
+
+  const components: TaxCompRef[] = [];
+
+  if (isNested) {
+    parsed.forEach((outer: any, outerIndex: number) => {
+      if (Array.isArray(outer)) {
+        outer.forEach((comp: any, innerIndex: number) => {
+          if (comp && typeof comp === 'object') {
+            components.push({
+              outerIndex,
+              innerIndex,
+              component: comp,
+              minorAmount: Math.round(Number(comp.amount || 0) * 100),
+            });
+          }
+        });
+      }
+    });
+  } else {
+    parsed.forEach((comp: any, innerIndex: number) => {
+      if (comp && typeof comp === 'object') {
+        components.push({
+          innerIndex,
+          component: comp,
+          minorAmount: Math.round(Number(comp.amount || 0) * 100),
+        });
+      }
+    });
+  }
+
+  if (components.length === 0) {
+    return new Array(numChecks).fill(typeof sourceBreakdownRaw === 'string' ? sourceBreakdownRaw : JSON.stringify(sourceBreakdownRaw || null));
+  }
+
+  const compAllocations: number[][] = components.map((comp) => allocateMinorUnits(comp.minorAmount, weights));
+
+  const checkCompSums = new Array(numChecks).fill(0);
+  for (let m = 0; m < components.length; m++) {
+    for (let k = 0; k < numChecks; k++) {
+      checkCompSums[k] += compAllocations[m][k];
+    }
+  }
+
+  const deltas = checkTaxMinors.map((target, k) => target - checkCompSums[k]);
+
+  while (true) {
+    const deficitIdx = deltas.findIndex((d) => d > 0);
+    const excessIdx = deltas.findIndex((d) => d < 0);
+
+    if (deficitIdx === -1 || excessIdx === -1) break;
+
+    let transferredCompIdx = -1;
+    for (let m = 0; m < components.length; m++) {
+      if (compAllocations[m][excessIdx] > 0) {
+        transferredCompIdx = m;
+        break;
+      }
+    }
+
+    if (transferredCompIdx === -1) break;
+
+    compAllocations[transferredCompIdx][excessIdx] -= 1;
+    compAllocations[transferredCompIdx][deficitIdx] += 1;
+
+    deltas[excessIdx] += 1;
+    deltas[deficitIdx] -= 1;
+  }
+
+  const result: (string | null)[] = [];
+
+  for (let k = 0; k < numChecks; k++) {
+    if (isNested) {
+      const clonedNested = parsed.map((outer: any[], outerIdx: number) => {
+        if (!Array.isArray(outer)) return outer;
+        return outer.map((comp: any, innerIdx: number) => {
+          const compIdx = components.findIndex((c) => c.outerIndex === outerIdx && c.innerIndex === innerIdx);
+          const minor = compIdx !== -1 ? compAllocations[compIdx][k] : Math.round(Number(comp?.amount || 0) * 100);
+          return {
+            ...comp,
+            amount: minor / 100,
+          };
+        });
+      });
+      result.push(JSON.stringify(clonedNested));
+    } else {
+      const clonedFlat = parsed.map((comp: any, innerIdx: number) => {
+        const compIdx = components.findIndex((c) => c.innerIndex === innerIdx);
+        const minor = compIdx !== -1 ? compAllocations[compIdx][k] : Math.round(Number(comp?.amount || 0) * 100);
+        return {
+          ...comp,
+          amount: minor / 100,
+        };
+      });
+      result.push(JSON.stringify(clonedFlat));
+    }
+  }
+
+  return result;
+}
+
 // Divide one unpaid dine-in bill into independently payable guest checks.
 // The kitchen order and inventory rows remain singular; bill_items stores only
 // the whole-unit quantity allocated to each resulting check.
@@ -373,19 +495,37 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
         throw Object.assign(new Error('This check has already been split'), { statusCode: 409 });
       }
       const txnActiveItems = db.prepare("SELECT * FROM order_items WHERE order_id = ? AND status NOT IN ('cancelled', 'voided', 'void_adjustment') ORDER BY id").all(txnSource.order_id) as any[];
-      if (txnActiveItems.length !== activeItems.length) {
-        throw Object.assign(new Error('Order items changed during request'), { statusCode: 400 });
-      }
+      const txnItemById = new Map(txnActiveItems.map((item) => [Number(item.id), item]));
+      const txnAssigned = new Map<number, number>();
+
+      const txnNormalized = checks.map((check: any, index: number) => {
+        const label = String(check?.label || `Guest ${index + 1}`).trim().slice(0, 40) || `Guest ${index + 1}`;
+        if (!Array.isArray(check?.items) || check.items.length === 0) throw Object.assign(new Error(`${label} must contain at least one item`), { statusCode: 400 });
+        const seenItems = new Set<number>();
+        const items = check.items.map((entry: any) => {
+          const itemId = Number(entry?.order_item_id);
+          const quantity = Number(entry?.quantity);
+          const item = txnItemById.get(itemId);
+          if (!item || !Number.isSafeInteger(quantity) || quantity < 1) throw Object.assign(new Error(`Invalid item allocation in ${label}`), { statusCode: 400 });
+          if (seenItems.has(itemId)) throw Object.assign(new Error(`${label} contains the same item more than once`), { statusCode: 400 });
+          seenItems.add(itemId);
+          txnAssigned.set(itemId, (txnAssigned.get(itemId) || 0) + quantity);
+          return { item, quantity };
+        });
+        return { label, items };
+      });
+
       for (const item of txnActiveItems) {
-        if ((assigned.get(Number(item.id)) || 0) !== Number(item.quantity)) {
+        if ((txnAssigned.get(Number(item.id)) || 0) !== Number(item.quantity)) {
           throw Object.assign(new Error(`Allocate all ${item.quantity} × ${item.product_name}`), { statusCode: 400 });
         }
       }
 
       const groupId = randomUUID();
-      const weights = normalized.map((check: { items: { item: any; quantity: number }[] }) =>
+      const weights = txnNormalized.map((check: { items: { item: any; quantity: number }[] }) =>
         check.items.reduce((sum: number, entry: { item: any; quantity: number }) => sum + Number(entry.item.total || entry.item.subtotal || 0) * entry.quantity / Number(entry.item.quantity), 0)
       );
+
       const fields = ['subtotal', 'tax_amount', 'discount_amount', 'delivery_charge', 'packaging_charge', 'round_off', 'total'] as const;
       const allocations: Record<string, number[]> = {};
       for (const field of fields) {
@@ -394,28 +534,11 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
         allocations[field] = allocatedMinors.map((minor) => minor / 100);
       }
 
-      const parsedBreakdown = typeof txnSource.tax_breakdown === 'string'
-        ? (() => { try { return JSON.parse(txnSource.tax_breakdown); } catch { return null; } })()
-        : txnSource.tax_breakdown;
-
-      let checkTaxBreakdowns: (string | null)[] = normalized.map(() => (typeof txnSource.tax_breakdown === 'string' ? txnSource.tax_breakdown : JSON.stringify(txnSource.tax_breakdown || null)));
-      if (Array.isArray(parsedBreakdown)) {
-        const linesPerCheck: any[][] = normalized.map(() => []);
-        for (const line of parsedBreakdown) {
-          const lineMinor = Math.round(Number(line?.amount || 0) * 100);
-          const lineMinors = allocateMinorUnits(lineMinor, weights);
-          lineMinors.forEach((minor, checkIdx) => {
-            linesPerCheck[checkIdx].push({
-              ...line,
-              amount: minor / 100,
-            });
-          });
-        }
-        checkTaxBreakdowns = linesPerCheck.map((lines) => JSON.stringify(lines));
-      }
+      const checkTaxMinors = allocations.tax_amount.map((amt) => Math.round(amt * 100));
+      const checkTaxBreakdowns = allocateTaxBreakdown(txnSource.tax_breakdown, checkTaxMinors, weights);
 
       const billIds: number[] = [];
-      normalized.forEach((check, index) => {
+      txnNormalized.forEach((check, index) => {
         let billId: number;
         const splitBk = checkTaxBreakdowns[index];
         if (index === 0) {

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -26,6 +26,36 @@ import { sendEvent } from '../services/telemetry';
 
 const router = Router();
 
+function scaleTaxBreakdown(raw: unknown, ratio: number): unknown {
+  if (raw === null || raw === undefined || ratio === 1) return raw;
+  const wasString = typeof raw === 'string';
+  let parsed = raw;
+  if (wasString) {
+    try {
+      parsed = JSON.parse(raw as string);
+    } catch {
+      return raw;
+    }
+  }
+
+  const scale = (value: any): any => {
+    if (Array.isArray(value)) return value.map(scale);
+    if (!value || typeof value !== 'object') return value;
+    const result = { ...value };
+    if (Object.prototype.hasOwnProperty.call(result, 'amount')) {
+      const amount = Number(result.amount);
+      if (Number.isFinite(amount)) {
+        const scaled = Number((amount * ratio).toFixed(2));
+        result.amount = typeof value.amount === 'string' ? scaled.toFixed(2) : scaled;
+      }
+    }
+    return result;
+  };
+
+  const scaled = scale(parsed);
+  return wasString ? JSON.stringify(scaled) : scaled;
+}
+
 function getOrderWithItems(db: ReturnType<typeof getDatabase>, orderId: number, billId?: number): any {
   const order = parseRowJson(db.prepare('SELECT * FROM orders WHERE id = ?').get(orderId));
   if (!order) return order;
@@ -36,8 +66,17 @@ function getOrderWithItems(db: ReturnType<typeof getDatabase>, orderId: number, 
     .map((item) => {
       const quantity = allocated.get(Number(item.id));
       if (quantity === undefined || quantity === Number(item.quantity)) return item;
-      const ratio = quantity / Number(item.quantity);
-      return { ...item, quantity, subtotal: Number((Number(item.subtotal) * ratio).toFixed(2)), tax_amount: Number((Number(item.tax_amount || 0) * ratio).toFixed(2)), total: Number((Number(item.total) * ratio).toFixed(2)) };
+      const originalQuantity = Number(item.quantity);
+      if (originalQuantity <= 0) return item;
+      const ratio = quantity / originalQuantity;
+      return {
+        ...item,
+        quantity,
+        subtotal: Number((Number(item.subtotal) * ratio).toFixed(2)),
+        tax_amount: Number((Number(item.tax_amount || 0) * ratio).toFixed(2)),
+        tax_breakdown: scaleTaxBreakdown(item.tax_breakdown, ratio),
+        total: Number((Number(item.total) * ratio).toFixed(2)),
+      };
     });
   return {
     ...order,
@@ -706,14 +745,6 @@ function hasSnapshotLines(raw: unknown): boolean {
   ));
 }
 
-function hasSplitAllocatedSnapshot(raw: unknown): boolean {
-  const parsed = parseTaxSnapshot(raw);
-  if (Array.isArray(parsed)) return parsed.some(hasSplitAllocatedSnapshot);
-  if (!parsed || typeof parsed !== 'object') return false;
-  return (parsed as any).splitAllocation === SPLIT_TAX_SNAPSHOT_VERSION
-    && Array.isArray((parsed as any).lines);
-}
-
 function getSplitBillAllocationWeights(
   db: ReturnType<typeof getDatabase>,
   orderId: number | string,
@@ -763,12 +794,15 @@ export function syncUnpaidBillsForOrder(
   country: string,
 ): void {
   const bills = db.prepare('SELECT * FROM bills WHERE order_id = ? ORDER BY id').all(orderId) as any[];
+  const splitBills = bills.some((bill) => bill.split_group_id);
+  if (splitBills && bills.some((bill) => bill.payment_status === 'paid')) {
+    throw Object.assign(new Error('Cannot modify an order after a split check is paid'), { statusCode: 409 });
+  }
   const unpaidBills = bills.filter((bill) => bill.payment_status !== 'paid');
   if (unpaidBills.length === 0) return;
 
   const pack = getActiveCountryPack(country);
   const { total: billTotal, adjustment: billRoundOff } = applyPayableRounding(source.total, pack);
-  const splitBills = bills.some((bill) => bill.split_group_id);
 
   if (!splitBills) {
     const update = db.prepare(`

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -924,8 +924,16 @@ function allocateTaxBreakdown(
     return new Array(numChecks).fill(typeof sourceBreakdownRaw === 'string' ? sourceBreakdownRaw : JSON.stringify(sourceBreakdownRaw || null));
   }
 
+  const ownerWeightsForComponent = (comp: TaxCompRef): number[] | null => {
+    const weightIndex = comp.outerIndex === undefined ? comp.innerIndex : comp.outerIndex;
+    const candidate = componentWeights?.[weightIndex];
+    return candidate && candidate.length === weights.length && candidate.some((weight) => weight > 0)
+      ? candidate
+      : null;
+  };
+
   const compAllocations: number[][] = components.map((comp) => {
-    const ownerWeights = comp.outerIndex === undefined ? null : componentWeights?.[comp.outerIndex];
+    const ownerWeights = ownerWeightsForComponent(comp);
     const allocationWeights = ownerWeights && ownerWeights.length === weights.length && ownerWeights.some((weight) => weight > 0)
       ? ownerWeights
       : weights;
@@ -933,11 +941,18 @@ function allocateTaxBreakdown(
   });
 
   const allocationGroups = new Map<string, { entries: Array<{ allocations: number[] }>; weights: number[]; sourceMinor: number }>();
+  const flatOwnerAllocations = new Array(numChecks).fill(0);
   components.forEach((comp, index) => {
-    const ownerWeights = comp.outerIndex === undefined ? null : componentWeights?.[comp.outerIndex];
+    const ownerWeights = ownerWeightsForComponent(comp);
     const allocationWeights = ownerWeights && ownerWeights.length === weights.length && ownerWeights.some((weight) => weight > 0)
       ? ownerWeights
       : weights;
+    if (comp.outerIndex === undefined && ownerWeights) {
+      for (let checkIndex = 0; checkIndex < numChecks; checkIndex += 1) {
+        flatOwnerAllocations[checkIndex] += compAllocations[index][checkIndex];
+      }
+      return;
+    }
     const groupKey = comp.outerIndex === undefined ? 'flat' : `outer:${comp.outerIndex}`;
     const group = allocationGroups.get(groupKey) || { entries: [], weights: allocationWeights, sourceMinor: 0 };
     group.entries.push({ allocations: compAllocations[index] });
@@ -946,7 +961,7 @@ function allocateTaxBreakdown(
   });
   for (const [groupKey, group] of allocationGroups) {
     const target = groupKey === 'flat'
-      ? checkTaxMinors
+      ? checkTaxMinors.map((targetMinor, index) => targetMinor - flatOwnerAllocations[index])
       : allocateSignedMinorUnits(group.sourceMinor, group.weights);
     reconcileSnapshotAllocations(group.entries, target);
   }
@@ -1036,8 +1051,8 @@ function collectLegacyTaxContribution(
     const effectiveWeights = ownerWeights.some((weight) => weight > 0) ? ownerWeights : weights;
     const totalWeight = effectiveWeights.reduce((sum, weight) => sum + weight, 0);
     if (totalWeight <= 0) continue;
-    if (persistedBreakdowns.has(Number(item.id))) {
-      const sourceMinor = Math.round(sourceCents);
+    const sourceMinor = Math.round(sourceCents);
+    if (Number.isInteger(sourceMinor) && Math.abs(sourceCents - sourceMinor) < 1e-6) {
       const ownerAllocation = allocateSignedMinorUnits(sourceMinor, effectiveWeights);
       for (let index = 0; index < weights.length; index += 1) {
         ownerTaxMinors[index] += ownerAllocation[index];
@@ -1087,9 +1102,16 @@ function allocateLegacyTaxContribution(
     ? sourceTaxMinor
     : sourceTaxMinor - snapshotSourceTaxMinor;
   const taxWeights = contribution.taxWeights.some((weight) => weight > 0) ? contribution.taxWeights : fallbackWeights;
-  const legacyTaxMinors = contribution.ownerTaxMinors !== null
-    && contribution.ownerTaxSourceMinor === legacySourceTaxMinor
-    ? contribution.ownerTaxMinors
+  const ownerTaxSourceMinor = contribution.ownerTaxSourceMinor;
+  const ownerTaxFitsResidual = ownerTaxSourceMinor !== null
+    && (ownerTaxSourceMinor === 0
+      || legacySourceTaxMinor === 0
+      || Math.sign(ownerTaxSourceMinor) === Math.sign(legacySourceTaxMinor))
+    && (ownerTaxSourceMinor === 0 || Math.abs(ownerTaxSourceMinor) <= Math.abs(legacySourceTaxMinor));
+  const legacyTaxMinors = contribution.ownerTaxMinors !== null && ownerTaxFitsResidual
+    ? contribution.ownerTaxMinors.map((minor, index) => (
+      minor + allocateSignedMinorUnits(legacySourceTaxMinor - ownerTaxSourceMinor!, fallbackWeights)[index]
+    ))
     : allocateSignedMinorUnits(legacySourceTaxMinor, taxWeights);
   const exclusiveSourceMinor = contribution.allExclusive
     ? legacySourceTaxMinor
@@ -1097,10 +1119,17 @@ function allocateLegacyTaxContribution(
   const exclusiveWeights = contribution.exclusiveWeights.some((weight) => weight > 0)
     ? contribution.exclusiveWeights
     : fallbackWeights;
+  const ownerExclusiveSourceMinor = contribution.ownerExclusiveTaxSourceMinor;
+  const ownerExclusiveFitsResidual = ownerExclusiveSourceMinor !== null
+    && (ownerExclusiveSourceMinor === 0
+      || exclusiveSourceMinor === 0
+      || Math.sign(ownerExclusiveSourceMinor) === Math.sign(exclusiveSourceMinor))
+    && (ownerExclusiveSourceMinor === 0 || Math.abs(ownerExclusiveSourceMinor) <= Math.abs(exclusiveSourceMinor));
   const legacyExclusiveTaxMinors = contribution.hasLegacyTaxEvidence || legacySourceTaxMinor !== 0
-    ? contribution.ownerExclusiveTaxMinors !== null
-      && contribution.ownerExclusiveTaxSourceMinor === exclusiveSourceMinor
-      ? contribution.ownerExclusiveTaxMinors
+    ? contribution.ownerExclusiveTaxMinors !== null && ownerExclusiveFitsResidual
+      ? contribution.ownerExclusiveTaxMinors.map((minor, index) => (
+        minor + allocateSignedMinorUnits(exclusiveSourceMinor - ownerExclusiveSourceMinor!, fallbackWeights)[index]
+      ))
       : allocateSignedMinorUnits(exclusiveSourceMinor, exclusiveWeights)
     : new Array(fallbackWeights.length).fill(0);
   return { legacySourceTaxMinor, legacyTaxMinors, legacyExclusiveTaxMinors };
@@ -1226,7 +1255,29 @@ function getTaxBreakdownWeights(
   itemWeights: (item: any) => number[],
 ): Array<number[] | null> | undefined {
   const parsed = parseTaxSnapshot(sourceRaw);
-  if (!Array.isArray(parsed) || !Array.isArray(parsed[0])) return undefined;
+  if (!Array.isArray(parsed)) return undefined;
+  const componentKey = (component: any): string => `${component?.title ?? component?.name ?? component?.label ?? ''}\u0000${component?.rate ?? ''}`;
+  if (!Array.isArray(parsed[0])) {
+    const ownerWeightsByKey = new Map<string, number[]>();
+    for (const item of items) {
+      if (['cancelled', 'voided', 'void_adjustment'].includes(item.status) || hasSnapshotLines(item.tax_snapshot)) continue;
+      const itemBreakdown = parseTaxSnapshot(item.tax_breakdown);
+      if (!Array.isArray(itemBreakdown)) continue;
+      const itemComponents = itemBreakdown.flatMap((entry: any) => Array.isArray(entry) ? entry : [entry]);
+      const weights = itemWeights(item);
+      if (!weights.some((weight) => weight > 0)) continue;
+      for (const component of itemComponents) {
+        if (!component || typeof component !== 'object') continue;
+        const key = componentKey(component);
+        const ownerWeights = ownerWeightsByKey.get(key) || new Array(weights.length).fill(0);
+        for (let index = 0; index < weights.length; index += 1) ownerWeights[index] += weights[index];
+        ownerWeightsByKey.set(key, ownerWeights);
+      }
+    }
+    return parsed.map((component: any) => (
+      component && typeof component === 'object' ? ownerWeightsByKey.get(componentKey(component)) || null : null
+    ));
+  }
   const voidedByKey = new Map<string, any[]>();
   for (const item of items) {
     if (item.status !== 'voided') continue;

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -26,8 +26,17 @@ import { sendEvent } from '../services/telemetry';
 
 const router = Router();
 
-function scaleTaxBreakdown(raw: unknown, ratio: number): unknown {
+function scaleTaxBreakdown(
+  raw: unknown,
+  ratio: number,
+  ownerWeights?: number[],
+  childIndex = 0,
+  sourceTaxMinor?: number,
+): unknown {
   if (raw === null || raw === undefined || ratio === 1) return raw;
+  if (ownerWeights && ownerWeights.length > 0) {
+    return allocateTaxBreakdownForChild(raw, ownerWeights, childIndex, sourceTaxMinor);
+  }
   const wasString = typeof raw === 'string';
   let parsed = raw;
   if (wasString) {
@@ -56,11 +65,33 @@ function scaleTaxBreakdown(raw: unknown, ratio: number): unknown {
   return wasString ? JSON.stringify(scaled) : scaled;
 }
 
-function getOrderWithItems(db: ReturnType<typeof getDatabase>, orderId: number, billId?: number): any {
+export function getOrderWithItems(db: ReturnType<typeof getDatabase>, orderId: number, billId?: number): any {
   const order = parseRowJson(db.prepare('SELECT * FROM orders WHERE id = ?').get(orderId));
   if (!order) return order;
   const allocations = billId === undefined ? [] : db.prepare('SELECT order_item_id, quantity FROM bill_items WHERE bill_id = ?').all(billId) as any[];
   const allocated = new Map(allocations.map((row) => [Number(row.order_item_id), Number(row.quantity)]));
+  const childItemAllocations = new Map<number, { weights: number[]; index: number }>();
+  if (billId !== undefined) {
+    const bill = db.prepare('SELECT split_group_id FROM bills WHERE id = ?').get(billId) as any;
+    if (bill?.split_group_id) {
+      const childBills = db.prepare('SELECT id FROM bills WHERE split_group_id = ? ORDER BY id').all(bill.split_group_id) as any[];
+      const childIds = childBills.map((child) => Number(child.id));
+      const childRows = childIds.length === 0
+        ? []
+        : db.prepare(`SELECT bill_id, order_item_id, quantity FROM bill_items WHERE bill_id IN (${childIds.map(() => '?').join(',')})`).all(...childIds) as any[];
+      const quantities = new Map<number, number[]>();
+      for (const row of childRows) {
+        const itemId = Number(row.order_item_id);
+        const weights = quantities.get(itemId) || new Array(childIds.length).fill(0);
+        weights[childIds.indexOf(Number(row.bill_id))] = Number(row.quantity);
+        quantities.set(itemId, weights);
+      }
+      for (const [itemId, weights] of quantities) {
+        const index = childIds.indexOf(Number(billId));
+        if (index !== -1) childItemAllocations.set(itemId, { weights, index });
+      }
+    }
+  }
   const itemRows = (db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(orderId) as any[])
     .filter((item) => allocations.length === 0 || allocated.has(Number(item.id)))
     .map((item) => {
@@ -74,7 +105,13 @@ function getOrderWithItems(db: ReturnType<typeof getDatabase>, orderId: number, 
         quantity,
         subtotal: Number((Number(item.subtotal) * ratio).toFixed(2)),
         tax_amount: Number((Number(item.tax_amount || 0) * ratio).toFixed(2)),
-        tax_breakdown: scaleTaxBreakdown(item.tax_breakdown, ratio),
+        tax_breakdown: scaleTaxBreakdown(
+          item.tax_breakdown,
+          ratio,
+          childItemAllocations.get(Number(item.id))?.weights,
+          childItemAllocations.get(Number(item.id))?.index,
+          Math.round(Number(item.tax_amount || 0) * 100),
+        ),
         total: Number((Number(item.total) * ratio).toFixed(2)),
       };
     });
@@ -403,7 +440,7 @@ interface TaxSnapshotAllocationResult {
 }
 
 function reconcileSnapshotAllocations(
-  entries: SnapshotTaxAllocation[],
+  entries: Array<{ allocations: number[] }>,
   targets: number[],
 ): void {
   if (entries.length === 0 || targets.length === 0) return;
@@ -432,6 +469,56 @@ function reconcileSnapshotAllocations(
     deltas[excessIndex] += 1;
     deltas[deficitIndex] -= 1;
   }
+}
+
+function allocateTaxBreakdownForChild(
+  raw: unknown,
+  weights: number[],
+  childIndex: number,
+  sourceTaxMinor?: number,
+): string | unknown {
+  const parsed = typeof raw === 'string'
+    ? (() => { try { return JSON.parse(raw); } catch { return null; } })()
+    : raw;
+  if (!Array.isArray(parsed) || parsed.length === 0) return raw;
+  const isNested = Array.isArray(parsed[0]);
+  const entries: Array<{ outerIndex?: number; innerIndex: number; original: unknown; allocations: number[] }> = [];
+  if (isNested) {
+    parsed.forEach((outer: any, outerIndex: number) => {
+      if (!Array.isArray(outer)) return;
+      outer.forEach((component: any, innerIndex: number) => {
+        const amount = snapshotMinorAmount(component?.amount);
+        if (amount !== null) entries.push({ outerIndex, innerIndex, original: component.amount, allocations: allocateSignedMinorUnits(amount, weights) });
+      });
+    });
+  } else {
+    parsed.forEach((component: any, innerIndex: number) => {
+      const amount = snapshotMinorAmount(component?.amount);
+      if (amount !== null) entries.push({ innerIndex, original: component.amount, allocations: allocateSignedMinorUnits(amount, weights) });
+    });
+  }
+  if (entries.length === 0) return raw;
+
+  const target = sourceTaxMinor === undefined
+    ? entries.reduce((sum, entry) => sum + snapshotMinorAmount(entry.original)!, 0)
+    : sourceTaxMinor;
+  reconcileSnapshotAllocations(entries, allocateSignedMinorUnits(target, weights));
+  const cloned = JSON.parse(JSON.stringify(parsed));
+  if (isNested) {
+    cloned.forEach((outer: any[], outerIndex: number) => {
+      if (!Array.isArray(outer)) return;
+      outer.forEach((component: any, innerIndex: number) => {
+        const entry = entries.find((candidate) => candidate.outerIndex === outerIndex && candidate.innerIndex === innerIndex);
+        if (entry) component.amount = formatSnapshotMinorAmount(entry.original, entry.allocations[childIndex]);
+      });
+    });
+  } else {
+    cloned.forEach((component: any, innerIndex: number) => {
+      const entry = entries.find((candidate) => candidate.outerIndex === undefined && candidate.innerIndex === innerIndex);
+      if (entry) component.amount = formatSnapshotMinorAmount(entry.original, entry.allocations[childIndex]);
+    });
+  }
+  return typeof raw === 'string' ? JSON.stringify(cloned) : cloned;
 }
 
 function allocateTaxSnapshotsWithTax(
@@ -609,6 +696,7 @@ function allocateTaxBreakdown(
   sourceBreakdownRaw: any,
   checkTaxMinors: number[],
   weights: number[],
+  componentWeights?: Array<number[] | null>,
 ): (string | null)[] {
   const numChecks = weights.length;
   const parsed = typeof sourceBreakdownRaw === 'string'
@@ -661,39 +749,18 @@ function allocateTaxBreakdown(
     return new Array(numChecks).fill(typeof sourceBreakdownRaw === 'string' ? sourceBreakdownRaw : JSON.stringify(sourceBreakdownRaw || null));
   }
 
-  const compAllocations: number[][] = components.map((comp) => allocateMinorUnits(comp.minorAmount, weights));
+  const compAllocations: number[][] = components.map((comp) => {
+    const ownerWeights = comp.outerIndex === undefined ? null : componentWeights?.[comp.outerIndex];
+    const allocationWeights = ownerWeights && ownerWeights.length === weights.length && ownerWeights.some((weight) => weight > 0)
+      ? ownerWeights
+      : weights;
+    return allocateSignedMinorUnits(comp.minorAmount, allocationWeights);
+  });
 
-  const checkCompSums = new Array(numChecks).fill(0);
-  for (let m = 0; m < components.length; m++) {
-    for (let k = 0; k < numChecks; k++) {
-      checkCompSums[k] += compAllocations[m][k];
-    }
-  }
-
-  const deltas = checkTaxMinors.map((target, k) => target - checkCompSums[k]);
-
-  while (true) {
-    const deficitIdx = deltas.findIndex((d) => d > 0);
-    const excessIdx = deltas.findIndex((d) => d < 0);
-
-    if (deficitIdx === -1 || excessIdx === -1) break;
-
-    let transferredCompIdx = -1;
-    for (let m = 0; m < components.length; m++) {
-      if (compAllocations[m][excessIdx] > 0) {
-        transferredCompIdx = m;
-        break;
-      }
-    }
-
-    if (transferredCompIdx === -1) break;
-
-    compAllocations[transferredCompIdx][excessIdx] -= 1;
-    compAllocations[transferredCompIdx][deficitIdx] += 1;
-
-    deltas[excessIdx] += 1;
-    deltas[deficitIdx] -= 1;
-  }
+  reconcileSnapshotAllocations(
+    compAllocations.map((allocations) => ({ allocations })),
+    checkTaxMinors,
+  );
 
   const result: (string | null)[] = [];
 
@@ -749,7 +816,14 @@ function getSplitBillAllocationWeights(
   db: ReturnType<typeof getDatabase>,
   orderId: number | string,
   bills: any[],
-): { weights: number[]; snapshotWeights: Array<number[] | null>; snapshotExclusions: boolean[] } {
+): {
+  weights: number[];
+  snapshotWeights: Array<number[] | null>;
+  snapshotExclusions: boolean[];
+  legacyTaxMinors: number[];
+  legacyExclusiveTaxMinors: number[];
+  legacySourceTaxMinor: number;
+} {
   const items = db.prepare('SELECT * FROM order_items WHERE order_id = ? ORDER BY id').all(orderId) as any[];
   const billIds = bills.map((bill) => Number(bill.id));
   const billItems = billIds.length === 0
@@ -783,8 +857,95 @@ function getSplitBillAllocationWeights(
     return itemWeights.some((weight) => weight > 0) ? itemWeights : weights;
   });
   const snapshotExclusions = snapshotItems.map((item) => ['voided', 'void_adjustment'].includes(item.status));
+  const legacyTaxMinors = new Array(bills.length).fill(0);
+  const legacyExclusiveTaxMinors = new Array(bills.length).fill(0);
+  let legacySourceTaxMinor = 0;
+  for (const item of items) {
+    if (['cancelled', 'voided', 'void_adjustment'].includes(item.status) || hasSnapshotLines(item.tax_snapshot)) continue;
+    const itemTaxMinor = Math.round(Number(item.tax_amount || 0) * 100);
+    if (itemTaxMinor === 0) continue;
+    const itemWeights = bills.map((bill) => quantities.get(Number(bill.id))?.get(Number(item.id)) || 0);
+    const allocations = allocateSignedMinorUnits(itemTaxMinor, itemWeights.some((weight) => weight > 0) ? itemWeights : weights);
+    legacySourceTaxMinor += itemTaxMinor;
+    allocations.forEach((minor, index) => {
+      legacyTaxMinors[index] += minor;
+      if (item.tax_type !== 'inclusive') legacyExclusiveTaxMinors[index] += minor;
+    });
+  }
 
-  return { weights, snapshotWeights, snapshotExclusions };
+  return {
+    weights,
+    snapshotWeights,
+    snapshotExclusions,
+    legacyTaxMinors,
+    legacyExclusiveTaxMinors,
+    legacySourceTaxMinor,
+  };
+}
+
+function getBillItemWeights(
+  db: ReturnType<typeof getDatabase>,
+  bills: any[],
+  itemId: number,
+): number[] {
+  const billIds = bills.map((bill) => Number(bill.id));
+  if (billIds.length === 0) return [];
+  const rows = db.prepare(`SELECT bill_id, quantity FROM bill_items WHERE order_item_id = ? AND bill_id IN (${billIds.map(() => '?').join(',')})`).all(itemId, ...billIds) as any[];
+  const quantities = new Map(rows.map((row) => [Number(row.bill_id), Number(row.quantity)]));
+  return bills.map((bill) => quantities.get(Number(bill.id)) || 0);
+}
+
+function resolveSplitTaxAllocations(
+  sourceTaxMinor: number,
+  fallbackTaxMinors: number[],
+  snapshotAllocation: TaxSnapshotAllocationResult,
+  legacySourceTaxMinor: number,
+  legacyTaxMinors: number[],
+  legacyExclusiveTaxMinors: number[],
+): { taxMinors: number[]; exclusiveTaxMinors: number[] | null } {
+  const snapshotTaxMinors = snapshotAllocation.taxMinors;
+  if (snapshotTaxMinors !== null) {
+    const snapshotSourceTaxMinor = snapshotTaxMinors.reduce((sum, minor) => sum + minor, 0);
+    const residualTaxMinor = sourceTaxMinor - snapshotSourceTaxMinor;
+    if (residualTaxMinor === 0) {
+      return {
+        taxMinors: snapshotTaxMinors,
+        exclusiveTaxMinors: snapshotAllocation.exclusiveTaxMinors,
+      };
+    }
+    if (residualTaxMinor === legacySourceTaxMinor) {
+      return {
+        taxMinors: snapshotTaxMinors.map((minor, index) => minor + legacyTaxMinors[index]),
+        exclusiveTaxMinors: snapshotAllocation.exclusiveTaxMinors
+          ? snapshotAllocation.exclusiveTaxMinors.map((minor, index) => minor + legacyExclusiveTaxMinors[index])
+          : null,
+      };
+    }
+    return { taxMinors: fallbackTaxMinors, exclusiveTaxMinors: null };
+  }
+  if (legacySourceTaxMinor === sourceTaxMinor) {
+    return { taxMinors: legacyTaxMinors, exclusiveTaxMinors: legacyExclusiveTaxMinors };
+  }
+  return { taxMinors: fallbackTaxMinors, exclusiveTaxMinors: null };
+}
+
+function getTaxBreakdownWeights(
+  sourceRaw: unknown,
+  items: any[],
+  itemWeights: (item: any) => number[],
+): Array<number[] | null> | undefined {
+  const parsed = parseTaxSnapshot(sourceRaw);
+  if (!Array.isArray(parsed) || !Array.isArray(parsed[0])) return undefined;
+  let itemIndex = 0;
+  return parsed.map(() => {
+    while (itemIndex < items.length) {
+      const item = items[itemIndex++];
+      if (item.status === 'cancelled') continue;
+      const breakdown = parseTaxSnapshot(item.tax_breakdown);
+      if (Array.isArray(breakdown) && breakdown.length > 0) return itemWeights(item);
+    }
+    return null;
+  });
 }
 
 export function syncUnpaidBillsForOrder(
@@ -795,7 +956,7 @@ export function syncUnpaidBillsForOrder(
 ): void {
   const bills = db.prepare('SELECT * FROM bills WHERE order_id = ? ORDER BY id').all(orderId) as any[];
   const splitBills = bills.some((bill) => bill.split_group_id);
-  if (splitBills && bills.some((bill) => bill.payment_status === 'paid')) {
+  if (splitBills && bills.some((bill) => bill.payment_status !== 'unpaid' || Number(bill.paid_amount || 0) > 0)) {
     throw Object.assign(new Error('Cannot modify an order after a split check is paid'), { statusCode: 409 });
   }
   const unpaidBills = bills.filter((bill) => bill.payment_status !== 'paid');
@@ -820,7 +981,14 @@ export function syncUnpaidBillsForOrder(
     return;
   }
 
-  const { weights, snapshotWeights, snapshotExclusions } = getSplitBillAllocationWeights(db, orderId, bills);
+  const {
+    weights,
+    snapshotWeights,
+    snapshotExclusions,
+    legacyTaxMinors,
+    legacyExclusiveTaxMinors,
+    legacySourceTaxMinor,
+  } = getSplitBillAllocationWeights(db, orderId, bills);
   const fields = {
     subtotal: Math.round(source.subtotal * 100),
     taxAmount: Math.round(source.taxAmount * 100),
@@ -837,17 +1005,30 @@ export function syncUnpaidBillsForOrder(
   const allocatedTaxMinors = allocations.taxAmount.map((amount) => Math.round(amount * 100));
   const snapshotAllocation = allocateTaxSnapshotsWithTax(source.taxSnapshot, weights, snapshotWeights, snapshotExclusions);
   const sourceTaxMinor = Math.round(Number(source.taxAmount || 0) * 100);
-  const snapshotTaxMinors = snapshotAllocation.taxMinors;
-  const snapshotTaxMatches = snapshotTaxMinors !== null
-    && snapshotTaxMinors.reduce((sum, minor) => sum + minor, 0) === sourceTaxMinor;
-  const taxMinors = snapshotTaxMatches ? snapshotTaxMinors : allocatedTaxMinors;
-  if (snapshotTaxMatches) {
+  const resolvedTax = resolveSplitTaxAllocations(
+    sourceTaxMinor,
+    allocatedTaxMinors,
+    snapshotAllocation,
+    legacySourceTaxMinor,
+    legacyTaxMinors,
+    legacyExclusiveTaxMinors,
+  );
+  const taxMinors = resolvedTax.taxMinors;
+  if (resolvedTax.exclusiveTaxMinors) {
     allocations.taxAmount = taxMinors.map((minor) => minor / 100);
-    if (snapshotAllocation.exclusiveTaxMinors) {
-      allocations.total = composeSplitTotals(allocations, snapshotAllocation.exclusiveTaxMinors);
-    }
+    allocations.total = composeSplitTotals(allocations, resolvedTax.exclusiveTaxMinors);
   }
-  const breakdowns = allocateTaxBreakdown(source.taxBreakdown, taxMinors, weights);
+  const sourceItems = db.prepare('SELECT * FROM order_items WHERE order_id = ? ORDER BY id').all(orderId) as any[];
+  const breakdowns = allocateTaxBreakdown(
+    source.taxBreakdown,
+    taxMinors,
+    weights,
+    getTaxBreakdownWeights(
+      source.taxBreakdown,
+      sourceItems,
+      (item) => getBillItemWeights(db, bills, Number(item.id)),
+    ),
+  );
   const snapshots = snapshotAllocation.snapshots;
   const update = db.prepare(`
     UPDATE bills SET subtotal = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?,
@@ -939,17 +1120,51 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
       const snapshotExclusions = snapshotItems.map((item) => ['voided', 'void_adjustment'].includes(item.status));
       const snapshotAllocation = allocateTaxSnapshotsWithTax(txnSource.tax_snapshot, weights, snapshotWeights, snapshotExclusions);
       const sourceTaxMinor = Math.round(Number(txnSource.tax_amount || 0) * 100);
-      const snapshotTaxMinors = snapshotAllocation.taxMinors;
-      const snapshotTaxMatches = snapshotTaxMinors !== null
-        && snapshotTaxMinors.reduce((sum, minor) => sum + minor, 0) === sourceTaxMinor;
-      const resolvedTaxMinors = snapshotTaxMatches ? snapshotTaxMinors : checkTaxMinors;
-      if (snapshotTaxMatches) {
-        allocations.tax_amount = resolvedTaxMinors.map((minor) => minor / 100);
-        if (snapshotAllocation.exclusiveTaxMinors) {
-          allocations.total = composeSplitTotals(allocations, snapshotAllocation.exclusiveTaxMinors);
-        }
+      const legacyTaxMinors = new Array(txnNormalized.length).fill(0);
+      const legacyExclusiveTaxMinors = new Array(txnNormalized.length).fill(0);
+      let legacySourceTaxMinor = 0;
+      for (const item of txnSnapshotItems) {
+        if (['cancelled', 'voided', 'void_adjustment'].includes(item.status) || hasSnapshotLines(item.tax_snapshot)) continue;
+        const itemTaxMinor = Math.round(Number(item.tax_amount || 0) * 100);
+        if (itemTaxMinor === 0) continue;
+        const itemWeights = txnNormalized.map((check: { items: { item: any; quantity: number }[] }) => (
+          check.items.find((entry) => Number(entry.item.id) === Number(item.id))?.quantity || 0
+        ));
+        const allocationsForItem = allocateSignedMinorUnits(
+          itemTaxMinor,
+          itemWeights.some((weight) => weight > 0) ? itemWeights : weights,
+        );
+        legacySourceTaxMinor += itemTaxMinor;
+        allocationsForItem.forEach((minor, index) => {
+          legacyTaxMinors[index] += minor;
+          if (item.tax_type !== 'inclusive') legacyExclusiveTaxMinors[index] += minor;
+        });
       }
-      const resolvedTaxBreakdowns = allocateTaxBreakdown(txnSource.tax_breakdown, resolvedTaxMinors, weights);
+      const resolvedTax = resolveSplitTaxAllocations(
+        sourceTaxMinor,
+        checkTaxMinors,
+        snapshotAllocation,
+        legacySourceTaxMinor,
+        legacyTaxMinors,
+        legacyExclusiveTaxMinors,
+      );
+      const resolvedTaxMinors = resolvedTax.taxMinors;
+      if (resolvedTax.exclusiveTaxMinors) {
+        allocations.tax_amount = resolvedTaxMinors.map((minor) => minor / 100);
+        allocations.total = composeSplitTotals(allocations, resolvedTax.exclusiveTaxMinors);
+      }
+      const resolvedTaxBreakdowns = allocateTaxBreakdown(
+        txnSource.tax_breakdown,
+        resolvedTaxMinors,
+        weights,
+        getTaxBreakdownWeights(
+          txnSource.tax_breakdown,
+          txnSnapshotItems,
+          (item) => txnNormalized.map((check: { items: { item: any; quantity: number }[] }) => (
+            check.items.find((entry) => Number(entry.item.id) === Number(item.id))?.quantity || 0
+          )),
+        ),
+      );
       const checkTaxSnapshots = snapshotAllocation.snapshots;
 
       const billIds: number[] = [];

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -573,7 +573,7 @@ function allocateMinorUnits(sourceMinor: number, weights: number[]): number[] {
 // Tax snapshots may contain signed evidence for a historical adjustment. Keep
 // allocateMinorUnits' non-negative contract unchanged and allocate the
 // magnitude with the same largest-remainder ordering before restoring the sign.
-function allocateSignedMinorUnits(sourceMinor: number, weights: number[]): number[] {
+export function allocateSignedMinorUnits(sourceMinor: number, weights: number[]): number[] {
   const sign = sourceMinor < 0 ? -1 : 1;
   return allocateMinorUnits(Math.abs(sourceMinor), weights).map((minor) => minor * sign);
 }
@@ -999,7 +999,7 @@ interface LegacyTaxContribution {
   exclusiveWeights: number[];
   exclusiveSourceMinor: number;
   allExclusive: boolean;
-  hasLegacyItems: boolean;
+  hasLegacyTaxEvidence: boolean;
 }
 
 function collectLegacyTaxContribution(
@@ -1037,7 +1037,14 @@ function collectLegacyTaxContribution(
     else allExclusive = false;
     hasLegacyItems = true;
   }
-  return { taxWeights, exclusiveWeights, exclusiveSourceMinor: Math.round(exclusiveSourceMinor), allExclusive, hasLegacyItems };
+  const hasDocumentLegacyTax = sourceBreakdownRaw !== undefined && taxBreakdownMinorTotal(sourceBreakdownRaw) !== 0;
+  return {
+    taxWeights,
+    exclusiveWeights,
+    exclusiveSourceMinor: Math.round(exclusiveSourceMinor),
+    allExclusive,
+    hasLegacyTaxEvidence: hasLegacyItems || hasDocumentLegacyTax,
+  };
 }
 
 function allocateLegacyTaxContribution(
@@ -1060,7 +1067,7 @@ function allocateLegacyTaxContribution(
   const exclusiveWeights = contribution.exclusiveWeights.some((weight) => weight > 0)
     ? contribution.exclusiveWeights
     : fallbackWeights;
-  const legacyExclusiveTaxMinors = contribution.hasLegacyItems
+  const legacyExclusiveTaxMinors = contribution.hasLegacyTaxEvidence || legacySourceTaxMinor !== 0
     ? allocateSignedMinorUnits(exclusiveSourceMinor, exclusiveWeights)
     : new Array(fallbackWeights.length).fill(0);
   return { legacySourceTaxMinor, legacyTaxMinors, legacyExclusiveTaxMinors };
@@ -1270,7 +1277,8 @@ export function syncUnpaidBillsForOrder(
   };
   const allocations = Object.fromEntries(Object.entries(fields).map(([field, value]) => [
     field,
-    allocateMinorUnits(value, weights).map((minor) => minor / 100),
+    (field === 'roundOff' ? allocateSignedMinorUnits(value, weights) : allocateMinorUnits(value, weights))
+      .map((minor) => minor / 100),
   ])) as Record<keyof typeof fields, number[]>;
   const allocatedTaxMinors = allocations.taxAmount.map((amount) => Math.round(amount * 100));
   const snapshotAllocation = allocateTaxSnapshotsWithTax(source.taxSnapshot, weights, snapshotWeights, snapshotExclusions);
@@ -1380,7 +1388,9 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
       const allocations: Record<string, number[]> = {};
       for (const field of fields) {
         const totalMinor = Math.round(Number(txnSource[field] || 0) * 100);
-        const allocatedMinors = allocateMinorUnits(totalMinor, weights);
+        const allocatedMinors = field === 'round_off'
+          ? allocateSignedMinorUnits(totalMinor, weights)
+          : allocateMinorUnits(totalMinor, weights);
         allocations[field] = allocatedMinors.map((minor) => minor / 100);
       }
 

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -351,7 +351,49 @@ function formatSnapshotMinorAmount(original: unknown, minor: number): string | n
  * tax evidence, so allocate each component in integer minor units with the
  * same non-negative largest-remainder allocator used for bill totals.
  */
-export function allocateTaxSnapshots(sourceRaw: unknown, weights: number[]): (string | null)[] {
+interface SnapshotTaxAllocation {
+  original: unknown;
+  allocations: number[];
+}
+
+function reconcileSnapshotAllocations(
+  entries: SnapshotTaxAllocation[],
+  targets: number[],
+): void {
+  if (entries.length === 0 || targets.length === 0) return;
+  const sums = targets.map((_, index) => entries.reduce(
+    (sum, entry) => sum + entry.allocations[index],
+    0,
+  ));
+  const deltas = targets.map((target, index) => target - sums[index]);
+
+  while (true) {
+    const deficitIndex = deltas.findIndex((delta) => delta > 0);
+    const excessIndex = deltas.findIndex((delta) => delta < 0);
+    if (deficitIndex === -1 || excessIndex === -1) return;
+
+    const positiveEntry = entries.find((entry) => entry.allocations[excessIndex] > 0);
+    if (positiveEntry) {
+      positiveEntry.allocations[excessIndex] -= 1;
+      positiveEntry.allocations[deficitIndex] += 1;
+    } else {
+      const negativeEntry = entries.find((entry) => entry.allocations[deficitIndex] < 0);
+      if (!negativeEntry) return;
+      negativeEntry.allocations[deficitIndex] += 1;
+      negativeEntry.allocations[excessIndex] -= 1;
+    }
+
+    deltas[excessIndex] += 1;
+    deltas[deficitIndex] -= 1;
+  }
+}
+
+export function allocateTaxSnapshots(
+  sourceRaw: unknown,
+  weights: number[],
+  targetTaxMinors?: number[],
+  snapshotWeights?: number[][],
+): (string | null)[] {
   const parsed = parseTaxSnapshot(sourceRaw);
   const sourceText = typeof sourceRaw === 'string'
     ? sourceRaw
@@ -362,60 +404,113 @@ export function allocateTaxSnapshots(sourceRaw: unknown, weights: number[]): (st
   ));
   if (!hasTaxSnapshots) return new Array(weights.length).fill(sourceText);
 
-  return weights.map((_, childIndex) => {
-    const child = JSON.parse(JSON.stringify(parsed));
-    const childSnapshots = Array.isArray(child) ? child : [child];
+  const sourceSnapshots = Array.isArray(parsed) ? parsed : [parsed];
+  const allocations: SnapshotTaxAllocation[] = [];
+  const entryByKey = new Map<string, SnapshotTaxAllocation>();
 
-    for (const snapshot of childSnapshots) {
-      if (!snapshot || typeof snapshot !== 'object' || !Array.isArray(snapshot.lines)) continue;
-      snapshot.splitAllocation = SPLIT_TAX_SNAPSHOT_VERSION;
-      snapshot.lines = snapshot.lines.map((line: any) => {
-        if (!line || typeof line !== 'object') return line;
-        const nextLine = { ...line };
+  sourceSnapshots.forEach((sourceSnapshot: any, snapshotIndex: number) => {
+    if (!sourceSnapshot || typeof sourceSnapshot !== 'object' || !Array.isArray(sourceSnapshot.lines)) return;
+    const localWeights = Array.isArray(snapshotWeights?.[snapshotIndex])
+      && snapshotWeights[snapshotIndex].length === weights.length
+      ? snapshotWeights[snapshotIndex]
+      : weights;
+    const snapshotEntries: SnapshotTaxAllocation[] = [];
+
+    sourceSnapshot.lines.forEach((sourceLine: any, lineIndex: number) => {
+      if (!sourceLine || typeof sourceLine !== 'object') return;
+      if (Array.isArray(sourceLine.components)) {
+        sourceLine.components.forEach((sourceComponent: any, componentIndex: number) => {
+          if (!sourceComponent || typeof sourceComponent !== 'object') return;
+          const sourceMinor = snapshotMinorAmount(sourceComponent.amount);
+          if (sourceMinor === null) return;
+          const entry: SnapshotTaxAllocation = {
+            original: sourceComponent.amount,
+            allocations: allocateSignedMinorUnits(sourceMinor, localWeights),
+          };
+          allocations.push(entry);
+          snapshotEntries.push(entry);
+          entryByKey.set(`${snapshotIndex}:${lineIndex}:${componentIndex}`, entry);
+        });
+      } else {
+        const sourceMinor = snapshotMinorAmount(sourceLine.taxAmount);
+        if (sourceMinor !== null) {
+          const entry: SnapshotTaxAllocation = {
+            original: sourceLine.taxAmount,
+            allocations: allocateSignedMinorUnits(sourceMinor, localWeights),
+          };
+          allocations.push(entry);
+          snapshotEntries.push(entry);
+          entryByKey.set(`${snapshotIndex}:${lineIndex}:taxAmount`, entry);
+        }
+      }
+    });
+
+    if (snapshotEntries.length > 0) {
+      const snapshotTotal = snapshotEntries.reduce(
+        (sum, entry) => sum + snapshotMinorAmount(entry.original)!,
+        0,
+      );
+      reconcileSnapshotAllocations(
+        snapshotEntries,
+        allocateSignedMinorUnits(snapshotTotal, localWeights),
+      );
+    }
+  });
+
+  if (targetTaxMinors && targetTaxMinors.length === weights.length) {
+    reconcileSnapshotAllocations(allocations, targetTaxMinors);
+  }
+
+  return weights.map((_, childIndex) => {
+    const childResult = JSON.parse(JSON.stringify(parsed));
+    const childResultSnapshots = Array.isArray(childResult) ? childResult : [childResult];
+    sourceSnapshots.forEach((sourceSnapshot: any, snapshotIndex: number) => {
+      const childSnapshot = childResultSnapshots[snapshotIndex];
+      if (!sourceSnapshot || !childSnapshot || !Array.isArray(sourceSnapshot.lines)) return;
+      childSnapshot.splitAllocation = SPLIT_TAX_SNAPSHOT_VERSION;
+      sourceSnapshot.lines.forEach((sourceLine: any, lineIndex: number) => {
+        const line = childSnapshot.lines?.[lineIndex];
+        if (!sourceLine || !line || typeof line !== 'object') return;
         for (const field of ['grossAmount', 'taxableBase'] as const) {
-          const sourceMinor = snapshotMinorAmount(line[field]);
+          const sourceMinor = snapshotMinorAmount(sourceLine[field]);
           if (sourceMinor !== null) {
-            nextLine[field] = formatSnapshotMinorAmount(
-              line[field],
+            line[field] = formatSnapshotMinorAmount(
+              sourceLine[field],
               allocateSignedMinorUnits(sourceMinor, weights)[childIndex],
             );
           }
         }
-
-        if (Array.isArray(line.components)) {
-          const nextComponents = line.components.map((component: any) => {
-            if (!component || typeof component !== 'object') return component;
-            const sourceMinor = snapshotMinorAmount(component.amount);
-            if (sourceMinor === null) return { ...component };
-            return {
-              ...component,
-              amount: formatSnapshotMinorAmount(
-                component.amount,
-                allocateSignedMinorUnits(sourceMinor, weights)[childIndex],
-              ),
-            };
+      });
+    });
+    sourceSnapshots.forEach((sourceSnapshot: any, snapshotIndex: number) => {
+      if (!sourceSnapshot || typeof sourceSnapshot !== 'object' || !Array.isArray(sourceSnapshot.lines)) return;
+      const resultSnapshot = childResultSnapshots[snapshotIndex];
+      sourceSnapshot.lines.forEach((sourceLine: any, lineIndex: number) => {
+        const resultLine = resultSnapshot?.lines?.[lineIndex];
+        if (!sourceLine || !resultLine || typeof resultLine !== 'object') return;
+        if (Array.isArray(sourceLine.components)) {
+          let componentTotal = 0;
+          let allComponentsAllocated = true;
+          sourceLine.components.forEach((sourceComponent: any, componentIndex: number) => {
+            const resultComponent = resultLine.components?.[componentIndex];
+            const entry = entryByKey.get(`${snapshotIndex}:${lineIndex}:${componentIndex}`);
+            if (!resultComponent || !entry) {
+              allComponentsAllocated = false;
+              return;
+            }
+            resultComponent.amount = formatSnapshotMinorAmount(entry.original, entry.allocations[childIndex]);
+            componentTotal += entry.allocations[childIndex];
           });
-          nextLine.components = nextComponents;
-
-          const componentMinors = nextComponents.map((component: any) => snapshotMinorAmount(component?.amount));
-          if (componentMinors.every((minor: number | null): minor is number => minor !== null)) {
-            const componentTotal = componentMinors.reduce((sum: number, minor: number) => sum + minor, 0);
-            nextLine.taxAmount = formatSnapshotMinorAmount(line.taxAmount, componentTotal);
+          if (allComponentsAllocated) {
+            resultLine.taxAmount = formatSnapshotMinorAmount(sourceLine.taxAmount, componentTotal);
           }
         } else {
-          const sourceMinor = snapshotMinorAmount(line.taxAmount);
-          if (sourceMinor !== null) {
-            nextLine.taxAmount = formatSnapshotMinorAmount(
-              line.taxAmount,
-              allocateSignedMinorUnits(sourceMinor, weights)[childIndex],
-            );
-          }
+          const entry = entryByKey.get(`${snapshotIndex}:${lineIndex}:taxAmount`);
+          if (entry) resultLine.taxAmount = formatSnapshotMinorAmount(entry.original, entry.allocations[childIndex]);
         }
-        return nextLine;
       });
-    }
-
-    return JSON.stringify(child);
+    });
+    return JSON.stringify(childResult);
   });
 }
 
@@ -541,6 +636,128 @@ function allocateTaxBreakdown(
   return result;
 }
 
+interface OrderBillSyncValues {
+  subtotal: number;
+  taxAmount: number;
+  taxBreakdown: string | null;
+  taxSnapshot: string | null;
+  discountAmount: number;
+  deliveryCharge: number;
+  packagingCharge: number;
+  total: number;
+}
+
+function hasSnapshotLines(raw: unknown): boolean {
+  const parsed = parseTaxSnapshot(raw);
+  return (Array.isArray(parsed) ? parsed : [parsed]).some((snapshot) => (
+    snapshot && typeof snapshot === 'object' && Array.isArray((snapshot as any).lines)
+  ));
+}
+
+function getSplitBillAllocationWeights(
+  db: ReturnType<typeof getDatabase>,
+  orderId: number | string,
+  bills: any[],
+): { weights: number[]; snapshotWeights: number[][] } {
+  const items = db.prepare('SELECT * FROM order_items WHERE order_id = ? ORDER BY id').all(orderId) as any[];
+  const billIds = bills.map((bill) => Number(bill.id));
+  const billItems = billIds.length === 0
+    ? []
+    : db.prepare(`SELECT bill_id, order_item_id, quantity FROM bill_items WHERE bill_id IN (${billIds.map(() => '?').join(',')})`).all(...billIds) as any[];
+  const quantities = new Map<number, Map<number, number>>();
+  for (const row of billItems) {
+    const byItem = quantities.get(Number(row.bill_id)) || new Map<number, number>();
+    byItem.set(Number(row.order_item_id), Number(row.quantity));
+    quantities.set(Number(row.bill_id), byItem);
+  }
+
+  const weights = bills.map((bill) => {
+    const byItem = quantities.get(Number(bill.id)) || new Map<number, number>();
+    return items
+      .filter((item) => !['cancelled', 'voided', 'void_adjustment'].includes(item.status))
+      .reduce((sum, item) => {
+        const quantity = byItem.get(Number(item.id)) || 0;
+        if (quantity <= 0 || Number(item.quantity) <= 0) return sum;
+        return sum + Number(item.total || item.subtotal || 0) * quantity / Number(item.quantity);
+      }, 0);
+  });
+
+  const snapshotWeights = items
+    .filter((item) => item.status !== 'cancelled' && hasSnapshotLines(item.tax_snapshot))
+    .map((item) => {
+      const itemWeights = bills.map((bill) => (
+        quantities.get(Number(bill.id))?.get(Number(item.id)) || 0
+      ));
+      return itemWeights.some((weight) => weight > 0) ? itemWeights : weights;
+    });
+
+  return { weights, snapshotWeights };
+}
+
+export function syncUnpaidBillsForOrder(
+  db: ReturnType<typeof getDatabase>,
+  orderId: number | string,
+  source: OrderBillSyncValues,
+  country: string,
+): void {
+  const bills = db.prepare('SELECT * FROM bills WHERE order_id = ? ORDER BY id').all(orderId) as any[];
+  const unpaidBills = bills.filter((bill) => bill.payment_status !== 'paid');
+  if (unpaidBills.length === 0) return;
+
+  const pack = getActiveCountryPack(country);
+  const { total: billTotal, adjustment: billRoundOff } = applyPayableRounding(source.total, pack);
+  const splitBills = bills.some((bill) => bill.split_group_id);
+
+  if (!splitBills) {
+    const update = db.prepare(`
+      UPDATE bills SET subtotal = ?, total = ?, balance = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?,
+        discount_amount = ?, delivery_charge = ?, packaging_charge = ?, round_off = ?, updated_at = ?
+      WHERE id = ?
+    `);
+    for (const bill of unpaidBills) {
+      update.run(
+        source.subtotal, billTotal, Math.max(0, billTotal - Number(bill.paid_amount || 0)), source.taxAmount,
+        source.taxBreakdown, source.taxSnapshot, source.discountAmount, source.deliveryCharge,
+        source.packagingCharge, billRoundOff, now(), bill.id,
+      );
+    }
+    return;
+  }
+
+  const { weights, snapshotWeights } = getSplitBillAllocationWeights(db, orderId, bills);
+  const fields = {
+    subtotal: Math.round(source.subtotal * 100),
+    taxAmount: Math.round(source.taxAmount * 100),
+    discountAmount: Math.round(source.discountAmount * 100),
+    deliveryCharge: Math.round(source.deliveryCharge * 100),
+    packagingCharge: Math.round(source.packagingCharge * 100),
+    roundOff: Math.round(billRoundOff * 100),
+    total: Math.round(billTotal * 100),
+  };
+  const allocations = Object.fromEntries(Object.entries(fields).map(([field, value]) => [
+    field,
+    allocateMinorUnits(value, weights).map((minor) => minor / 100),
+  ])) as Record<keyof typeof fields, number[]>;
+  const taxMinors = allocations.taxAmount.map((amount) => Math.round(amount * 100));
+  const breakdowns = allocateTaxBreakdown(source.taxBreakdown, taxMinors, weights);
+  const snapshots = allocateTaxSnapshots(source.taxSnapshot, weights, taxMinors, snapshotWeights);
+  const update = db.prepare(`
+    UPDATE bills SET subtotal = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?,
+      delivery_charge = ?, packaging_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ?
+    WHERE id = ?
+  `);
+
+  bills.forEach((bill, index) => {
+    if (bill.payment_status === 'paid') return;
+    const total = allocations.total[index];
+    update.run(
+      allocations.subtotal[index], allocations.taxAmount[index], breakdowns[index], snapshots[index],
+      allocations.discountAmount[index], allocations.deliveryCharge[index], allocations.packagingCharge[index],
+      allocations.roundOff[index], total, Math.max(0, total - Number(bill.paid_amount || 0)), now(), bill.id,
+    );
+  });
+}
+
 // Divide one unpaid dine-in bill into independently payable guest checks.
 // The kitchen order and inventory rows remain singular; bill_items stores only
 // the whole-unit quantity allocated to each resulting check.
@@ -604,7 +821,12 @@ router.post('/:id/split-check', requireRole('owner', 'manager', 'cashier'), (req
 
       const checkTaxMinors = allocations.tax_amount.map((amt) => Math.round(amt * 100));
       const checkTaxBreakdowns = allocateTaxBreakdown(txnSource.tax_breakdown, checkTaxMinors, weights);
-      const checkTaxSnapshots = allocateTaxSnapshots(txnSource.tax_snapshot, weights);
+      const snapshotWeights = txnActiveItems
+        .filter((item) => hasSnapshotLines(item.tax_snapshot))
+        .map((item) => txnNormalized.map((check: { items: { item: any; quantity: number }[] }) => (
+          check.items.find((entry) => Number(entry.item.id) === Number(item.id))?.quantity || 0
+        )));
+      const checkTaxSnapshots = allocateTaxSnapshots(txnSource.tax_snapshot, weights, checkTaxMinors, snapshotWeights);
 
       const billIds: number[] = [];
       txnNormalized.forEach((check, index) => {

--- a/main/routes/index.ts
+++ b/main/routes/index.ts
@@ -315,7 +315,7 @@ export function registerRoutes(app: Express): void {
             )
           LIMIT 1
         `).get(orderId)) {
-          throw Object.assign(new Error('Cannot cancel items on a paid or partially paid order'), { statusCode: 400 });
+          throw Object.assign(new Error('Cannot cancel items on a paid or partially paid order'), { statusCode: 409 });
         }
 
         // Completed and cancelled orders are terminal. This guard must run

--- a/main/routes/index.ts
+++ b/main/routes/index.ts
@@ -6,7 +6,7 @@ import { productRoutes } from './products';
 import { addonGroupRoutes } from './addon-groups';
 import { orderRoutes } from './orders';
 import { orderItemRoutes } from './order-items';
-import { billRoutes } from './bills';
+import { billRoutes, syncUnpaidBillsForOrder } from './bills';
 import { tableRoutes } from './tables';
 import { kitchenStationRoutes } from './kitchen-stations';
 import { kitchenRoutes } from './kitchen';
@@ -38,7 +38,6 @@ import {
   invertTaxBreakdown,
   invertTaxSnapshot,
 } from '../services/tax';
-import { applyPayableRounding } from '../services/tax-engine';
 import { cloudSync } from '../services/cloud-sync';
 import { parsePhoneE164, stripPhoneDigits } from '../lib/phone';
 import QRCode from 'qrcode';
@@ -498,15 +497,16 @@ export function registerRoutes(app: Express): void {
           `).run(subtotal, taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, newDiscountAmount, total, roundOff, now(), orderId);
         }
 
-        // Sync bill if it exists
-        const existingBill = db.prepare("SELECT * FROM bills WHERE order_id = ? AND payment_status != 'paid'").get(orderId) as any;
-        if (existingBill) {
-          const pack = getActiveCountryPack(tenantInfo.country);
-          const { total: billTotal, adjustment: billRoundOff } = applyPayableRounding(total, pack);
-          const newBillBalance = Math.max(0, billTotal - (existingBill.paid_amount || 0));
-          db.prepare(`UPDATE bills SET total = ?, balance = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, round_off = ?, updated_at = ? WHERE id = ?`)
-            .run(billTotal, newBillBalance, taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, newDiscountAmount, billRoundOff, now(), existingBill.id);
-        }
+        syncUnpaidBillsForOrder(db, orderId, {
+          subtotal,
+          taxAmount: taxRollup.taxAmount,
+          taxBreakdown: JSON.stringify(taxRollup.breakdowns),
+          taxSnapshot: taxRollup.snapshotJson,
+          discountAmount: newDiscountAmount,
+          deliveryCharge: order.delivery_charge || 0,
+          packagingCharge: order.packaging_charge || 0,
+          total,
+        }, tenantInfo.country);
 
         const updatedOrder = db.prepare('SELECT * FROM orders WHERE id = ?').get(orderId) as any;
         const items = attachEffectiveAddons(db, db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(orderId).map(parseItemJson) as any[]);
@@ -666,15 +666,16 @@ export function registerRoutes(app: Express): void {
           UPDATE orders SET subtotal = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, total = ?, round_off = ?, updated_at = ? WHERE id = ?
         `).run(subtotal, taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, newDiscountAmount, total, roundOff, now(), orderId);
 
-        // Sync bill if it exists
-        const existingBill = db.prepare("SELECT * FROM bills WHERE order_id = ? AND payment_status != 'paid'").get(orderId) as any;
-        if (existingBill) {
-          const pack = getActiveCountryPack(tenantInfo.country);
-          const { total: billTotal, adjustment: billRoundOff } = applyPayableRounding(total, pack);
-          const newBillBalance = Math.max(0, billTotal - (existingBill.paid_amount || 0));
-          db.prepare(`UPDATE bills SET total = ?, balance = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, round_off = ?, updated_at = ? WHERE id = ?`)
-            .run(billTotal, newBillBalance, taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, newDiscountAmount, billRoundOff, now(), existingBill.id);
-        }
+        syncUnpaidBillsForOrder(db, orderId, {
+          subtotal,
+          taxAmount: taxRollup.taxAmount,
+          taxBreakdown: JSON.stringify(taxRollup.breakdowns),
+          taxSnapshot: taxRollup.snapshotJson,
+          discountAmount: newDiscountAmount,
+          deliveryCharge: order.delivery_charge || 0,
+          packagingCharge: order.packaging_charge || 0,
+          total,
+        }, tenantInfo.country);
 
         const updatedOrder = db.prepare('SELECT * FROM orders WHERE id = ?').get(orderId) as any;
         const items = attachEffectiveAddons(db, db.prepare('SELECT * FROM order_items WHERE order_id = ?').all(orderId).map(parseItemJson) as any[]);

--- a/main/routes/printers.ts
+++ b/main/routes/printers.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { getDatabase, now, attachEffectiveAddons, isKotPrintingEnabled, parseItemJson } from '../db';
+import { getOrderWithItems } from './bills';
 import { v4 as uuidv4 } from 'uuid';
 import { printViaNetwork, printViaUSB, buildTestPage, printReceiptDetailed, printKOTDetailed, detectConnectedPrinters, prepareReceipt, escPosToText } from '../printers/thermal';
 import { getSupportedPrinterProfiles, resolvePrinterProfile } from '../printers/profiles';
@@ -339,17 +340,7 @@ router.post('/print-bill', requireRole('owner', 'manager', 'cashier'), async (re
     }
 
     // Fetch order items
-    let items: any[] = getEffectiveOrderItems(db, bill.order_id);
-    const allocations = db.prepare('SELECT order_item_id, quantity FROM bill_items WHERE bill_id = ?').all(bill.id) as any[];
-    if (allocations.length > 0) {
-      const byItem = new Map(allocations.map((row) => [Number(row.order_item_id), Number(row.quantity)]));
-      items = items.filter((item) => byItem.has(Number(item.id))).map((item) => {
-        const quantity = byItem.get(Number(item.id))!;
-        const ratio = quantity / Number(item.quantity);
-        return { ...item, quantity, subtotal: Number((Number(item.subtotal) * ratio).toFixed(2)), tax_amount: Number((Number(item.tax_amount || 0) * ratio).toFixed(2)), total: Number((Number(item.total) * ratio).toFixed(2)) };
-      });
-    }
-    order.items = items;
+    order.items = getOrderWithItems(db, Number(bill.order_id), Number(bill.id))?.items || [];
 
     // Fetch table info
     if (order.table_id) {

--- a/main/routes/reports.ts
+++ b/main/routes/reports.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from 'express';
 import Decimal from 'decimal.js';
 import { getDatabase, getSettingValue, parseDbTimestamp, utcDayBounds, utcTodayDate } from '../db';
 import { requireRole } from '../middleware/security';
-import { getOrderWithItems } from './bills';
+import { getOrdersWithItemsForBills } from './bills';
 import { aggregateTaxComponents } from '../services/tax-components';
 
 const router = Router();
@@ -206,11 +206,12 @@ router.get('/tax-components', requireRole('owner', 'manager'), (req: Request, re
       ORDER BY b.created_at, b.id
     `).all(windowStart, windowEnd) as any[];
 
+    const orders = getOrdersWithItemsForBills(db, bills);
     const documents = bills.map((bill) => ({
       tax_amount: bill.tax_amount,
       tax_snapshot: bill.tax_snapshot,
       tax_breakdown: bill.tax_breakdown,
-      items: getOrderWithItems(db, Number(bill.order_id), Number(bill.id))?.items || [],
+      items: orders.get(Number(bill.id))?.items || [],
     }));
     const taxAmount = bills.reduce(
       (sum, bill) => sum.plus(bill.tax_amount || 0),

--- a/main/routes/reports.ts
+++ b/main/routes/reports.ts
@@ -1,7 +1,8 @@
 import { Router, Request, Response } from 'express';
 import Decimal from 'decimal.js';
-import { getDatabase, getSettingValue, parseDbTimestamp, parseItemJson, utcDayBounds, utcTodayDate } from '../db';
+import { getDatabase, getSettingValue, parseDbTimestamp, utcDayBounds, utcTodayDate } from '../db';
 import { requireRole } from '../middleware/security';
+import { getOrderWithItems } from './bills';
 import { aggregateTaxComponents } from '../services/tax-components';
 
 const router = Router();
@@ -205,27 +206,11 @@ router.get('/tax-components', requireRole('owner', 'manager'), (req: Request, re
       ORDER BY b.created_at, b.id
     `).all(windowStart, windowEnd) as any[];
 
-    const itemsByOrder = new Map<number, any[]>();
-    if (bills.length > 0) {
-      const orderIds = Array.from(new Set(bills.map((bill) => Number(bill.order_id))));
-      const placeholders = orderIds.map(() => '?').join(',');
-      const items = db.prepare(`
-        SELECT * FROM order_items
-        WHERE order_id IN (${placeholders})
-        ORDER BY order_id, id
-      `).all(...orderIds).map(parseItemJson) as any[];
-      for (const item of items) {
-        const list = itemsByOrder.get(item.order_id) || [];
-        list.push(item);
-        itemsByOrder.set(item.order_id, list);
-      }
-    }
-
     const documents = bills.map((bill) => ({
       tax_amount: bill.tax_amount,
       tax_snapshot: bill.tax_snapshot,
       tax_breakdown: bill.tax_breakdown,
-      items: itemsByOrder.get(bill.order_id) || [],
+      items: getOrderWithItems(db, Number(bill.order_id), Number(bill.id))?.items || [],
     }));
     const taxAmount = bills.reduce(
       (sum, bill) => sum.plus(bill.tax_amount || 0),

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -205,7 +205,8 @@ function documentLegacyComponents(
  * Resolves receipt/report tax components without double-counting mixed orders.
  * A valid item snapshot (including an exempt snapshot with zero components)
  * is authoritative for that item; uncategorized items retain their legacy
- * tax_breakdown. Document-level data is used only when item rows are absent.
+ * tax_breakdown. Split bills use their marked child snapshot, then add only
+ * document-level legacy residuals that are not already represented.
  */
 export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent[] {
   // Split bills persist child-specific snapshot amounts. Prefer those copies

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -43,6 +43,7 @@ function hasSplitAllocatedSnapshot(value: unknown): boolean {
 }
 
 function decimalOrNull(value: unknown): Decimal | null {
+  if (value instanceof Decimal) return value;
   if (typeof value !== 'string' && typeof value !== 'number') return null;
   try {
     const decimal = new Decimal(value);
@@ -105,7 +106,7 @@ function flattenLegacyBreakdown(value: unknown): DecimalTaxComponent[] {
     if (!entry || typeof entry !== 'object') continue;
     const raw = entry as Record<string, unknown>;
     const amount = decimalOrNull(raw.amount);
-    if (!amount) continue;
+    if (!amount || amount.isZero()) continue;
     const rate = decimalOrNull(raw.rate);
     components.push({
       title: String(raw.title || raw.name || 'Tax'),
@@ -213,8 +214,12 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
   if (hasSplitAllocatedSnapshot(document.tax_snapshot)) {
     const splitSnapshot = flattenSnapshots(document.tax_snapshot);
     if (splitSnapshot.present) {
+      const hasItemSnapshot = (document.items || []).some((item) => flattenSnapshots(item.tax_snapshot).present);
+      const snapshotComponents = hasItemSnapshot
+        ? splitSnapshot.components
+        : splitSnapshot.components.filter((component) => !component.amount.isZero());
       const represented = mergeComponents([
-        ...splitSnapshot.components,
+        ...snapshotComponents,
         ...legacyItemComponents(document),
       ]);
       const target = decimalOrNull(document.tax_amount);
@@ -228,9 +233,13 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
           : representedTotal.comparedTo(target) < 0));
       return reconcileTotal(
         mergeComponents([
-          ...represented,
+          ...represented.map((component) => ({
+            title: component.title,
+            rate: component.rate === null ? null : new Decimal(component.rate).toString(),
+            amount: new Decimal(component.amount),
+          })),
           ...(needsDocumentResidual
-            ? documentLegacyComponents(document, splitSnapshot.components)
+            ? documentLegacyComponents(document, snapshotComponents)
             : []),
         ]),
         document.tax_amount,
@@ -282,13 +291,12 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
           amount: new Decimal(component.amount),
         })));
       }
-      return reconcileTotal(
-        mergeComponents([
-          ...components,
-          ...(hasSnapshotEvidence ? documentLegacyComponents(document, itemSnapshotComponents) : []),
-        ]),
-        document.tax_amount,
-      );
+      const legacyItems = legacyItemComponents(document);
+      const documentResidual = hasSnapshotEvidence
+        && ((document.tax_amount !== undefined && document.tax_amount !== null) || legacyItems.length > 0)
+        ? documentLegacyComponents(document, itemSnapshotComponents)
+        : [];
+      return reconcileTotal(mergeComponents([...components, ...documentResidual]), document.tax_amount);
     }
   }
 

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -213,11 +213,25 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
   if (hasSplitAllocatedSnapshot(document.tax_snapshot)) {
     const splitSnapshot = flattenSnapshots(document.tax_snapshot);
     if (splitSnapshot.present) {
+      const represented = mergeComponents([
+        ...splitSnapshot.components,
+        ...legacyItemComponents(document),
+      ]);
+      const target = decimalOrNull(document.tax_amount);
+      const representedTotal = represented.reduce(
+        (sum, component) => sum.plus(component.amount),
+        new Decimal(0),
+      );
+      const needsDocumentResidual = !target
+        || (!target.isZero() && (target.isNegative()
+          ? representedTotal.comparedTo(target) > 0
+          : representedTotal.comparedTo(target) < 0));
       return reconcileTotal(
         mergeComponents([
-          ...splitSnapshot.components,
-          ...legacyItemComponents(document),
-          ...documentLegacyComponents(document, splitSnapshot.components),
+          ...represented,
+          ...(needsDocumentResidual
+            ? documentLegacyComponents(document, splitSnapshot.components)
+            : []),
         ]),
         document.tax_amount,
       );

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -177,9 +177,12 @@ function legacyItemComponents(document: TaxDocument): DecimalTaxComponent[] {
   });
 }
 
-function documentLegacyComponents(document: TaxDocument): DecimalTaxComponent[] {
+function documentLegacyComponents(
+  document: TaxDocument,
+  coveredComponents: DecimalTaxComponent[] = [],
+): DecimalTaxComponent[] {
   const remainingItems = new Map<string, Decimal>();
-  for (const component of legacyItemComponents(document)) {
+  for (const component of [...legacyItemComponents(document), ...coveredComponents]) {
     const key = `${component.title}\u0000${component.rate ?? ''}`;
     remainingItems.set(key, (remainingItems.get(key) || new Decimal(0)).plus(component.amount));
   }
@@ -214,7 +217,7 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
         mergeComponents([
           ...splitSnapshot.components,
           ...legacyItemComponents(document),
-          ...documentLegacyComponents(document),
+          ...documentLegacyComponents(document, splitSnapshot.components),
         ]),
         document.tax_amount,
       );

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -268,7 +268,12 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
 
   const snapshot = flattenSnapshots(document.tax_snapshot);
   const components = mergeComponents(
-    snapshot.present ? snapshot.components : flattenLegacyBreakdown(document.tax_breakdown),
+    snapshot.present
+      ? [
+        ...snapshot.components,
+        ...documentLegacyComponents(document, snapshot.components),
+      ]
+      : flattenLegacyBreakdown(document.tax_breakdown),
   );
   return reconcileTotal(
     components,

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -170,7 +170,7 @@ function reconcileTotal(
 
 function legacyItemComponents(document: TaxDocument): DecimalTaxComponent[] {
   return (document.items || []).filter(
-    (item) => item.status !== 'cancelled' && item.status !== 'voided',
+    (item) => item.status !== 'cancelled' && item.status !== 'voided' && item.status !== 'void_adjustment',
   ).flatMap((item) => {
     const snapshot = flattenSnapshots(item.tax_snapshot);
     return snapshot.present ? [] : flattenLegacyBreakdown(item.tax_breakdown);
@@ -198,7 +198,7 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
   }
 
   const activeItems = document.items?.filter(
-    (item) => item.status !== 'cancelled' && item.status !== 'voided',
+    (item) => item.status !== 'cancelled' && item.status !== 'voided' && item.status !== 'void_adjustment',
   );
 
   if (activeItems && activeItems.length > 0) {

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -230,6 +230,7 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
 
   if (activeItems && activeItems.length > 0) {
     const components: DecimalTaxComponent[] = [];
+    const itemSnapshotComponents: DecimalTaxComponent[] = [];
     let hasItemTaxEvidence = false;
     let hasSnapshotEvidence = false;
     for (const item of activeItems) {
@@ -238,6 +239,7 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
       hasSnapshotEvidence ||= snapshot.present;
       hasItemTaxEvidence ||= snapshot.present || legacy.length > 0;
       components.push(...(snapshot.present ? snapshot.components : legacy));
+      if (snapshot.present) itemSnapshotComponents.push(...snapshot.components);
     }
     if (hasItemTaxEvidence) {
       const chargeSnapshot = flattenSnapshots(document.tax_snapshot, true);
@@ -256,13 +258,23 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
         return mergeComponents([
           ...reconcileTotal(mergeComponents(components), itemTarget),
           ...chargeComponents,
+          ...documentLegacyComponents(document, [
+            ...itemSnapshotComponents,
+            ...chargeSnapshot.components,
+          ]),
         ].map((component) => ({
           title: component.title,
           rate: component.rate === null ? null : new Decimal(component.rate).toString(),
           amount: new Decimal(component.amount),
         })));
       }
-      return reconcileTotal(mergeComponents(components), document.tax_amount);
+      return reconcileTotal(
+        mergeComponents([
+          ...components,
+          ...(hasSnapshotEvidence ? documentLegacyComponents(document, itemSnapshotComponents) : []),
+        ]),
+        document.tax_amount,
+      );
     }
   }
 

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -177,6 +177,26 @@ function legacyItemComponents(document: TaxDocument): DecimalTaxComponent[] {
   });
 }
 
+function documentLegacyComponents(document: TaxDocument): DecimalTaxComponent[] {
+  const remainingItems = new Map<string, Decimal>();
+  for (const component of legacyItemComponents(document)) {
+    const key = `${component.title}\u0000${component.rate ?? ''}`;
+    remainingItems.set(key, (remainingItems.get(key) || new Decimal(0)).plus(component.amount));
+  }
+  return flattenLegacyBreakdown(document.tax_breakdown).flatMap((component) => {
+    const key = `${component.title}\u0000${component.rate ?? ''}`;
+    const itemAmount = remainingItems.get(key) || new Decimal(0);
+    const sameSign = itemAmount.isZero() || component.amount.isZero()
+      || itemAmount.isPositive() === component.amount.isPositive();
+    const consumed = sameSign
+      ? Decimal.min(itemAmount.abs(), component.amount.abs()).mul(component.amount.isNegative() ? -1 : 1)
+      : new Decimal(0);
+    const residual = component.amount.minus(consumed);
+    remainingItems.set(key, itemAmount.minus(consumed));
+    return residual.isZero() ? [] : [{ ...component, amount: residual }];
+  });
+}
+
 /**
  * Resolves receipt/report tax components without double-counting mixed orders.
  * A valid item snapshot (including an exempt snapshot with zero components)
@@ -191,7 +211,11 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
     const splitSnapshot = flattenSnapshots(document.tax_snapshot);
     if (splitSnapshot.present) {
       return reconcileTotal(
-        mergeComponents([...splitSnapshot.components, ...legacyItemComponents(document)]),
+        mergeComponents([
+          ...splitSnapshot.components,
+          ...legacyItemComponents(document),
+          ...documentLegacyComponents(document),
+        ]),
         document.tax_amount,
       );
     }

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -168,6 +168,15 @@ function reconcileTotal(
   return reconciled;
 }
 
+function legacyItemComponents(document: TaxDocument): DecimalTaxComponent[] {
+  return (document.items || []).filter(
+    (item) => item.status !== 'cancelled' && item.status !== 'voided',
+  ).flatMap((item) => {
+    const snapshot = flattenSnapshots(item.tax_snapshot);
+    return snapshot.present ? [] : flattenLegacyBreakdown(item.tax_breakdown);
+  });
+}
+
 /**
  * Resolves receipt/report tax components without double-counting mixed orders.
  * A valid item snapshot (including an exempt snapshot with zero components)
@@ -181,7 +190,10 @@ export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent
   if (hasSplitAllocatedSnapshot(document.tax_snapshot)) {
     const splitSnapshot = flattenSnapshots(document.tax_snapshot);
     if (splitSnapshot.present) {
-      return reconcileTotal(mergeComponents(splitSnapshot.components), document.tax_amount);
+      return reconcileTotal(
+        mergeComponents([...splitSnapshot.components, ...legacyItemComponents(document)]),
+        document.tax_amount,
+      );
     }
   }
 

--- a/main/services/tax-components.ts
+++ b/main/services/tax-components.ts
@@ -22,6 +22,8 @@ interface DecimalTaxComponent {
   amount: Decimal;
 }
 
+const SPLIT_TAX_SNAPSHOT_VERSION = 'minor-unit-v1';
+
 function parseJson(value: unknown): unknown {
   if (typeof value !== 'string') return value;
   try {
@@ -29,6 +31,15 @@ function parseJson(value: unknown): unknown {
   } catch {
     return value;
   }
+}
+
+function hasSplitAllocatedSnapshot(value: unknown): boolean {
+  const parsed = parseJson(value);
+  if (Array.isArray(parsed)) return parsed.some(hasSplitAllocatedSnapshot);
+  if (!parsed || typeof parsed !== 'object') return false;
+  const snapshot = parsed as Record<string, unknown>;
+  return snapshot.splitAllocation === SPLIT_TAX_SNAPSHOT_VERSION
+    && Array.isArray(snapshot.lines);
 }
 
 function decimalOrNull(value: unknown): Decimal | null {
@@ -164,6 +175,16 @@ function reconcileTotal(
  * tax_breakdown. Document-level data is used only when item rows are absent.
  */
 export function resolveTaxComponents(document: TaxDocument): DisplayTaxComponent[] {
+  // Split bills persist child-specific snapshot amounts. Prefer those copies
+  // over the shared order-item snapshots, which describe the source order and
+  // would otherwise swap item tax for full document-level charge tax.
+  if (hasSplitAllocatedSnapshot(document.tax_snapshot)) {
+    const splitSnapshot = flattenSnapshots(document.tax_snapshot);
+    if (splitSnapshot.present) {
+      return reconcileTotal(mergeComponents(splitSnapshot.components), document.tax_amount);
+    }
+  }
+
   const activeItems = document.items?.filter(
     (item) => item.status !== 'cancelled' && item.status !== 'voided',
   );

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -387,6 +387,54 @@ async function main() {
       'aggregate resolved snapshot tax equals source order tax exactly',
     );
 
+    const unevenComponentSnapshot = JSON.stringify({
+      lines: [{
+        taxAmount: '0.02',
+        components: [
+          { label: 'Component A', rate: '5', amount: '0.01' },
+          { label: 'Component B', rate: '5', amount: '0.01' },
+        ],
+      }],
+    });
+    const unevenComponentChildren = allocateTaxSnapshots(unevenComponentSnapshot, [1, 2], [1, 1]);
+    const unevenComponentAmounts = unevenComponentChildren.map((raw: string | null) => {
+      const snapshot = JSON.parse(raw as string);
+      return snapshot.lines[0].components.map((component: any) => Number(component.amount));
+    });
+    assertEqual(JSON.stringify(unevenComponentAmounts.map((components: number[]) => Number(components.reduce((sum, amount) => sum + amount, 0).toFixed(2)))), JSON.stringify([0.01, 0.01]), 'uneven split snapshot components reconcile to each child tax target');
+    assertEqual(JSON.stringify(unevenComponentAmounts.reduce((totals: number[], components: number[]) => components.map((amount, index) => Number((totals[index] + amount).toFixed(2))), [0, 0])), JSON.stringify([0.01, 0.01]), 'uneven split snapshot components remain additive across children');
+
+    const cancelledSnapshotItem = snapshotItems[0];
+    const cancelSnapshotRes = await api(baseUrl, `/api/orders/${snapshotOrderRes.data.order.id}/items/${cancelledSnapshotItem.id}/cancel`, {
+      method: 'PATCH',
+      headers: authHeader,
+    });
+    assertEqual(cancelSnapshotRes.status, 200, 'cancelling an item after splitting keeps the order mutation supported');
+    const cancelledSnapshotBills = db.prepare('SELECT * FROM bills WHERE order_id = ? ORDER BY id').all(snapshotOrderRes.data.order.id) as any[];
+    for (const childBill of cancelledSnapshotBills) {
+      const childRes = await api(baseUrl, `/api/bills/${childBill.id}`, { headers: authHeader });
+      const child = childRes.data.bill;
+      const backendComponents = resolveBackendTaxComponents({ ...child, items: child.order.items });
+      const frontendComponents = resolveFrontendTaxComponents(child);
+      assert(child.tax_snapshot && JSON.parse(child.tax_snapshot).some((snapshot: any) => snapshot.splitAllocation === 'minor-unit-v1'), 'cancel sync preserves marked child tax snapshots');
+      assertEqual(JSON.stringify(backendComponents), JSON.stringify(frontendComponents), 'cancel sync keeps backend and frontend tax attribution aligned');
+      assertEqual(Number(backendComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'cancel sync resolved tax reconciles to each child tax amount');
+    }
+
+    const restoreSnapshotRes = await api(baseUrl, `/api/orders/${snapshotOrderRes.data.order.id}/items/${cancelledSnapshotItem.id}/restore`, {
+      method: 'PATCH',
+      headers: authHeader,
+    });
+    assertEqual(restoreSnapshotRes.status, 200, 'restoring an item after splitting keeps the order mutation supported');
+    const restoredSnapshotBills = db.prepare('SELECT * FROM bills WHERE order_id = ? ORDER BY id').all(snapshotOrderRes.data.order.id) as any[];
+    for (const childBill of restoredSnapshotBills) {
+      const childRes = await api(baseUrl, `/api/bills/${childBill.id}`, { headers: authHeader });
+      const child = childRes.data.bill;
+      const backendComponents = resolveBackendTaxComponents({ ...child, items: child.order.items });
+      assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedSnapshotComponents), 'restore sync recomputes child item and charge tax attribution');
+      assertEqual(Number(backendComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'restore sync resolved tax reconciles to each child tax amount');
+    }
+
     const signedSnapshot = JSON.stringify({
       lines: [{
         grossAmount: '-0.03',

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -14,6 +14,7 @@ const { orderRoutes } = require('../main/routes/orders');
 const { billRoutes, allocateTaxSnapshots } = require('../main/routes/bills');
 const { paymentMethodRoutes } = require('../main/routes/payment-methods');
 const { settingsRoutes } = require('../main/routes/settings');
+const { reportRoutes } = require('../main/routes/reports');
 const { resolveTaxComponents: resolveBackendTaxComponents } = require('../main/services/tax-components');
 const { resolveTaxComponents: resolveFrontendTaxComponents } = require('../frontend/src/lib/printer/tax-components');
 const { MIGRATIONS } = require('../main/db');
@@ -26,7 +27,7 @@ async function main() {
   seedCategory(db, 'split-cat', 'Split menu');
   seedProduct(db, 'split-coffee', 'split-cat', 'Coffee', 100);
   seedProduct(db, 'split-toast', 'split-cat', 'Toast', 90);
-  const app = createApp({ '/api/orders': orderRoutes, '/api/bills': billRoutes, '/api/payment-methods': paymentMethodRoutes, '/api/settings': settingsRoutes });
+  const app = createApp({ '/api/orders': orderRoutes, '/api/bills': billRoutes, '/api/payment-methods': paymentMethodRoutes, '/api/settings': settingsRoutes, '/api/reports': reportRoutes });
   const { baseUrl, server } = await startServer(app);
   try {
     assertEqual((db.prepare("SELECT value FROM settings WHERE key = 'split_checks_enabled'").get() as any).value, 'false', 'fresh database seeds split checks disabled');
@@ -107,12 +108,13 @@ async function main() {
       { label: 'Unpaid sibling', items: [{ order_item_id: paidSiblingItem.id, quantity: 1 }] },
     ] }, headers: authHeader });
     assertEqual(paidSiblingSplit.status, 201, 'paid-sibling mutation fixture splits successfully');
-    const paidSiblingPayment = await api(baseUrl, `/api/bills/${paidSiblingSplit.data.bills[0].id}/payments`, { method: 'POST', body: { payments: [{ method: 'cash', amount: paidSiblingSplit.data.bills[0].total }] }, headers: authHeader });
-    assertEqual(paidSiblingPayment.status, 200, 'paid-sibling mutation fixture pays one child');
+    const paidSiblingPayment = await api(baseUrl, `/api/bills/${paidSiblingSplit.data.bills[0].id}/payments`, { method: 'POST', body: { payments: [{ method: 'cash', amount: 10 }] }, headers: authHeader });
+    assertEqual(paidSiblingPayment.status, 200, 'partially-paid sibling mutation fixture accepts a payment');
+    assertEqual((db.prepare('SELECT payment_status FROM bills WHERE id = ?').get(paidSiblingSplit.data.bills[0].id) as any).payment_status, 'partial', 'partially-paid sibling remains marked partial');
     const paidSiblingCancel = await api(baseUrl, `/api/orders/${paidSiblingOrderRes.data.order.id}/items/${paidSiblingItem.id}/cancel`, { method: 'PATCH', headers: authHeader });
-    assertEqual(paidSiblingCancel.status, 409, 'cancelling an item with a paid split sibling is rejected');
-    assertEqual((db.prepare('SELECT status FROM order_items WHERE id = ?').get(paidSiblingItem.id) as any).status, 'pending', 'rejected paid-sibling cancellation leaves the item active');
-    assertEqual((db.prepare('SELECT COUNT(*) AS n FROM bills WHERE order_id = ? AND payment_status = \'unpaid\'').get(paidSiblingOrderRes.data.order.id) as any).n, 1, 'rejected paid-sibling cancellation leaves the unpaid child intact');
+    assertEqual(paidSiblingCancel.status, 409, 'cancelling an item with a partially-paid split sibling is rejected');
+    assertEqual((db.prepare('SELECT status FROM order_items WHERE id = ?').get(paidSiblingItem.id) as any).status, 'pending', 'rejected partial-paid cancellation leaves the item active');
+    assertEqual((db.prepare('SELECT COUNT(*) AS n FROM bills WHERE order_id = ? AND payment_status = \'unpaid\'').get(paidSiblingOrderRes.data.order.id) as any).n, 1, 'rejected partial-paid cancellation leaves the unpaid child intact');
 
     const addTarget = await api(baseUrl, '/api/payment-methods', { method: 'POST', body: { name: 'GPay' }, headers: authHeader });
     const merged = await api(baseUrl, `/api/payment-methods/${googlePayId}/merge`, { method: 'POST', body: { target_type: 'custom', target_id: addTarget.data.payment_method.id }, headers: authHeader });
@@ -307,16 +309,16 @@ async function main() {
 
     const partialLegacyOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }] }, headers: authHeader });
     const partialLegacyItem = partialLegacyOrderRes.data.order.items[0];
-    const partialLegacyBreakdown = JSON.stringify([[{ title: 'Legacy Tax', rate: 2, amount: 0.70 }]]);
-    const partialLegacyTotal = Number((partialLegacyOrderRes.data.order.subtotal + 0.70).toFixed(2));
+    const partialLegacyBreakdown = JSON.stringify([[{ title: 'Legacy Tax A', rate: 2, amount: 0.01 }, { title: 'Legacy Tax B', rate: 2, amount: 0.01 }]]);
+    const partialLegacyTotal = Number((partialLegacyOrderRes.data.order.subtotal + 0.02).toFixed(2));
     db.prepare('UPDATE order_items SET tax_amount = ?, tax_breakdown = ?, tax_snapshot = NULL, total = ? WHERE id = ?')
-      .run(0.70, partialLegacyBreakdown, partialLegacyTotal, partialLegacyItem.id);
+      .run(0.02, partialLegacyBreakdown, partialLegacyTotal, partialLegacyItem.id);
     db.prepare('UPDATE orders SET tax_amount = ?, tax_breakdown = ?, tax_snapshot = NULL, total = ? WHERE id = ?')
-      .run(0.70, partialLegacyBreakdown, partialLegacyTotal, partialLegacyOrderRes.data.order.id);
+      .run(0.02, partialLegacyBreakdown, partialLegacyTotal, partialLegacyOrderRes.data.order.id);
     const partialLegacyBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: partialLegacyOrderRes.data.order.id }, headers: authHeader });
     const partialLegacySnapshot = JSON.stringify({ lines: [{ components: [{ label: 'Categorized Tax', rate: '5', amount: '0.00' }] }] });
     db.prepare('UPDATE bills SET tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, total = ?, balance = ? WHERE id = ?')
-      .run(0.70, partialLegacyBreakdown, partialLegacySnapshot, partialLegacyTotal, partialLegacyTotal, partialLegacyBillRes.data.bill.id);
+      .run(0.02, partialLegacyBreakdown, partialLegacySnapshot, partialLegacyTotal, partialLegacyTotal, partialLegacyBillRes.data.bill.id);
     const partialLegacySplit = await api(baseUrl, `/api/bills/${partialLegacyBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
       { label: 'Partial legacy one', items: [{ order_item_id: partialLegacyItem.id, quantity: 1 }] },
       { label: 'Partial legacy two', items: [{ order_item_id: partialLegacyItem.id, quantity: 1 }] },
@@ -328,15 +330,14 @@ async function main() {
       const child = childRes.data.bill;
       const childItem = child.order.items[0];
       assertEqual(childItem.quantity, 1, 'partial-quantity child exposes only its billed quantity');
-      assertEqual(childItem.tax_breakdown[0][0].amount, 0.35, 'partial-quantity child scales nested legacy tax evidence');
+      assertEqual(Number(childItem.tax_breakdown[0].reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), 0.01, 'partial-quantity child scales nested legacy tax evidence to its tax target');
       const backendComponents = resolveBackendTaxComponents({ ...child, items: child.order.items });
       const frontendComponents = resolveFrontendTaxComponents(child);
-      const expectedLegacyComponents = [{ title: 'Legacy Tax', rate: 2, amount: 0.35 }];
-      assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedLegacyComponents), 'backend split resolver scopes legacy tax to the child quantity');
-      assertEqual(JSON.stringify(frontendComponents), JSON.stringify(expectedLegacyComponents), 'frontend split resolver scopes legacy tax to the child quantity');
+      assertEqual(JSON.stringify(backendComponents), JSON.stringify(frontendComponents), 'backend and frontend split resolvers agree for partial legacy tax');
+      assertEqual(Number(backendComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'partial legacy tax components reconcile to each child tax amount');
       partialLegacyTax = Number((partialLegacyTax + child.tax_amount).toFixed(2));
     }
-    assertEqual(partialLegacyTax, 0.70, 'partial-quantity legacy tax reconciles across children');
+    assertEqual(partialLegacyTax, 0.02, 'partial-quantity legacy tax reconciles across children');
 
     // I. Split Tax Snapshot Attribution (categorized item + configured charge)
     const splitTaxPack = {
@@ -473,6 +474,62 @@ async function main() {
     ];
     assertEqual(JSON.stringify(resolveBackendTaxComponents(mixedLegacyDocument)), JSON.stringify(mixedLegacyExpected), 'backend split resolver preserves legacy item tax beside marked snapshots');
     assertEqual(JSON.stringify(resolveFrontendTaxComponents(mixedLegacyDocument)), JSON.stringify(mixedLegacyExpected), 'frontend split resolver preserves legacy item tax beside marked snapshots');
+
+    seedProduct(db, 'split-mixed-legacy-item', 'split-tax-cat', 'Mixed Legacy Item', 20);
+    const mixedOrderRes = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'dine_in',
+        guest_count: 2,
+        items: [
+          { product_id: 'split-tax-item-a', quantity: 1 },
+          { product_id: 'split-mixed-legacy-item', quantity: 2 },
+        ],
+      },
+      headers: authHeader,
+    });
+    const mixedCategorizedItem = mixedOrderRes.data.order.items.find((item: any) => item.product_id === 'split-tax-item-a');
+    const mixedLegacyItem = mixedOrderRes.data.order.items.find((item: any) => item.product_id === 'split-mixed-legacy-item');
+    const mixedLegacyBreakdown = [{ title: 'Legacy Item Tax', rate: 2, amount: 0.50 }];
+    const mixedBreakdown = JSON.stringify([mixedCategorizedItem.tax_breakdown, mixedLegacyBreakdown]);
+    const mixedTotal = Number((mixedOrderRes.data.order.subtotal + 1.50).toFixed(2));
+    db.prepare('UPDATE order_items SET tax_amount = ?, tax_breakdown = ?, tax_snapshot = NULL, total = ? WHERE id = ?')
+      .run(0.50, JSON.stringify(mixedLegacyBreakdown), 40.50, mixedLegacyItem.id);
+    db.prepare('UPDATE orders SET tax_amount = ?, tax_breakdown = ?, total = ? WHERE id = ?')
+      .run(1.50, mixedBreakdown, mixedTotal, mixedOrderRes.data.order.id);
+    const mixedBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: mixedOrderRes.data.order.id }, headers: authHeader });
+    const reportDate = new Date().toISOString().slice(0, 10);
+    const mixedReportBefore = await api(baseUrl, `/api/reports/tax-components?start_date=${reportDate}&end_date=${reportDate}`, { headers: authHeader });
+    const mixedSplit = await api(baseUrl, `/api/bills/${mixedBillRes.data.bill.id}/split-check`, {
+      method: 'POST',
+      body: { checks: [
+        { label: 'Mixed owner one', items: [{ order_item_id: mixedCategorizedItem.id, quantity: 1 }, { order_item_id: mixedLegacyItem.id, quantity: 1 }] },
+        { label: 'Mixed owner two', items: [{ order_item_id: mixedLegacyItem.id, quantity: 1 }] },
+      ] },
+      headers: authHeader,
+    });
+    assertEqual(mixedSplit.status, 201, 'mixed snapshot and legacy tax split returns 201');
+    const mixedAggregate = new Map<string, number>();
+    for (const childBill of mixedSplit.data.bills) {
+      const childRes = await api(baseUrl, `/api/bills/${childBill.id}`, { headers: authHeader });
+      const child = childRes.data.bill;
+      const childItemIds = new Set(child.order.items.map((item: any) => Number(item.id)));
+      const expectedMixedComponents = childItemIds.has(Number(mixedCategorizedItem.id))
+        ? [{ title: 'Item Tax', rate: 5, amount: 1 }, { title: 'Legacy Item Tax', rate: 2, amount: 0.25 }]
+        : [{ title: 'Legacy Item Tax', rate: 2, amount: 0.25 }];
+      const backendComponents = resolveBackendTaxComponents({ ...child, items: child.order.items });
+      const frontendComponents = resolveFrontendTaxComponents(child);
+      assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedMixedComponents), 'mixed split backend resolver preserves item and legacy ownership');
+      assertEqual(JSON.stringify(frontendComponents), JSON.stringify(expectedMixedComponents), 'mixed split frontend resolver preserves item and legacy ownership');
+      assertEqual(Number(backendComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'mixed split tax components reconcile to each child tax amount');
+      for (const component of backendComponents) mixedAggregate.set(component.title, Number(((mixedAggregate.get(component.title) || 0) + component.amount).toFixed(2)));
+    }
+    assertEqual(mixedAggregate.get('Item Tax'), 1, 'mixed split item tax remains with its categorized owner');
+    assertEqual(mixedAggregate.get('Legacy Item Tax'), 0.50, 'mixed split legacy tax reconciles across item quantities');
+    assertEqual(Number(Array.from(mixedAggregate.values()).reduce((sum, amount) => sum + amount, 0).toFixed(2)), 1.50, 'mixed split tax categories reconcile to the source tax');
+    const mixedReportAfter = await api(baseUrl, `/api/reports/tax-components?start_date=${reportDate}&end_date=${reportDate}`, { headers: authHeader });
+    const reportAmount = (response: any, title: string) => Number((response.data.taxComponents.components.find((component: any) => component.title === title)?.amount || 0).toFixed(2));
+    assertEqual(reportAmount(mixedReportAfter, 'Legacy Item Tax'), reportAmount(mixedReportBefore, 'Legacy Item Tax'), 'tax component report keeps mixed legacy tax additive after splitting');
 
     const voidSnapshotOrderRes = await api(baseUrl, '/api/orders', {
       method: 'POST',

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -9,12 +9,15 @@ Module._load = function (request: string, parent: unknown, isMain: boolean) {
   return originalLoad.apply(this, arguments as any);
 };
 
-const { initTestDb, createApp, startServer, seedOwnerUser, seedManagerUser, seedCategory, seedProduct, api, assert, assertEqual, getResults, closeDatabase, now } = require('./helpers/test-setup');
+const { initTestDb, createApp, startServer, seedOwnerUser, seedManagerUser, seedCategory, seedProduct, installAndActivateTestTaxPack, api, assert, assertEqual, getResults, closeDatabase, now } = require('./helpers/test-setup');
 const { orderRoutes } = require('../main/routes/orders');
-const { billRoutes } = require('../main/routes/bills');
+const { billRoutes, allocateTaxSnapshots } = require('../main/routes/bills');
 const { paymentMethodRoutes } = require('../main/routes/payment-methods');
 const { settingsRoutes } = require('../main/routes/settings');
+const { resolveTaxComponents: resolveBackendTaxComponents } = require('../main/services/tax-components');
+const { resolveTaxComponents: resolveFrontendTaxComponents } = require('../frontend/src/lib/printer/tax-components');
 const { MIGRATIONS } = require('../main/db');
+const dualRatePackData = require('./fixtures/synthetic-dual-rate-pack.json');
 
 async function main() {
   const db = initTestDb();
@@ -286,6 +289,118 @@ async function main() {
       const compSum = Number(b.tax_breakdown.reduce((s: number, c: any) => s + Number(c.amount || 0), 0).toFixed(2));
       assertEqual(compSum, b.tax_amount, 'sum of flat component amounts equals bill tax_amount exactly');
     }
+
+    // I. Split Tax Snapshot Attribution (categorized item + configured charge)
+    const splitTaxPack = {
+      ...dualRatePackData,
+      id: 'test-split-tax-pack',
+      country: 'IN',
+      currency: 'INR',
+      categories: dualRatePackData.categories.map((category: any) => ({
+        ...category,
+        ruleIds: category.id === 'standard'
+          ? ['item-tax']
+          : category.id === 'packaging'
+            ? ['charge-tax']
+            : [],
+      })),
+      rules: [
+        { ...dualRatePackData.rules[0], id: 'item-tax', label: 'Item Tax', categoryIds: ['standard'], rate: '5' },
+        { ...dualRatePackData.rules[1], id: 'charge-tax', label: 'Charge Tax', categoryIds: ['packaging'], rate: '5' },
+      ],
+    };
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('country', 'IN', ?), ('business_type', 'restaurant', ?), ('state_code', '27', ?)")
+      .run(now(), now(), now());
+    installAndActivateTestTaxPack(db, splitTaxPack);
+    seedCategory(db, 'split-tax-cat', 'Split tax menu');
+    seedProduct(db, 'split-tax-item-a', 'split-tax-cat', 'Tax Item A', 20, { tax_category_id: 'standard', tax_behavior: 'exclusive' });
+    seedProduct(db, 'split-tax-item-b', 'split-tax-cat', 'Tax Item B', 20, { tax_category_id: 'standard', tax_behavior: 'exclusive' });
+    db.prepare(`
+      INSERT OR REPLACE INTO tax_overrides (
+        id, pack_version_id, entity_type, entity_id, field_name, value_json,
+        created_by_user_id, created_at, updated_at
+      ) VALUES (?, ?, 'packaging', NULL, 'tax_category_id', ?, NULL, ?, ?)
+    `).run(
+      'split-packaging-tax-override',
+      `${splitTaxPack.id}@${splitTaxPack.version}`,
+      JSON.stringify({ categoryId: 'packaging' }),
+      now(),
+      now(),
+    );
+
+    const snapshotOrderRes = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'dine_in',
+        guest_count: 2,
+        packaging_charge: 20,
+        items: [
+          { product_id: 'split-tax-item-a', quantity: 1 },
+          { product_id: 'split-tax-item-b', quantity: 1 },
+        ],
+      },
+      headers: authHeader,
+    });
+    assertEqual(snapshotOrderRes.status, 201, 'categorized items plus configured packaging charge order is created');
+    assertEqual(snapshotOrderRes.data.order.tax_amount, 3, 'source tax includes two item taxes and one packaging tax');
+    const snapshotBillRes = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: snapshotOrderRes.data.order.id },
+      headers: authHeader,
+    });
+    const snapshotItems = snapshotOrderRes.data.order.items;
+    const snapshotSplit = await api(baseUrl, `/api/bills/${snapshotBillRes.data.bill.id}/split-check`, {
+      method: 'POST',
+      body: { checks: [
+        { label: 'Snapshot Guest 1', items: [{ order_item_id: snapshotItems[0].id, quantity: 1 }] },
+        { label: 'Snapshot Guest 2', items: [{ order_item_id: snapshotItems[1].id, quantity: 1 }] },
+      ] },
+      headers: authHeader,
+    });
+    assertEqual(snapshotSplit.status, 201, 'snapshot-tax split returns 201');
+
+    const expectedSnapshotComponents = [
+      { title: 'Item Tax', rate: 5, amount: 1 },
+      { title: 'Charge Tax', rate: 5, amount: 0.5 },
+    ];
+    const aggregateSnapshotComponents = new Map<string, number>();
+    for (const splitBill of snapshotSplit.data.bills) {
+      const childRes = await api(baseUrl, `/api/bills/${splitBill.id}`, { headers: authHeader });
+      const child = childRes.data.bill;
+      const backendComponents = resolveBackendTaxComponents({
+        ...child,
+        items: child.order.items,
+      });
+      const frontendComponents = resolveFrontendTaxComponents(child);
+      assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedSnapshotComponents), 'backend thermal receipt tax components keep item and charge attribution per child');
+      assertEqual(JSON.stringify(frontendComponents), JSON.stringify(expectedSnapshotComponents), 'frontend receipt tax components keep item and charge attribution per child');
+      assertEqual(Number(backendComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'resolved child tax components reconcile to child tax_amount');
+      for (const component of backendComponents) {
+        aggregateSnapshotComponents.set(component.title, (aggregateSnapshotComponents.get(component.title) || 0) + component.amount);
+      }
+    }
+    assertEqual(aggregateSnapshotComponents.get('Item Tax'), 2, 'item tax components reconcile across split children');
+    assertEqual(aggregateSnapshotComponents.get('Charge Tax'), 1, 'configured charge tax components reconcile across split children');
+    assertEqual(
+      Number(Array.from(aggregateSnapshotComponents.values()).reduce((sum, amount) => sum + amount, 0).toFixed(2)),
+      snapshotOrderRes.data.order.tax_amount,
+      'aggregate resolved snapshot tax equals source order tax exactly',
+    );
+
+    const signedSnapshot = JSON.stringify({
+      lines: [{
+        grossAmount: '-0.03',
+        taxableBase: '-0.03',
+        taxAmount: '-0.03',
+        components: [{ label: 'Signed Adjustment', rate: '5', amount: '-0.03' }],
+      }],
+    });
+    const signedChildren = allocateTaxSnapshots(signedSnapshot, [1, 1]);
+    const signedAmounts = signedChildren.map((raw: string | null) => Number(
+      JSON.parse(raw as string).lines[0].components[0].amount,
+    ));
+    assertEqual(JSON.stringify(signedAmounts), JSON.stringify([-0.02, -0.01]), 'signed tax snapshot allocation keeps each child non-duplicated');
+    assertEqual(Number(signedAmounts.reduce((sum: number, amount: number) => sum + amount, 0).toFixed(2)), -0.03, 'signed tax snapshot allocations reconcile exactly to the source');
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
     closeDatabase();

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -396,13 +396,31 @@ async function main() {
         ],
       }],
     });
-    const unevenComponentChildren = allocateTaxSnapshots(unevenComponentSnapshot, [1, 2], [1, 1]);
+    const unevenComponentChildren = allocateTaxSnapshots(unevenComponentSnapshot, [1, 2]);
     const unevenComponentAmounts = unevenComponentChildren.map((raw: string | null) => {
       const snapshot = JSON.parse(raw as string);
       return snapshot.lines[0].components.map((component: any) => Number(component.amount));
     });
-    assertEqual(JSON.stringify(unevenComponentAmounts.map((components: number[]) => Number(components.reduce((sum, amount) => sum + amount, 0).toFixed(2)))), JSON.stringify([0.01, 0.01]), 'uneven split snapshot components reconcile to each child tax target');
+    assertEqual(JSON.stringify(unevenComponentAmounts.map((components: number[]) => Number(components.reduce((sum, amount) => sum + amount, 0).toFixed(2)))), JSON.stringify([0, 0.02]), 'uneven split snapshot components reconcile within their owner');
     assertEqual(JSON.stringify(unevenComponentAmounts.reduce((totals: number[], components: number[]) => components.map((amount, index) => Number((totals[index] + amount).toFixed(2))), [0, 0])), JSON.stringify([0.01, 0.01]), 'uneven split snapshot components remain additive across children');
+
+    const ownedSnapshots = JSON.stringify([
+      { lines: [{ grossAmount: '0.03', taxableBase: '0.03', taxAmount: '0.01', components: [{ label: 'Item A Tax', rate: '5', amount: '0.01' }] }] },
+      { lines: [{ grossAmount: '0.04', taxableBase: '0.04', taxAmount: '0.01', components: [{ label: 'Item B Tax', rate: '5', amount: '0.01' }] }] },
+    ]);
+    const ownedChildren = allocateTaxSnapshots(ownedSnapshots, [1, 2], [[1, 0], [0, 1]]);
+    const ownedValues = ownedChildren.map((raw: string | null) => {
+      const snapshots = JSON.parse(raw as string);
+      return snapshots.map((snapshot: any) => ({
+        grossAmount: Number(snapshot.lines[0].grossAmount),
+        taxAmount: Number(snapshot.lines[0].taxAmount),
+        componentAmount: Number(snapshot.lines[0].components[0].amount),
+      }));
+    });
+    assertEqual(JSON.stringify(ownedValues), JSON.stringify([
+      [{ grossAmount: 0.03, taxAmount: 0.01, componentAmount: 0.01 }, { grossAmount: 0, taxAmount: 0, componentAmount: 0 }],
+      [{ grossAmount: 0, taxAmount: 0, componentAmount: 0 }, { grossAmount: 0.04, taxAmount: 0.01, componentAmount: 0.01 }],
+    ]), 'snapshot allocations preserve item ownership for tax and line bases');
 
     const cancelledSnapshotItem = snapshotItems[0];
     const cancelSnapshotRes = await api(baseUrl, `/api/orders/${snapshotOrderRes.data.order.id}/items/${cancelledSnapshotItem.id}/cancel`, {

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -359,6 +359,24 @@ async function main() {
     });
     assertEqual(snapshotSplit.status, 201, 'snapshot-tax split returns 201');
 
+    const splitDiscountSnapshot = db.prepare('SELECT tax_snapshot FROM bills WHERE id = ?').get(snapshotSplit.data.bills[0].id) as any;
+    const splitDiscountRes = await api(baseUrl, `/api/bills/${snapshotSplit.data.bills[0].id}/applyDiscount`, {
+      method: 'POST',
+      body: { type: 'percentage', value: 10 },
+      headers: authHeader,
+    });
+    assertEqual(splitDiscountRes.status, 409, 'discounting a split child is rejected before overwriting its tax snapshot');
+    const preservedDiscountBill = db.prepare('SELECT * FROM bills WHERE id = ?').get(snapshotSplit.data.bills[0].id) as any;
+    assertEqual(preservedDiscountBill.tax_snapshot, splitDiscountSnapshot.tax_snapshot, 'rejected split-child discount preserves the marked tax snapshot');
+    const preservedDiscountComponents = resolveBackendTaxComponents({
+      ...preservedDiscountBill,
+      tax_breakdown: JSON.parse(preservedDiscountBill.tax_breakdown),
+      tax_snapshot: preservedDiscountBill.tax_snapshot,
+      items: snapshotItems,
+    });
+    assertEqual(JSON.stringify(preservedDiscountComponents.map((component: any) => component.title)), JSON.stringify(['Item Tax', 'Charge Tax']), 'rejected split-child discount preserves tax attribution');
+    assertEqual(Number(preservedDiscountComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), preservedDiscountBill.tax_amount, 'preserved split-child discount snapshot still reconciles to tax_amount');
+
     const expectedSnapshotComponents = [
       { title: 'Item Tax', rate: 5, amount: 1 },
       { title: 'Charge Tax', rate: 5, amount: 0.5 },
@@ -386,6 +404,65 @@ async function main() {
       snapshotOrderRes.data.order.tax_amount,
       'aggregate resolved snapshot tax equals source order tax exactly',
     );
+
+    const voidSnapshotOrderRes = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'dine_in',
+        guest_count: 2,
+        packaging_charge: 20,
+        items: [
+          { product_id: 'split-tax-item-a', quantity: 1 },
+          { product_id: 'split-tax-item-b', quantity: 1 },
+        ],
+      },
+      headers: authHeader,
+    });
+    const voidSnapshotItems = voidSnapshotOrderRes.data.order.items;
+    const voidSnapshotBillRes = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: voidSnapshotOrderRes.data.order.id },
+      headers: authHeader,
+    });
+    const voidSnapshotSplit = await api(baseUrl, `/api/bills/${voidSnapshotBillRes.data.bill.id}/split-check`, {
+      method: 'POST',
+      body: { checks: [
+        { label: 'Void Snapshot Guest 1', items: [{ order_item_id: voidSnapshotItems[0].id, quantity: 1 }] },
+        { label: 'Void Snapshot Guest 2', items: [{ order_item_id: voidSnapshotItems[1].id, quantity: 1 }] },
+      ] },
+      headers: authHeader,
+    });
+    assertEqual(voidSnapshotSplit.status, 201, 'snapshot-tax split for void regression returns 201');
+    const voidTargetItem = voidSnapshotItems.find((item: any) => item.product_id === 'split-tax-item-a');
+    const voidSurvivingItem = voidSnapshotItems.find((item: any) => item.product_id === 'split-tax-item-b');
+    const voidPrepareRes = await api(baseUrl, `/api/order-items/${voidTargetItem.id}/status`, {
+      method: 'PATCH',
+      body: { status: 'preparing' },
+      headers: authHeader,
+    });
+    assertEqual(voidPrepareRes.status, 200, 'snapshot item moves to preparing before the void regression');
+    const voidSnapshotCancelRes = await api(baseUrl, `/api/orders/${voidSnapshotOrderRes.data.order.id}/items/${voidTargetItem.id}/cancel`, {
+      method: 'PATCH',
+      body: { override_pin: '1234' },
+      headers: mgrUser.authHeader,
+    });
+    assertEqual(voidSnapshotCancelRes.status, 200, 'voiding a split snapshot item keeps the mutation supported');
+    const voidSnapshotBills = db.prepare('SELECT * FROM bills WHERE order_id = ? ORDER BY id').all(voidSnapshotOrderRes.data.order.id) as any[];
+    let voidResolvedTax = 0;
+    for (const childBill of voidSnapshotBills) {
+      const childRes = await api(baseUrl, `/api/bills/${childBill.id}`, { headers: authHeader });
+      const child = childRes.data.bill;
+      const components = resolveBackendTaxComponents({ ...child, items: child.order.items });
+      const billItems = db.prepare('SELECT order_item_id FROM bill_items WHERE bill_id = ?').all(child.id) as any[];
+      const ownsSurvivingItem = billItems.some((item: any) => Number(item.order_item_id) === Number(voidSurvivingItem.id));
+      const expectedAmounts = ownsSurvivingItem ? [1, 1] : [0, 0];
+      assertEqual(JSON.stringify(components.map((component: any) => component.title)), JSON.stringify(['Item Tax', 'Charge Tax']), 'voided split child keeps item and charge tax categories');
+      assertEqual(JSON.stringify(components.map((component: any) => component.amount)), JSON.stringify(expectedAmounts), 'void evidence is not allocated to the sibling child');
+      assertEqual(Number(components.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'voided split child tax components reconcile exactly');
+      assert(child.tax_snapshot && JSON.parse(child.tax_snapshot).some((snapshot: any) => snapshot && snapshot.splitAllocation === 'minor-unit-v1'), 'void sync preserves marked child tax snapshots');
+      voidResolvedTax = Number((voidResolvedTax + child.tax_amount).toFixed(2));
+    }
+    assertEqual(voidResolvedTax, voidSnapshotCancelRes.data.order.tax_amount, 'voided split child tax totals reconcile to the updated order');
 
     const unevenComponentSnapshot = JSON.stringify({
       lines: [{

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -99,6 +99,21 @@ async function main() {
     assertEqual(secondPay.status, 200, 'second guest check paid with custom method');
     assertEqual((db.prepare('SELECT status FROM orders WHERE id = ?').get(order.id) as any).status, 'completed', 'order completes only after every check is paid');
 
+    const paidSiblingOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }] }, headers: authHeader });
+    const paidSiblingItem = paidSiblingOrderRes.data.order.items[0];
+    const paidSiblingBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: paidSiblingOrderRes.data.order.id }, headers: authHeader });
+    const paidSiblingSplit = await api(baseUrl, `/api/bills/${paidSiblingBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
+      { label: 'Paid sibling', items: [{ order_item_id: paidSiblingItem.id, quantity: 1 }] },
+      { label: 'Unpaid sibling', items: [{ order_item_id: paidSiblingItem.id, quantity: 1 }] },
+    ] }, headers: authHeader });
+    assertEqual(paidSiblingSplit.status, 201, 'paid-sibling mutation fixture splits successfully');
+    const paidSiblingPayment = await api(baseUrl, `/api/bills/${paidSiblingSplit.data.bills[0].id}/payments`, { method: 'POST', body: { payments: [{ method: 'cash', amount: paidSiblingSplit.data.bills[0].total }] }, headers: authHeader });
+    assertEqual(paidSiblingPayment.status, 200, 'paid-sibling mutation fixture pays one child');
+    const paidSiblingCancel = await api(baseUrl, `/api/orders/${paidSiblingOrderRes.data.order.id}/items/${paidSiblingItem.id}/cancel`, { method: 'PATCH', headers: authHeader });
+    assertEqual(paidSiblingCancel.status, 409, 'cancelling an item with a paid split sibling is rejected');
+    assertEqual((db.prepare('SELECT status FROM order_items WHERE id = ?').get(paidSiblingItem.id) as any).status, 'pending', 'rejected paid-sibling cancellation leaves the item active');
+    assertEqual((db.prepare('SELECT COUNT(*) AS n FROM bills WHERE order_id = ? AND payment_status = \'unpaid\'').get(paidSiblingOrderRes.data.order.id) as any).n, 1, 'rejected paid-sibling cancellation leaves the unpaid child intact');
+
     const addTarget = await api(baseUrl, '/api/payment-methods', { method: 'POST', body: { name: 'GPay' }, headers: authHeader });
     const merged = await api(baseUrl, `/api/payment-methods/${googlePayId}/merge`, { method: 'POST', body: { target_type: 'custom', target_id: addTarget.data.payment_method.id }, headers: authHeader });
     assertEqual(merged.status, 200, 'used custom method merged');
@@ -289,6 +304,39 @@ async function main() {
       const compSum = Number(b.tax_breakdown.reduce((s: number, c: any) => s + Number(c.amount || 0), 0).toFixed(2));
       assertEqual(compSum, b.tax_amount, 'sum of flat component amounts equals bill tax_amount exactly');
     }
+
+    const partialLegacyOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }] }, headers: authHeader });
+    const partialLegacyItem = partialLegacyOrderRes.data.order.items[0];
+    const partialLegacyBreakdown = JSON.stringify([[{ title: 'Legacy Tax', rate: 2, amount: 0.70 }]]);
+    const partialLegacyTotal = Number((partialLegacyOrderRes.data.order.subtotal + 0.70).toFixed(2));
+    db.prepare('UPDATE order_items SET tax_amount = ?, tax_breakdown = ?, tax_snapshot = NULL, total = ? WHERE id = ?')
+      .run(0.70, partialLegacyBreakdown, partialLegacyTotal, partialLegacyItem.id);
+    db.prepare('UPDATE orders SET tax_amount = ?, tax_breakdown = ?, tax_snapshot = NULL, total = ? WHERE id = ?')
+      .run(0.70, partialLegacyBreakdown, partialLegacyTotal, partialLegacyOrderRes.data.order.id);
+    const partialLegacyBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: partialLegacyOrderRes.data.order.id }, headers: authHeader });
+    const partialLegacySnapshot = JSON.stringify({ lines: [{ components: [{ label: 'Categorized Tax', rate: '5', amount: '0.00' }] }] });
+    db.prepare('UPDATE bills SET tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, total = ?, balance = ? WHERE id = ?')
+      .run(0.70, partialLegacyBreakdown, partialLegacySnapshot, partialLegacyTotal, partialLegacyTotal, partialLegacyBillRes.data.bill.id);
+    const partialLegacySplit = await api(baseUrl, `/api/bills/${partialLegacyBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
+      { label: 'Partial legacy one', items: [{ order_item_id: partialLegacyItem.id, quantity: 1 }] },
+      { label: 'Partial legacy two', items: [{ order_item_id: partialLegacyItem.id, quantity: 1 }] },
+    ] }, headers: authHeader });
+    assertEqual(partialLegacySplit.status, 201, 'partial-quantity legacy tax split returns 201');
+    let partialLegacyTax = 0;
+    for (const childBill of partialLegacySplit.data.bills) {
+      const childRes = await api(baseUrl, `/api/bills/${childBill.id}`, { headers: authHeader });
+      const child = childRes.data.bill;
+      const childItem = child.order.items[0];
+      assertEqual(childItem.quantity, 1, 'partial-quantity child exposes only its billed quantity');
+      assertEqual(childItem.tax_breakdown[0][0].amount, 0.35, 'partial-quantity child scales nested legacy tax evidence');
+      const backendComponents = resolveBackendTaxComponents({ ...child, items: child.order.items });
+      const frontendComponents = resolveFrontendTaxComponents(child);
+      const expectedLegacyComponents = [{ title: 'Legacy Tax', rate: 2, amount: 0.35 }];
+      assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedLegacyComponents), 'backend split resolver scopes legacy tax to the child quantity');
+      assertEqual(JSON.stringify(frontendComponents), JSON.stringify(expectedLegacyComponents), 'frontend split resolver scopes legacy tax to the child quantity');
+      partialLegacyTax = Number((partialLegacyTax + child.tax_amount).toFixed(2));
+    }
+    assertEqual(partialLegacyTax, 0.70, 'partial-quantity legacy tax reconciles across children');
 
     // I. Split Tax Snapshot Attribution (categorized item + configured charge)
     const splitTaxPack = {

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -498,6 +498,13 @@ async function main() {
     db.prepare('UPDATE orders SET tax_amount = ?, tax_breakdown = ?, total = ? WHERE id = ?')
       .run(1.50, mixedBreakdown, mixedTotal, mixedOrderRes.data.order.id);
     const mixedBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: mixedOrderRes.data.order.id }, headers: authHeader });
+    const mixedDiscountRes = await api(baseUrl, `/api/bills/${mixedBillRes.data.bill.id}/applyDiscount`, {
+      method: 'POST',
+      body: { type: 'percentage', value: 20 },
+      headers: authHeader,
+    });
+    assertEqual(mixedDiscountRes.status, 200, 'discounting an unsplit mixed-tax bill succeeds');
+    assertEqual(mixedDiscountRes.data.bill.tax_amount, 1.2, 'discount scales mixed snapshot and legacy tax together');
     const reportDate = new Date().toISOString().slice(0, 10);
     const mixedReportBefore = await api(baseUrl, `/api/reports/tax-components?start_date=${reportDate}&end_date=${reportDate}`, { headers: authHeader });
     const mixedSplit = await api(baseUrl, `/api/bills/${mixedBillRes.data.bill.id}/split-check`, {
@@ -515,8 +522,8 @@ async function main() {
       const child = childRes.data.bill;
       const childItemIds = new Set(child.order.items.map((item: any) => Number(item.id)));
       const expectedMixedComponents = childItemIds.has(Number(mixedCategorizedItem.id))
-        ? [{ title: 'Item Tax', rate: 5, amount: 1 }, { title: 'Legacy Item Tax', rate: 2, amount: 0.25 }]
-        : [{ title: 'Legacy Item Tax', rate: 2, amount: 0.25 }];
+        ? [{ title: 'Item Tax', rate: 5, amount: 0.8 }, { title: 'Legacy Item Tax', rate: 2, amount: 0.2 }]
+        : [{ title: 'Legacy Item Tax', rate: 2, amount: 0.2 }];
       const backendComponents = resolveBackendTaxComponents({ ...child, items: child.order.items });
       const frontendComponents = resolveFrontendTaxComponents(child);
       assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedMixedComponents), 'mixed split backend resolver preserves item and legacy ownership');
@@ -524,9 +531,9 @@ async function main() {
       assertEqual(Number(backendComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'mixed split tax components reconcile to each child tax amount');
       for (const component of backendComponents) mixedAggregate.set(component.title, Number(((mixedAggregate.get(component.title) || 0) + component.amount).toFixed(2)));
     }
-    assertEqual(mixedAggregate.get('Item Tax'), 1, 'mixed split item tax remains with its categorized owner');
-    assertEqual(mixedAggregate.get('Legacy Item Tax'), 0.50, 'mixed split legacy tax reconciles across item quantities');
-    assertEqual(Number(Array.from(mixedAggregate.values()).reduce((sum, amount) => sum + amount, 0).toFixed(2)), 1.50, 'mixed split tax categories reconcile to the source tax');
+    assertEqual(mixedAggregate.get('Item Tax'), 0.8, 'mixed split item tax remains with its categorized owner after discount');
+    assertEqual(mixedAggregate.get('Legacy Item Tax'), 0.4, 'mixed split legacy tax remains scaled across item quantities');
+    assertEqual(Number(Array.from(mixedAggregate.values()).reduce((sum, amount) => sum + amount, 0).toFixed(2)), 1.2, 'mixed split tax categories reconcile to the discounted source tax');
     const mixedReportAfter = await api(baseUrl, `/api/reports/tax-components?start_date=${reportDate}&end_date=${reportDate}`, { headers: authHeader });
     const reportAmount = (response: any, title: string) => Number((response.data.taxComponents.components.find((component: any) => component.title === title)?.amount || 0).toFixed(2));
     assertEqual(reportAmount(mixedReportAfter, 'Legacy Item Tax'), reportAmount(mixedReportBefore, 'Legacy Item Tax'), 'tax component report keeps mixed legacy tax additive after splitting');

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -524,6 +524,12 @@ async function main() {
       const expectedMixedComponents = childItemIds.has(Number(mixedCategorizedItem.id))
         ? [{ title: 'Item Tax', rate: 5, amount: 0.8 }, { title: 'Legacy Item Tax', rate: 2, amount: 0.2 }]
         : [{ title: 'Legacy Item Tax', rate: 2, amount: 0.2 }];
+      const persistedBreakdown = (child.tax_breakdown || []).map((component: any) => ({
+        title: component.title,
+        rate: component.rate,
+        amount: Number(Number(component.amount || 0).toFixed(2)),
+      }));
+      assertEqual(JSON.stringify(persistedBreakdown), JSON.stringify(expectedMixedComponents), 'persisted child breakdown preserves mixed item and legacy ownership');
       const backendComponents = resolveBackendTaxComponents({ ...child, items: child.order.items });
       const frontendComponents = resolveFrontendTaxComponents(child);
       assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedMixedComponents), 'mixed split backend resolver preserves item and legacy ownership');
@@ -537,6 +543,111 @@ async function main() {
     const mixedReportAfter = await api(baseUrl, `/api/reports/tax-components?start_date=${reportDate}&end_date=${reportDate}`, { headers: authHeader });
     const reportAmount = (response: any, title: string) => Number((response.data.taxComponents.components.find((component: any) => component.title === title)?.amount || 0).toFixed(2));
     assertEqual(reportAmount(mixedReportAfter, 'Legacy Item Tax'), reportAmount(mixedReportBefore, 'Legacy Item Tax'), 'tax component report keeps mixed legacy tax additive after splitting');
+
+    seedProduct(db, 'split-rounding-legacy-item', 'split-tax-cat', 'Rounding Legacy Item', 40);
+    const roundingOrderRes = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'dine_in',
+        guest_count: 2,
+        items: [
+          { product_id: 'split-mixed-legacy-item', quantity: 1 },
+          { product_id: 'split-rounding-legacy-item', quantity: 1 },
+        ],
+      },
+      headers: authHeader,
+    });
+    const roundingItems = roundingOrderRes.data.order.items;
+    const roundingBreakdown = [{ title: 'Rounded Legacy Tax', rate: 2, amount: 0.01 }];
+    for (const item of roundingItems) {
+      db.prepare('UPDATE order_items SET tax_amount = 0.01, tax_breakdown = ?, tax_snapshot = NULL, total = subtotal + 0.01 WHERE id = ?')
+        .run(JSON.stringify(roundingBreakdown), item.id);
+    }
+    const roundingTotal = Number((roundingOrderRes.data.order.subtotal + 0.02).toFixed(2));
+    db.prepare('UPDATE orders SET tax_amount = 0.02, tax_breakdown = ?, tax_snapshot = NULL, total = ? WHERE id = ?')
+      .run(JSON.stringify([roundingBreakdown, roundingBreakdown]), roundingTotal, roundingOrderRes.data.order.id);
+    const roundingBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: roundingOrderRes.data.order.id }, headers: authHeader });
+    const maxDiscount = db.prepare("SELECT value FROM settings WHERE key = 'discount_max_percentage'").get() as any;
+    db.prepare("UPDATE settings SET value = '100' WHERE key = 'discount_max_percentage'").run();
+    const roundingDiscountRes = await api(baseUrl, `/api/bills/${roundingBillRes.data.bill.id}/applyDiscount`, {
+      method: 'POST',
+      body: { type: 'percentage', value: 66.67 },
+      headers: authHeader,
+    });
+    if (maxDiscount) db.prepare("UPDATE settings SET value = ? WHERE key = 'discount_max_percentage'").run(maxDiscount.value);
+    assertEqual(roundingDiscountRes.status, 200, 'discounted sub-cent legacy tax remains split-compatible');
+    assertEqual(roundingDiscountRes.data.bill.tax_amount, 0.01, 'discounted sub-cent legacy tax keeps the aggregate source cent');
+    const roundingSplit = await api(baseUrl, `/api/bills/${roundingBillRes.data.bill.id}/split-check`, {
+      method: 'POST',
+      body: { checks: [
+        { label: 'Rounding owner one', items: [{ order_item_id: roundingItems[0].id, quantity: 1 }] },
+        { label: 'Rounding owner two', items: [{ order_item_id: roundingItems[1].id, quantity: 1 }] },
+      ] },
+      headers: authHeader,
+    });
+    assertEqual(roundingSplit.status, 201, 'discounted sub-cent legacy split returns 201');
+    for (const childBill of roundingSplit.data.bills) {
+      const childRes = await api(baseUrl, `/api/bills/${childBill.id}`, { headers: authHeader });
+      const child = childRes.data.bill;
+      const ownsFirstItem = child.order.items.some((item: any) => Number(item.id) === Number(roundingItems[0].id));
+      const expectedRounding = ownsFirstItem ? [{ title: 'Rounded Legacy Tax', rate: 2, amount: 0.01 }] : [];
+      const components = resolveBackendTaxComponents({ ...child, items: child.order.items });
+      assertEqual(JSON.stringify(components), JSON.stringify(expectedRounding), 'discounted sub-cent legacy tax stays with its owning child');
+      assertEqual(Number(components.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'discounted sub-cent legacy components reconcile exactly');
+    }
+
+    const voidLegacyOrderRes = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'dine_in',
+        guest_count: 2,
+        items: [
+          { product_id: 'split-mixed-legacy-item', quantity: 1 },
+          { product_id: 'split-rounding-legacy-item', quantity: 1 },
+        ],
+      },
+      headers: authHeader,
+    });
+    const voidLegacyItems = voidLegacyOrderRes.data.order.items;
+    const voidLegacyBreakdown = [{ title: 'Void Legacy Tax', rate: 2, amount: 0.01 }];
+    for (const item of voidLegacyItems) {
+      db.prepare('UPDATE order_items SET tax_amount = 0.01, tax_breakdown = ?, tax_snapshot = NULL, total = subtotal + 0.01 WHERE id = ?')
+        .run(JSON.stringify(voidLegacyBreakdown), item.id);
+    }
+    const voidLegacyTotal = Number((voidLegacyOrderRes.data.order.subtotal + 0.02).toFixed(2));
+    db.prepare('UPDATE orders SET tax_amount = 0.02, tax_breakdown = ?, tax_snapshot = NULL, total = ? WHERE id = ?')
+      .run(JSON.stringify([voidLegacyBreakdown, voidLegacyBreakdown]), voidLegacyTotal, voidLegacyOrderRes.data.order.id);
+    const voidLegacyBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: voidLegacyOrderRes.data.order.id }, headers: authHeader });
+    const voidLegacySplit = await api(baseUrl, `/api/bills/${voidLegacyBillRes.data.bill.id}/split-check`, {
+      method: 'POST',
+      body: { checks: [
+        { label: 'Void legacy owner one', items: [{ order_item_id: voidLegacyItems[0].id, quantity: 1 }] },
+        { label: 'Void legacy owner two', items: [{ order_item_id: voidLegacyItems[1].id, quantity: 1 }] },
+      ] },
+      headers: authHeader,
+    });
+    assertEqual(voidLegacySplit.status, 201, 'legacy tax split for void ownership returns 201');
+    const voidLegacyPrepare = await api(baseUrl, `/api/order-items/${voidLegacyItems[0].id}/status`, {
+      method: 'PATCH',
+      body: { status: 'preparing' },
+      headers: authHeader,
+    });
+    assertEqual(voidLegacyPrepare.status, 200, 'legacy tax item can enter preparing before void');
+    const voidLegacyCancel = await api(baseUrl, `/api/orders/${voidLegacyOrderRes.data.order.id}/items/${voidLegacyItems[0].id}/cancel`, {
+      method: 'PATCH',
+      body: { override_pin: '1234' },
+      headers: mgrUser.authHeader,
+    });
+    assertEqual(voidLegacyCancel.status, 200, 'voiding legacy tax item remains supported after splitting');
+    for (const childBill of db.prepare('SELECT * FROM bills WHERE order_id = ? ORDER BY id').all(voidLegacyOrderRes.data.order.id) as any[]) {
+      const childRes = await api(baseUrl, `/api/bills/${childBill.id}`, { headers: authHeader });
+      const child = childRes.data.bill;
+      const ownsSurviving = child.order.items.some((item: any) => Number(item.id) === Number(voidLegacyItems[1].id));
+      const expectedVoidLegacy = ownsSurviving ? [{ title: 'Void Legacy Tax', rate: 2, amount: 0.01 }] : [];
+      const components = resolveBackendTaxComponents({ ...child, items: child.order.items });
+      assertEqual(JSON.stringify(components), JSON.stringify(expectedVoidLegacy), 'void adjustment legacy tax stays with its original owner');
+      assertEqual(Number(components.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'void adjustment legacy components reconcile exactly');
+    }
 
     const voidSnapshotOrderRes = await api(baseUrl, '/api/orders', {
       method: 'POST',

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -29,6 +29,8 @@ async function main() {
   seedProduct(db, 'split-coffee', 'split-cat', 'Coffee', 100);
   seedProduct(db, 'split-toast', 'split-cat', 'Toast', 90);
   const app = createApp({ '/api/orders': orderRoutes, '/api/bills': billRoutes, '/api/payment-methods': paymentMethodRoutes, '/api/settings': settingsRoutes, '/api/reports': reportRoutes });
+  const { registerRoutes } = require('../main/routes/index');
+  registerRoutes(app);
   const { baseUrl, server } = await startServer(app);
   try {
     assertEqual((db.prepare("SELECT value FROM settings WHERE key = 'split_checks_enabled'").get() as any).value, 'false', 'fresh database seeds split checks disabled');
@@ -175,8 +177,6 @@ async function main() {
     assertEqual(unevenSum, 10.01, 'unequal split totals reconcile exactly to $10.01');
 
     // D. Void Adjustment Exclusion
-    const { registerRoutes } = require('../main/routes/index');
-    registerRoutes(app);
     db.prepare("INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('kds_enabled', 'true', datetime('now'))").run();
     const mgrUser = seedManagerUser(db);
     const voidOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }, { product_id: 'split-toast', quantity: 1 }] }, headers: authHeader });
@@ -639,10 +639,10 @@ async function main() {
     assertEqual(ownerLocalSplit.status, 201, 'nested owner-local legacy split returns 201');
     assertEqual(JSON.stringify(ownerLocalSplit.data.bills.map((bill: any) => bill.tax_amount)), JSON.stringify([0, 0.02]), 'child tax totals use the same owner-local rounding as nested legacy evidence');
     for (const [index, childBill] of ownerLocalSplit.data.bills.entries()) {
-      const breakdown = childBill.tax_breakdown as Array<Array<{ title: string; rate: number; amount: number }>>;
-      const breakdownTotal = Number(breakdown.flat().reduce((sum, component) => sum + component.amount, 0).toFixed(2));
+      const breakdown = childBill.tax_breakdown as Array<{ title: string; rate: number; amount: number }>;
+      const breakdownTotal = Number(breakdown.reduce((sum, component) => sum + component.amount, 0).toFixed(2));
       assertEqual(breakdownTotal, childBill.tax_amount, 'nested owner-local breakdown reconciles to its child tax total');
-      assertEqual(JSON.stringify(breakdown.map((group) => group.map((component) => component.amount))), JSON.stringify(index === 0 ? [[0], [0]] : [[0.01], [0.01]]), 'nested legacy component cents remain with their owner allocation');
+      assertEqual(JSON.stringify(breakdown.map((component) => component.amount)), JSON.stringify(index === 0 ? [] : [0.01, 0.01]), 'nested legacy component cents remain with their owner allocation');
     }
 
     const voidLegacyOrderRes = await api(baseUrl, '/api/orders', {
@@ -752,7 +752,8 @@ async function main() {
       assertEqual(JSON.stringify(components.map((component: any) => component.title)), JSON.stringify(['Item Tax', 'Charge Tax']), 'voided split child keeps item and charge tax categories');
       assertEqual(JSON.stringify(components.map((component: any) => component.amount)), JSON.stringify(expectedAmounts), 'void evidence is not allocated to the sibling child');
       assertEqual(Number(components.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'voided split child tax components reconcile exactly');
-      assert(child.tax_snapshot && JSON.parse(child.tax_snapshot).some((snapshot: any) => snapshot && snapshot.splitAllocation === 'minor-unit-v1'), 'void sync preserves marked child tax snapshots');
+      const voidChildSnapshots = typeof child.tax_snapshot === 'string' ? JSON.parse(child.tax_snapshot) : child.tax_snapshot;
+      assert(child.tax_snapshot && voidChildSnapshots.some((snapshot: any) => snapshot && snapshot.splitAllocation === 'minor-unit-v1'), 'void sync preserves marked child tax snapshots');
       voidResolvedTax = Number((voidResolvedTax + child.tax_amount).toFixed(2));
     }
     assertEqual(voidResolvedTax, voidSnapshotCancelRes.data.order.tax_amount, 'voided split child tax totals reconcile to the updated order');
@@ -771,7 +772,7 @@ async function main() {
       const snapshot = JSON.parse(raw as string);
       return snapshot.lines[0].components.map((component: any) => Number(component.amount));
     });
-    assertEqual(JSON.stringify(unevenComponentAmounts.map((components: number[]) => Number(components.reduce((sum, amount) => sum + amount, 0).toFixed(2)))), JSON.stringify([0, 0.02]), 'uneven split snapshot components reconcile within their owner');
+    assertEqual(JSON.stringify(unevenComponentAmounts.map((components: number[]) => Number(components.reduce((sum, amount) => sum + amount, 0).toFixed(2)))), JSON.stringify([0.01, 0.01]), 'uneven split snapshot components reconcile within their owner');
     assertEqual(JSON.stringify(unevenComponentAmounts.reduce((totals: number[], components: number[]) => components.map((amount, index) => Number((totals[index] + amount).toFixed(2))), [0, 0])), JSON.stringify([0.01, 0.01]), 'uneven split snapshot components remain additive across children');
 
     const ownedSnapshots = JSON.stringify([
@@ -812,7 +813,8 @@ async function main() {
         : [{ title: 'Item Tax', rate: 5, amount: 0 }, { title: 'Charge Tax', rate: 5, amount: 0 }];
       assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedCancelledComponents), 'cancel sync preserves exact item and charge tax attribution');
       assertEqual(JSON.stringify(frontendComponents), JSON.stringify(expectedCancelledComponents), 'cancel sync preserves exact frontend item and charge tax attribution');
-      assert(child.tax_snapshot && JSON.parse(child.tax_snapshot).some((snapshot: any) => snapshot.splitAllocation === 'minor-unit-v1'), 'cancel sync preserves marked child tax snapshots');
+      const cancelledChildSnapshots = typeof child.tax_snapshot === 'string' ? JSON.parse(child.tax_snapshot) : child.tax_snapshot;
+      assert(child.tax_snapshot && cancelledChildSnapshots.some((snapshot: any) => snapshot.splitAllocation === 'minor-unit-v1'), 'cancel sync preserves marked child tax snapshots');
       assertEqual(JSON.stringify(backendComponents), JSON.stringify(frontendComponents), 'cancel sync keeps backend and frontend tax attribution aligned');
       assertEqual(Number(backendComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'cancel sync resolved tax reconciles to each child tax amount');
       for (const component of backendComponents) {

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -597,6 +597,54 @@ async function main() {
       assertEqual(Number(components.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'discounted sub-cent legacy components reconcile exactly');
     }
 
+    seedProduct(db, 'split-owner-local-tax-a', 'split-tax-cat', 'Owner Local Tax A', 1);
+    seedProduct(db, 'split-owner-local-tax-b', 'split-tax-cat', 'Owner Local Tax B', 1);
+    const ownerLocalOrderRes = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'dine_in',
+        guest_count: 2,
+        items: [
+          { product_id: 'split-owner-local-tax-a', quantity: 3 },
+          { product_id: 'split-owner-local-tax-b', quantity: 3 },
+        ],
+      },
+      headers: authHeader,
+    });
+    const ownerLocalItems = ownerLocalOrderRes.data.order.items;
+    const ownerLocalBreakdowns = ownerLocalItems.map((_: any, index: number) => ([{
+      title: `Owner Local Tax ${index + 1}`,
+      rate: 2,
+      amount: 0.01,
+    }]));
+    ownerLocalItems.forEach((item: any, index: number) => {
+      db.prepare('UPDATE order_items SET tax_amount = ?, tax_breakdown = ?, tax_snapshot = NULL, total = ? WHERE id = ?')
+        .run(0.01, JSON.stringify(ownerLocalBreakdowns[index]), 3.01, item.id);
+    });
+    db.prepare('UPDATE orders SET tax_amount = ?, tax_breakdown = ?, tax_snapshot = NULL, total = ? WHERE id = ?')
+      .run(0.02, JSON.stringify(ownerLocalBreakdowns), 6.02, ownerLocalOrderRes.data.order.id);
+    const ownerLocalBillRes = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: ownerLocalOrderRes.data.order.id },
+      headers: authHeader,
+    });
+    const ownerLocalSplit = await api(baseUrl, `/api/bills/${ownerLocalBillRes.data.bill.id}/split-check`, {
+      method: 'POST',
+      body: { checks: [
+        { label: 'Owner local one', items: ownerLocalItems.map((item: any) => ({ order_item_id: item.id, quantity: 1 })) },
+        { label: 'Owner local two', items: ownerLocalItems.map((item: any) => ({ order_item_id: item.id, quantity: 2 })) },
+      ] },
+      headers: authHeader,
+    });
+    assertEqual(ownerLocalSplit.status, 201, 'nested owner-local legacy split returns 201');
+    assertEqual(JSON.stringify(ownerLocalSplit.data.bills.map((bill: any) => bill.tax_amount)), JSON.stringify([0, 0.02]), 'child tax totals use the same owner-local rounding as nested legacy evidence');
+    for (const [index, childBill] of ownerLocalSplit.data.bills.entries()) {
+      const breakdown = childBill.tax_breakdown as Array<Array<{ title: string; rate: number; amount: number }>>;
+      const breakdownTotal = Number(breakdown.flat().reduce((sum, component) => sum + component.amount, 0).toFixed(2));
+      assertEqual(breakdownTotal, childBill.tax_amount, 'nested owner-local breakdown reconciles to its child tax total');
+      assertEqual(JSON.stringify(breakdown.map((group) => group.map((component) => component.amount))), JSON.stringify(index === 0 ? [[0], [0]] : [[0.01], [0.01]]), 'nested legacy component cents remain with their owner allocation');
+    }
+
     const voidLegacyOrderRes = await api(baseUrl, '/api/orders', {
       method: 'POST',
       body: {

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -393,6 +393,11 @@ async function main() {
       assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedSnapshotComponents), 'backend thermal receipt tax components keep item and charge attribution per child');
       assertEqual(JSON.stringify(frontendComponents), JSON.stringify(expectedSnapshotComponents), 'frontend receipt tax components keep item and charge attribution per child');
       assertEqual(Number(backendComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'resolved child tax components reconcile to child tax_amount');
+      assertEqual(
+        Number((child.subtotal - child.discount_amount + child.tax_amount + child.delivery_charge + child.packaging_charge + child.round_off).toFixed(2)),
+        child.total,
+        'split child total composes from allocated exclusive tax and bill fields',
+      );
       for (const component of backendComponents) {
         aggregateSnapshotComponents.set(component.title, (aggregateSnapshotComponents.get(component.title) || 0) + component.amount);
       }
@@ -404,6 +409,22 @@ async function main() {
       snapshotOrderRes.data.order.tax_amount,
       'aggregate resolved snapshot tax equals source order tax exactly',
     );
+
+    const mixedLegacyDocument = {
+      tax_amount: 1.5,
+      tax_snapshot: JSON.stringify([{ splitAllocation: 'minor-unit-v1', lines: [{ components: [{ label: 'Item Tax', rate: '5', amount: '1.00' }] }] }]),
+      tax_breakdown: JSON.stringify([[{ title: 'Legacy Tax', rate: 2, amount: 0.5 }]]),
+      items: [
+        { tax_snapshot: JSON.stringify({ splitAllocation: 'minor-unit-v1', lines: [{ components: [{ label: 'Item Tax', rate: '5', amount: '1.00' }] }]}), tax_breakdown: null, status: 'pending' },
+        { tax_snapshot: null, tax_breakdown: JSON.stringify([{ title: 'Legacy Tax', rate: 2, amount: 0.5 }]), status: 'pending' },
+      ],
+    };
+    const mixedLegacyExpected = [
+      { title: 'Item Tax', rate: 5, amount: 1 },
+      { title: 'Legacy Tax', rate: 2, amount: 0.5 },
+    ];
+    assertEqual(JSON.stringify(resolveBackendTaxComponents(mixedLegacyDocument)), JSON.stringify(mixedLegacyExpected), 'backend split resolver preserves legacy item tax beside marked snapshots');
+    assertEqual(JSON.stringify(resolveFrontendTaxComponents(mixedLegacyDocument)), JSON.stringify(mixedLegacyExpected), 'frontend split resolver preserves legacy item tax beside marked snapshots');
 
     const voidSnapshotOrderRes = await api(baseUrl, '/api/orders', {
       method: 'POST',
@@ -506,15 +527,33 @@ async function main() {
     });
     assertEqual(cancelSnapshotRes.status, 200, 'cancelling an item after splitting keeps the order mutation supported');
     const cancelledSnapshotBills = db.prepare('SELECT * FROM bills WHERE order_id = ? ORDER BY id').all(snapshotOrderRes.data.order.id) as any[];
+    const cancelledSnapshotTotals = new Map<string, number>();
     for (const childBill of cancelledSnapshotBills) {
       const childRes = await api(baseUrl, `/api/bills/${childBill.id}`, { headers: authHeader });
       const child = childRes.data.bill;
       const backendComponents = resolveBackendTaxComponents({ ...child, items: child.order.items });
       const frontendComponents = resolveFrontendTaxComponents(child);
+      const childBillItems = db.prepare('SELECT order_item_id FROM bill_items WHERE bill_id = ?').all(childBill.id) as any[];
+      const ownsSurvivingSnapshotItem = childBillItems.some((item: any) => Number(item.order_item_id) === Number(snapshotItems[1].id));
+      const expectedCancelledComponents = ownsSurvivingSnapshotItem
+        ? [{ title: 'Item Tax', rate: 5, amount: 1 }, { title: 'Charge Tax', rate: 5, amount: 1 }]
+        : [{ title: 'Item Tax', rate: 5, amount: 0 }, { title: 'Charge Tax', rate: 5, amount: 0 }];
+      assertEqual(JSON.stringify(backendComponents), JSON.stringify(expectedCancelledComponents), 'cancel sync preserves exact item and charge tax attribution');
+      assertEqual(JSON.stringify(frontendComponents), JSON.stringify(expectedCancelledComponents), 'cancel sync preserves exact frontend item and charge tax attribution');
       assert(child.tax_snapshot && JSON.parse(child.tax_snapshot).some((snapshot: any) => snapshot.splitAllocation === 'minor-unit-v1'), 'cancel sync preserves marked child tax snapshots');
       assertEqual(JSON.stringify(backendComponents), JSON.stringify(frontendComponents), 'cancel sync keeps backend and frontend tax attribution aligned');
       assertEqual(Number(backendComponents.reduce((sum: number, component: any) => sum + component.amount, 0).toFixed(2)), child.tax_amount, 'cancel sync resolved tax reconciles to each child tax amount');
+      for (const component of backendComponents) {
+        cancelledSnapshotTotals.set(component.title, Number(((cancelledSnapshotTotals.get(component.title) || 0) + component.amount).toFixed(2)));
+      }
     }
+    assertEqual(cancelledSnapshotTotals.get('Item Tax'), 1, 'cancel sync item tax reconciles across children');
+    assertEqual(cancelledSnapshotTotals.get('Charge Tax'), 1, 'cancel sync charge tax reconciles across children');
+    assertEqual(
+      Number(Array.from(cancelledSnapshotTotals.values()).reduce((sum, amount) => sum + amount, 0).toFixed(2)),
+      cancelSnapshotRes.data.order.tax_amount,
+      'cancel sync aggregate tax attribution reconciles to the updated order',
+    );
 
     const restoreSnapshotRes = await api(baseUrl, `/api/orders/${snapshotOrderRes.data.order.id}/items/${cancelledSnapshotItem.id}/restore`, {
       method: 'PATCH',

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -11,7 +11,7 @@ Module._load = function (request: string, parent: unknown, isMain: boolean) {
 
 const { initTestDb, createApp, startServer, seedOwnerUser, seedManagerUser, seedCategory, seedProduct, installAndActivateTestTaxPack, api, assert, assertEqual, getResults, closeDatabase, now } = require('./helpers/test-setup');
 const { orderRoutes } = require('../main/routes/orders');
-const { billRoutes, allocateTaxSnapshots } = require('../main/routes/bills');
+const { billRoutes, allocateSignedMinorUnits, allocateTaxSnapshots } = require('../main/routes/bills');
 const { paymentMethodRoutes } = require('../main/routes/payment-methods');
 const { settingsRoutes } = require('../main/routes/settings');
 const { reportRoutes } = require('../main/routes/reports');
@@ -23,6 +23,7 @@ const dualRatePackData = require('./fixtures/synthetic-dual-rate-pack.json');
 async function main() {
   const db = initTestDb();
   db.prepare("INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('telemetry_enabled', 'false', ?)").run(now());
+  assertEqual(JSON.stringify(allocateSignedMinorUnits(-2, [1, 3])), JSON.stringify([-1, -1]), 'negative round-off uses signed largest-remainder allocation');
   const { authHeader } = seedOwnerUser(db);
   seedCategory(db, 'split-cat', 'Split menu');
   seedProduct(db, 'split-coffee', 'split-cat', 'Coffee', 100);

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -136,30 +136,34 @@ async function main() {
     const oneCentSum = Number(oneCentSplit.data.bills.reduce((sum: number, b: any) => sum + b.total, 0).toFixed(2));
     assertEqual(oneCentSum, 0.01, 'one-cent split totals sum exactly to $0.01');
 
-    // C. Uneven Weight Allocation
-    const unevenOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 3, items: [{ product_id: 'split-coffee', quantity: 3 }] }, headers: authHeader });
-    const unevenItem = unevenOrderRes.data.order.items[0];
+    // C. Unequal Weight Allocation
+    seedProduct(db, 'split-unequal-a', 'split-cat', 'Product A', 6.00);
+    seedProduct(db, 'split-unequal-b', 'split-cat', 'Product B', 4.00);
+    const unevenOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-unequal-a', quantity: 1 }, { product_id: 'split-unequal-b', quantity: 1 }] }, headers: authHeader });
+    const itemA = unevenOrderRes.data.order.items.find((i: any) => i.product_id === 'split-unequal-a');
+    const itemB = unevenOrderRes.data.order.items.find((i: any) => i.product_id === 'split-unequal-b');
     const unevenBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: unevenOrderRes.data.order.id }, headers: authHeader });
-    db.prepare('UPDATE bills SET subtotal = 10.00, total = 10.00, balance = 10.00 WHERE id = ?').run(unevenBillRes.data.bill.id);
+    db.prepare('UPDATE bills SET subtotal = 10.01, total = 10.01, balance = 10.01 WHERE id = ?').run(unevenBillRes.data.bill.id);
     const unevenSplit = await api(baseUrl, `/api/bills/${unevenBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
-      { label: 'Guest 1', items: [{ order_item_id: unevenItem.id, quantity: 1 }] },
-      { label: 'Guest 2', items: [{ order_item_id: unevenItem.id, quantity: 1 }] },
-      { label: 'Guest 3', items: [{ order_item_id: unevenItem.id, quantity: 1 }] },
+      { label: 'Guest 1 (Product A)', items: [{ order_item_id: itemA.id, quantity: 1 }] },
+      { label: 'Guest 2 (Product B)', items: [{ order_item_id: itemB.id, quantity: 1 }] },
     ] }, headers: authHeader });
-    assertEqual(unevenSplit.status, 201, 'uneven weight split returns 201');
-    assertEqual(JSON.stringify(unevenSplit.data.bills.map((b: any) => b.total)), JSON.stringify([3.34, 3.33, 3.33]), 'largest remainder distributes $10.00 deterministically into 3.34, 3.33, 3.33');
+    assertEqual(unevenSplit.status, 201, 'unequal weight split returns 201');
+    assertEqual(JSON.stringify(unevenSplit.data.bills.map((b: any) => b.total)), JSON.stringify([6.01, 4.00]), 'largest remainder distributes $10.01 into 6.01 and 4.00 according to 60/40 item weights');
     const unevenSum = Number(unevenSplit.data.bills.reduce((sum: number, b: any) => sum + b.total, 0).toFixed(2));
-    assertEqual(unevenSum, 10.00, 'uneven split totals reconcile exactly to $10.00');
+    assertEqual(unevenSum, 10.01, 'unequal split totals reconcile exactly to $10.01');
 
     // D. Void Adjustment Exclusion
     const { registerRoutes } = require('../main/routes/index');
     registerRoutes(app);
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('kds_enabled', 'true', datetime('now'))").run();
     const mgrUser = seedManagerUser(db);
     const voidOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }, { product_id: 'split-toast', quantity: 1 }] }, headers: authHeader });
     const voidOrder = voidOrderRes.data.order;
     const voidItemToCancel = voidOrder.items.find((i: any) => i.product_id === 'split-toast');
     const activeItemToKeep = voidOrder.items.find((i: any) => i.product_id === 'split-coffee');
-    db.prepare("UPDATE order_items SET status = 'preparing' WHERE id = ?").run(voidItemToCancel.id);
+    const prepRes = await api(baseUrl, `/api/order-items/${voidItemToCancel.id}/status`, { method: 'PATCH', body: { status: 'preparing' }, headers: authHeader });
+    assertEqual(prepRes.status, 200, 'item moved to preparing via order-items API');
     const cancelRes = await api(baseUrl, `/api/orders/${voidOrder.id}/items/${voidItemToCancel.id}/cancel`, { method: 'PATCH', body: { override_pin: '1234' }, headers: mgrUser.authHeader });
     assertEqual(cancelRes.status, 200, 'in-progress item voided with manager PIN');
     const voidAdjRow = db.prepare("SELECT * FROM order_items WHERE order_id = ? AND status = 'void_adjustment'").get(voidOrder.id) as any;
@@ -211,6 +215,77 @@ async function main() {
     assertEqual(concStatuses[1], 409, 'concurrent HTTP request: duplicate request returns 409');
     const concSplitGroups = db.prepare("SELECT COUNT(DISTINCT split_group_id) AS n FROM bills WHERE order_id = ? AND split_group_id IS NOT NULL").get(concOrderRes.data.order.id) as any;
     assertEqual(concSplitGroups.n, 1, 'concurrent HTTP request: exactly one split group exists in database');
+
+    // G. Nested Tax Breakdown Allocation & Reconciliation
+    const taxOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }] }, headers: authHeader });
+    const taxItem = taxOrderRes.data.order.items[0];
+    const taxBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: taxOrderRes.data.order.id }, headers: authHeader });
+    const nestedBreakdown = [
+      [
+        { title: 'Tax A', rate: 2.5, amount: 0.01 },
+        { title: 'Tax B', rate: 2.5, amount: 0.01 },
+      ],
+    ];
+    db.prepare('UPDATE bills SET subtotal = 1.00, tax_amount = 0.02, tax_breakdown = ?, total = 1.02, balance = 1.02 WHERE id = ?')
+      .run(JSON.stringify(nestedBreakdown), taxBillRes.data.bill.id);
+
+    const taxSplit = await api(baseUrl, `/api/bills/${taxBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
+      { label: 'Guest 1', items: [{ order_item_id: taxItem.id, quantity: 1 }] },
+      { label: 'Guest 2', items: [{ order_item_id: taxItem.id, quantity: 1 }] },
+    ] }, headers: authHeader });
+
+    assertEqual(taxSplit.status, 201, 'nested tax breakdown split returns 201');
+    assertEqual(taxSplit.data.bills.length, 2, 'returns 2 split bills');
+
+    let totalTaxA = 0;
+    let totalTaxB = 0;
+    let totalTaxAmount = 0;
+
+    for (const b of taxSplit.data.bills) {
+      const dbRow = db.prepare('SELECT tax_breakdown FROM bills WHERE id = ?').get(b.id) as any;
+      const dbBreakdown = JSON.parse(dbRow.tax_breakdown);
+      assert(Array.isArray(dbBreakdown), 'persisted DB tax_breakdown is an array');
+      assert(Array.isArray(dbBreakdown[0]), 'persisted DB tax_breakdown outer array preserved as nested array');
+
+      assert(Array.isArray(b.tax_breakdown), 'API response tax_breakdown is an array');
+      const innerComps = b.tax_breakdown;
+      const compSum = Number(innerComps.reduce((s: number, c: any) => s + Number(c.amount || 0), 0).toFixed(2));
+      assertEqual(compSum, b.tax_amount, 'sum of check component amounts equals bill tax_amount exactly');
+      totalTaxAmount = Number((totalTaxAmount + b.tax_amount).toFixed(2));
+
+      for (const comp of innerComps) {
+        if (comp.title === 'Tax A') totalTaxA = Number((totalTaxA + comp.amount).toFixed(2));
+        if (comp.title === 'Tax B') totalTaxB = Number((totalTaxB + comp.amount).toFixed(2));
+      }
+    }
+
+    assertEqual(totalTaxAmount, 0.02, 'sum of split tax_amounts equals source tax_amount 0.02');
+    assertEqual(totalTaxA, 0.01, 'Tax A reconciles across checks to 0.01');
+    assertEqual(totalTaxB, 0.01, 'Tax B reconciles across checks to 0.01');
+
+    // H. Legacy Flat Tax Breakdown Allocation
+    const flatOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }] }, headers: authHeader });
+    const flatItem = flatOrderRes.data.order.items[0];
+    const flatBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: flatOrderRes.data.order.id }, headers: authHeader });
+    const flatBreakdown = [
+      { title: 'State Tax', rate: 5.0, amount: 0.50 },
+      { title: 'Local Tax', rate: 2.0, amount: 0.20 },
+    ];
+    db.prepare('UPDATE bills SET subtotal = 10.00, tax_amount = 0.70, tax_breakdown = ?, total = 10.70, balance = 10.70 WHERE id = ?')
+      .run(JSON.stringify(flatBreakdown), flatBillRes.data.bill.id);
+
+    const flatSplit = await api(baseUrl, `/api/bills/${flatBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
+      { label: 'Guest 1', items: [{ order_item_id: flatItem.id, quantity: 1 }] },
+      { label: 'Guest 2', items: [{ order_item_id: flatItem.id, quantity: 1 }] },
+    ] }, headers: authHeader });
+
+    assertEqual(flatSplit.status, 201, 'flat tax breakdown split returns 201');
+    for (const b of flatSplit.data.bills) {
+      assert(Array.isArray(b.tax_breakdown), 'flat tax_breakdown is an array');
+      assert(!Array.isArray(b.tax_breakdown[0]), 'flat tax_breakdown elements are objects, not nested arrays');
+      const compSum = Number(b.tax_breakdown.reduce((s: number, c: any) => s + Number(c.amount || 0), 0).toFixed(2));
+      assertEqual(compSum, b.tax_amount, 'sum of flat component amounts equals bill tax_amount exactly');
+    }
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
     closeDatabase();

--- a/tests/payment-methods-split-checks.test.ts
+++ b/tests/payment-methods-split-checks.test.ts
@@ -9,7 +9,7 @@ Module._load = function (request: string, parent: unknown, isMain: boolean) {
   return originalLoad.apply(this, arguments as any);
 };
 
-const { initTestDb, createApp, startServer, seedOwnerUser, seedCategory, seedProduct, api, assert, assertEqual, getResults, closeDatabase, now } = require('./helpers/test-setup');
+const { initTestDb, createApp, startServer, seedOwnerUser, seedManagerUser, seedCategory, seedProduct, api, assert, assertEqual, getResults, closeDatabase, now } = require('./helpers/test-setup');
 const { orderRoutes } = require('../main/routes/orders');
 const { billRoutes } = require('../main/routes/bills');
 const { paymentMethodRoutes } = require('../main/routes/payment-methods');
@@ -102,6 +102,115 @@ async function main() {
     const rewritten = JSON.parse((db.prepare('SELECT payment_details FROM bills WHERE id = ?').get(split.data.bills[1].id) as any).payment_details);
     assertEqual(rewritten[0].method, 'GPay', 'historical payment name replaced');
     assertEqual((db.prepare('SELECT COUNT(*) AS n FROM payment_method_merges').get() as any).n, 1, 'one compact local merge record retained');
+
+    // ── Issue #253 Regression Tests ──────────────────────────────────────────
+    // A. Two-Cent / Four-Check Underflow
+    seedProduct(db, 'split-tiny', 'split-cat', 'Tiny Product', 0.02);
+    const underflowOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 4, items: [{ product_id: 'split-tiny', quantity: 4 }] }, headers: authHeader });
+    const underflowItem = underflowOrderRes.data.order.items[0];
+    const underflowBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: underflowOrderRes.data.order.id }, headers: authHeader });
+    db.prepare('UPDATE bills SET subtotal = 0.02, total = 0.02, balance = 0.02 WHERE id = ?').run(underflowBillRes.data.bill.id);
+    const underflowSplit = await api(baseUrl, `/api/bills/${underflowBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
+      { label: 'Guest 1', items: [{ order_item_id: underflowItem.id, quantity: 1 }] },
+      { label: 'Guest 2', items: [{ order_item_id: underflowItem.id, quantity: 1 }] },
+      { label: 'Guest 3', items: [{ order_item_id: underflowItem.id, quantity: 1 }] },
+      { label: 'Guest 4', items: [{ order_item_id: underflowItem.id, quantity: 1 }] },
+    ] }, headers: authHeader });
+    assertEqual(underflowSplit.status, 201, 'underflow $0.02 split across 4 checks returns 201');
+    assert(underflowSplit.data.bills.every((b: any) => b.total >= 0 && b.balance >= 0), 'no resulting total or balance is negative');
+    const underflowSum = Number(underflowSplit.data.bills.reduce((sum: number, b: any) => sum + b.total, 0).toFixed(2));
+    assertEqual(underflowSum, 0.02, 'allocated totals sum exactly to source total $0.02');
+
+    // B. One-Cent Split
+    seedProduct(db, 'split-1cent', 'split-cat', '1 Cent Product', 0.01);
+    const oneCentOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-1cent', quantity: 2 }] }, headers: authHeader });
+    const oneCentItem = oneCentOrderRes.data.order.items[0];
+    const oneCentBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: oneCentOrderRes.data.order.id }, headers: authHeader });
+    db.prepare('UPDATE bills SET subtotal = 0.01, total = 0.01, balance = 0.01 WHERE id = ?').run(oneCentBillRes.data.bill.id);
+    const oneCentSplit = await api(baseUrl, `/api/bills/${oneCentBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
+      { label: 'Guest 1', items: [{ order_item_id: oneCentItem.id, quantity: 1 }] },
+      { label: 'Guest 2', items: [{ order_item_id: oneCentItem.id, quantity: 1 }] },
+    ] }, headers: authHeader });
+    assertEqual(oneCentSplit.status, 201, 'one-cent split across 2 checks returns 201');
+    assert(oneCentSplit.data.bills.every((b: any) => b.total >= 0), 'one-cent split has no negative totals');
+    const oneCentSum = Number(oneCentSplit.data.bills.reduce((sum: number, b: any) => sum + b.total, 0).toFixed(2));
+    assertEqual(oneCentSum, 0.01, 'one-cent split totals sum exactly to $0.01');
+
+    // C. Uneven Weight Allocation
+    const unevenOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 3, items: [{ product_id: 'split-coffee', quantity: 3 }] }, headers: authHeader });
+    const unevenItem = unevenOrderRes.data.order.items[0];
+    const unevenBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: unevenOrderRes.data.order.id }, headers: authHeader });
+    db.prepare('UPDATE bills SET subtotal = 10.00, total = 10.00, balance = 10.00 WHERE id = ?').run(unevenBillRes.data.bill.id);
+    const unevenSplit = await api(baseUrl, `/api/bills/${unevenBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
+      { label: 'Guest 1', items: [{ order_item_id: unevenItem.id, quantity: 1 }] },
+      { label: 'Guest 2', items: [{ order_item_id: unevenItem.id, quantity: 1 }] },
+      { label: 'Guest 3', items: [{ order_item_id: unevenItem.id, quantity: 1 }] },
+    ] }, headers: authHeader });
+    assertEqual(unevenSplit.status, 201, 'uneven weight split returns 201');
+    assertEqual(JSON.stringify(unevenSplit.data.bills.map((b: any) => b.total)), JSON.stringify([3.34, 3.33, 3.33]), 'largest remainder distributes $10.00 deterministically into 3.34, 3.33, 3.33');
+    const unevenSum = Number(unevenSplit.data.bills.reduce((sum: number, b: any) => sum + b.total, 0).toFixed(2));
+    assertEqual(unevenSum, 10.00, 'uneven split totals reconcile exactly to $10.00');
+
+    // D. Void Adjustment Exclusion
+    const { registerRoutes } = require('../main/routes/index');
+    registerRoutes(app);
+    const mgrUser = seedManagerUser(db);
+    const voidOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }, { product_id: 'split-toast', quantity: 1 }] }, headers: authHeader });
+    const voidOrder = voidOrderRes.data.order;
+    const voidItemToCancel = voidOrder.items.find((i: any) => i.product_id === 'split-toast');
+    const activeItemToKeep = voidOrder.items.find((i: any) => i.product_id === 'split-coffee');
+    db.prepare("UPDATE order_items SET status = 'preparing' WHERE id = ?").run(voidItemToCancel.id);
+    const cancelRes = await api(baseUrl, `/api/orders/${voidOrder.id}/items/${voidItemToCancel.id}/cancel`, { method: 'PATCH', body: { override_pin: '1234' }, headers: mgrUser.authHeader });
+    assertEqual(cancelRes.status, 200, 'in-progress item voided with manager PIN');
+    const voidAdjRow = db.prepare("SELECT * FROM order_items WHERE order_id = ? AND status = 'void_adjustment'").get(voidOrder.id) as any;
+    assert(voidAdjRow !== undefined, 'void_adjustment row created in order_items');
+    const voidBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: voidOrder.id }, headers: authHeader });
+    const voidSplit = await api(baseUrl, `/api/bills/${voidBillRes.data.bill.id}/split-check`, { method: 'POST', body: { checks: [
+      { label: 'Guest 1', items: [{ order_item_id: activeItemToKeep.id, quantity: 1 }] },
+      { label: 'Guest 2', items: [{ order_item_id: activeItemToKeep.id, quantity: 1 }] },
+    ] }, headers: authHeader });
+    assertEqual(voidSplit.status, 201, 'split check succeeds allocating only physical active items without allocating void_adjustment');
+    const billItemRows = db.prepare('SELECT * FROM bill_items WHERE bill_id IN (?, ?)').all(voidSplit.data.bills[0].id, voidSplit.data.bills[1].id) as any[];
+    assert(!billItemRows.some((bi: any) => bi.order_item_id === voidAdjRow.id), 'bill_items rows do not reference void_adjustment item ID');
+
+    // E. Repeat Safety
+    const repeatOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }] }, headers: authHeader });
+    const repeatItem = repeatOrderRes.data.order.items[0];
+    const repeatBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: repeatOrderRes.data.order.id }, headers: authHeader });
+    const repeatSplitPayload = { checks: [
+      { label: 'Guest 1', items: [{ order_item_id: repeatItem.id, quantity: 1 }] },
+      { label: 'Guest 2', items: [{ order_item_id: repeatItem.id, quantity: 1 }] },
+    ] };
+    const firstRepeatSplit = await api(baseUrl, `/api/bills/${repeatBillRes.data.bill.id}/split-check`, { method: 'POST', body: repeatSplitPayload, headers: authHeader });
+    assertEqual(firstRepeatSplit.status, 201, 'first split request returns 201');
+    const secondRepeatSplit = await api(baseUrl, `/api/bills/${repeatBillRes.data.bill.id}/split-check`, { method: 'POST', body: repeatSplitPayload, headers: authHeader });
+    assertEqual(secondRepeatSplit.status, 409, 'repeated split request returns 409 Conflict');
+    const childSplit = await api(baseUrl, `/api/bills/${firstRepeatSplit.data.bills[1].id}/split-check`, { method: 'POST', body: repeatSplitPayload, headers: authHeader });
+    assertEqual(childSplit.status, 409, 'splitting child bill returns 409 Conflict');
+    const totalSplitGroups = db.prepare("SELECT COUNT(DISTINCT split_group_id) AS n FROM bills WHERE order_id = ? AND split_group_id IS NOT NULL").get(repeatOrderRes.data.order.id) as any;
+    assertEqual(totalSplitGroups.n, 1, 'only one split group exists in database for order');
+
+    // F. Concurrent HTTP Request Regression
+    const concOrderRes = await api(baseUrl, '/api/orders', { method: 'POST', body: { type: 'dine_in', guest_count: 2, items: [{ product_id: 'split-coffee', quantity: 2 }] }, headers: authHeader });
+    const concItem = concOrderRes.data.order.items[0];
+    const concBillRes = await api(baseUrl, '/api/bills/generate', { method: 'POST', body: { order_id: concOrderRes.data.order.id }, headers: authHeader });
+    const concPayload1 = { checks: [
+      { label: 'Group A Guest 1', items: [{ order_item_id: concItem.id, quantity: 1 }] },
+      { label: 'Group A Guest 2', items: [{ order_item_id: concItem.id, quantity: 1 }] },
+    ] };
+    const concPayload2 = { checks: [
+      { label: 'Group B Guest 1', items: [{ order_item_id: concItem.id, quantity: 1 }] },
+      { label: 'Group B Guest 2', items: [{ order_item_id: concItem.id, quantity: 1 }] },
+    ] };
+    const [concRes1, concRes2] = await Promise.all([
+      api(baseUrl, `/api/bills/${concBillRes.data.bill.id}/split-check`, { method: 'POST', body: concPayload1, headers: authHeader }),
+      api(baseUrl, `/api/bills/${concBillRes.data.bill.id}/split-check`, { method: 'POST', body: concPayload2, headers: authHeader }),
+    ]);
+    const concStatuses = [concRes1.status, concRes2.status].sort();
+    assertEqual(concStatuses[0], 201, 'concurrent HTTP request: exactly one request returns 201');
+    assertEqual(concStatuses[1], 409, 'concurrent HTTP request: duplicate request returns 409');
+    const concSplitGroups = db.prepare("SELECT COUNT(DISTINCT split_group_id) AS n FROM bills WHERE order_id = ? AND split_group_id IS NOT NULL").get(concOrderRes.data.order.id) as any;
+    assertEqual(concSplitGroups.n, 1, 'concurrent HTTP request: exactly one split group exists in database');
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
     closeDatabase();

--- a/tests/tax-components.test.ts
+++ b/tests/tax-components.test.ts
@@ -225,6 +225,31 @@ test('document legacy tax is not duplicated when child item evidence matches it'
   assert.deepEqual(resolveFrontendTaxComponents(document), expected);
 });
 
+test('marked child snapshots consume mirrored document components before residual legacy tax', () => {
+  const document = {
+    tax_amount: 1.75,
+    tax_snapshot: JSON.stringify({
+      splitAllocation: 'minor-unit-v1',
+      lines: [{ components: [
+        { label: 'Item Tax', rate: '5', amount: '1.00' },
+        { label: 'Charge Tax', rate: '5', amount: '0.50' },
+      ] }],
+    }),
+    tax_breakdown: [
+      { title: 'Item Tax', rate: 5, amount: 1 },
+      { title: 'Charge Tax', rate: 5, amount: 0.5 },
+      { title: 'Legacy Charge Tax', rate: 2, amount: 0.25 },
+    ],
+  };
+  const expected = [
+    { title: 'Item Tax', rate: 5, amount: 1 },
+    { title: 'Charge Tax', rate: 5, amount: 0.5 },
+    { title: 'Legacy Charge Tax', rate: 2, amount: 0.25 },
+  ];
+  assert.deepEqual(resolveBackendTaxComponents(document), expected);
+  assert.deepEqual(resolveFrontendTaxComponents(document), expected);
+});
+
 test('frontend split printing keeps the child-scoped order payload', () => {
   const childOrder = {
     items: [{

--- a/tests/tax-components.test.ts
+++ b/tests/tax-components.test.ts
@@ -269,6 +269,27 @@ test('itemless generated bills retain residual document legacy tax beside mirror
   assert.deepEqual(resolveFrontendTaxComponents(document), expected);
 });
 
+test('active item snapshots retain residual document legacy tax without relabeling it', () => {
+  const document = {
+    tax_amount: 1.5,
+    tax_snapshot: null,
+    tax_breakdown: [
+      { title: 'Item Tax', rate: 5, amount: 1 },
+      { title: 'Legacy Charge Tax', rate: 2, amount: 0.5 },
+    ],
+    items: [{
+      tax_snapshot: { lines: [{ components: [{ label: 'Item Tax', rate: '5', amount: '1.00' }] }] },
+      tax_breakdown: [{ title: 'Item Tax', rate: 5, amount: 1 }],
+    }],
+  };
+  const expected = [
+    { title: 'Item Tax', rate: 5, amount: 1 },
+    { title: 'Legacy Charge Tax', rate: 2, amount: 0.5 },
+  ];
+  assert.deepEqual(resolveBackendTaxComponents(document), expected);
+  assert.deepEqual(resolveFrontendTaxComponents(document), expected);
+});
+
 test('frontend split printing keeps the child-scoped order payload', () => {
   const childOrder = {
     items: [{

--- a/tests/tax-components.test.ts
+++ b/tests/tax-components.test.ts
@@ -4,7 +4,10 @@ import {
   aggregateTaxComponents,
   resolveTaxComponents as resolveBackendTaxComponents,
 } from '../main/services/tax-components';
-import { resolveTaxComponents as resolveFrontendTaxComponents } from '../frontend/src/lib/printer/tax-components';
+import {
+  preferChildScopedBill,
+  resolveTaxComponents as resolveFrontendTaxComponents,
+} from '../frontend/src/lib/printer/tax-components';
 
 const taxSnapshot = {
   lines: [{
@@ -176,4 +179,50 @@ test('charge snapshots are added once and stay unscaled by item discounts', () =
     backend.reduce((sum, component) => sum + component.amount, 0),
     10,
   );
+});
+
+test('frontend split printing keeps the child-scoped order payload', () => {
+  const childOrder = {
+    items: [{
+      status: 'pending',
+      tax_snapshot: null,
+      tax_breakdown: [{ title: 'Legacy Tax', rate: 2, amount: 0.1 }],
+    }],
+  };
+  const unscopedOrder = {
+    items: [
+      ...childOrder.items,
+      { status: 'pending', tax_snapshot: null, tax_breakdown: [{ title: 'Legacy Tax', rate: 2, amount: 0.1 }] },
+    ],
+  };
+  const childBill = {
+    tax_amount: 1,
+    tax_snapshot: JSON.stringify({
+      splitAllocation: 'minor-unit-v1',
+      lines: [{ components: [{ label: 'Item Tax', rate: '5', amount: '0.70' }, { label: 'Charge Tax', rate: '5', amount: '0.20' }] }],
+    }),
+    order: childOrder,
+  };
+  const printableBill = preferChildScopedBill(childBill as any, unscopedOrder as any);
+  assert.equal(printableBill.order, childOrder);
+  assert.deepEqual(resolveFrontendTaxComponents(printableBill), [
+    { title: 'Item Tax', rate: 5, amount: 0.7 },
+    { title: 'Charge Tax', rate: 5, amount: 0.2 },
+    { title: 'Legacy Tax', rate: 2, amount: 0.1 },
+  ]);
+});
+
+test('frontend split resolution excludes void adjustment tax evidence', () => {
+  const document = {
+    tax_amount: 0.1,
+    tax_breakdown: [],
+    items: [
+      { status: 'pending', tax_snapshot: null, tax_breakdown: [{ title: 'Legacy Tax', rate: 2, amount: 0.1 }] },
+      { status: 'voided', tax_snapshot: null, tax_breakdown: [{ title: 'Legacy Tax', rate: 2, amount: 0.1 }] },
+      { status: 'void_adjustment', tax_snapshot: null, tax_breakdown: [{ title: 'Legacy Tax', rate: 2, amount: -0.1 }] },
+    ],
+  };
+  assert.deepEqual(resolveFrontendTaxComponents(document), [
+    { title: 'Legacy Tax', rate: 2, amount: 0.1 },
+  ]);
 });

--- a/tests/tax-components.test.ts
+++ b/tests/tax-components.test.ts
@@ -250,6 +250,63 @@ test('marked child snapshots consume mirrored document components before residua
   assert.deepEqual(resolveFrontendTaxComponents(document), expected);
 });
 
+test('split flat legacy entries stay with their child item owners', () => {
+  const sourceSnapshot = (amount: string) => JSON.stringify({
+    splitAllocation: 'minor-unit-v1',
+    lines: [{ components: [{ label: 'Categorized Tax', rate: '5', amount }] }],
+  });
+  const childDocuments = [
+    {
+      tax_amount: 2,
+      tax_snapshot: sourceSnapshot('1.00'),
+      tax_breakdown: [
+        { title: 'Legacy Item A', rate: 2, amount: 0.33 },
+        { title: 'Legacy Item B', rate: 2, amount: 0.33 },
+      ],
+      items: [
+        { tax_snapshot: { lines: [{ components: [{ label: 'Categorized Tax', rate: '5', amount: '1.00' }] }] } },
+        { tax_snapshot: null, tax_breakdown: [{ title: 'Legacy Item A', rate: 2, amount: 1 }] },
+      ],
+    },
+    {
+      tax_amount: 2,
+      tax_snapshot: sourceSnapshot('1.00'),
+      tax_breakdown: [
+        { title: 'Legacy Item A', rate: 2, amount: 0.67 },
+        { title: 'Legacy Item B', rate: 2, amount: 0.67 },
+      ],
+      items: [
+        { tax_snapshot: { lines: [{ components: [{ label: 'Categorized Tax', rate: '5', amount: '1.00' }] }] } },
+        { tax_snapshot: null, tax_breakdown: [{ title: 'Legacy Item B', rate: 2, amount: 1 }] },
+      ],
+    },
+  ];
+  const expected = [
+    [
+      { title: 'Categorized Tax', rate: 5, amount: 1 },
+      { title: 'Legacy Item A', rate: 2, amount: 1 },
+    ],
+    [
+      { title: 'Categorized Tax', rate: 5, amount: 1 },
+      { title: 'Legacy Item B', rate: 2, amount: 1 },
+    ],
+  ];
+
+  childDocuments.forEach((document, index) => {
+    assert.deepEqual(resolveBackendTaxComponents(document), expected[index]);
+    assert.deepEqual(resolveFrontendTaxComponents(document), expected[index]);
+  });
+  const aggregate = childDocuments.flatMap((document) => resolveBackendTaxComponents(document));
+  assert.deepEqual(aggregate.reduce((totals, component) => {
+    totals[component.title] = (totals[component.title] || 0) + component.amount;
+    return totals;
+  }, {} as Record<string, number>), {
+    'Categorized Tax': 2,
+    'Legacy Item A': 1,
+    'Legacy Item B': 1,
+  });
+});
+
 test('itemless generated bills retain residual document legacy tax beside mirrored snapshots', () => {
   const document = {
     tax_amount: 1.75,

--- a/tests/tax-components.test.ts
+++ b/tests/tax-components.test.ts
@@ -181,6 +181,50 @@ test('charge snapshots are added once and stay unscaled by item discounts', () =
   );
 });
 
+test('marked split snapshots retain document-level legacy tax', () => {
+  const document = {
+    tax_amount: 1.5,
+    tax_snapshot: JSON.stringify({
+      splitAllocation: 'minor-unit-v1',
+      lines: [{ components: [{ label: 'Item Tax', rate: '5', amount: '1.00' }] }],
+    }),
+    tax_breakdown: [{ title: 'Legacy Charge Tax', rate: 2, amount: 0.5 }],
+    items: [{
+      status: 'pending',
+      tax_snapshot: JSON.stringify({ lines: [{ components: [{ label: 'Item Tax', rate: '5', amount: '1.00' }] }] }),
+      tax_breakdown: null,
+    }],
+  };
+  const expected = [
+    { title: 'Item Tax', rate: 5, amount: 1 },
+    { title: 'Legacy Charge Tax', rate: 2, amount: 0.5 },
+  ];
+  assert.deepEqual(resolveBackendTaxComponents(document), expected);
+  assert.deepEqual(resolveFrontendTaxComponents(document), expected);
+});
+
+test('document legacy tax is not duplicated when child item evidence matches it', () => {
+  const document = {
+    tax_amount: 1.5,
+    tax_snapshot: JSON.stringify({
+      splitAllocation: 'minor-unit-v1',
+      lines: [{ components: [{ label: 'Item Tax', rate: '5', amount: '1.00' }] }],
+    }),
+    tax_breakdown: [{ title: 'Legacy Item Tax', rate: 2, amount: 0.5 }],
+    items: [{
+      status: 'pending',
+      tax_snapshot: null,
+      tax_breakdown: [{ title: 'Legacy Item Tax', rate: 2, amount: 0.5 }],
+    }],
+  };
+  const expected = [
+    { title: 'Item Tax', rate: 5, amount: 1 },
+    { title: 'Legacy Item Tax', rate: 2, amount: 0.5 },
+  ];
+  assert.deepEqual(resolveBackendTaxComponents(document), expected);
+  assert.deepEqual(resolveFrontendTaxComponents(document), expected);
+});
+
 test('frontend split printing keeps the child-scoped order payload', () => {
   const childOrder = {
     items: [{

--- a/tests/tax-components.test.ts
+++ b/tests/tax-components.test.ts
@@ -250,6 +250,25 @@ test('marked child snapshots consume mirrored document components before residua
   assert.deepEqual(resolveFrontendTaxComponents(document), expected);
 });
 
+test('itemless generated bills retain residual document legacy tax beside mirrored snapshots', () => {
+  const document = {
+    tax_amount: 1.75,
+    tax_snapshot: JSON.stringify({
+      lines: [{ components: [{ label: 'Item Tax', rate: '5', amount: '1.00' }] }],
+    }),
+    tax_breakdown: [
+      { title: 'Item Tax', rate: 5, amount: 1 },
+      { title: 'Legacy Charge Tax', rate: 2, amount: 0.75 },
+    ],
+  };
+  const expected = [
+    { title: 'Item Tax', rate: 5, amount: 1 },
+    { title: 'Legacy Charge Tax', rate: 2, amount: 0.75 },
+  ];
+  assert.deepEqual(resolveBackendTaxComponents(document), expected);
+  assert.deepEqual(resolveFrontendTaxComponents(document), expected);
+});
+
 test('frontend split printing keeps the child-scoped order payload', () => {
   const childOrder = {
     items: [{


### PR DESCRIPTION
## Intent

Continue the existing FloCafe draft PR #269 in place on the existing remote branch fix/253-split-check-allocation; do not create a replacement PR, touch issue #241/Iran work, or change unrelated issues, and do not mark the PR ready or merge it. Preserve the current #253 transaction-boundary hardening, non-negative integer largest-remainder allocation, void_adjustment exclusion, and repeat/concurrency behavior. Fix the residual user-visible attribution defect where a split bill containing categorized item tax snapshots plus configured packaging/delivery/service charge-tax snapshots reconciles each child tax total but receipt/thermal components swap item tax and charge tax attribution. The accepted implementation may allocate and persist split-specific item and charge tax snapshots in integer minor units or make every per-bill resolver consume the already allocated child breakdown; this implementation persists child-specific minor-unit snapshots and makes backend/frontend resolvers consume the marked child snapshots. Add an executable regression that creates categorized item tax plus configured charge tax, splits the bill, resolves each child receipt/thermal tax component, asserts item/charge category attribution and exact aggregate reconciliation, and preserves legacy nested and flat tax_breakdown compatibility. Preserve signed snapshot reconciliation without weakening the non-negative largest-remainder allocator or void_adjustment exclusion. Keep the change scoped to #253. Before delivery, run focused split tests, the full suite, backend and frontend lint and builds, git diff --check, and complete no-mistakes validation against current main. Commit on the local branch that tracks origin/fix/253-split-check-allocation or explicitly push the final HEAD to origin:fix/253-split-check-allocation so PR #269 updates in place; never open another PR or merge.

## What Changed

- Added minor-unit split-check allocation for tax snapshots, tax breakdowns, bill totals, charges, discounts, and signed round-offs, persisting child-specific tax attribution while excluding `void_adjustment` items.
- Updated bill hydration, receipt/thermal printing, payment UI, and tax reports to consume child-scoped tax data, reconcile item and charge taxes, and preserve legacy nested and flat `tax_breakdown` compatibility.
- Centralized unpaid-bill synchronization for order edits and expanded documentation and regression coverage for split checks, tax attribution, reconciliation, and payment behavior.

## Risk Assessment

⚠️ Medium: No concrete source-verifiable defect was found, but the change spans complex stateful tax allocation and resolver paths whose remaining validation is owned by later pipeline phases.

## Testing

Restored missing locked dependencies with `npm ci`, ran the three targeted suites successfully, captured reviewer-visible CLI/thermal evidence, removed transient `node_modules`, and left the worktree clean. No screenshot was needed because this is a receipt/thermal data-path change rather than screen layout behavior.

<details>
<summary>Evidence: Split-tax end-to-end evidence</summary>

`Live split route persisted child snapshots and preserved Item Tax/Charge Tax attribution; aggregate reconciliation and signed allocation passed. 187/187 passed.`

```text

> flo-desktop@3.0.5 test:payment-methods-split
> node tests/run-electron-node-test.cjs tests/payment-methods-split-checks.test.ts

[DB] Opening database at: /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-payment-methods-split-gzA1t2/flo.db
[DB] Schema: v0 → v66
[DB] Triggering auto-backup before migrating v0 → v66...
[DB] Auto-backup before migrating v0 → v66 created at /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-payment-methods-split-gzA1t2/backups/flo-backup-2026-08-13T22-31-05-665Z-pre-v0-to-v66.db
[DB] Applying migration v1: initial_schema
[DB] Install defaults loaded; first-run setup pending
[DB] Migration v1 complete
[DB] Applying migration v2: hash_plaintext_pins
[DB] Migration v2 complete
[DB] Applying migration v3: cloud_identity_and_outbox
[DB] Migration v3 complete
[DB] Applying migration v4: add_notes_limits_settings
[DB] Migration v4 complete
[DB] Applying migration v5: add_print_logs_table
[DB] Migration v5 complete
[DB] Applying migration v6: add_loyalty_settings
[DB] Migration v6 complete
[DB] Applying migration v7: add_discount_settings
[DB] Migration v7 complete
[DB] Applying migration v8: add_loyalty_index
[DB] Migration v8 complete
[DB] Applying migration v9: add_sequences_table
[DB] Migration v9 complete
[DB] Applying migration v10: fix_sequences_composite_key
[DB] Migration v10 complete
[DB] Applying migration v11: first_run_setup_uses_welcome_form
[DB] Migration v11 complete
[DB] Applying migration v12: fix_table_integer_ids
[DB] Migration v12 complete
[DB] Applying migration v13: fix_null_table_ids
[DB] Migration v13 complete
[DB] Applying migration v14: simplify_loyalty_settings
[DB] Migration v14 complete
[DB] Applying migration v15: add_instagram_handle_setting
[DB] Migration v15 complete
[DB] Applying migration v16: add_terms_accepted_at_to_users
[DB] Migration v16 complete
[DB] Applying migration v17: add_held_orders_table
[DB] Migration v17 complete
[DB] Applying migration v18: fix_null_category_ids
[DB] Migration v18 complete
[DB] Applying migration v19: backfill_product_cb_percent_and_tags
[DB] Migration v19 complete
[DB] Applying migration v20: add_tables_is_active
[DB] Migration v20 complete
[DB] Applying migration v21: clear_legacy_loyalty_expiry
[DB] Migration v21 complete
[DB] Applying migration v22: add_customers_phone_digits
[DB] Migration v22 complete
[DB] Applying migration v23: normalize_customer_phones
[MIGRATION v23] normalized: 0, unparseable: 0
[MIGRATION v23] merged 0 duplicate customer(s)
[MIGRATION v23] verification: 0 customers, 0 still non-E.164
[DB] Migration v23 complete
[DB] Applying migration v24: normalize_customer_phones_retry
[MIGRATION v24] normalized: 0, unparseable: 0
[DB] Migration v24 complete
[DB] Applying migration v25: add_order_item_addons_table
[MIGRATION v25] backfilled addons for 0 order items (0 unparseable, skipped)
[DB] Migration v25 complete
[DB] Applying migration v26: add_kds_default_view
[DB] Migration v26 complete
[DB] Applying migration v27: add_station_printer_link_and_user_stations
[DB] Migration v27 complete
[DB] Applying migration v28: seed_telemetry_settings
[DB] Migration v28 complete
[DB] Applying migration v29: whatsapp_messaging
[DB] Migration v29 complete
[DB] Applying migration v30: drop_order_items_addons_json_column
[MIGRATION v30] backfilled 0 order_item(s) still missing a normalized addons snapshot
[MIGRATION v30] Dropped order_items.addons — order_item_addons is now the only place selected addons live.
[DB] Migration v30 complete
[DB] Applying migration v31: add_customers_tag_counts_column
[DB] Migration v31 complete
[DB] Applying migration v32: add_kds_and_kot_printing_toggles
[DB] Migration v32 complete
[DB] Applying migration v33: add_addon_groups_allow_multiple_quantities
[DB] Migration v33 complete
[DB] Applying migration v34: add_order_items_voided_at
[DB] Migration v34 complete
[DB] Applying migration v35: add_tax_pack_configuration_tables
[DB] Migration v35 complete
[DB] Applying migration v36: add_product_and_addon_tax_categories
[DB] Migration v36 complete
[DB] Applying migration v37: add_transaction_tax_snapshots_and_charge_categories
[DB] Migration v37 complete
[DB] Applying migration v38: register_bundled_tax_pack_versions
[DB] Migration v38 complete
[DB] Applying migration v39: add_users_tokens_valid_after
[DB] Migration v39 complete
[DB] Applying migration v40: v2_cloud_defaults_and_tax_toggle
[DB] Migration v40 complete
[DB] Applying migration v41: support_ticket_outbox
[DB] Migration v41 complete
[DB] Applying migration v42: add_global_cashback_percent
[DB] Migration v42 complete
[DB] Applying migration v43: telemetry_default_on_for_new_installs
[DB] Migration v43 complete
[DB] Applying migration v44: store_diagnostics_outbox
[DB] Migration v44 complete
[DB] Applying migration v45: add_performance_indexes_and_normalize_timestamps
[DB] Migration v45 complete
[DB] Applying migration v46: normalize_cloud_enabled_flags_to_01
[DB] Migration v46 complete
[DB] Applying migration v47: store_diagnostics_enabled_by_default
[DB] Migration v47 complete
[DB] Applying migration v48: deactivate_reusable_demo_credentials
[DB] Migration v48 complete
[DB] Applying migration v49: add_payment_idempotency_records
[DB] Migration v49 complete
[DB] Applying migration v50: add_order_idempotency_records
[DB] Migration v50 complete
[DB] Applying migration v51: enforce_global_payment_transaction_refs
[DB] Migration v51 complete
[DB] Applying migration v52: restore_method_scoped_transaction_refs
[DB] Migration v52 complete
[DB] Applying migration v53: scope_idempotency_records_to_user
[DB] Migration v53 complete
[DB] Applying migration v54: repair_retry_ownership_and_payment_reference_history
[DB] Migration v54 complete
[DB] Applying migration v55: durable_token_revocations
[DB] Migration v55 complete
[DB] Applying migration v56: persist_station_assignment_scope
[DB] Migration v56 complete
[DB] Applying migration v57: rename_gstin_to_generic_tax_registration_number
[DB] Migration v57 complete
[DB] Applying migration v58: configurable_manual_payment_methods
[DB] Migration v58 complete
[DB] Applying migration v59: split_checks_by_item_quantity
[DB] Migration v59 complete
[DB] Applying migration v60: seed_split_checks_disabled_setting
[DB] Migration v60 complete
[DB] Applying migration v61: seed_server_app_enabled_setting
[DB] Migration v61 complete
[DB] Applying migration v62: normalize_cloud_last_error
[DB] Migration v62 complete
[DB] Applying migration v63: seed_printer_trim_decimals_setting
[DB] Migration v63 complete
[DB] Applying migration v64: drop_unused_printer_usb_device_path
[DB] Migration v64 complete
[DB] Applying migration v65: seed_bill_content_visibility_settings
[DB] Migration v65 complete
[DB] Applying migration v66: seed_bill_template_settings
[DB] Migration v66 complete
[DB] integrity_check: ok
[DB] foreign_key_check: clean
  ✓ negative round-off uses signed largest-remainder allocation
[Auth] Generated new JWT secret for this install
  ✓ fresh database seeds split checks disabled
  ✓ missing split-check setting reads as a safe default
  ✓ fallback keeps split checks disabled
  ✓ fresh database seeds printer decimal trimming disabled
  ✓ missing printer decimal-trim setting reads as a safe default
  ✓ fallback keeps printer decimal trimming disabled
  ✓ fresh database seeds the classic bill template
  ✓ fresh database seeds an empty bill footer
  ✓ bill-template migration preserves an existing template choice
  ✓ bill-template migration preserves an existing footer
  ✓ missing bill template reads as a safe default
  ✓ missing bill template falls back to classic
  ✓ missing bill footer reads as a safe default
  ✓ missing bill footer falls back to an empty message
  ✓ fresh database shows restaurant name by default
  ✓ fresh database hides tax ID by default
  ✓ fresh database shows tax breakdown by default
  ✓ fresh database shows customer name by default
  ✓ fresh database shows customer number by default
  ✓ fresh database shows table number by default
  ✓ bill template setting can be saved for backend invoice printing
  ✓ bill footer setting can be saved for backend in

... [5025 bytes truncated] ...

st returns 409 Conflict
  ✓ splitting child bill returns 409 Conflict
  ✓ only one split group exists in database for order
  ✓ concurrent HTTP request: exactly one request returns 201
  ✓ concurrent HTTP request: duplicate request returns 409
  ✓ concurrent HTTP request: exactly one split group exists in database
  ✓ nested tax breakdown split returns 201
  ✓ returns 2 split bills
  ✓ persisted DB tax_breakdown is an array
  ✓ persisted DB tax_breakdown outer array preserved as nested array
  ✓ API response tax_breakdown is an array
  ✓ sum of check component amounts equals bill tax_amount exactly
  ✓ persisted DB tax_breakdown is an array
  ✓ persisted DB tax_breakdown outer array preserved as nested array
  ✓ API response tax_breakdown is an array
  ✓ sum of check component amounts equals bill tax_amount exactly
  ✓ sum of split tax_amounts equals source tax_amount 0.02
  ✓ Tax A reconciles across checks to 0.01
  ✓ Tax B reconciles across checks to 0.01
  ✓ flat tax breakdown split returns 201
  ✓ flat tax_breakdown is an array
  ✓ flat tax_breakdown elements are objects, not nested arrays
  ✓ sum of flat component amounts equals bill tax_amount exactly
  ✓ flat tax_breakdown is an array
  ✓ flat tax_breakdown elements are objects, not nested arrays
  ✓ sum of flat component amounts equals bill tax_amount exactly
  ✓ partial-quantity legacy tax split returns 201
  ✓ partial-quantity child exposes only its billed quantity
  ✓ partial-quantity child scales nested legacy tax evidence to its tax target
  ✓ backend and frontend split resolvers agree for partial legacy tax
  ✓ partial legacy tax components reconcile to each child tax amount
  ✓ partial-quantity child exposes only its billed quantity
  ✓ partial-quantity child scales nested legacy tax evidence to its tax target
  ✓ backend and frontend split resolvers agree for partial legacy tax
  ✓ partial legacy tax components reconcile to each child tax amount
  ✓ partial-quantity legacy tax reconciles across children
  ✓ categorized items plus configured packaging charge order is created
  ✓ source tax includes two item taxes and one packaging tax
  ✓ snapshot-tax split returns 201
  ✓ discounting a split child is rejected before overwriting its tax snapshot
  ✓ rejected split-child discount preserves the marked tax snapshot
  ✓ rejected split-child discount preserves tax attribution
  ✓ preserved split-child discount snapshot still reconciles to tax_amount
  ✓ backend thermal receipt tax components keep item and charge attribution per child
  ✓ frontend receipt tax components keep item and charge attribution per child
  ✓ resolved child tax components reconcile to child tax_amount
  ✓ split child total composes from allocated exclusive tax and bill fields
  ✓ backend thermal receipt tax components keep item and charge attribution per child
  ✓ frontend receipt tax components keep item and charge attribution per child
  ✓ resolved child tax components reconcile to child tax_amount
  ✓ split child total composes from allocated exclusive tax and bill fields
  ✓ item tax components reconcile across split children
  ✓ configured charge tax components reconcile across split children
  ✓ aggregate resolved snapshot tax equals source order tax exactly
  ✓ backend split resolver preserves legacy item tax beside marked snapshots
  ✓ frontend split resolver preserves legacy item tax beside marked snapshots
  ✓ discounting an unsplit mixed-tax bill succeeds
  ✓ discount scales mixed snapshot and legacy tax together
  ✓ mixed snapshot and legacy tax split returns 201
  ✓ persisted child breakdown preserves mixed item and legacy ownership
  ✓ mixed split backend resolver preserves item and legacy ownership
  ✓ mixed split frontend resolver preserves item and legacy ownership
  ✓ mixed split tax components reconcile to each child tax amount
  ✓ persisted child breakdown preserves mixed item and legacy ownership
  ✓ mixed split backend resolver preserves item and legacy ownership
  ✓ mixed split frontend resolver preserves item and legacy ownership
  ✓ mixed split tax components reconcile to each child tax amount
  ✓ mixed split item tax remains with its categorized owner after discount
  ✓ mixed split legacy tax remains scaled across item quantities
  ✓ mixed split tax categories reconcile to the discounted source tax
  ✓ tax component report keeps mixed legacy tax additive after splitting
  ✓ discounted sub-cent legacy tax remains split-compatible
  ✓ discounted sub-cent legacy tax keeps the aggregate source cent
  ✓ discounted sub-cent legacy split returns 201
  ✓ discounted sub-cent legacy tax stays with its owning child
  ✓ discounted sub-cent legacy components reconcile exactly
  ✓ discounted sub-cent legacy tax stays with its owning child
  ✓ discounted sub-cent legacy components reconcile exactly
  ✓ nested owner-local legacy split returns 201
  ✓ child tax totals use the same owner-local rounding as nested legacy evidence
  ✓ nested owner-local breakdown reconciles to its child tax total
  ✓ nested legacy component cents remain with their owner allocation
  ✓ nested owner-local breakdown reconciles to its child tax total
  ✓ nested legacy component cents remain with their owner allocation
  ✓ legacy tax split for void ownership returns 201
  ✓ legacy tax item can enter preparing before void
  ✓ voiding legacy tax item remains supported after splitting
  ✓ void adjustment legacy tax stays with its original owner
  ✓ void adjustment legacy components reconcile exactly
  ✓ void adjustment legacy tax stays with its original owner
  ✓ void adjustment legacy components reconcile exactly
  ✓ snapshot-tax split for void regression returns 201
  ✓ snapshot item moves to preparing before the void regression
  ✓ voiding a split snapshot item keeps the mutation supported
  ✓ voided split child keeps item and charge tax categories
  ✓ void evidence is not allocated to the sibling child
  ✓ voided split child tax components reconcile exactly
  ✓ void sync preserves marked child tax snapshots
  ✓ voided split child keeps item and charge tax categories
  ✓ void evidence is not allocated to the sibling child
  ✓ voided split child tax components reconcile exactly
  ✓ void sync preserves marked child tax snapshots
  ✓ voided split child tax totals reconcile to the updated order
  ✓ uneven split snapshot components reconcile within their owner
  ✓ uneven split snapshot components remain additive across children
  ✓ snapshot allocations preserve item ownership for tax and line bases
  ✓ cancelling an item after splitting keeps the order mutation supported
  ✓ cancel sync preserves exact item and charge tax attribution
  ✓ cancel sync preserves exact frontend item and charge tax attribution
  ✓ cancel sync preserves marked child tax snapshots
  ✓ cancel sync keeps backend and frontend tax attribution aligned
  ✓ cancel sync resolved tax reconciles to each child tax amount
  ✓ cancel sync preserves exact item and charge tax attribution
  ✓ cancel sync preserves exact frontend item and charge tax attribution
  ✓ cancel sync preserves marked child tax snapshots
  ✓ cancel sync keeps backend and frontend tax attribution aligned
  ✓ cancel sync resolved tax reconciles to each child tax amount
  ✓ cancel sync item tax reconciles across children
  ✓ cancel sync charge tax reconciles across children
  ✓ cancel sync aggregate tax attribution reconciles to the updated order
  ✓ restoring an item after splitting keeps the order mutation supported
  ✓ restore sync recomputes child item and charge tax attribution
  ✓ restore sync resolved tax reconciles to each child tax amount
  ✓ restore sync recomputes child item and charge tax attribution
  ✓ restore sync resolved tax reconciles to each child tax amount
  ✓ signed tax snapshot allocation keeps each child non-duplicated
  ✓ signed tax snapshot allocations reconcile exactly to the source
[DB] Database closed

187/187 passed
```
</details>
<details>
<summary>Evidence: Thermal rendering evidence</summary>

Source: Thermal rendering evidence (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01KZWQ7K5ZMR9WD9HTXH4H3P9S/printer-rendering.log</code>)

```text
Rendered thermal receipt checks passed: categorized VAT and legacy levy labels rendered, categorized item legacy copy was omitted. 110 passed, 0 failed.
```
</details>
- Outcome: 🔧 3 issues found → auto-fixed ✅ across 2 runs (22m56s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c2c9eab290bffdc3a407074e25dc608816a09d61","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (14) ✅</summary>

- 🚨 `main/routes/bills.ts:366` - Snapshot components are allocated independently, but child tax totals are allocated separately. Largest-remainder allocation is not additive: with two 0.01 components and child weights 1:2, components allocate as [0,1]¢ each while total tax allocates [1,1]¢. The first child then has a marked snapshot totaling 0 but tax_amount 0.01, causing the resolver to emit generic Tax or distort item/charge attribution. Reconcile component allocations against each allocated child tax minor target at this shared boundary, preserving signed handling.
- ⚠️ `main/services/tax-components.ts:181` - The resolver now depends on the split marker, but supported item cancel/restore flows can overwrite one unpaid split child with the unmarked aggregate tax snapshot (`main/routes/index.ts` updates a bill selected only by order_id). That child then misses this fast path and falls back to shared item snapshots plus the full charge snapshot, making the original attribution swap reachable again. Preserve/recompute child-specific snapshots at that bill-sync boundary or prevent these mutations after splitting.

🔧 Fix: Fixed tax snapshot attribution and post-split bill resync
2 issues (1 error, 1 warning) still open:
- 🚨 `main/routes/bills.ts:432` - Required criterion: “Fix the residual user-visible attribution defect ... asserts item/charge category attribution.” Each source snapshot is first allocated with owner-specific weights, but the new global reconciliation at this boundary transfers cents across independent item/charge snapshot entries. For example, 1¢ of item A on child 1 and 1¢ of item B on child 2 can reconcile to a bill-weight target of [0,2], moving item A’s cent to child 2. The marked snapshot then makes receipt/thermal resolvers show the wrong attribution. Reconcile within ownership-preserving boundaries or derive child totals from owner-aware component allocations.
- ⚠️ `main/routes/bills.ts:450` - Required criterion: “persists child-specific minor-unit snapshots.” Component allocations use per-snapshot weights, but grossAmount and taxableBase are allocated using aggregate bill weights. An item snapshot owned by child 1 can therefore have its persisted gross value spread onto child 2, making child snapshot evidence internally inconsistent. Allocate these fields with the corresponding local snapshot weights and preserve signed minor-unit reconciliation.

🔧 Fix: Preserve owner-local split tax snapshot allocation
2 errors still open:
- 🚨 `main/routes/bills.ts:1445` - Required criterion: “Preserve or recompute marked child-specific tax snapshots across supported post-split unpaid bill/order mutation paths so receipt and thermal resolvers cannot regress to shared source snapshots.” The unpaid split-child `POST /api/bills/:id/applyDiscount` path remains reachable and writes the unallocated aggregate `taxRollup.snapshotJson` at `main/routes/bills.ts:1445`, removing the split marker and recreating the attribution swap. Reject this operation for split children or apply an owner-aware child allocation.
- 🚨 `main/routes/bills.ts:678` - Required criterion: “Preserve signed snapshot reconciliation without weakening the non-negative largest-remainder allocator or void_adjustment exclusion.” After a split, voiding a prepared item creates a `voided` original plus a `void_adjustment`; `snapshotWeights` includes both because this filter excludes only `cancelled` items. The adjustment has no `bill_items`, so it falls back to aggregate weights and distributes its negative snapshot across sibling checks, while ordinary total allocation excludes both statuses. This can show negative tax on a child that owns no voided item and make child tax inconsistent with its allocated total. Exclude void evidence from child snapshots or preserve the original owner for the adjustment pair at this shared boundary.

🔧 Fix: Preserve split tax snapshots through mutation paths
4 issues (3 errors, 1 warning) still open:
- 🚨 `main/services/tax-components.ts:181` - The any-marked-snapshot fast path ignores legacy item tax. Mixed orders can contain categorized snapshots plus legacy tax_breakdown entries; the snapshot sum then does not cover tax_amount, but marked child snapshots still make both resolvers skip legacy components and scale the remaining snapshot components to the full tax total. This contradicts the required “preserves legacy nested and flat tax_breakdown compatibility.” Preserve residual legacy tax or only use the fast path when snapshots cover the complete tax.
- 🚨 `main/routes/bills.ts:758` - When snapshot tax allocation matches, this replaces each child tax_amount with owner-local snapshot tax, while total/subtotal/charge fields were already allocated using aggregate bill weights. For example, exclusive items totaling 20+2 tax and 40+2 tax split into weights 22:42 produce child totals 22.00/42.00, subtotals 20.63/39.37, but owner-local tax 2.00/2.00; the child financial fields no longer add to their displayed totals. Derive totals from consistent child financial allocations, accounting for exclusive versus inclusive tax, or keep tax_amount allocation aligned with total.
- 🚨 `main/routes/bills.ts:1331` - The new split-child discount rejection is checked before the withTxn block, and the transaction re-reads neither the bill nor split_group_id before writing taxRollup.snapshotJson. If applyDiscount reads an unsplit bill, split-check commits, and applyDiscount then enters its transaction, it overwrites the newly split child and removes the marker. Revalidate split_group_id inside the transaction before the UPDATE; apply the same lock-boundary recheck to sibling order-discount paths.
- ⚠️ `tests/payment-methods-split-checks.test.ts:515` - The acceptance requires executable coverage that asserts item/charge attribution and exact reconciliation, but the post-split cancel regression only checks backend/frontend equality and that their sum matches each child tax_amount (lines 512-516). Two resolvers returning the same incorrect attribution would pass. Assert concrete Item Tax and Charge Tax amounts per child and aggregate them after cancellation, as the restore/void cases do.

🔧 Fix: Preserve legacy tax and compositional split totals
2 errors still open:
- 🚨 `main/services/tax-components.ts:194` - Required criterion: “preserves legacy nested and flat tax_breakdown compatibility.” The marked-snapshot branch merges legacy item tax without ensuring items belong to the child bill. Reports pass all order items to every split-bill document, duplicating legacy tax across children; partial-quantity bill items also retain unscaled tax_breakdown. Scope legacy evidence to bill_items and child quantity before merging.
- 🚨 `main/routes/bills.ts:796` - The helper allocates across every split bill, then skips paid rows. Item cancellation remains allowed when another split child is paid; cancelling the only item on an unpaid child can allocate the surviving order/charge total to the paid child while leaving it unchanged, producing inconsistent bill and order totals. Reject such mutations or protect paid-child allocations before updating unpaid children.

🔧 Fix: Scope partial legacy tax and protect paid split siblings
4 issues (2 errors, 2 warnings) still open:
- 🚨 `main/services/tax-components.ts:194` - The required “preserves legacy nested and flat tax_breakdown compatibility” is still violated because this branch merges legacy evidence from whatever `document.items` the caller supplies. `/api/reports/tax-components` passes all order items to every split bill, duplicating legacy tax across children; the printer path filters by bill but scales only subtotal/tax_amount/total, leaving partial-quantity legacy tax unscaled. Scope items and quantities at a shared bill-hydration boundary before this merge.
- 🚨 `main/routes/bills.ts:917` - Mixed marked-snapshot plus legacy orders still lose ownership attribution. With marked item tax 1.00, legacy item tax 0.50, and two equal children, snapshot totals do not equal source tax, so this falls back to aggregate child tax targets of 0.75 each; the marked snapshot remains [1.00, 0], legacy breakdown becomes [0.25, 0.25], and resolver reconciliation changes the visible categories to approximately [Item 0.60, Legacy 0.15] and [Item 0.00, Legacy 0.75]. This contradicts the required exact item/charge attribution and legacy compatibility. Allocate the residual legacy tax owner-locally or only use the marked path when it covers the complete tax.
- ⚠️ `main/routes/bills.ts:48` - `scaleTaxBreakdown` rounds each legacy component independently. A quantity-2 legacy item with two 0.01 components and 0.02 total tax split one unit per child produces child tax_amount 0.01 but child breakdown 0.01 + 0.01 = 0.02; the backend resolver may rescale this while the frontend legacy path does not, so receipt/thermal outputs diverge. Use owner-local minor-unit/remainder reconciliation for legacy breakdowns before rendering.
- ⚠️ `main/routes/bills.ts:830` - The new split-sync guard rejects only fully paid siblings, and the update loop skips only `payment_status === &#39;paid&#39;`. A split child can be `partial`; cancelling an item can reduce its allocated total below its existing paid_amount, after which this writes total and balance while retaining the old paid_amount/status, creating an overpaid partial bill and inconsistent settlement state. Reject mutations after any split-child payment or preserve the paid child allocation explicitly.

🔧 Fix: Scope legacy tax ownership and block paid split mutations
2 issues (1 error, 1 warning) still open:
- 🚨 `main/routes/bills.ts:980` - The split legacy residual compares scaled bill tax/snapshots with raw pre-discount `order_items.tax_amount`. A mixed categorized+legacy order discounted before splitting therefore falls back to aggregate child tax targets, while both resolvers merge unscaled child legacy evidence; item-versus-legacy attribution becomes incorrect despite totals reconciling. This contradicts the required preservation of legacy nested/flat breakdown compatibility and exact category attribution. Derive the residual from the already scaled source breakdown or apply the same discount scaling before child resolution.
- ⚠️ `main/routes/reports.ts:212` - The tax-components report now calls `getOrderWithItems` once per bill, and that helper performs multiple database queries plus repeated split-group scans. This replaces the previous batched item query with an N+1 path for long date ranges. Batch or cache hydration by order/split group.

🔧 Fix: Fix discount-scaled tax and batch report hydration
3 issues (2 errors, 1 warning) still open:
- 🚨 `main/routes/bills.ts:1018` - Per-item legacy tax is rounded before reconciliation (line 959), and a mismatch falls back to aggregate child tax targets at line 1018. Example: two legacy rows with 0.01 tax each and a 66.67% discount produce source tax 0.01, but each child-scoped row rounds to 0.00; backend/frontend resolution then loses legacy attribution and can disagree. This contradicts the required preservation of legacy nested/flat tax_breakdown compatibility. Reconcile legacy allocations against the aggregate source minor total before fallback.
- 🚨 `main/routes/bills.ts:1037` - The breakdown-owner mapper skips only cancelled items, so voided and void_adjustment evidence is still processed. A voided legacy item retains its bill_items owner, but its synthetic adjustment has no bill_items row and therefore falls back to active sibling weights in allocateTaxBreakdown; on a split legacy-only order this can persist positive tax on the original child and negative tax on the sibling, which the unmarked resolvers display. Exclude void evidence or preserve the original owner for the adjustment pair, maintaining the required void_adjustment exclusion.
- ⚠️ `main/routes/bills.ts:853` - allocateTaxBreakdown still performs a global reconciliation across independent source entries at lines 853-856. In an uneven mixed snapshot/legacy split, this can transfer a cent from a marked item entry to a legacy owner to match child totals. The receipt/thermal resolver uses marked snapshots, but the frontend payment UI renders bill.tax_breakdown directly (frontend/src/components/pos/PaymentModal.tsx:371), so the cashier can see the item/legacy category on the wrong child. Reconcile within ownership boundaries or make this consumer use the marked-snapshot resolver.

🔧 Fix: Preserve legacy split tax ownership and void attribution
2 errors still open:
- 🚨 `frontend/src/lib/printer/tax-components.ts:150` - Required criterion: “makes backend/frontend resolvers consume the marked child snapshots” while preserving legacy attribution. The resolver merges `document.order?.items` at this line, but the Orders page overwrites fresh child data with the unscoped list order (`{ ...latestBill, order }`). Printing a split child with mixed marked and legacy tax therefore includes the sibling’s full legacy tax, then rescales categories to the child total, producing incorrect attribution.
- 🚨 `frontend/src/lib/printer/tax-components.ts:135` - Required criterion: “Preserve signed snapshot reconciliation without weakening the non-negative largest-remainder allocator or void_adjustment exclusion.” Both frontend item filters omit `void_adjustment`. A legacy-only split after a prepared-item void can therefore include the synthetic negative tax line in browser/thermal resolution, diverging from the backend and showing shifted or negative tax.

🔧 Fix: Preserve child-scoped frontend printing and void-tax filtering
3 issues (2 errors, 1 warning) still open:
- 🚨 `main/routes/bills.ts:1035` - The required “preserves legacy nested and flat tax_breakdown compatibility” is violated for bill-level legacy tax with no legacy item rows. The residual is allocated into legacyTaxMinors, but this branch returns zero legacyExclusiveTaxMinors; composeSplitTotals then omits that exclusive tax from each child total while tax_amount includes it. Derive exclusivity from the legacy breakdown or preserve compositional totals.
- 🚨 `main/services/tax-components.ts:194` - The required “preserves legacy nested and flat tax_breakdown compatibility” is violated when a marked child snapshot coexists with legacy document-level tax. This fast path merges only marked snapshots and legacy item rows, never document.tax_breakdown, so a legacy charge component is dropped and reconcileTotal relabels its amount as item tax. The frontend resolver has the same defect at frontend/src/lib/printer/tax-components.ts:163.
- ⚠️ `main/routes/bills.ts:1245` - The requirement to preserve non-negative integer largest-remainder allocation is undermined because roundOff is passed to allocateMinorUnits even though applyPayableRounding can produce negative values. For a -2¢ adjustment with child weights 1:3, this allocator yields [0,-2] instead of signed largest-remainder allocation [-1,-1], shifting the child total distribution. Allocate signed round-off separately while keeping ordinary fields on the non-negative allocator.

🔧 Fix: Preserve legacy tax and signed split allocations
3 issues (2 errors, 1 warning) still open:
- 🚨 `main/services/tax-components.ts:217` - The required behavior is to “make backend/frontend resolvers consume the marked child snapshots” while preserving legacy breakdown compatibility. The split fast path merges the child snapshot with `documentLegacyComponents`, which re-adds the child’s normal item/charge `tax_breakdown` mirror. A child with snapshot Item Tax 1.00 + Charge Tax 0.50 and the same persisted breakdown merges to 3.00, then rescales to 1.50, displaying 0.75/0.375 instead of 1.00/0.50. The frontend has the same defect at `frontend/src/lib/printer/tax-components.ts:175-178`. Include only residual document-level legacy entries not represented by the marked snapshot.
- 🚨 `main/routes/bills.ts:1035` - The required nested legacy tax compatibility and exact child reconciliation are still violated because child tax totals and persisted breakdowns use different rounding boundaries. `allocateLegacyTaxContribution` aggregates all legacy owner weights and allocates the residual once (lines 1003-1035), while `allocateTaxBreakdown` allocates each nested owner group independently (lines 919-923). With two 1¢ legacy rows each split 1:2, tax_amount allocates [1¢,1¢] but both per-row breakdown cents allocate to child 2, so child 1 loses the named legacy component and the resolver falls back to generic/scaled tax. Derive child tax totals from the same owner-local breakdown allocations or reconcile at each owner boundary.
- ⚠️ `main/routes/bills.ts:920` - The required flat `tax_breakdown` compatibility is incomplete. Flat entries are treated as one global group and reconciled against `checkTaxMinors` at lines 920-923, so cents can move between independent item/charge owners when flat legacy data coexists with child-specific snapshots. `PaymentModal` renders `bill.tax_breakdown` directly, allowing cashier-visible attribution to differ from the marked-snapshot receipt/thermal resolver. Preserve owner-local allocations where ownership is known or make this consumer use the marked child resolver.

🔧 Fix: Preserve owner-local split tax attribution
1 error still open:
- 🚨 `frontend/src/components/pos/PaymentModal.tsx:372` - This changed hunk passes the bare `/bills/generate` response to `resolveTaxComponents`. For a non-split mixed legacy bill, it has no `order.items`; the resolver therefore selects `tax_snapshot` and skips `tax_breakdown`, hiding the residual legacy components in the payment modal. This contradicts the required “preserves legacy nested and flat tax_breakdown compatibility.” In the no-items snapshot path, merge residual document legacy components after subtracting mirrored snapshot components (as the marked-child path does).

🔧 Fix: Preserve residual legacy tax in generated bills
1 error still open:
- 🚨 `main/services/tax-components.ts:265` - The required criterion “preserves legacy nested and flat tax_breakdown compatibility” remains violated when active item snapshots coexist with document-level legacy tax and no charge snapshot. At `main/services/tax-components.ts:265` (and frontend `frontend/src/lib/printer/tax-components.ts:238`), the resolver reconciles only item snapshot components to the full tax_amount, relabeling the legacy residual as item tax; e.g. Item Tax 1.00 plus Legacy Charge Tax 0.50 renders Item Tax 1.50. Include residual document-level legacy components in this active-item path, or only take the snapshot fast path when item evidence covers the document total.

🔧 Fix: Preserve active-item legacy tax attribution
1 error still open:
- 🚨 `main/services/tax-components.ts:220` - Required criterion: “preserves legacy nested and flat tax_breakdown compatibility.” The split fast path merges child-scoped legacy item evidence with residual entries from the globally allocated flat bill breakdown. With two distinct legacy item taxes of 1.00 split across weights 1:2, the flat breakdown is allocated roughly 0.67/0.33 per child, then reconciliation scales the merged results, visibly moving part of each item’s tax to the other child. Preserve flat-entry ownership during allocation or exclude already represented child item evidence from this residual merge; the frontend path has the same defect at `frontend/src/lib/printer/tax-components.ts:183`.

🔧 Fix: Preserve flat legacy tax ownership across split children
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `main/routes/bills.ts:1532` - The split-check endpoint returns HTTP 500 (`Cannot read properties of undefined (reading &#39;0&#39;)`) even for a basic two-check dine-in order, so child bills are not created.
- 🚨 `main/services/tax-components.ts:230` - The backend marked split-snapshot resolver passes number components into Decimal-only merge logic, throwing `component.amount.toDecimalPlaces is not a function` for Item Tax plus Charge Tax.
- 🚨 `main/services/tax-components.ts:288` - A categorized item snapshot still leaks stale document-level legacy tax (`WRONG`) into resolved components instead of suppressing it.
- `npm run test:tax-components`
- `npm run test:payment-methods-split`
- `node tests/run-electron-node-test.cjs /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01KZWQ7K5ZMR9WD9HTXH4H3P9S/split-diagnostic.test.ts`
- `git diff --check ae4c31e... a815e70...`
- <code>Final worktree status check; repository-local `node_modules` removed after testing</code>

🔧 Fix: Fixed split tax attribution regressions
✅ Re-checked - no issues remain.
- `npm run test:tax-components`
- `npm run test:payment-methods-split`
- `npm run test:printer`
- <code>`git status --short --branch` after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 error</summary>

- 🚨 Targeted backend and frontend ESLint checks could not start because required dependencies are not installed; git diff --check passes.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
