### PR TITLE
fix: fail closed when macOS quarantine check encounters errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:kds-contract": "node tests/run-electron-node-test.cjs tests/kds-contract.test.ts",
     "test:kds-frontend-conflict": "ts-node --transpile-only -P tests/tsconfig.json tests/kds-frontend-conflict.test.ts",
     "test:e2e": "npm run build && npm run build:frontend && cd frontend && npx playwright install chromium && npx playwright test",
-    "test:release-config": "ts-node --transpile-only -P tests/tsconfig.json tests/release-config.test.ts",
+    "test:release-config": "ts-node --transpile-only -P tests/tsconfig.json tests/release-config.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/verify-electron-runtime-xattr.test.ts",
     "test:windows-uninstaller": "node tests/run-windows-uninstaller-tests.cjs",
     "test:telemetry": "node tests/run-electron-node-test.cjs tests/telemetry-delivery.test.ts",
     "test:static-routes": "node tests/run-electron-node-test.cjs tests/static-route-resolution.test.ts",

--- a/scripts/verify-electron-runtime.cjs
+++ b/scripts/verify-electron-runtime.cjs
@@ -7,15 +7,34 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
-if (process.platform !== 'darwin') process.exit(0);
+// macOS `xattr -p` exit semantics:
+//   0                         -> attribute present (value on stdout)
+//   1 + "No such xattr"       -> attribute absent (the documented clean state)
+//   any other status / stderr -> unexpected failure (permission, tool missing,
+//                                 I/O error, ...) and must NOT be treated as
+//                                 clean (GHSA-wjr9-g33j-w22x).
+function classifyQuarantine(status, stderr, stdout) {
+  if (status === 0) {
+    return { state: 'present', value: String(stdout || '') };
+  }
+  if (status === 1 && /no such xattr/i.test(String(stderr || ''))) {
+    return { state: 'absent' };
+  }
+  return { state: 'error', message: String(stderr || '').trim() };
+}
 
