### PR TITLE
fix(catalog): enforce category invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Flo Cafe are documented here. Dates are release dates, not commit dates. Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [3.2.0] - 2026-08-15
+
+### Added
+- Added the Customer Display experience for showing order and payment status on a dedicated screen.
+- Added configurable invoice numbering settings with upgrade-safe defaults and focused regression coverage.
+- Added the Iran country profile and Persian/Farsi runtime foundation, including translation bundle plumbing and HTML language/direction metadata.
+- Added the Morocco country profile with MAD currency support.
+- Added paginated bill-history APIs for large order histories.
+
+### Changed
+- Catalog listing now batches child-category loading and normalizes catalog API contracts for stable string IDs and boolean flags.
+- POS cart identity and append retries are now collision-safe and idempotent across retry paths.
+- Shutdown, database recovery, and Windows uninstall flows now report partial or graceful outcomes more consistently.
+
+### Fixed
+- Category writes now trim and require non-empty names, validate active parents, reject self/ancestor cycles, and handle child categories explicitly during deletion or reassignment.
+- Product, category, and add-on catalog updates now distinguish omitted fields from explicit `null`, so nullable fields can be intentionally cleared.
+- Product add-on links are validated before writes, preventing duplicate, inactive, or unknown add-on group references from partially mutating products.
+- Barcode lookups, disabled discount-type visibility, split-check tax attribution, order cancellation, held-order restore, and menu CSV imports now behave deterministically across edge cases.
+- Phone-number validation, normalization, clearing, and repair are unified across backend routes and frontend views.
+- Receipt currency symbols are derived correctly for printer output.
+- Database import/export migrations preserve clearer failure and repair behavior.
+
 ## [3.0.5] - 2026-08-12
 
 ### Added

