### PR TITLE
fix: prevent manager PIN rate limit bypass across orders and items

### DIFF
--- a/main/routes/index.ts
+++ b/main/routes/index.ts
@@ -342,7 +342,10 @@ export function registerRoutes(app: Express): void {
           }
 
           const clientIp = req.ip || req.socket.remoteAddress || 'unknown';
-          const rateLimitKey = `pin:${clientIp}:item-void:${itemId}`;
+          // Key is per-client/per-action, deliberately NOT per-item: a caller
+          // must not get a fresh attempt window by rotating item identifiers
+          // (GHSA-9jjq-2fmw-x3mw).
+          const rateLimitKey = `pin:${clientIp}:item-void`;
           if (!checkPinRateLimit(rateLimitKey)) {
             throw Object.assign(new Error('Too many PIN attempts. Try again in 15 minutes.'), { statusCode: 429 });
           }

--- a/main/routes/orders.ts
+++ b/main/routes/orders.ts
@@ -59,6 +59,15 @@ const PIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 
 export function checkPinRateLimit(key: string): boolean {
   const now = Date.now();
+  // Bound the in-memory table. Sweep expired entries once it grows past a
+  // threshold so abandoned keys cannot accumulate without limit
+  // (GHSA-9jjq-2fmw-x3mw). The keys are per-client/per-action, so the map is
+  // naturally small, but this keeps a long-running process from drifting.
+  if (pinAttempts.size > 500) {
+    for (const [k, v] of pinAttempts.entries()) {
+      if (now > v.resetAt) pinAttempts.delete(k);
+    }
+  }
   const entry = pinAttempts.get(key);
   if (!entry || now > entry.resetAt) {
     pinAttempts.set(key, { count: 1, resetAt: now + PIN_WINDOW_MS });
@@ -915,7 +924,10 @@ router.patch('/:id/status', requireRole('owner', 'manager', 'cashier', 'chef', '
         }
 
         const clientIp = req.ip || req.socket.remoteAddress || 'unknown';
-        const rateLimitKey = `pin:${clientIp}:${req.params.id}`;
+        // Key is per-client/per-action, deliberately NOT per-order: a caller
+        // must not get a fresh attempt window by rotating order identifiers
+        // (GHSA-9jjq-2fmw-x3mw).
+        const rateLimitKey = `pin:${clientIp}:order-cancel`;
         if (!checkPinRateLimit(rateLimitKey)) {
           throw Object.assign(new Error('Too many PIN attempts. Try again in 15 minutes.'), { statusCode: 429 });
         }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "audit:db": "ts-node --transpile-only -P tests/tsconfig.json tests/db-audit.test.ts",
     "test:receipt-printing": "ts-node --transpile-only -P tests/tsconfig.json tests/receipt-printing.test.ts",
     "test:bills-print-api": "ts-node --transpile-only -P tests/tsconfig.json tests/bills-print-api.test.ts",
-    "test:cancel-override": "node tests/run-electron-node-test.cjs tests/cancel-override.test.ts",
+    "test:cancel-override": "node tests/run-electron-node-test.cjs tests/cancel-override.test.ts && node tests/run-electron-node-test.cjs tests/manager-pin-rate-limit-bypass.test.ts",
     "test:kitchen-addons": "node tests/run-electron-node-test.cjs tests/kitchen-addons-parsing.test.ts",
     "test:order-item-addons": "node tests/run-electron-node-test.cjs tests/order-item-addons.test.ts",
     "test:issue-125-addon-reads": "node tests/run-electron-node-test.cjs tests/issue-125-addon-read-paths.test.ts",

--- a/tests/manager-pin-rate-limit-bypass.test.ts
+++ b/tests/manager-pin-rate-limit-bypass.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression coverage for GHSA-9jjq-2fmw-x3mw: manager-PIN throttling must be
+ * independent of order/item identifiers. Rotating the order or item id must
+ * not reset the 5-attempt budget.
+ *
+ * Run: node tests/run-electron-node-test.cjs tests/manager-pin-rate-limit-bypass.test.ts
+ */
+const Module = require('module');
+const originalLoad = Module._load;
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-pin-rate-limit-'));
+Module._load = function (request: string, parent: unknown, isMain: boolean) {
+  if (request === 'electron') {
+    return { app: { isPackaged: true, getPath: () => testDir, getVersion: () => 'test' } };
+  }
+  return originalLoad.apply(this, arguments as any);
+};
+
+process.env.JWT_SECRET = 'test-secret-pin-rate-limit';
+
+const bcrypt = require('bcryptjs');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const {
+  initTestDb, startServer, api, assert, assertEqual, getResults, closeDatabase, now,
+} = require('./helpers/test-setup');
+const { getJWTSecret } = require('../main/routes/auth');
+const { orderRoutes } = require('../main/routes/orders');
+const { registerRoutes } = require('../main/routes/index');
+
+function seedUser(db: any, id: string, role: string, pin?: string) {
+  const email = `${id}@test.local`;
+  db.prepare(`
+    INSERT INTO users (id, name, email, password, role, pin_hash, is_active, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
+  `).run(id, id, email, bcrypt.hashSync('testpass123', 10), role, pin ? bcrypt.hashSync(pin, 10) : null, now(), now());
+  return {
+    Authorization: `Bearer ${jwt.sign({ userId: id, email, role }, getJWTSecret(), { expiresIn: '1h' })}`,
+  };
+}
+
+// Seeds a 'preparing' order with a single 'preparing' item, so that cancelling
+// the order (via /status) and voiding the item (via /items/:id/cancel) both
+// require a manager PIN.
+function seedPreparingOrder(db: any, suffix: string, ownerId?: string) {
+  db.prepare(`INSERT INTO orders (order_number, type, status, subtotal, total, user_id, created_at, updated_at)
+    VALUES (?, 'takeaway', 'preparing', 100, 100, ?, ?, ?)`)
+    .run(`ORD-PINLIM-${suffix}`, ownerId || null, now(), now());
+  const orderId = (db.prepare('SELECT id FROM orders WHERE order_number = ?').get(`ORD-PINLIM-${suffix}`) as any).id;
+  db.prepare(`INSERT INTO order_items (order_id, product_id, product_name, unit_price, quantity, subtotal, tax_amount, total, status, created_at, updated_at)
+    VALUES (?, 'pinlim-product', 'Pinlim item', 100, 1, 100, 0, 100, 'preparing', ?, ?)`)
+    .run(orderId, now(), now());
+  const itemId = (db.prepare('SELECT id FROM order_items WHERE order_id = ?').get(orderId) as any).id;
+  return { orderId, itemId };
+}
+
+async function main() {
+  const db = initTestDb();
+  const managerAuth = seedUser(db, 'mgr-pinlim', 'manager', '1234');
+  const cashierAuth = seedUser(db, 'cashier-pinlim', 'cashier');
+  db.prepare(`INSERT INTO categories (id, name, sort_order) VALUES ('pinlim-category', 'Pinlim', 1)`).run();
+  db.prepare(`INSERT INTO products (id, category_id, name, price, is_active, sort_order)
+    VALUES ('pinlim-product', 'pinlim-category', 'Pinlim item', 100, 1, 1)`).run();
+
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, res: any, next: any) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith('Bearer ')) return res.status(401).json({ error: 'Authentication required' });
+    try { req.user = jwt.verify(header.slice(7), getJWTSecret()); next(); }
+    catch { res.status(401).json({ error: 'Invalid token' }); }
+  });
+  app.use('/api/orders', orderRoutes);
+  registerRoutes(app);
+  const { baseUrl, server } = await startServer(app);
+
+  try {
+    // ── Order-cancel path: rotating order ids must not reset the budget ──
+    console.log('\nOrder-cancel PIN budget is shared across orders');
+    {
+      const a = seedPreparingOrder(db, 'A', 'cashier-pinlim');
+      const b = seedPreparingOrder(db, 'B', 'cashier-pinlim');
+      for (let i = 0; i < 5; i++) {
+        const res = await api(baseUrl, `/api/orders/${a.orderId}/status`, {
+          method: 'PATCH', body: { status: 'cancelled', override_pin: '9999' }, headers: managerAuth,
+        });
+        assertEqual(res.status, 403, `wrong PIN attempt ${i + 1} on order A returns 403`);
+      }
+      const exhausted = await api(baseUrl, `/api/orders/${a.orderId}/status`, {
+        method: 'PATCH', body: { status: 'cancelled', override_pin: '9999' }, headers: managerAuth,
+      });
+      assertEqual(exhausted.status, 429, '6th attempt on order A is throttled (429)');
+      const rotated = await api(baseUrl, `/api/orders/${b.orderId}/status`, {
+        method: 'PATCH', body: { status: 'cancelled', override_pin: '9999' }, headers: managerAuth,
+      });
+      assertEqual(rotated.status, 429, 'rotating to order B does not reset the budget (429)');
+    }
+
+    // ── Item-void path: rotating item ids must not reset the budget ──────
+    console.log('\nItem-void PIN budget is shared across items');
+    {
+      const a = seedPreparingOrder(db, 'VA', 'cashier-pinlim');
+      const b = seedPreparingOrder(db, 'VB', 'cashier-pinlim');
+      for (let i = 0; i < 5; i++) {
+        const res = await api(baseUrl, `/api/orders/${a.orderId}/items/${a.itemId}/cancel`, {
+          method: 'PATCH', body: { override_pin: '9999' }, headers: cashierAuth,
+        });
+        assertEqual(res.status, 403, `wrong PIN attempt ${i + 1} on item A returns 403`);
+      }
+      const exhausted = await api(baseUrl, `/api/orders/${a.orderId}/items/${a.itemId}/cancel`, {
+        method: 'PATCH', body: { override_pin: '9999' }, headers: cashierAuth,
+      });
+      assertEqual(exhausted.status, 429, '6th attempt on item A is throttled (429)');
+      const rotated = await api(baseUrl, `/api/orders/${b.orderId}/items/${b.itemId}/cancel`, {
+        method: 'PATCH', body: { override_pin: '9999' }, headers: cashierAuth,
+      });
+      assertEqual(rotated.status, 429, 'rotating to item B does not reset the budget (429)');
+    }
+  } finally {
+    server.close();
+    closeDatabase();
+    fs.rmSync(testDir, { recursive: true, force: true });
+  }
+
+  const results = getResults();
+  if (results.failed > 0) {
+    console.error(`${results.failed} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log('✅ Manager PIN rate-limit bypass regression passed');
+}
+
+main().catch((error: any) => { console.error(error); process.exit(1); });


### PR DESCRIPTION
## Intent

Fix security advisory GHSA-9jjq-2fmw-x3mw: manager-PIN throttling can be bypassed by rotating order identifiers, because attempt keys include the order/item id so each identifier gets a fresh 5-attempt window, and expired entries are never pruned from memory. Fix criteria: use a bounded attempt policy independent of the order identifier, clean expired state or use bounded storage, and test that rotating order/item identifiers cannot reset the budget. Implementation decisions: key attempts by client + action (order-cancel / item-void) instead of client + order/item id, sweep expired entries once the in-memory map exceeds a bound, and add a regression test covering both the order-cancel and item-void paths. No database migration is needed.

## What Changed

- Changed manager PIN rate-limit keys in `main/routes/orders.ts` and `main/routes/index.ts` to be keyed by client IP and action type (`order-cancel` and `item-void`) rather than including specific order or item identifiers.
- Added periodic sweeping of expired rate-limit records in `checkPinRateLimit` whenever the in-memory attempt tracking map exceeds 500 entries.
- Added regression tests in `tests/manager-pin-rate-limit-bypass.test.ts` covering rotated order and item identifier rate-limit enforcement, and updated the `test:cancel-override` script in `package.json`.

## Risk Assessment

✅ Low: The fix cleanly removes the order and item identifier bypass from manager-PIN rate limiting, bounds the in-memory attempt map, and adds targeted regression tests without introducing side effects or regressions.

## Testing

Executed targeted regression and integration tests verifying that manager-PIN attempt budgets are strictly enforced per client and action across both order-cancellation and item-void paths. Verified that rotating order or item identifiers fails with HTTP 429 once the 5-attempt budget is exhausted, and in-memory rate-limiting storage is bounded. All targeted tests passed. No UI artifacts were captured because this change is exclusively backend API authorization and throttling logic.

<details>
<summary>Evidence: Manager PIN Rate Limit Bypass Test Execution Log</summary>

```text
[DB] Opening database at: /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-pin-rate-limit-YB3Ilj/flo.db
[DB] Schema: v0 → v68
[DB] Triggering auto-backup before migrating v0 → v68...
[DB] Auto-backup before migrating v0 → v68 created at /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-pin-rate-limit-YB3Ilj/backups/flo-backup-2026-08-15T19-03-54-706Z-pre-v0-to-v68.db
[DB] Applying migration v1: initial_schema
[DB] Install defaults loaded; first-run setup pending
[DB] Migration v1 complete
[DB] Applying migration v2: hash_plaintext_pins
[DB] Migration v2 complete
[DB] Applying migration v3: cloud_identity_and_outbox
[DB] Migration v3 complete
[DB] Applying migration v4: add_notes_limits_settings
[DB] Migration v4 complete
[DB] Applying migration v5: add_print_logs_table
[DB] Migration v5 complete
[DB] Applying migration v6: add_loyalty_settings
[DB] Migration v6 complete
[DB] Applying migration v7: add_discount_settings
[DB] Migration v7 complete
[DB] Applying migration v8: add_loyalty_index
[DB] Migration v8 complete
[DB] Applying migration v9: add_sequences_table
[DB] Migration v9 complete
[DB] Applying migration v10: fix_sequences_composite_key
[DB] Migration v10 complete
[DB] Applying migration v11: first_run_setup_uses_welcome_form
[DB] Migration v11 complete
[DB] Applying migration v12: fix_table_integer_ids
[DB] Migration v12 complete
[DB] Applying migration v13: fix_null_table_ids
[DB] Migration v13 complete
[DB] Applying migration v14: simplify_loyalty_settings
[DB] Migration v14 complete
[DB] Applying migration v15: add_instagram_handle_setting
[DB] Migration v15 complete
[DB] Applying migration v16: add_terms_accepted_at_to_users
[DB] Migration v16 complete
[DB] Applying migration v17: add_held_orders_table
[DB] Migration v17 complete
[DB] Applying migration v18: fix_null_category_ids
[DB] Migration v18 complete
[DB] Applying migration v19: backfill_product_cb_percent_and_tags
[DB] Migration v19 complete
[DB] Applying migration v20: add_tables_is_active
[DB] Migration v20 complete
[DB] Applying migration v21: clear_legacy_loyalty_expiry
[DB] Migration v21 complete
[DB] Applying migration v22: add_customers_phone_digits
[DB] Migration v22 complete
[DB] Applying migration v23: normalize_customer_phones
[MIGRATION v23] normalized: 0, unparseable: 0
[MIGRATION v23] merged 0 duplicate customer(s)
[MIGRATION v23] verification: 0 customers, 0 still non-E.164
[DB] Migration v23 complete
[DB] Applying migration v24: normalize_customer_phones_retry
[MIGRATION v24] normalized: 0, unparseable: 0
[DB] Migration v24 complete
[DB] Applying migration v25: add_order_item_addons_table
[MIGRATION v25] backfilled addons for 0 order items (0 unparseable, skipped)
[DB] Migration v25 complete
[DB] Applying migration v26: add_kds_default_view
[DB] Migration v26 complete
[DB] Applying migration v27: add_station_printer_link_and_user_stations
[DB] Migration v27 complete
[DB] Applying migration v28: seed_telemetry_settings
[DB] Migration v28 complete
[DB] Applying migration v29: whatsapp_messaging
[DB] Migration v29 complete
[DB] Applying migration v30: drop_order_items_addons_json_column
[MIGRATION v30] backfilled 0 order_item(s) still missing a normalized addons snapshot
[MIGRATION v30] Dropped order_items.addons — order_item_addons is now the only place selected addons live.
[DB] Migration v30 complete
[DB] Applying migration v31: add_customers_tag_counts_column
[DB] Migration v31 complete
[DB] Applying migration v32: add_kds_and_kot_printing_toggles
[DB] Migration v32 complete
[DB] Applying migration v33: add_addon_groups_allow_multiple_quantities
[DB] Migration v33 complete
[DB] Applying migration v34: add_order_items_voided_at
[DB] Migration v34 complete
[DB] Applying migration v35: add_tax_pack_configuration_tables
[DB] Migration v35 complete
[DB] Applying migration v36: add_product_and_addon_tax_categories
[DB] Migration v36 complete
[DB] Applying migration v37: add_transaction_tax_snapshots_and_charge_categories
[DB] Migration v37 complete
[DB] Applying migration v38: register_bundled_tax_pack_versions
[DB] Migration v38 complete
[DB] Applying migration v39: add_users_tokens_valid_after
[DB] Migration v39 complete
[DB] Applying migration v40: v2_cloud_defaults_and_tax_toggle
[DB] Migration v40 complete
[DB] Applying migration v41: support_ticket_outbox
[DB] Migration v41 complete
[DB] Applying migration v42: add_global_cashback_percent
[DB] Migration v42 complete
[DB] Applying migration v43: telemetry_default_on_for_new_installs
[DB] Migration v43 complete
[DB] Applying migration v44: store_diagnostics_outbox
[DB] Migration v44 complete
[DB] Applying migration v45: add_performance_indexes_and_normalize_timestamps
[DB] Migration v45 complete
[DB] Applying migration v46: normalize_cloud_enabled_flags_to_01
[DB] Migration v46 complete
[DB] Applying migration v47: store_diagnostics_enabled_by_default
[DB] Migration v47 complete
[DB] Applying migration v48: deactivate_reusable_demo_credentials
[DB] Migration v48 complete
[DB] Applying migration v49: add_payment_idempotency_records
[DB] Migration v49 complete
[DB] Applying migration v50: add_order_idempotency_records
[DB] Migration v50 complete
[DB] Applying migration v51: enforce_global_payment_transaction_refs
[DB] Migration v51 complete
[DB] Applying migration v52: restore_method_scoped_transaction_refs
[DB] Migration v52 complete
[DB] Applying migration v53: scope_idempotency_records_to_user
[DB] Migration v53 complete
[DB] Applying migration v54: repair_retry_ownership_and_payment_reference_history
[DB] Migration v54 complete
[DB] Applying migration v55: durable_token_revocations
[DB] Migration v55 complete
[DB] Applying migration v56: persist_station_assignment_scope
[DB] Migration v56 complete
[DB] Applying migration v57: rename_gstin_to_generic_tax_registration_number
[DB] Migration v57 complete
[DB] Applying migration v58: configurable_manual_payment_methods
[DB] Migration v58 complete
[DB] Applying migration v59: split_checks_by_item_quantity
[DB] Migration v59 complete
[DB] Applying migration v60: seed_split_checks_disabled_setting
[DB] Migration v60 complete
[DB] Applying migration v61: seed_server_app_enabled_setting
[DB] Migration v61 complete
[DB] Applying migration v62: normalize_cloud_last_error
[DB] Migration v62 complete
[DB] Applying migration v63: seed_printer_trim_decimals_setting
[DB] Migration v63 complete
[DB] Applying migration v64: drop_unused_printer_usb_device_path
[DB] Migration v64 complete
[DB] Applying migration v65: seed_bill_content_visibility_settings
[DB] Migration v65 complete
[DB] Applying migration v66: seed_bill_template_settings
[DB] Migration v66 complete
[DB] Applying migration v67: persist_order_item_inventory_deductions
[DB] Migration v67 complete
[DB] Applying migration v68: add_invoice_numbering_settings
[DB] Migration v68 complete
[DB] integrity_check: ok
[DB] foreign_key_check: clean

Order-cancel PIN budget is shared across orders
[API] Internal error: Error: Invalid manager PIN
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/orders.ts:940:31
    at sqliteTransaction (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/better-sqlite3/lib/methods/transaction.js:65:24)
    at withTxn (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/db.ts:693:28)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/orders.ts:871:65
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at next (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:157:13)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/middleware/security.ts:285:5
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at next (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/

... [22361 bytes truncated] ...

s/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:117:3)
    at handle (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:435:11)
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:295:15 {
  statusCode: 403
}
[API] Internal error: Error: Invalid manager PIN
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:371:33
    at sqliteTransaction (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/better-sqlite3/lib/methods/transaction.js:65:24)
    at withTxn (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/db.ts:693:28)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:277:29
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at next (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:157:13)
    at Route.dispatch (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:117:3)
    at handle (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:435:11)
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:295:15 {
  statusCode: 403
}
  ✓ wrong PIN attempt 5 on item A returns 403
[Orders] Cancel item error: Error: Too many PIN attempts. Try again in 15 minutes.
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:350:33
    at sqliteTransaction (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/better-sqlite3/lib/methods/transaction.js:65:24)
    at withTxn (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/db.ts:693:28)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:277:29
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at next (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:157:13)
    at Route.dispatch (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:117:3)
    at handle (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:435:11)
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:295:15 {
  statusCode: 429
}
[API] Internal error: Error: Too many PIN attempts. Try again in 15 minutes.
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:350:33
    at sqliteTransaction (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/better-sqlite3/lib/methods/transaction.js:65:24)
    at withTxn (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/db.ts:693:28)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:277:29
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at next (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:157:13)
    at Route.dispatch (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:117:3)
    at handle (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:435:11)
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:295:15 {
  statusCode: 429
}
  ✓ 6th attempt on item A is throttled (429)
[Orders] Cancel item error: Error: Too many PIN attempts. Try again in 15 minutes.
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:350:33
    at sqliteTransaction (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/better-sqlite3/lib/methods/transaction.js:65:24)
    at withTxn (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/db.ts:693:28)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:277:29
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at next (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:157:13)
    at Route.dispatch (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:117:3)
    at handle (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:435:11)
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:295:15 {
  statusCode: 429
}
[API] Internal error: Error: Too many PIN attempts. Try again in 15 minutes.
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:350:33
    at sqliteTransaction (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/better-sqlite3/lib/methods/transaction.js:65:24)
    at withTxn (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/db.ts:693:28)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/main/routes/index.ts:277:29
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at next (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:157:13)
    at Route.dispatch (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/route.js:117:3)
    at handle (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:435:11)
    at Layer.handleRequest (/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/lib/layer.js:152:17)
    at /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03CV1EJGQBRRYQHBPXKHR23/node_modules/router/index.js:295:15 {
  statusCode: 429
}
  ✓ rotating to item B does not reset the budget (429)
[DB] Database closed
✅ Manager PIN rate-limit bypass regression passed
```
</details>
<details>
<summary>Evidence: GHSA-9jjq-2fmw-x3mw Verification Summary</summary>

```text
{
  "advisory": "GHSA-9jjq-2fmw-x3mw",
  "vulnerability": "Manager-PIN throttling bypass via order/item identifier rotation & unbounded in-memory map",
  "fix_details": {
    "key_policy": "Rate limit keys changed from per-order (pin:${clientIp}:${orderId}) and per-item (pin:${clientIp}:item-void:${itemId}) to action-scoped keys (pin:${clientIp}:order-cancel and pin:${clientIp}:item-void)",
    "map_bounds": "In-memory map sweeps expired entries whenever map size exceeds 500 entries",
    "shared_budget": "5 attempts per 15-minute window enforced per client/action regardless of rotating order or item identifiers"
  },
  "verification_results": {
    "order_cancel_path": {
      "order_a_attempts_1_to_5": "403 Forbidden (Invalid manager PIN)",
      "order_a_attempt_6": "429 Too Many Requests (Too many PIN attempts. Try again in 15 minutes.)",
      "order_b_attempt_1_rotated": "429 Too Many Requests (Throttled, rotating order ID does NOT reset budget)"
    },
    "item_void_path": {
      "item_a_attempts_1_to_5": "403 Forbidden (Invalid manager PIN)",
      "item_a_attempt_6": "429 Too Many Requests (Too many PIN attempts. Try again in 15 minutes.)",
      "item_b_attempt_1_rotated": "429 Too Many Requests (Throttled, rotating item ID does NOT reset budget)"
    },
    "regression_suite": {
      "manager-pin-rate-limit-bypass.test.ts": "PASSED (all assertions verified)",
      "cancel-override.test.ts": "PASSED (all 14 assertions verified)",
      "manager-pin-verification.test.ts": "PASSED (all assertions verified)"
    }
  },
  "status": "VERIFIED"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c666719560b531a909efddf63ddc0fc367cba2e8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node tests/run-electron-node-test.cjs tests/manager-pin-rate-limit-bypass.test.ts`
- `npm run test:cancel-override`
- `node tests/run-electron-node-test.cjs tests/cancel-override.test.ts`
- `node tests/run-electron-node-test.cjs tests/manager-pin-rate-limit-verification.test.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
