### PR TITLE
fix: require Master PIN for schema-mismatch database imports

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -290,7 +290,7 @@ export default function SettingsPage() {
   // ?tab=/?action= deep-link params directly (lazy init, once at mount) instead of being set
   // by the mount effect below — that effect now only owns the actual async fetches.
   const [activeTab, setActiveTab] = useState(() => searchParams?.get('tab') || 'store');
-  const [masterPinStatus, setMasterPinStatus] = useState<{ available: boolean; isSet: boolean }>({ available: false, isSet: false });
+  const [masterPinStatus, setMasterPinStatus] = useState<{ available: boolean; isSet: boolean; schemaVersion: number | null }>({ available: false, isSet: false, schemaVersion: null });
   const [healthCheckOpen, setHealthCheckOpen] = useState(() => searchParams?.get('action') === 'health-check');
   const [healthReport, setHealthReport] = useState<HealthCheckReport | null>(null);
   const [applyingFixes, setApplyingFixes] = useState(false);
@@ -4079,7 +4079,16 @@ export default function SettingsPage() {
 
                       const overwrite = await confirm(t('settings.importOverwriteConfirm'), { confirmLabel: t('settings.replaceAll') });
 
-                      if (overwrite && masterPinStatus.available) {
+                      // A schema-mismatch import takes the same destructive
+                      // delete-and-replace path as an overwrite, so it needs the
+                      // same Master PIN confirmation (GHSA-xxv4-gm82-4639).
+                      const rawImportVersion = String(data.schema_version ?? '');
+                      const importVersion = /^(?:0|[1-9]\d*)$/.test(rawImportVersion) ? Number(rawImportVersion) : null;
+                      const schemaMismatch = masterPinStatus.schemaVersion != null
+                        && (importVersion === null || importVersion !== masterPinStatus.schemaVersion);
+                      const destructive = overwrite || schemaMismatch;
+
+                      if (destructive && masterPinStatus.available) {
                         if (!masterPinStatus.isSet) {
                           toast.error(t('settings.masterPinRequiredForReplace'));
                           return;

--- a/main/routes/database-tools.ts
+++ b/main/routes/database-tools.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { resetDatabaseWithBackup, listBackups, deleteBackup } from '../db';
+import { resetDatabaseWithBackup, listBackups, deleteBackup, getCurrentSchemaVersion } from '../db';
 import { clearInMemoryRevokedTokens, clearUserAuthCache, requireRole } from '../middleware/security';
 import { requireMasterPin } from '../middleware/master-pin';
 import { asyncHandler } from '../middleware/async-handler';
@@ -55,7 +55,7 @@ router.post('/backups/:fileName/delete', requireRole('owner'), requireMasterPin,
 });
 
 router.get('/master-pin/status', requireRole('owner'), (_req: Request, res: Response) => {
-  res.json({ available: isMasterPinAvailable(), isSet: isMasterPinSet() });
+  res.json({ available: isMasterPinAvailable(), isSet: isMasterPinSet(), schemaVersion: getCurrentSchemaVersion() });
 });
 
 router.post('/master-pin/reset', requireRole('owner'), (req: Request, res: Response) => {

--- a/main/routes/database.ts
+++ b/main/routes/database.ts
@@ -37,6 +37,15 @@ const USER_REDACT_COLS = new Set(['password', 'pin', 'pin_hash']);
 const EXPORT_EXCLUDE_TABLES = new Set(['cloud_sync_outbox', 'support_ticket_outbox', 'store_diagnostics_outbox', 'kds_pairing_tokens']);
 const USER_ROLES = new Set(['owner', 'manager', 'cashier', 'waiter', 'chef']);
 
+// Parses an import file's schema_version exactly as the import handler does.
+// A missing or malformed value collapses to -1 (and an omitted version to 0),
+// which always counts as a mismatch against the live schema — and therefore as
+// a destructive, delete-and-replace import that needs Master PIN confirmation.
+function parseImportSchemaVersion(value: unknown): number {
+  const raw = String(value ?? '0');
+  return /^(?:0|[1-9]\d*)$/.test(raw) ? Number(raw) : -1;
+}
+
 router.get('/export', requireRole('owner'), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
@@ -109,7 +118,20 @@ router.get('/export', requireRole('owner'), (req: Request, res: Response) => {
 });
 
 router.post('/import', requireRole('owner'),
-  (req: Request, res: Response, next: () => void) => (req.body?.overwrite ? requireMasterPin(req, res, next) : next()),
+  (req: Request, res: Response, next: () => void) => {
+    // A schema-mismatch import reaches the same delete-and-replace path as an
+    // explicit overwrite (the `overwrite || hasVersionMismatch` branch below),
+    // so it must require the same Master PIN confirmation. Gate on both
+    // triggers so an owner cannot bypass the destructive-operation confirmation
+    // by submitting a deliberately mismatched or malformed schema_version
+    // (GHSA-xxv4-gm82-4639).
+    const body = req.body as { overwrite?: unknown; data?: Record<string, unknown> } | undefined;
+    const overwrite = Boolean(body?.overwrite);
+    const schemaVersionMismatch = body?.data && typeof body.data === 'object'
+      ? parseImportSchemaVersion(body.data.schema_version) !== getCurrentSchemaVersion()
+      : false;
+    return (overwrite || schemaVersionMismatch) ? requireMasterPin(req, res, next) : next();
+  },
   asyncHandler(async (req: Request, res: Response) => {
   return withDatabaseMaintenanceLock(async (signal) => {
     try {
@@ -129,10 +151,12 @@ router.post('/import', requireRole('owner'),
     const preservedKdsEnabled = captureKdsEnabledSetting(db);
     const preservedProtectedSettings = captureRestoreProtectedSettings(db);
     const importData = data.data as Record<string, any[]>;
-    const importSchemaVersionRaw = String(data.schema_version ?? '0');
-    const importSchemaVersion = /^(?:0|[1-9]\d*)$/.test(importSchemaVersionRaw)
-      ? Number(importSchemaVersionRaw)
-      : -1;
+    const importSchemaVersion = parseImportSchemaVersion(data.schema_version);
+    const hasVersionMismatch = importSchemaVersion !== getCurrentSchemaVersion();
+
+    if (hasVersionMismatch) {
+      console.log(`[DB Import] Version mismatch: import v${importSchemaVersion} vs current v${getCurrentSchemaVersion()}. Using data-only merge.`);
+    }
 
     const requiredTables = ['settings', 'categories', 'products', 'users'];
     const importedTables = Object.keys(importData);
@@ -194,11 +218,6 @@ router.post('/import', requireRole('owner'),
 
     const { path: backupPath } = await createBackupUnlocked(undefined, signal);
     throwIfDatabaseMaintenanceAborted(signal);
-    const hasVersionMismatch = importSchemaVersion !== getCurrentSchemaVersion();
-
-    if (hasVersionMismatch) {
-      console.log(`[DB Import] Version mismatch: import v${importSchemaVersion} vs current v${getCurrentSchemaVersion()}. Using data-only merge.`);
-    }
 
     const previousForeignKeys = Number(db.pragma('foreign_keys', { simple: true })) === 1;
     db.pragma('foreign_keys = OFF');

--- a/tests/database-tools-api.test.ts
+++ b/tests/database-tools-api.test.ts
@@ -297,10 +297,30 @@ async function runTests() {
     db.prepare("INSERT OR IGNORE INTO categories (id, name, sort_order) VALUES ('ghsa-sentinel', 'Sentinel', 999)").run();
     const sentinelCount = () => (db.prepare("SELECT COUNT(*) AS c FROM categories WHERE id = 'ghsa-sentinel'").get() as { c: number }).c;
 
+    // GET /api/db-tools/master-pin/status exposes live schemaVersion alongside availability
+    const pinStatus = await request(app).get('/api/db-tools/master-pin/status').set('Authorization', `Bearer ${ownerToken}`);
+    assert(pinStatus.status === 200, `master-pin status returns 200 (got ${pinStatus.status})`);
+    assert(pinStatus.body.available === true, 'master-pin status reports available: true');
+    assert(pinStatus.body.isSet === true, 'master-pin status reports isSet: true');
+    assert(pinStatus.body.schemaVersion === currentVersion, `master-pin status includes live schemaVersion (got ${pinStatus.body.schemaVersion}, expected ${currentVersion})`);
+
     // Mismatched (future) schema version, no PIN → rejected and DB unchanged.
     const futureNoPin = await importWithoutPin({ schema_version: String(currentVersion + 1), data: emptyPayload });
     assert(futureNoPin.status === 403, `future schema_version import without a PIN is rejected (got ${futureNoPin.status})`);
     assert(sentinelCount() === 1, 'rejected schema-mismatch import leaves the database unchanged');
+
+    // Mismatched schema version with wrong PIN → rejected and DB unchanged.
+    const mismatchedWrongPin = await request(app).post('/api/db/import').set('Authorization', `Bearer ${ownerToken}`).send({
+      overwrite: false,
+      master_pin: '0000',
+      data: { schema_version: String(currentVersion + 1), data: emptyPayload },
+    });
+    assert(mismatchedWrongPin.status === 403, `mismatched schema_version with wrong PIN is rejected (got ${mismatchedWrongPin.status})`);
+    assert(sentinelCount() === 1, 'rejected wrong-PIN schema-mismatch import leaves the database unchanged');
+
+    // Fresh install (schema version 0), no PIN → rejected.
+    const freshZeroNoPin = await importWithoutPin({ schema_version: '0', data: emptyPayload });
+    assert(freshZeroNoPin.status === 403, `fresh schema_version 0 import without a PIN is rejected (got ${freshZeroNoPin.status})`);
 
     // Old (upgrade-path) schema version, no PIN → rejected.
     const oldNoPin = await importWithoutPin({ schema_version: String(currentVersion - 1), data: emptyPayload });

--- a/tests/database-tools-api.test.ts
+++ b/tests/database-tools-api.test.ts
@@ -286,6 +286,54 @@ async function runTests() {
     assert(entry.kind === 'manual', 'a backup created via POST /db/backup is classified as manual, not auto');
   }
 
+  // ── Test 3c: schema-mismatch import requires the Master PIN (GHSA-xxv4-gm82-4639) ──
+  console.log('\nTest 3c: POST /db/import destructive path is master-PIN gated');
+  {
+    const currentVersion = getCurrentSchemaVersion();
+    const emptyPayload = { settings: [], categories: [], products: [], users: [] };
+    const importWithoutPin = (payload: Record<string, unknown>) =>
+      request(app).post('/api/db/import').set('Authorization', `Bearer ${ownerToken}`).send({ overwrite: false, data: payload });
+
+    db.prepare("INSERT OR IGNORE INTO categories (id, name, sort_order) VALUES ('ghsa-sentinel', 'Sentinel', 999)").run();
+    const sentinelCount = () => (db.prepare("SELECT COUNT(*) AS c FROM categories WHERE id = 'ghsa-sentinel'").get() as { c: number }).c;
+
+    // Mismatched (future) schema version, no PIN → rejected and DB unchanged.
+    const futureNoPin = await importWithoutPin({ schema_version: String(currentVersion + 1), data: emptyPayload });
+    assert(futureNoPin.status === 403, `future schema_version import without a PIN is rejected (got ${futureNoPin.status})`);
+    assert(sentinelCount() === 1, 'rejected schema-mismatch import leaves the database unchanged');
+
+    // Old (upgrade-path) schema version, no PIN → rejected.
+    const oldNoPin = await importWithoutPin({ schema_version: String(currentVersion - 1), data: emptyPayload });
+    assert(oldNoPin.status === 403, `old-schema (upgrade-path) import without a PIN is rejected (got ${oldNoPin.status})`);
+
+    // Malformed schema version, no PIN → treated as destructive and rejected.
+    const malformedNoPin = await importWithoutPin({ schema_version: 'not-a-version', data: emptyPayload });
+    assert(malformedNoPin.status === 403, `malformed schema_version import without a PIN is rejected (got ${malformedNoPin.status})`);
+
+    // Omitted schema version, no PIN → defaults to 0 (a mismatch) and is rejected.
+    const omittedNoPin = await importWithoutPin({ data: emptyPayload });
+    assert(omittedNoPin.status === 403, `omitted schema_version import without a PIN is rejected (got ${omittedNoPin.status})`);
+
+    // Mismatched schema version with the correct PIN → allowed.
+    const mismatchedWithPin = await request(app).post('/api/db/import').set('Authorization', `Bearer ${ownerToken}`).send({
+      overwrite: false,
+      master_pin: '1234',
+      data: { schema_version: String(currentVersion + 1), data: emptyPayload },
+    });
+    assert(mismatchedWithPin.status === 200, `schema-mismatch import with the correct PIN succeeds (got ${mismatchedWithPin.status}, ${JSON.stringify(mismatchedWithPin.body)})`);
+
+    // Matching schema version, no overwrite, no PIN → non-destructive merge, allowed.
+    const matchingNoPin = await importWithoutPin({ schema_version: String(currentVersion), data: emptyPayload });
+    assert(matchingNoPin.status === 200, `matching-schema import without overwrite needs no PIN (got ${matchingNoPin.status})`);
+
+    // Matching schema version + explicit overwrite, no PIN → still rejected.
+    const matchingOverwriteNoPin = await request(app).post('/api/db/import').set('Authorization', `Bearer ${ownerToken}`).send({
+      overwrite: true,
+      data: { schema_version: String(currentVersion), data: emptyPayload },
+    });
+    assert(matchingOverwriteNoPin.status === 403, `matching-schema overwrite import without a PIN is still rejected (got ${matchingOverwriteNoPin.status})`);
+  }
+
   // ── Test 4: POST /db-tools/initialize ────────────────────────────────────
   console.log('\nTest 4: POST /db-tools/initialize');
   {


### PR DESCRIPTION
## Intent

Fix security advisory GHSA-xxv4-gm82-4639: a database import with a schema-version mismatch can enter the destructive delete-and-replace path without the Master PIN confirmation required for an explicit overwrite, letting an authenticated owner erase or replace local data without that secondary confirmation. Require the same destructive-operation authorization for schema-mismatch imports; cover matching, mismatched, malformed, fresh, and upgrade-path imports; ensure rejected imports leave the existing database unchanged. Implementation decisions: gate the Master PIN on overwrite OR schemaVersionMismatch (treating missing/malformed schema_version as a mismatch) in the import route middleware, share one version-parsing helper between the gate and the handler, and expose the live schema version via GET /db-tools/master-pin/status so the settings import UI can prompt for the PIN when an import is destructive. No database migration is needed.

## What Changed

- Gated `POST /api/db/import` behind Master PIN confirmation when `overwrite` is true or when the imported `schema_version` is missing, malformed, or mismatches the active database schema.
- Updated `GET /api/db-tools/master-pin/status` to include the current `schemaVersion`, and updated the settings import UI to check for schema mismatches and prompt for the Master PIN.
- Added regression tests in `tests/database-tools-api.test.ts` covering matching, mismatched, malformed, fresh, and upgrade-path imports, verifying rejected imports leave the database unchanged.

## Risk Assessment

✅ Low: The change is clean, well-bounded, and correctly resolves GHSA-xxv4-gm82-4639 by enforcing Master PIN authorization on schema-mismatch database imports across the backend middleware, handler, frontend UI, and integration tests.

## Testing

Targeted test suites and end-to-end execution verified the Master PIN authorization gate on POST /api/db/import for mismatched (future, upgrade-path, malformed, omitted, and v0) schema versions as well as explicit overwrites, confirmed untouched database state on rejection, verified safe non-destructive merge on matching schema imports without PIN, validated schemaVersion exposure via GET /api/db-tools/master-pin/status, and confirmed both backend and Next.js frontend builds compile cleanly with zero errors; complete verification logs, structured JSON results, and an interactive HTML report artifact were recorded to the evidence directory.

<details>
<summary>Evidence: GHSA-xxv4-gm82-4639 Interactive HTML Verification Report &amp; UI Demonstration</summary>

```text
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>GHSA-xxv4-gm82-4639 Verification Report - FloCafe</title>
  <style>
    :root {
      --bg: #f8fafc;
      --card-bg: #ffffff;
      --border: #e2e8f0;
      --text: #0f172a;
      --text-muted: #64748b;
      --success: #10b981;
      --success-bg: #ecfdf5;
      --danger: #ef4444;
      --danger-bg: #fef2f2;
      --warning: #f59e0b;
      --warning-bg: #fffbeb;
      --primary: #3b82f6;
    }
    body {
      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
      background-color: var(--bg);
      color: var(--text);
      margin: 0;
      padding: 32px;
      line-height: 1.5;
    }
    .container {
      max-width: 1000px;
      margin: 0 auto;
    }
    .header {
      background: var(--card-bg);
      padding: 24px;
      border-radius: 12px;
      border: 1px solid var(--border);
      margin-bottom: 24px;
    }
    .badge {
      display: inline-block;
      padding: 4px 10px;
      border-radius: 9999px;
      font-size: 12px;
      font-weight: 600;
    }
    .badge-success { background: var(--success-bg); color: #065f46; border: 1px solid #a7f3d0; }
    .badge-danger { background: var(--danger-bg); color: #991b1b; border: 1px solid #fecaca; }
    .badge-info { background: #eff6ff; color: #1e40af; border: 1px solid #bfdbfe; }
    h1 { margin: 12px 0 6px 0; font-size: 24px; }
    h2 { font-size: 18px; margin-top: 24px; margin-bottom: 12px; }
    p { margin: 0 0 12px 0; color: var(--text-muted); }
    table {
      width: 100%;
      border-collapse: collapse;
      background: var(--card-bg);
      border-radius: 8px;
      overflow: hidden;
      border: 1px solid var(--border);
      margin-bottom: 24px;
    }
    th, td {
      padding: 12px 16px;
      text-align: left;
      border-bottom: 1px solid var(--border);
      font-size: 14px;
    }
    th {
      background: #f1f5f9;
      font-weight: 600;
      color: #334155;
    }
    tr:last-child td { border-bottom: none; }
    .status-pass {
      color: var(--success);
      font-weight: 600;
      display: flex;
      align-items: center;
      gap: 6px;
    }
    .code-pill {
      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
      background: #f1f5f9;
      padding: 2px 6px;
      border-radius: 4px;
      font-size: 13px;
    }
    .ui-preview-card {
      background: var(--card-bg);
      border: 1px solid var(--border);
      border-radius: 12px;
      padding: 24px;
      margin-bottom: 24px;
    }
    .modal-mock {
      max-width: 440px;
      margin: 20px auto;
      background: #ffffff;
      border-radius: 16px;
      box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
      border: 1px solid #e2e8f0;
      overflow: hidden;
    }
    .modal-header {
      padding: 20px 24px 16px;
      border-bottom: 1px solid #f1f5f9;
    }
    .modal-title {
      font-size: 18px;
      font-weight: 600;
      color: #0f172a;
      margin: 0;
    }
    .modal-body {
      padding: 20px 24px;
    }
    .modal-desc {
      font-size: 14px;
      color: #64748b;
      margin-bottom: 16px;
    }
    .pin-input-group {
      display: flex;
      justify-content: center;
      gap: 12px;
      margin: 24px 0;
    }
    .pin-digit {
      width: 48px;
      height: 52px;
      border: 2px solid #cbd5e1;
      border-radius: 8px;
      text-align: center;
      font-size: 24px;
      line-height: 48px;
      font-weight: bold;
      background: #f8fafc;
    }
    .pin-digit.filled {
      border-color: #3b82f6;
      background: #ffffff;
    }
    .modal-actions {
      display: flex;
      justify-content: flex-end;
      gap: 12px;
      padding: 16px 24px;
      background: #f8fafc;
      border-top: 1px solid #f1f5f9;
    }
    .btn {
      padding: 8px 16px;
      border-radius: 8px;
      font-size: 14px;
      font-weight: 500;
      cursor: pointer;
      border: 1px solid transparent;
    }
    .btn-secondary {
      background: #ffffff;
      border-color: #cbd5e1;
      color: #334155;
    }
    .btn-primary {
      background: #dc2626;
      color: #ffffff;
    }
  </style>
</head>
<body>
  <div class="container">
    <div class="header">
      <span class="badge badge-success">VERIFIED & COMPLIANT</span>
      <span class="badge badge-info" style="margin-left: 8px;">Schema Version: 68</span>
      <h1>Security Advisory GHSA-xxv4-gm82-4639 Verification</h1>
      <p>Authorization Gate for Schema-Mismatch & Destructive Database Imports</p>
      <p style="font-size: 13px; color: #475569; margin-top: 8px;">
        <strong>Advisory Summary:</strong> Prevents an authenticated user from bypassing Master PIN authorization during destructive delete-and-replace database imports by submitting a mismatched or malformed schema_version.
      </p>
    </div>

    <h2>Test Scenario Matrix (11 / 11 Passed)</h2>
    <table>
      <thead>
        <tr>
          <th>Scenario / Test Case</th>
          <th>Import Payload</th>
          <th>PIN Provided</th>
          <th>Expected</th>
          <th>Actual</th>
          <th>DB State</th>
          <th>Verdict</th>
        </tr>
      </thead>
      <tbody>
        <tr>
          <td><strong>Status Endpoint</strong>: schemaVersion Exposure</td>
          <td><span class="code-pill">GET /db-tools/master-pin/status</span></td>
          <td>N/A</td>
          <td>200 OK with schemaVersion: 68</td>
          <td>200 OK</td>
          <td>N/A</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Future Schema Mismatch</strong> without PIN</td>
          <td><span class="code-pill">schema_version: "69"</span></td>
          <td>None</td>
          <td>403 Forbidden</td>
          <td>403 Forbidden</td>
          <td>Unchanged (Sentinel Intact)</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Old Schema (Upgrade-Path)</strong> without PIN</td>
          <td><span class="code-pill">schema_version: "67"</span></td>
          <td>None</td>
          <td>403 Forbidden</td>
          <td>403 Forbidden</td>
          <td>Unchanged (Sentinel Intact)</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Malformed Schema</strong> without PIN</td>
          <td><span class="code-pill">schema_version: "v-invalid-99"</span></td>
          <td>None</td>
          <td>403 Forbidden</td>
          <td>403 Forbidden</td>
          <td>Unchanged (Sentinel Intact)</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Omitted Schema Version</strong> without PIN</td>
          <td><span class="code-pill">schema_version: undefined</span></td>
          <td>None</td>
          <td>403 Forbidden</td>
          <td>403 Forbidden</td>
          <td>Unchanged (Sentinel Intact)</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Fresh Install Version 0</strong> without PIN</td>
          <td><span class="code-pill">schema_version: "0"</span></td>
          <td>None</td>
          <td>403 Forbidden</td>
          <td>403 Forbidden</td>
          <td>Unchanged (Sentinel Intact)</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Schema Mismatch with WRONG PIN</strong></td>
          <td><span class="code-pill">schema_version: "69"</span></td>
          <td><span class="code-pill">"0000"</span></td>
          <td>403 Forbidden</td>
          <td>403 Forbidden</td>
          <td>Unchanged (Sentinel Intact)</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Schema Mismatch with CORRECT PIN</strong></td>
          <td><span class="code-pill">schema_version: "69"</span></td>
          <td><span class="code-pill">"1234"</span></td>
          <td>200 OK (Destructive Import)</td>
          <td>200 OK</td>
          <td>Authorized Replacement Applied</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Matching Schema, No Overwrite</strong> (Safe Merge)</td>
          <td><span class="code-pill">schema_version: "68", overwrite: false</span></td>
          <td>None</td>
          <td>200 OK (Merge)</td>
          <td>200 OK</td>
          <td>Merged Non-destructively</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Matching Schema + Overwrite</strong> without PIN</td>
          <td><span class="code-pill">schema_version: "68", overwrite: true</span></td>
          <td>None</td>
          <td>403 Forbidden</td>
          <td>403 Forbidden</td>
          <td>Unchanged</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
        <tr>
          <td><strong>Matching Schema + Overwrite</strong> with PIN</td>
          <td><span class="code-pill">schema_version: "68", overwrite: true</span></td>
          <td><span class="code-pill">"1234"</span></td>
          <td>200 OK</td>
          <td>200 OK</td>
          <td>Authorized Replacement Applied</td>
          <td><span class="status-pass">✓ Pass</span></td>
        </tr>
      </tbody>
    </table>

    <h2>Frontend UI Experience (Master PIN Confirmation Modal)</h2>
    <div class="ui-preview-card">
      <p>When an owner attempts to import a database file with a differing schema version, the Settings UI compares the file's schema version against the live schema version retrieved from <code>GET /api/db-tools/master-pin/status</code>. Because the import is destructive, the application intercepts the import and presents the Master PIN confirmation modal before sending the payload.</p>

      <div class="modal-mock">
        <div class="modal-header">
          <h3 class="modal-title">Confirm Database Import</h3>
        </div>
        <div class="modal-body">
          <p class="modal-desc">
            This database import requires replacing local tables. Please enter your 4-digit Master PIN to authorize this operation.
          </p>
          <div class="pin-input-group">
            <div class="pin-digit filled">•</div>
            <div class="pin-digit filled">•</div>
            <div class="pin-digit filled">•</div>
            <div class="pin-digit"></div>
          </div>
        </div>
        <div class="modal-actions">
          <button class="btn btn-secondary">Cancel</button>
          <button class="btn btn-primary">Authorize & Import</button>
        </div>
      </div>
    </div>
  </div>
</body>
</html>
```
</details>
<details>
<summary>Evidence: E2E Test Scenario Verification Results (JSON)</summary>

```text
{
  "timestamp": "2026-08-15T18:34:48.941Z",
  "advisory": "GHSA-xxv4-gm82-4639",
  "title": "Database import schema-version mismatch Master PIN enforcement",
  "currentSchemaVersion": 68,
  "summary": "11/11 scenarios passed",
  "scenarios": [
    {
      "scenario": "Master PIN status endpoint exposes live schemaVersion",
      "endpoint": "GET /api/db-tools/master-pin/status",
      "expectedStatus": 200,
      "actualStatus": 200,
      "responseBody": {
        "available": true,
        "isSet": true,
        "schemaVersion": 68
      },
      "passed": true
    },
    {
      "scenario": "Future schema version mismatch without Master PIN is rejected and leaves DB intact",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": false,
        "data": {
          "schema_version": "69"
        }
      },
      "expectedStatus": 403,
      "actualStatus": 403,
      "dbIntact": true,
      "passed": true
    },
    {
      "scenario": "Old / upgrade-path schema version mismatch without Master PIN is rejected and leaves DB intact",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": false,
        "data": {
          "schema_version": "67"
        }
      },
      "expectedStatus": 403,
      "actualStatus": 403,
      "dbIntact": true,
      "passed": true
    },
    {
      "scenario": "Malformed schema version without Master PIN is rejected and leaves DB intact",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": false,
        "data": {
          "schema_version": "v-invalid-99"
        }
      },
      "expectedStatus": 403,
      "actualStatus": 403,
      "dbIntact": true,
      "passed": true
    },
    {
      "scenario": "Omitted schema version without Master PIN is rejected (treated as default 0 mismatch)",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": false,
        "data": {}
      },
      "expectedStatus": 403,
      "actualStatus": 403,
      "dbIntact": true,
      "passed": true
    },
    {
      "scenario": "Fresh install schema version 0 without Master PIN is rejected against initialized DB",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": false,
        "data": {
          "schema_version": "0"
        }
      },
      "expectedStatus": 403,
      "actualStatus": 403,
      "dbIntact": true,
      "passed": true
    },
    {
      "scenario": "Mismatched schema version with wrong Master PIN is rejected and leaves DB intact",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": false,
        "master_pin": "0000",
        "data": {
          "schema_version": "69"
        }
      },
      "expectedStatus": 403,
      "actualStatus": 403,
      "dbIntact": true,
      "passed": true
    },
    {
      "scenario": "Mismatched schema version with correct Master PIN succeeds and performs authorized import",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": false,
        "master_pin": "1234",
        "data": {
          "schema_version": "69"
        }
      },
      "expectedStatus": 200,
      "actualStatus": 200,
      "responseBody": {
        "success": true,
        "message": "Data imported with schema compatibility (some fields may be missing)",
        "backup": "/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-e2e-evidence-vPwlkQ/backups/flo-backup-2026-08-15T18-34-48-827Z-de64a91a.db",
        "schemaVersionMismatch": true,
        "importedSchemaVersion": 69,
        "currentSchemaVersion": 68,
        "placeholderUsersCreated": 0
      },
      "passed": true
    },
    {
      "scenario": "Matching schema version without overwrite needs no PIN and performs safe merge",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": false,
        "data": {
          "schema_version": "68"
        }
      },
      "expectedStatus": 200,
      "actualStatus": 200,
      "passed": true
    },
    {
      "scenario": "Matching schema version with overwrite=true and NO PIN is rejected",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": true,
        "data": {
          "schema_version": "68"
        }
      },
      "expectedStatus": 403,
      "actualStatus": 403,
      "dbIntact": true,
      "passed": true
    },
    {
      "scenario": "Matching schema version with overwrite=true and correct Master PIN succeeds",
      "endpoint": "POST /api/db/import",
      "payload": {
        "overwrite": true,
        "master_pin": "1234",
        "data": {
          "schema_version": "68"
        }
      },
      "expectedStatus": 200,
      "actualStatus": 200,
      "passed": true
    }
  ]
}
```
</details>
<details>
<summary>Evidence: E2E Execution Transcript and Database State Log</summary>

```text
======================================================================
 FloCafe Security Advisory GHSA-xxv4-gm82-4639 Verification Evidence
======================================================================
Timestamp: 2026-08-15T18:34:48.506Z
Current Schema Version: 68

[Setup] Initialized system: status=200, masterPinSet=true

--- Scenario 1: GET /api/db-tools/master-pin/status ---
Request: GET /api/db-tools/master-pin/status
Response: status=200, body={"available":true,"isSet":true,"schemaVersion":68}
Verdict: PASSED

--- Scenario 2: Future Schema Version Mismatch without PIN ---
Request: POST /api/db/import with schema_version=69, overwrite=false, no PIN
Response: status=403, body={"error":"Invalid Master PIN"}
Sentinel check: Intact (not deleted)
Verdict: PASSED

--- Scenario 3: Old Schema Version (Upgrade-Path) Mismatch without PIN ---
Request: POST /api/db/import with schema_version=67, overwrite=false, no PIN
Response: status=403, body={"error":"Invalid Master PIN"}
Sentinel check: Intact
Verdict: PASSED

--- Scenario 4: Malformed Schema Version without PIN ---
Request: POST /api/db/import with schema_version="v-invalid-99", overwrite=false, no PIN
Response: status=403, body={"error":"Invalid Master PIN"}
Sentinel check: Intact
Verdict: PASSED

--- Scenario 5: Missing / Omitted Schema Version without PIN ---
Request: POST /api/db/import with schema_version omitted, overwrite=false, no PIN
Response: status=403, body={"error":"Invalid Master PIN"}
Sentinel check: Intact
Verdict: PASSED

--- Scenario 6: Fresh Install Schema Version 0 without PIN ---
Request: POST /api/db/import with schema_version="0", overwrite=false, no PIN
Response: status=403, body={"error":"Invalid Master PIN"}
Sentinel check: Intact
Verdict: PASSED

--- Scenario 7: Mismatched Schema Version with Wrong Master PIN ---
Request: POST /api/db/import with schema_version=69, master_pin="0000"
Response: status=403, body={"error":"Invalid Master PIN"}
Sentinel check: Intact
Verdict: PASSED

--- Scenario 8: Mismatched Schema Version with Correct Master PIN ---
Request: POST /api/db/import with schema_version=69, master_pin="1234"
Response: status=200, body={"success":true,"message":"Data imported with schema compatibility (some fields may be missing)","backup":"/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-e2e-evidence-vPwlkQ/backups/flo-backup-2026-08-15T18-34-48-827Z-de64a91a.db","schemaVersionMismatch":true,"importedSchemaVersion":69,"currentSchemaVersion":68,"placeholderUsersCreated":0}
Sentinel check: Cleared by authorized destructive import
Verdict: PASSED

--- Scenario 9: Matching Schema Version, overwrite=false, no PIN ---
Request: POST /api/db/import with schema_version=68, overwrite=false, no PIN
Response: status=200, body={"success":true,"message":"Database imported successfully","backup":"/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-e2e-evidence-vPwlkQ/backups/flo-backup-2026-08-15T18-34-48-847Z-d68eb499.db","schemaVersionMismatch":false,"importedSchemaVersion":68,"currentSchemaVersion":68,"placeholderUsersCreated":0}
Sentinel check: Intact (non-destructive merge)
New category check: Created successfully
Verdict: PASSED

--- Scenario 10: Matching Schema Version with overwrite=true, NO PIN ---
Request: POST /api/db/import with schema_version=68, overwrite=true, no PIN
Response: status=403, body={"error":"Invalid Master PIN"}
Sentinel check: Intact (not overwritten)
Verdict: PASSED

--- Scenario 11: Matching Schema Version with overwrite=true and CORRECT PIN ---
Request: POST /api/db/import with schema_version=68, overwrite=true, master_pin="1234"
Response: status=200, body={"success":true,"message":"Database imported successfully","backup":"/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-e2e-evidence-vPwlkQ/backups/flo-backup-2026-08-15T18-34-48-930Z-41c886f7.db","schemaVersionMismatch":false,"importedSchemaVersion":68,"currentSchemaVersion":68,"placeholderUsersCreated":0}
Sentinel check: Cleared (authorized overwrite completed)
Verdict: PASSED

======================================================================
 Summary: 11/11 Scenarios Passed
======================================================================
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8687da747a6b6d036a526c578ad3d9b95e2c8dc7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:database-tools-api`
- `npm run test:master-pin`
- `npm run test:backup`
- `npm run build`
- `npx cross-env NEXT_BUILD_MODE=desktop npm --prefix frontend run build`
- `node tests/run-electron-node-test.cjs tests/database-tools-api.test.ts`
- `node tests/run-electron-node-test.cjs /Users/gurkiratkhaira/.gemini/antigravity-cli/brain/beb0c183-a784-4bc2-9117-d0ad37d16335/scratch/e2e-evidence-generator.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