--- a/main/routes/addon-groups.ts
+++ b/main/routes/addon-groups.ts
@@ -8,6 +8,10 @@ const VALID_TAX_BEHAVIORS = ['country_default', 'inclusive', 'exclusive', 'exemp
 
 const router = Router();
 
+function hasOwn(body: Record<string, unknown>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(body, field);
+}
+
 function toBoolean(value: unknown): boolean {
   return value === true || value === 1;
 }
@@ -210,7 +214,8 @@ router.put('/:id', requireRole('owner', 'manager'), (req: Request, res: Response
     }
 
     const reqName = name ?? null;
-    const reqDesc = description ?? null;
+    const hasDescription = hasOwn(req.body, 'description');
+    const reqDesc = description === undefined || description === null || description === '' ? null : description;
     const reqReq = is_required === undefined ? null : (is_required ? 1 : 0);
     const reqMin = min_selection ?? null;
     const reqMax = max_selection ?? null;
@@ -220,12 +225,12 @@ router.put('/:id', requireRole('owner', 'manager'), (req: Request, res: Response
 
     const { updated, updatedAddons } = withTxn(() => {
       db.prepare(`
-        UPDATE addon_groups SET name = COALESCE(?, name), description = COALESCE(?, description),
+        UPDATE addon_groups SET name = COALESCE(?, name), description = CASE WHEN ? = 1 THEN ? ELSE description END,
           is_required = COALESCE(?, is_required), min_selection = COALESCE(?, min_selection),
           max_selection = COALESCE(?, max_selection), allow_multiple_quantities = COALESCE(?, allow_multiple_quantities),
           sort_order = COALESCE(?, sort_order), is_active = COALESCE(?, is_active), updated_at = ?
         WHERE id = ?
-      `).run(reqName, reqDesc, reqReq, reqMin, reqMax, reqAllowMult, reqSort, reqActive, now(), req.params.id);
+      `).run(reqName, hasDescription ? 1 : 0, reqDesc, reqReq, reqMin, reqMax, reqAllowMult, reqSort, reqActive, now(), req.params.id);
 
       if (Array.isArray(addons)) {
         db.prepare('DELETE FROM addons WHERE addon_group_id = ?').run(req.params.id);

--- a/main/routes/categories.ts
+++ b/main/routes/categories.ts
@@ -1,8 +1,61 @@
 import { Router, Request, Response } from 'express';
+import expressRateLimit from 'express-rate-limit';
 import { getDatabase, now, generateShortId } from '../db';
 import { requireRole } from '../middleware/security';
 
 const router = Router();
+const categoryWriteRateLimit = expressRateLimit({ windowMs: 60 * 1000, limit: 60, standardHeaders: true, legacyHeaders: false });
+
+function hasOwn(body: Record<string, unknown>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(body, field);
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string') return String(value);
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeCategoryName(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function slugForName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+function validateParentCategory(db: ReturnType<typeof getDatabase>, parentId: unknown, categoryId?: string): string | null {
+  if (parentId === null || parentId === undefined || parentId === '') return null;
+  if (typeof parentId !== 'string') return 'parent_id must be a string or null';
+  if (categoryId && parentId === categoryId) return 'Category cannot be its own parent';
+
+  let current = db.prepare('SELECT id, parent_id FROM categories WHERE id = ? AND deleted_at IS NULL AND is_active = 1').get(parentId) as any;
+  if (!current) return 'Parent category not found or inactive';
+
+  const seen = new Set<string>();
+  while (current?.parent_id) {
+    if (categoryId && current.parent_id === categoryId) return 'Category parent cannot create a cycle';
+    if (seen.has(current.parent_id)) return 'Category tree already contains a cycle';
+    seen.add(current.parent_id);
+    current = db.prepare('SELECT id, parent_id FROM categories WHERE id = ? AND deleted_at IS NULL').get(current.parent_id) as any;
+  }
+  return null;
+}
+
+function isDescendantCategory(db: ReturnType<typeof getDatabase>, categoryId: string, possibleDescendantId: string): boolean {
+  let current = db.prepare('SELECT parent_id FROM categories WHERE id = ? AND deleted_at IS NULL').get(possibleDescendantId) as any;
+  const seen = new Set<string>();
+  while (current?.parent_id) {
+    if (current.parent_id === categoryId) return true;
+    if (seen.has(current.parent_id)) return false;
+    seen.add(current.parent_id);
+    current = db.prepare('SELECT parent_id FROM categories WHERE id = ? AND deleted_at IS NULL').get(current.parent_id) as any;
+  }
+  return false;
+}
 
 function serializeCategory(category: any): any {
   if (!category) return category;
@@ -86,22 +139,39 @@ router.get('/:id', (req: Request, res: Response) => {
   }
 });
 
-router.post('/', requireRole('owner', 'manager'), (req: Request, res: Response) => {
+function createCategory(req: Request, res: Response) {
   try {
     const { name, description, parent_id, sort_order, is_active, color, icon } = req.body;
 
-    if (!name) {
+    const categoryName = normalizeCategoryName(name);
+    if (!categoryName) {
       return res.status(400).json({ error: 'Name is required' });
     }
 
-    const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-
     const db = getDatabase();
+    const parentError = validateParentCategory(db, parent_id);
+    if (parentError) {
+      return res.status(400).json({ error: parentError });
+    }
+
+    const slug = slugForName(categoryName);
     const id = generateShortId('categories');
     db.prepare(`
       INSERT INTO categories (id, name, slug, description, parent_id, sort_order, is_active, color, icon, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, name, slug, description || null, parent_id || null, sort_order || 0, is_active !== false ? 1 : 0, color || null, icon || null, now(), now());
+    `).run(
+      id,
+      categoryName,
+      slug,
+      normalizeOptionalString(description),
+      normalizeOptionalString(parent_id),
+      sort_order || 0,
+      is_active !== false ? 1 : 0,
+      normalizeOptionalString(color),
+      normalizeOptionalString(icon),
+      now(),
+      now()
+    );
 
     const category = db.prepare('SELECT * FROM categories WHERE id = ?').get(id);
     res.status(201).json({ category: serializeCategory(category) });
@@ -109,42 +179,83 @@ router.post('/', requireRole('owner', 'manager'), (req: Request, res: Response) 
     console.error("[API] Internal error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
-});
+}
 
-router.put('/:id', requireRole('owner', 'manager'), (req: Request, res: Response) => {
+router.post('/', categoryWriteRateLimit, requireRole('owner', 'manager'), createCategory);
+
+function updateCategory(req: Request, res: Response) {
   try {
     const { name, description, parent_id, sort_order, is_active, color, icon } = req.body;
     const db = getDatabase();
+    const categoryId = String(req.params.id);
 
-    const category = db.prepare('SELECT * FROM categories WHERE id = ? AND deleted_at IS NULL').get(req.params.id);
+    const category = db.prepare('SELECT * FROM categories WHERE id = ? AND deleted_at IS NULL').get(categoryId);
     if (!category) {
       return res.status(404).json({ error: 'Category not found' });
     }
 
-    const slug = name ? name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') : (category as any).slug;
+    const hasName = hasOwn(req.body, 'name');
+    const categoryName = hasName ? normalizeCategoryName(name) : null;
+    if (hasName && !categoryName) {
+      return res.status(400).json({ error: 'Name is required' });
+    }
+    if (hasOwn(req.body, 'parent_id')) {
+      const parentError = validateParentCategory(db, parent_id, categoryId);
+      if (parentError) {
+        return res.status(400).json({ error: parentError });
+      }
+    }
 
+    const slug = categoryName ? slugForName(categoryName) : (category as any).slug;
     const activeInt = is_active !== undefined ? (is_active ? 1 : 0) : undefined;
 
     db.prepare(`
-      UPDATE categories SET name = COALESCE(?, name), slug = ?, description = COALESCE(?, description),
-      parent_id = COALESCE(?, parent_id), sort_order = COALESCE(?, sort_order),
-      is_active = COALESCE(?, is_active), color = COALESCE(?, color), icon = COALESCE(?, icon),
-      updated_at = ?
-      WHERE id = ?
-    `).run(name, slug, description, parent_id, sort_order, activeInt, color, icon, now(), req.params.id);
+      UPDATE categories SET
+      name = CASE WHEN @has_name = 1 THEN @name ELSE name END,
+      slug = @slug,
+      description = CASE WHEN @has_description = 1 THEN @description ELSE description END,
+      parent_id = CASE WHEN @has_parent_id = 1 THEN @parent_id ELSE parent_id END,
+      sort_order = CASE WHEN @has_sort_order = 1 THEN @sort_order ELSE sort_order END,
+      is_active = CASE WHEN @has_is_active = 1 THEN @is_active ELSE is_active END,
+      color = CASE WHEN @has_color = 1 THEN @color ELSE color END,
+      icon = CASE WHEN @has_icon = 1 THEN @icon ELSE icon END,
+      updated_at = @updated_at
+      WHERE id = @id
+    `).run({
+      has_name: hasName ? 1 : 0,
+      name: categoryName,
+      slug,
+      has_description: hasOwn(req.body, 'description') ? 1 : 0,
+      description: normalizeOptionalString(description),
+      has_parent_id: hasOwn(req.body, 'parent_id') ? 1 : 0,
+      parent_id: normalizeOptionalString(parent_id),
+      has_sort_order: hasOwn(req.body, 'sort_order') ? 1 : 0,
+      sort_order: sort_order ?? null,
+      has_is_active: hasOwn(req.body, 'is_active') ? 1 : 0,
+      is_active: activeInt ?? null,
+      has_color: hasOwn(req.body, 'color') ? 1 : 0,
+      color: normalizeOptionalString(color),
+      has_icon: hasOwn(req.body, 'icon') ? 1 : 0,
+      icon: normalizeOptionalString(icon),
+      updated_at: now(),
+      id: categoryId,
+    });
 
-    const updated = db.prepare('SELECT * FROM categories WHERE id = ?').get(req.params.id);
+    const updated = db.prepare('SELECT * FROM categories WHERE id = ?').get(categoryId);
     res.json({ category: serializeCategory(updated) });
   } catch (error: any) {
     console.error("[API] Internal error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
-});
+}
 
-router.delete('/:id', requireRole('owner', 'manager'), (req: Request, res: Response) => {
+router.put('/:id', categoryWriteRateLimit, requireRole('owner', 'manager'), updateCategory);
+
+function deleteCategory(req: Request, res: Response) {
   try {
     const db = getDatabase();
-    const category = db.prepare('SELECT * FROM categories WHERE id = ? AND deleted_at IS NULL').get(req.params.id);
+    const categoryId = String(req.params.id);
+    const category = db.prepare('SELECT * FROM categories WHERE id = ? AND deleted_at IS NULL').get(categoryId);
     if (!category) {
       return res.status(404).json({ error: 'Category not found' });
     }
@@ -153,29 +264,44 @@ router.delete('/:id', requireRole('owner', 'manager'), (req: Request, res: Respo
 
     const { count: productCount } = db.prepare(
       'SELECT COUNT(*) as count FROM products WHERE category_id = ? AND deleted_at IS NULL'
-    ).get(req.params.id) as { count: number };
+    ).get(categoryId) as { count: number };
 
-    if (productCount > 0 && !action) {
+    const { count: childCount } = db.prepare(
+      'SELECT COUNT(*) as count FROM categories WHERE parent_id = ? AND deleted_at IS NULL'
+    ).get(categoryId) as { count: number };
+
+    if ((productCount > 0 || childCount > 0) && !action) {
       return res.status(400).json({
-        error: `Category has ${productCount} active product(s). Choose an action.`,
+        error: 'Category has active product(s) or child categories. Choose an action.',
         productCount,
+        childCount,
       });
     }
 
     const deleteCategory = db.transaction(() => {
       if (action === 'reassign') {
         if (!reassign_to) throw new Error('reassign_to is required for reassign action');
+        if (reassign_to === categoryId) throw new Error('Cannot reassign a category to itself');
         const targetCategory = db.prepare('SELECT id FROM categories WHERE id = ? AND deleted_at IS NULL').get(reassign_to);
         if (!targetCategory) throw new Error('Target category not found or deleted');
+        if (isDescendantCategory(db, categoryId, reassign_to)) {
+          throw new Error('Cannot reassign a category to one of its descendants');
+        }
         db.prepare('UPDATE products SET category_id = ?, updated_at = ? WHERE category_id = ? AND deleted_at IS NULL')
-          .run(reassign_to, now(), req.params.id);
+          .run(reassign_to, now(), categoryId);
+        db.prepare('UPDATE categories SET parent_id = ?, updated_at = ? WHERE parent_id = ? AND deleted_at IS NULL')
+          .run(reassign_to, now(), categoryId);
       } else if (action === 'delete_all') {
         db.prepare('UPDATE products SET deleted_at = ?, updated_at = ? WHERE category_id = ? AND deleted_at IS NULL')
-          .run(now(), now(), req.params.id);
+          .run(now(), now(), categoryId);
+        db.prepare('UPDATE categories SET parent_id = NULL, updated_at = ? WHERE parent_id = ? AND deleted_at IS NULL')
+          .run(now(), categoryId);
+      } else if (!action && productCount === 0 && childCount === 0) {
+        // Empty categories have no dependent rows to resolve.
       } else {
         throw new Error('Invalid action. Must be reassign or delete_all.');
       }
-      db.prepare('UPDATE categories SET deleted_at = ?, updated_at = ? WHERE id = ?').run(now(), now(), req.params.id);
+      db.prepare('UPDATE categories SET deleted_at = ?, updated_at = ? WHERE id = ?').run(now(), now(), categoryId);
     });
     try {
       deleteCategory();
@@ -187,6 +313,8 @@ router.delete('/:id', requireRole('owner', 'manager'), (req: Request, res: Respo
     console.error("[API] Internal error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
-});
+}
+
+router.delete('/:id', categoryWriteRateLimit, requireRole('owner', 'manager'), deleteCategory);
 
 export const categoryRoutes = router;

--- a/main/routes/products.ts
+++ b/main/routes/products.ts
@@ -272,6 +272,10 @@ const VALID_TAX_BEHAVIORS = ['country_default', 'inclusive', 'exclusive', 'exemp
 
 const router = Router();
 
+function hasOwn(body: Record<string, unknown>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(body, field);
+}
+
 function toBoolean(value: unknown): boolean {
   return value === true || value === 1;
 }
@@ -364,6 +368,27 @@ function normalizeBarcode(raw: unknown): string | null {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim();
   return trimmed || null;
+}
+
+function normalizeNullableString(raw: unknown): string | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'string') return String(raw);
+  const trimmed = raw.trim();
+  return trimmed || null;
+}
+
+function normalizeRequiredName(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  return trimmed || null;
+}
+
+function validateCategoryId(db: any, categoryId: unknown): string | null {
+  if (categoryId === null || categoryId === undefined || categoryId === '') return null;
+  if (typeof categoryId !== 'string') return 'category_id must be a string or null';
+  const category = db.prepare('SELECT id FROM categories WHERE id = ? AND deleted_at IS NULL AND is_active = 1').get(categoryId);
+  if (!category) return 'Category not found or inactive';
+  return null;
 }
 
 function validateAddonGroupIds(db: any, rawIds: unknown): { ids?: string[]; error?: string } {
@@ -684,8 +709,9 @@ router.post('/', requireRole('owner', 'manager'), (req: Request, res: Response) 
       low_stock_threshold, is_active, image_url, sort_order, cb_percent, tags, addon_group_ids
     } = req.body;
     const normalizedBarcode = normalizeBarcode(barcode);
+    const productName = normalizeRequiredName(name);
 
-    if (!name || price === undefined) {
+    if (!productName || price === undefined) {
       return res.status(400).json({ error: 'Name and price are required' });
     }
     const numericError = validateProductNumericFields(req.body, true);
@@ -712,6 +738,10 @@ router.post('/', requireRole('owner', 'manager'), (req: Request, res: Response) 
     }
 
     const db = getDatabase();
+    const categoryError = validateCategoryId(db, category_id);
+    if (categoryError) {
+      return res.status(400).json({ error: categoryError });
+    }
 
     // A barcode scan must resolve to exactly one product — unlike sku, which
     // is informational only, a duplicate barcode would make scanning ambiguous.
@@ -740,10 +770,10 @@ router.post('/', requireRole('owner', 'manager'), (req: Request, res: Response) 
           is_active, image_url, sort_order, cb_percent, tags, created_at, updated_at)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
-        id, category_id || null, name, sku || null, normalizedBarcode, description || null, price, cost_price || 0,
-        'none', 0, tax_category_id || null, tax_behavior || 'country_default',
+        id, normalizeNullableString(category_id), productName, normalizeNullableString(sku), normalizedBarcode, normalizeNullableString(description), price, cost_price || 0,
+        'none', 0, normalizeNullableString(tax_category_id), tax_behavior || 'country_default',
         track_inventory ? 1 : 0, stock_quantity || 0, low_stock_threshold || 0,
-        is_active !== false ? 1 : 0, image_url || null,
+        is_active !== false ? 1 : 0, normalizeNullableString(image_url),
         sort_order || 0, cb_percent !== undefined ? cb_percent : null, JSON.stringify(tags || []),
         now(), now()
       );
@@ -779,6 +809,11 @@ router.put('/:id', requireRole('owner', 'manager'), (req: Request, res: Response
       low_stock_threshold, is_active, image_url, sort_order, cb_percent, tags, addon_group_ids
     } = req.body;
     const normalizedBarcode = normalizeBarcode(barcode);
+    const hasName = hasOwn(req.body, 'name');
+    const productName = hasName ? normalizeRequiredName(name) : null;
+    if (hasName && !productName) {
+      return res.status(400).json({ error: 'Name is required' });
+    }
 
     const numericError = validateProductNumericFields(req.body, false);
     if (numericError) return res.status(400).json({ error: numericError });
@@ -795,6 +830,12 @@ router.put('/:id', requireRole('owner', 'manager'), (req: Request, res: Response
     const taxCategoryError = validateTaxCategoryId(tax_category_id);
     if (taxCategoryError) {
       return res.status(400).json({ error: taxCategoryError });
+    }
+    if (hasOwn(req.body, 'category_id')) {
+      const categoryError = validateCategoryId(db, category_id);
+      if (categoryError) {
+        return res.status(400).json({ error: categoryError });
+      }
     }
 
     // Validate image_url at write time (server-side security boundary)
@@ -819,6 +860,12 @@ router.put('/:id', requireRole('owner', 'manager'), (req: Request, res: Response
     const hasImageUrl = 'image_url' in req.body;
     const hasTaxCategoryId = 'tax_category_id' in req.body;
     const hasCbPercent = 'cb_percent' in req.body;
+    const hasCategoryId = hasOwn(req.body, 'category_id');
+    const hasSku = hasOwn(req.body, 'sku');
+    const hasBarcode = hasOwn(req.body, 'barcode');
+    const hasDescription = hasOwn(req.body, 'description');
+    const hasCostPrice = hasOwn(req.body, 'cost_price');
+    const hasTags = hasOwn(req.body, 'tags');
 
     const addonGroupValidation = validateAddonGroupIds(db, addon_group_ids);
     if (addonGroupValidation.error) {
@@ -830,13 +877,13 @@ router.put('/:id', requireRole('owner', 'manager'), (req: Request, res: Response
     const updateProduct = db.transaction(() => {
       db.prepare(`
         UPDATE products SET
-          category_id = COALESCE(@category_id, category_id),
-          name = COALESCE(@name, name),
-          sku = COALESCE(@sku, sku),
-          barcode = COALESCE(@barcode, barcode),
-          description = COALESCE(@description, description),
+          category_id = CASE WHEN @has_category_id = 1 THEN @category_id ELSE category_id END,
+          name = CASE WHEN @has_name = 1 THEN @name ELSE name END,
+          sku = CASE WHEN @has_sku = 1 THEN @sku ELSE sku END,
+          barcode = CASE WHEN @has_barcode = 1 THEN @barcode ELSE barcode END,
+          description = CASE WHEN @has_description = 1 THEN @description ELSE description END,
           price = COALESCE(@price, price),
-          cost = COALESCE(@cost, cost),
+          cost = CASE WHEN @has_cost = 1 THEN @cost ELSE cost END,
           tax_type = 'none',
           tax_rate = 0,
           tax_category_id = CASE WHEN @has_tax_category_id = 1 THEN @tax_category_id ELSE tax_category_id END,
@@ -848,22 +895,37 @@ router.put('/:id', requireRole('owner', 'manager'), (req: Request, res: Response
           image_url = CASE WHEN @has_image_url = 1 THEN @image_url ELSE image_url END,
           sort_order = COALESCE(@sort_order, sort_order),
           cb_percent = CASE WHEN @has_cb_percent = 1 THEN @cb_percent ELSE cb_percent END,
-          tags = COALESCE(@tags, tags),
+          tags = CASE WHEN @has_tags = 1 THEN @tags ELSE tags END,
           updated_at = @updated_at
         WHERE id = @id
       `).run({
-        category_id, name, sku, barcode: normalizedBarcode, description, price, cost: cost_price,
-        tax_category_id, tax_behavior,
+        has_category_id: hasCategoryId ? 1 : 0,
+        category_id: normalizeNullableString(category_id),
+        has_name: hasName ? 1 : 0,
+        name: productName,
+        has_sku: hasSku ? 1 : 0,
+        sku: normalizeNullableString(sku),
+        has_barcode: hasBarcode ? 1 : 0,
+        barcode: normalizedBarcode,
+        has_description: hasDescription ? 1 : 0,
+        description: normalizeNullableString(description),
+        price: price ?? null,
+        has_cost: hasCostPrice ? 1 : 0,
+        cost: cost_price ?? null,
+        tax_category_id: normalizeNullableString(tax_category_id),
+        tax_behavior: tax_behavior ?? null,
         has_tax_category_id: hasTaxCategoryId ? 1 : 0,
-        track_inventory: track_inventory ? 1 : track_inventory === 0 ? 0 : null,
-        stock_quantity, low_stock_threshold,
+        track_inventory: track_inventory ? 1 : track_inventory === 0 || track_inventory === false ? 0 : null,
+        stock_quantity: stock_quantity ?? null,
+        low_stock_threshold: low_stock_threshold ?? null,
         is_active: is_active !== undefined ? (is_active ? 1 : 0) : null,
         has_image_url: hasImageUrl ? 1 : 0,
-        image_url: hasImageUrl ? image_url : null,
-        sort_order,
+        image_url: hasImageUrl ? normalizeNullableString(image_url) : null,
+        sort_order: sort_order ?? null,
         has_cb_percent: hasCbPercent ? 1 : 0,
         cb_percent: hasCbPercent ? cb_percent : null,
-        tags: tags ? JSON.stringify(tags) : null,
+        has_tags: hasTags ? 1 : 0,
+        tags: hasTags ? JSON.stringify(tags || []) : null,
         updated_at: now(),
         id: req.params.id
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "3.0.5",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "3.0.5",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,6 +19,7 @@
         "electron-log": "^5.4.4",
         "electron-updater": "^6.8.9",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.6.2",
         "googleapis": "^173.0.0",
         "jsonwebtoken": "^9.0.2",
         "libphonenumber-js": "^1.13.10",
@@ -51,7 +52,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@borewit/text-codec": {
@@ -4125,6 +4126,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -4942,6 +4962,15 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.0.5",
+  "version": "3.2.0",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"
@@ -95,6 +95,7 @@
     "test:issue-133-kds-kot-toggles": "node tests/run-electron-node-test.cjs tests/issue-133-kds-kot-toggles.test.ts",
     "test:issue-137-barcode": "node tests/run-electron-node-test.cjs tests/issue-137-barcode.test.ts",
     "test:issue-244-product-addon-links": "node tests/run-electron-node-test.cjs tests/issue-244-product-addon-links.test.ts",
+    "test:issue-247-catalog-invariants": "node tests/run-electron-node-test.cjs tests/issue-247-catalog-invariants.test.ts",
     "test:issue-250-catalog-perf": "node tests/run-electron-node-test.cjs tests/issue-250-catalog-perf.test.ts",
     "test:issue-258-bill-pagination": "node tests/run-electron-node-test.cjs tests/issue-258-bill-pagination.test.ts",
     "test:issue-265-morocco-profile": "node tests/run-electron-node-test.cjs tests/issue-265-morocco-profile.test.ts",
@@ -181,6 +182,7 @@
     "electron-log": "^5.4.4",
     "electron-updater": "^6.8.9",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.6.2",
     "googleapis": "^173.0.0",
     "jsonwebtoken": "^9.0.2",
     "libphonenumber-js": "^1.13.10",

--- a/tests/issue-247-catalog-invariants.test.ts
+++ b/tests/issue-247-catalog-invariants.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Integration Test: Issue #247 — catalog tree and nullable-field invariants.
+ *
+ * Usage: node tests/run-electron-node-test.cjs tests/issue-247-catalog-invariants.test.ts
+ */
+
+const Module = require('module');
+const originalLoad = Module._load;
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-issue-247-'));
+
+Module._load = function (request: string, parent: unknown, isMain: boolean) {
+  if (request === 'electron') {
+    return { app: { isPackaged: true, getPath: () => testDir, getVersion: () => 'test' } };
+  }
+  return originalLoad.apply(this, arguments as any);
+};
+
+process.env.JWT_SECRET = 'test-secret-issue-247';
+
+const {
+  initTestDb,
+  createApp,
+  startServer,
+  seedOwnerUser,
+  seedCategory,
+  seedProduct,
+  api,
+  assert,
+  assertEqual,
+  getResults,
+  closeDatabase,
+  now,
+} = require('./helpers/test-setup');
+
+const { categoryRoutes } = require('../main/routes/categories');
+const { productRoutes } = require('../main/routes/products');
+const { addonGroupRoutes } = require('../main/routes/addon-groups');
+
+async function main() {
+  console.log('Integration Test: Issue #247 catalog invariants');
+  console.log('='.repeat(60));
+
+  const db = initTestDb();
+  const { authHeader } = seedOwnerUser(db);
+  const app = createApp({
+    '/api/categories': categoryRoutes,
+    '/api/products': productRoutes,
+    '/api/addon-groups': addonGroupRoutes,
+  });
+  const { baseUrl, server } = await startServer(app);
+
+  try {
+    console.log('\n─── Category create/update validation ───');
+    let res = await api(baseUrl, '/api/categories', {
+      method: 'POST',
+      headers: authHeader,
+      body: { name: '   ' },
+    });
+    assertEqual(res.status, 400, 'blank category names are rejected');
+
+    res = await api(baseUrl, '/api/categories', {
+      method: 'POST',
+      headers: authHeader,
+      body: { name: 'Bad Parent', parent_id: 'missing-parent' },
+    });
+    assertEqual(res.status, 400, 'missing category parents are rejected');
+
+    res = await api(baseUrl, '/api/categories', {
+      method: 'POST',
+      headers: authHeader,
+      body: { name: '  Parent Menu  ', description: 'Food', color: '#111111', icon: 'utensils' },
+    });
+    assertEqual(res.status, 201, 'trimmed root category is created');
+    const parentId = res.data.category.id;
+    assertEqual(res.data.category.name, 'Parent Menu', 'category name is stored trimmed');
+
+    res = await api(baseUrl, '/api/categories', {
+      method: 'POST',
+      headers: authHeader,
+      body: { name: 'Child Menu', parent_id: parentId },
+    });
+    assertEqual(res.status, 201, 'child category with active parent is created');
+    const childId = res.data.category.id;
+
+    res = await api(baseUrl, `/api/categories/${parentId}`, {
+      method: 'PUT',
+      headers: authHeader,
+      body: { parent_id: childId },
+    });
+    assertEqual(res.status, 400, 'ancestor cycles are rejected');
+
+    res = await api(baseUrl, `/api/categories/${childId}`, {
+      method: 'PUT',
+      headers: authHeader,
+      body: { parent_id: null },
+    });
+    assertEqual(res.status, 200, 'explicit null clears category parent');
+    assertEqual(db.prepare('SELECT parent_id FROM categories WHERE id = ?').get(childId).parent_id, null, 'parent_id is null after clear');
+
+    res = await api(baseUrl, `/api/categories/${parentId}`, {
+      method: 'PUT',
+      headers: authHeader,
+      body: { description: null, color: null, icon: null },
+    });
+    assertEqual(res.status, 200, 'category nullable fields can be explicitly cleared');
+    const clearedCategory = db.prepare('SELECT description, color, icon FROM categories WHERE id = ?').get(parentId) as any;
+    assertEqual(clearedCategory.description, null, 'category description cleared');
+    assertEqual(clearedCategory.color, null, 'category color cleared');
+    assertEqual(clearedCategory.icon, null, 'category icon cleared');
+
+    console.log('\n─── Category deletion child handling ───');
+    seedCategory(db, 'cat-247-target', 'Target');
+    seedCategory(db, 'cat-247-empty', 'Empty');
+    res = await api(baseUrl, '/api/categories/cat-247-empty', {
+      method: 'DELETE',
+      headers: authHeader,
+    });
+    assertEqual(res.status, 200, 'empty categories can be deleted without dependency action');
+    assert(Boolean(db.prepare('SELECT deleted_at FROM categories WHERE id = ?').get('cat-247-empty').deleted_at), 'empty category is soft-deleted');
+
+    db.prepare('UPDATE categories SET parent_id = ? WHERE id = ?').run(parentId, childId);
+    seedProduct(db, 'prod-247-reassign', parentId, 'Parent Product', 10);
+
+    res = await api(baseUrl, `/api/categories/${parentId}`, {
+      method: 'DELETE',
+      headers: authHeader,
+    });
+    assertEqual(res.status, 400, 'deleting a category with children/products requires an action');
+    assertEqual(res.data.childCount, 1, 'delete response reports child count');
+
+    res = await api(baseUrl, `/api/categories/${parentId}?action=reassign&reassign_to=${parentId}`, {
+      method: 'DELETE',
+      headers: authHeader,
+    });
+    assertEqual(res.status, 400, 'category deletion rejects reassignment to itself');
+
+    res = await api(baseUrl, `/api/categories/${parentId}?action=reassign&reassign_to=${childId}`, {
+      method: 'DELETE',
+      headers: authHeader,
+    });
+    assertEqual(res.status, 400, 'category deletion rejects reassignment to a descendant');
+
+    res = await api(baseUrl, `/api/categories/${parentId}?action=reassign&reassign_to=cat-247-target`, {
+      method: 'DELETE',
+      headers: authHeader,
+    });
+    assertEqual(res.status, 200, 'category deletion can reassign products and children to a valid target');
+    assertEqual(db.prepare('SELECT category_id FROM products WHERE id = ?').get('prod-247-reassign').category_id, 'cat-247-target', 'products are reassigned');
+    assertEqual(db.prepare('SELECT parent_id FROM categories WHERE id = ?').get(childId).parent_id, 'cat-247-target', 'children are reparented');
+
+    console.log('\n─── Product nullable field updates ───');
+    seedCategory(db, 'cat-247-products', 'Products');
+    seedProduct(db, 'prod-247-clear', 'cat-247-products', 'Clearable Product', 20);
+    db.prepare(`
+      UPDATE products SET sku = 'SKU-247', barcode = 'BAR-247', description = 'desc',
+        cost = 5, image_url = 'data:image/png;base64,AAAA', cb_percent = 10,
+        tags = '["a","b"]', tax_category_id = 'legacy-tax'
+      WHERE id = 'prod-247-clear'
+    `).run();
+
+    res = await api(baseUrl, '/api/products/prod-247-clear', {
+      method: 'PUT',
+      headers: authHeader,
+      body: {
+        category_id: null,
+        sku: null,
+        barcode: null,
+        description: null,
+        cost_price: null,
+        image_url: null,
+        cb_percent: null,
+        tax_category_id: null,
+        tags: null,
+      },
+    });
+    assertEqual(res.status, 200, 'product update accepts explicit null clears');
+    const clearedProduct = db.prepare(`
+      SELECT category_id, sku, barcode, description, cost, image_url, cb_percent, tax_category_id, tags
+      FROM products WHERE id = 'prod-247-clear'
+    `).get() as any;
+    assertEqual(clearedProduct.category_id, null, 'product category_id cleared');
+    assertEqual(clearedProduct.sku, null, 'product sku cleared');
+    assertEqual(clearedProduct.barcode, null, 'product barcode cleared');
+    assertEqual(clearedProduct.description, null, 'product description cleared');
+    assertEqual(clearedProduct.cost, null, 'product cost cleared');
+    assertEqual(clearedProduct.image_url, null, 'product image_url cleared');
+    assertEqual(clearedProduct.cb_percent, null, 'product cb_percent cleared');
+    assertEqual(clearedProduct.tax_category_id, null, 'product tax_category_id cleared');
+    assertEqual(clearedProduct.tags, '[]', 'product tags clear to an empty list');
+
+    console.log('\n─── Add-on nullable field updates ───');
+    db.prepare(`
+      INSERT INTO addon_groups (id, name, description, min_selection, max_selection, is_active, created_at, updated_at)
+      VALUES ('ag-247', 'Clearable Group', 'desc', 0, 1, 1, ?, ?)
+    `).run(now(), now());
+    db.prepare(`
+      INSERT INTO addons (id, addon_group_id, name, price, tax_category_id, is_active, created_at, updated_at)
+      VALUES ('addon-247', 'ag-247', 'Clearable Addon', 2, 'legacy-tax', 1, ?, ?)
+    `).run(now(), now());
+
+    res = await api(baseUrl, '/api/addon-groups/ag-247', {
+      method: 'PUT',
+      headers: authHeader,
+      body: { description: null },
+    });
+    assertEqual(res.status, 200, 'add-on group description can be explicitly cleared');
+    assertEqual(db.prepare('SELECT description FROM addon_groups WHERE id = ?').get('ag-247').description, null, 'add-on group description cleared');
+
+    res = await api(baseUrl, '/api/addon-groups/ag-247/addons/addon-247', {
+      method: 'PUT',
+      headers: authHeader,
+      body: { tax_category_id: null },
+    });
+    assertEqual(res.status, 200, 'add-on tax_category_id can be explicitly cleared');
+    assertEqual(db.prepare('SELECT tax_category_id FROM addons WHERE id = ?').get('addon-247').tax_category_id, null, 'add-on tax_category_id cleared');
+  } finally {
+    server.close();
+    closeDatabase();
+    fs.rmSync(testDir, { recursive: true, force: true });
+  }
+
+  const { passed, failed, total } = getResults();
+  console.log('\n' + '='.repeat(60));
+  console.log(`${passed}/${total} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- enforce category hierarchy invariants: trimmed non-empty names, active parents, no self/ancestor cycles, explicit child handling during deletion/reassignment
- make catalog updates presence-aware so omitted fields are preserved while explicit `null` clears nullable category/product/add-on fields
- bump the app version to 3.2.0 and add the 3.2.0 changelog notes used by the release workflow for GitHub Releases

Closes #247

## Verification
- `npm run test:issue-247-catalog-invariants`
- `npm run test:issue-244-product-addon-links`
- `npm run test:issue-250-catalog-perf`
- `npm run build`
- `./scripts/changelog-notes.sh 3.2.0`