-const electronDir = path.join(process.cwd(), 'node_modules', 'electron');
-if (!fs.existsSync(electronDir)) process.exit(0);
-
-const distDir = path.join(electronDir, 'dist');
-const app = fs.existsSync(distDir)
-  ? fs.readdirSync(distDir, { withFileTypes: true }).find((entry) => entry.isDirectory() && entry.name.endsWith('.app'))
-  : null;
+function readQuarantine(appPath) {
+  let stdout = '';
+  try {
+    stdout = execFileSync('xattr', ['-p', 'com.apple.quarantine', appPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return classifyQuarantine(0, '', stdout);
+  } catch (error) {
+    return classifyQuarantine(error && error.status, error && error.stderr, '');
+  }
+}
 
 function fail(message) {
   console.error(`::error::${message}`);
@@ -24,19 +43,39 @@ function fail(message) {
   process.exit(1);
 }
 
-if (!app) fail('node_modules/electron is installed but no dist/*.app bundle was found.');
+function main() {
+  if (process.platform !== 'darwin') process.exit(0);
 
-const appPath = path.join(distDir, app.name);
-let quarantine = '';
-try {
-  quarantine = execFileSync('xattr', ['-p', 'com.apple.quarantine', appPath], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
-} catch { /* no quarantine attribute */ }
-if (quarantine) fail(`${appPath} is marked com.apple.quarantine (${quarantine.trim()}).`);
+  const electronDir = path.join(process.cwd(), 'node_modules', 'electron');
+  if (!fs.existsSync(electronDir)) process.exit(0);
 
-try {
-  execFileSync('codesign', ['-dv', appPath], { stdio: 'ignore' });
-} catch {
-  fail(`${appPath} has no expected ad-hoc code signature and may be corrupted.`);
+  const distDir = path.join(electronDir, 'dist');
+  const app = fs.existsSync(distDir)
+    ? fs.readdirSync(distDir, { withFileTypes: true }).find((entry) => entry.isDirectory() && entry.name.endsWith('.app'))
+    : null;
+
+  if (!app) fail('node_modules/electron is installed but no dist/*.app bundle was found.');
+
+  const appPath = path.join(distDir, app.name);
+  const quarantine = readQuarantine(appPath);
+  if (quarantine.state === 'present') {
+    fail(`${appPath} is marked com.apple.quarantine (${quarantine.value.trim()}).`);
+  }
+  if (quarantine.state === 'error') {
+    fail(`could not read the quarantine attribute of ${appPath}: ${quarantine.message || 'unexpected xattr failure'}`);
+  }
+
+  try {
+    execFileSync('codesign', ['-dv', appPath], { stdio: 'ignore' });
+  } catch {
+    fail(`${appPath} has no expected ad-hoc code signature and may be corrupted.`);
+  }
+
+  console.log(`verify-electron-runtime: ${appPath} present, unquarantined, ad-hoc signed as expected.`);
 }
 
-console.log(`verify-electron-runtime: ${appPath} present, unquarantined, ad-hoc signed as expected.`);
+if (require.main === module) {
+  main();
+}
+
+module.exports = { classifyQuarantine, readQuarantine };

--- a/scripts/verify-electron-runtime.sh
+++ b/scripts/verify-electron-runtime.sh
@@ -63,8 +63,9 @@ fi
 # (GHSA-wjr9-g33j-w22x).
 if [ "$xattr_status" -ne 0 ]; then
   if [ "$xattr_status" -ne 1 ] || ! grep -qi 'no such xattr' "$QUARANTINE_STDERR"; then
+    XATTR_ERR=$(cat "$QUARANTINE_STDERR")
     rm -f "$QUARANTINE_STDERR"
-    fail "could not read the quarantine attribute of $APP: $(cat "$QUARANTINE_STDERR")"
+    fail "could not read the quarantine attribute of $APP: ${XATTR_ERR:-unexpected xattr failure}"
   fi
 fi
 rm -f "$QUARANTINE_STDERR"

--- a/scripts/verify-electron-runtime.sh
+++ b/scripts/verify-electron-runtime.sh
@@ -47,10 +47,27 @@ if [ -z "$APP" ]; then
   fail "$ELECTRON_DIR is installed but no dist/*.app bundle was found — the download is incomplete or corrupted."
 fi
 
-QUARANTINE=$(xattr -p com.apple.quarantine "$APP" 2>/dev/null || true)
+QUARANTINE_STDERR=$(mktemp)
+set +e
+QUARANTINE=$(xattr -p com.apple.quarantine "$APP" 2>"$QUARANTINE_STDERR")
+xattr_status=$?
+set -e
+
 if [ -n "$QUARANTINE" ]; then
+  rm -f "$QUARANTINE_STDERR"
   fail "$APP is marked com.apple.quarantine ($QUARANTINE). A plain npm install shouldn't set this — something in the download path tagged it, and combined with Electron's ad-hoc dev signature this is exactly what triggers the 'Electron has been blocked' dialog."
 fi
+
+# Only the documented "attribute absent" result (exit 1 with "No such xattr")
+# is an acceptable clean state. Any other failure must not be treated as clean
+# (GHSA-wjr9-g33j-w22x).
+if [ "$xattr_status" -ne 0 ]; then
+  if [ "$xattr_status" -ne 1 ] || ! grep -qi 'no such xattr' "$QUARANTINE_STDERR"; then
+    rm -f "$QUARANTINE_STDERR"
+    fail "could not read the quarantine attribute of $APP: $(cat "$QUARANTINE_STDERR")"
+  fi
+fi
+rm -f "$QUARANTINE_STDERR"
 
 if ! codesign -dv "$APP" >/dev/null 2>&1; then
   fail "$APP has no code signature at all (expected an ad-hoc dev signature) — the binary is likely corrupted."

--- a/tests/verify-electron-runtime-xattr.test.ts
+++ b/tests/verify-electron-runtime-xattr.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression coverage for GHSA-wjr9-g33j-w22x (CWE-754): the macOS Electron
+ * runtime verifier must not treat unexpected `xattr` failures as a clean
+ * quarantine check. Only the documented "attribute absent" result (exit 1
+ * with "No such xattr") is an acceptable clean state.
+ *
+ * This exercises the pure classification function from the cross-platform
+ * verifier, so it runs on every platform without needing `xattr`/`codesign`.
+ */
+import * as assert from 'node:assert/strict';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { classifyQuarantine } = require('../scripts/verify-electron-runtime.cjs');
+
+function run() {
+  console.log('Testing Electron runtime xattr classification...');
+
+  // Present attribute (exit 0, value on stdout) → must fail as quarantined.
+  const present = classifyQuarantine(0, '', '0083;1234567890;Electron');
+  assert.equal(present.state, 'present', 'exit 0 with stdout is "present"');
+  assert.equal(present.value, '0083;1234567890;Electron', 'present value is captured from stdout');
+
+  // Absent attribute (exit 1 + "No such xattr") → the only clean state.
+  const absent = classifyQuarantine(1, 'xattr: No such xattr: com.apple.quarantine', '');
+  assert.equal(absent.state, 'absent', 'exit 1 with "No such xattr" is "absent"');
+
+  // Unexpected failure (exit 1 + permission denied) → must NOT be clean.
+  const permissionDenied = classifyQuarantine(1, 'xattr: [Errno 13] Permission denied: /path/Electron.app', '');
+  assert.equal(permissionDenied.state, 'error', 'exit 1 with a permission error is "error", not clean');
+  assert.match(permissionDenied.message, /Permission denied/, 'permission error message is preserved');
+
+  // Unexpected failure (exit 1 + empty stderr) → must NOT be clean.
+  const silentFailure = classifyQuarantine(1, '', '');
+  assert.equal(silentFailure.state, 'error', 'exit 1 with no "No such xattr" stderr is "error", not clean');
+
+  // Missing tool (exit 127) → must NOT be clean.
+  const missingTool = classifyQuarantine(127, 'xattr: command not found', '');
+  assert.equal(missingTool.state, 'error', 'exit 127 (missing tool) is "error", not clean');
+
+  console.log('✅ Electron runtime xattr classification checks passed');
+}
+
+run();


### PR DESCRIPTION
## Intent

Fix security advisory GHSA-wjr9-g33j-w22x (CWE-754): the macOS Electron runtime verifier suppressed every xattr error and treated empty output as unquarantined, so unexpected failures were indistinguishable from a clean state. Capture the xattr exit status and accept only the documented 'attribute absent' result (exit 1 with 'No such xattr'); any other failure now fails the check. Add tests for present, absent, and unexpected failure.

## What Changed

- Update `verify-electron-runtime.cjs` and `verify-electron-runtime.sh` to capture `xattr` exit status and stderr, treating only explicit 'No such xattr' (exit 1) as unquarantined and failing on unexpected errors.
- Export quarantine classification logic from `verify-electron-runtime.cjs` and add unit test coverage in `tests/verify-electron-runtime-xattr.test.ts` for present, absent, and unexpected error scenarios.
- Wire `tests/verify-electron-runtime-xattr.test.ts` into the `test:release-config` script in `package.json`.

## Risk Assessment

✅ Low: The changes cleanly implement fail-closed quarantine verification for macOS Electron runtime in both Bash and CJS scripts with regression test coverage.

## Testing

Exercised unit regression tests and end-to-end simulated macOS xattr verification across clean, quarantined, permission-denied, silent-failure, and missing-tool execution scenarios for both CJS and Bash verifiers; all 12 test assertions and 10 E2E checks passed.

<details>
<summary>Evidence: Electron runtime xattr E2E verification log</summary>

<code>=&#10;E2E Verification for GHSA-wjr9-g33j-w22x: xattr exit status check&#10;=&#10;Case 1: Clean state (exit 1 with &#34;No such xattr&#34;) -&gt; PASS (both .cjs and .sh accept clean state)&#10;Case 2: Quarantined binary (exit 0 with quarantine value) -&gt; PASS (both .cjs and .sh fail on quarantine)&#10;Case 3: Permission denied (exit 1 with Permission denied) -&gt; PASS (both .cjs and .sh fail with error message)&#10;Case 4: Empty stderr on exit 1 (Silent failure) -&gt; PASS (both .cjs and .sh fail on unexpected silent failure)&#10;Case 5: Missing tool / unexpected exit code 127 -&gt; PASS (both .cjs and .sh fail on command error)&#10;All E2E scenarios for GHSA-wjr9-g33j-w22x successfully verified!</code>

```text
================================================================
E2E Verification for GHSA-wjr9-g33j-w22x: xattr exit status check
Timestamp: 2026-08-15T21:49:07.653Z
================================================================

### Case 1: Clean state (exit 1 with "No such xattr")
--- Test: verify-electron-runtime.cjs with mock behavior ---
Mock script:
echo "xattr: No such xattr: com.apple.quarantine" >&2
exit 1
Exit code: 0 (expected: 0)
Stdout: verify-electron-runtime: /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03P6MEMJBVH26WNWZJ262YG/node_modules/electron/dist/Electron.app present, unquarantined, ad-hoc signed as expected.
Stderr: 
Result: PASS

--- Test: verify-electron-runtime.sh with mock behavior ---
Mock script:
echo "xattr: No such xattr: com.apple.quarantine" >&2
exit 1
Exit code: 0 (expected: 0)
Stdout: verify-electron-runtime: node_modules/electron/dist/Electron.app present, unquarantined, ad-hoc signed as expected.
Stderr: 
Result: PASS

### Case 2: Quarantined binary (exit 0 with quarantine value)
--- Test: verify-electron-runtime.cjs with mock behavior ---
Mock script:
echo "0083;12345678;Safari;"
exit 0
Exit code: 1 (expected: 1)
Stdout: 
Stderr: ::error::/Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03P6MEMJBVH26WNWZJ262YG/node_modules/electron/dist/Electron.app is marked com.apple.quarantine (0083;12345678;Safari;).
Do NOT disable Gatekeeper system-wide to work around this.
Approved remediation: remove node_modules/electron and run npm install again.
Result: PASS

--- Test: verify-electron-runtime.sh with mock behavior ---
Mock script:
echo "0083;12345678;Safari;"
exit 0
Exit code: 1 (expected: 1)
Stdout: 
Stderr: ::error::node_modules/electron/dist/Electron.app is marked com.apple.quarantine (0083;12345678;Safari;). A plain npm install shouldn't set this — something in the download path tagged it, and combined with Electron's ad-hoc dev signature this is exactly what triggers the 'Electron has been blocked' dialog.

Do NOT run 'spctl --master-disable' or otherwise disable Gatekeeper system-wide to work around this.
Approved remediation: rm -rf node_modules/electron && npm install
If a clean reinstall still fails, this is a real problem with the electron package — open an issue
instead of bypassing Gatekeeper. See CONTRIBUTING.md's 'macOS Gatekeeper & the Electron dev binary' section.
Result: PASS

### Case 3: Permission denied (exit 1 with Permission denied)
--- Test: verify-electron-runtime.cjs with mock behavior ---
Mock script:
echo "xattr: [Errno 13] Permission denied: /path/to/Electron.app" >&2
exit 1
Exit code: 1 (expected: 1)
Stdout: 
Stderr: ::error::could not read the quarantine attribute of /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03P6MEMJBVH26WNWZJ262YG/node_modules/electron/dist/Electron.app: xattr: [Errno 13] Permission denied: /path/to/Electron.app
Do NOT disable Gatekeeper system-wide to work around this.
Approved remediation: remove node_modules/electron and run npm install again.
Result: PASS

--- Test: verify-electron-runtime.sh with mock behavior ---
Mock script:
echo "xattr: [Errno 13] Permission denied: /path/to/Electron.app" >&2
exit 1
Exit code: 1 (expected: 1)
Stdout: 
Stderr: ::error::could not read the quarantine attribute of node_modules/electron/dist/Electron.app: xattr: [Errno 13] Permission denied: /path/to/Electron.app

Do NOT run 'spctl --master-disable' or otherwise disable Gatekeeper system-wide to work around this.
Approved remediation: rm -rf node_modules/electron && npm install
If a clean reinstall still fails, this is a real problem with the electron package — open an issue
instead of bypassing Gatekeeper. See CONTRIBUTING.md's 'macOS Gatekeeper & the Electron dev binary' section.
Result: PASS

### Case 4: Empty stderr on exit 1 (Silent failure)
--- Test: verify-electron-runtime.cjs with mock behavior ---
Mock script:
exit 1
Exit code: 1 (expected: 1)
Stdout: 
Stderr: ::error::could not read the quarantine attribute of /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03P6MEMJBVH26WNWZJ262YG/node_modules/electron/dist/Electron.app: unexpected xattr failure
Do NOT disable Gatekeeper system-wide to work around this.
Approved remediation: remove node_modules/electron and run npm install again.
Result: PASS

--- Test: verify-electron-runtime.sh with mock behavior ---
Mock script:
exit 1
Exit code: 1 (expected: 1)
Stdout: 
Stderr: ::error::could not read the quarantine attribute of node_modules/electron/dist/Electron.app: unexpected xattr failure

Do NOT run 'spctl --master-disable' or otherwise disable Gatekeeper system-wide to work around this.
Approved remediation: rm -rf node_modules/electron && npm install
If a clean reinstall still fails, this is a real problem with the electron package — open an issue
instead of bypassing Gatekeeper. See CONTRIBUTING.md's 'macOS Gatekeeper & the Electron dev binary' section.
Result: PASS

### Case 5: Missing tool / unexpected exit code 127
--- Test: verify-electron-runtime.cjs with mock behavior ---
Mock script:
echo "xattr: command not found" >&2
exit 127
Exit code: 1 (expected: 1)
Stdout: 
Stderr: ::error::could not read the quarantine attribute of /Users/gurkiratkhaira/.no-mistakes/worktrees/16673a224c40/01M03P6MEMJBVH26WNWZJ262YG/node_modules/electron/dist/Electron.app: xattr: command not found
Do NOT disable Gatekeeper system-wide to work around this.
Approved remediation: remove node_modules/electron and run npm install again.
Result: PASS

--- Test: verify-electron-runtime.sh with mock behavior ---
Mock script:
echo "xattr: command not found" >&2
exit 127
Exit code: 1 (expected: 1)
Stdout: 
Stderr: ::error::could not read the quarantine attribute of node_modules/electron/dist/Electron.app: xattr: command not found

Do NOT run 'spctl --master-disable' or otherwise disable Gatekeeper system-wide to work around this.
Approved remediation: rm -rf node_modules/electron && npm install
If a clean reinstall still fails, this is a real problem with the electron package — open an issue
instead of bypassing Gatekeeper. See CONTRIBUTING.md's 'macOS Gatekeeper & the Electron dev binary' section.
Result: PASS

================================================================
All E2E scenarios for GHSA-wjr9-g33j-w22x successfully verified!
================================================================
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bc19b5578e8dcf935e986afccf743e546317c6b9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `scripts/verify-electron-runtime.sh:66` - In scripts/verify-electron-runtime.sh, `rm -f &#34;$QUARANTINE_STDERR&#34;` on line 66 is executed before `fail &#34;... $(cat &#34;$QUARANTINE_STDERR&#34;)&#34;` on line 67. Deleting the temporary file prior to the command substitution causes `cat` to fail on a non-existent path and discards the actual stderr output from `xattr`.

🔧 Fix: read xattr stderr before removing temporary file
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:release-config`
- `npx ts-node --transpile-only -P tests/tsconfig.json tests/verify-electron-runtime-xattr.test.ts`
- `node scripts/verify-electron-runtime.cjs`
- `bash scripts/verify-electron-runtime.sh`
- `End-to-end simulated xattr execution matrix covering present, absent, permission-denied, silent-failure, and missing-tool states for both .cjs and .sh verifiers`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
