### PR TITLE
fix(kds): confirm before kanban drag skips preparation stages

### DIFF
--- a/frontend/e2e/kds-kanban-skip-confirm.spec.ts
+++ b/frontend/e2e/kds-kanban-skip-confirm.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect, type Locator } from '@playwright/test';
+import path from 'path';
+
+const EVIDENCE_DIR = '/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04C9425M4HQACRQR7J9VQ0X';
+
+test('KDS kanban requires confirmation when skipping preparation stages', async ({ page }) => {
+  // Set generous desktop viewport
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  // 1. Create a fresh order via POS API with pending kitchen status
+  const loginRes = await page.request.post('http://localhost:3001/api/auth/login', {
+    data: { email: 'manager@flo.local', password: 'E2ePass123!' },
+  });
+  expect(loginRes.ok()).toBeTruthy();
+  const { access_token } = await loginRes.json();
+
+  const orderRes = await page.request.post('http://localhost:3001/api/orders', {
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      type: 'dine_in',
+      items: [{ product_id: 'e2e-product', quantity: 2 }],
+    },
+  });
+  expect(orderRes.ok()).toBeTruthy();
+  const { order } = await orderRes.json();
+  const orderNumStr = `#${order.order_number}`;
+
+  // 2. Open standalone KDS
+  await page.goto('http://localhost:3002/kds-standalone');
+  if (await page.getByTestId('kds-login-form').isVisible()) {
+    await page.getByTestId('kds-login-email').fill('manager@flo.local');
+    await page.getByTestId('kds-login-password').fill('E2ePass123!');
+    await page.getByTestId('kds-login-submit').click();
+  }
+  await expect(page.getByTestId('kds-workspace')).toBeVisible();
+
+  // 3. Switch to Kanban view
+  await page.getByRole('button', { name: 'Kanban' }).click();
+  await expect(page.getByRole('button', { name: 'Kanban' })).toHaveAttribute('aria-pressed', 'true');
+
+  // Column drop targets
+  const getColumn = (name: string) =>
+    page.locator('div.flex-1.min-w-\\[260px\\]').filter({ has: page.getByText(name, { exact: true }) }).locator('div[style*="min-height"]');
+
+  const waitingCol = getColumn('Waiting');
+  const preparingCol = getColumn('Preparing');
+  const readyCol = getColumn('Ready');
+  const deliveredCol = getColumn('Delivered');
+
+  await expect(waitingCol).toBeVisible();
+  await expect(preparingCol).toBeVisible();
+  await expect(readyCol).toBeVisible();
+  await expect(deliveredCol).toBeVisible();
+
+  const cardIn = (col: Locator) =>
+    col.locator('div.select-none.cursor-grab:not([data-dnd-placeholder])').filter({ hasText: orderNumStr }).first();
+
+  // Find the card for our order in Waiting column
+  await expect(cardIn(waitingCol)).toBeVisible();
+  await expect(cardIn(waitingCol)).not.toHaveClass(/pointer-events-none/);
+
+  // Capture screenshot: Initial Waiting state
+  await page.screenshot({
+    path: path.join(EVIDENCE_DIR, '01-kds-kanban-initial-waiting.png'),
+    fullPage: true,
+  });
+
+  // Helper for dnd-kit pointer drag and drop from card header
+  const dragCard = async (sourceCard: Locator, targetColumn: Locator, desc: string = '') => {
+    console.log(`\n[Drag] ${desc}`);
+    await expect(sourceCard).toBeVisible();
+    await expect(sourceCard).not.toHaveClass(/pointer-events-none/);
+
+    const headerLoc = sourceCard.locator('span.font-bold').first();
+    const sourceBox = await headerLoc.boundingBox();
+    const targetBox = await targetColumn.boundingBox();
+    if (!sourceBox || !targetBox) throw new Error('Could not compute bounding boxes for drag');
+
+    const startX = sourceBox.x + sourceBox.width / 2;
+    const startY = sourceBox.y + sourceBox.height / 2;
+    const endX = targetBox.x + targetBox.width / 2;
+    const endY = targetBox.y + 80;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 15, startY + 15, { steps: 5 });
+    await page.waitForTimeout(100);
+    await page.mouse.move(endX, endY, { steps: 30 });
+    await page.waitForTimeout(250);
+    await page.mouse.up();
+    await page.waitForTimeout(250);
+  };
+
+  // -------------------------------------------------------------
+  // Test Step A: Single-step forward move (Waiting -> Preparing)
+  // Single-step moves stay one-touch: NO confirmation dialog shown
+  // -------------------------------------------------------------
+  await dragCard(cardIn(waitingCol), preparingCol, 'Waiting -> Preparing (single-step)');
+  await expect(page.getByRole('heading', { name: 'Skip a stage?' })).toHaveCount(0);
+
+  await expect(cardIn(preparingCol)).toBeVisible();
+  await expect(cardIn(preparingCol)).not.toHaveClass(/pointer-events-none/);
+  await expect(cardIn(waitingCol)).toHaveCount(0);
+
+  await page.screenshot({
+    path: path.join(EVIDENCE_DIR, '02-kds-kanban-single-step-preparing.png'),
+    fullPage: true,
+  });
+
+  // ---------------------------------------------------------------------
+  // Test Step B: Multi-step forward move (Preparing -> Delivered, skipping Ready)
+  // Accidental completion protection: MUST require explicit confirmation
+  // ---------------------------------------------------------------------
+  await dragCard(cardIn(preparingCol), deliveredCol, 'Preparing -> Delivered (skips Ready)');
+
+  const dialogTitle = page.getByRole('heading', { name: 'Skip a stage?' });
+  await expect(dialogTitle).toBeVisible();
+  await expect(page.getByText('This will mark the item as Delivered and skip the stages in between.')).toBeVisible();
+  const cancelBtn = page.getByRole('button', { name: 'Cancel' });
+  const confirmDeliveredBtn = page.getByRole('button', { name: 'Mark as Delivered' });
+  await expect(cancelBtn).toBeVisible();
+  await expect(confirmDeliveredBtn).toBeVisible();
+
+  // Capture screenshot: Skip stage confirmation modal
+  await page.screenshot({
+    path: path.join(EVIDENCE_DIR, '03-kds-kanban-skip-stage-modal.png'),
+    fullPage: true,
+  });
+
+  // ---------------------------------------------------------------------
+  // Test Step C: Cancel confirmation -> card remains in Preparing
+  // ---------------------------------------------------------------------
+  await cancelBtn.click();
+  await expect(dialogTitle).toHaveCount(0);
+  await expect(cardIn(preparingCol)).toBeVisible();
+  await expect(cardIn(preparingCol)).not.toHaveClass(/pointer-events-none/);
+  await expect(cardIn(deliveredCol)).toHaveCount(0);
+
+  // ---------------------------------------------------------------------
+  // Test Step D: Drag again and Confirm -> card commits transition to Delivered
+  // ---------------------------------------------------------------------
+  await dragCard(cardIn(preparingCol), deliveredCol, 'Preparing -> Delivered (confirm)');
+  await expect(dialogTitle).toBeVisible();
+  await confirmDeliveredBtn.click();
+  await expect(dialogTitle).toHaveCount(0);
+
+  await expect(cardIn(deliveredCol)).toBeVisible();
+  await expect(cardIn(deliveredCol)).not.toHaveClass(/pointer-events-none/);
+  await expect(cardIn(preparingCol)).toHaveCount(0);
+
+  // Capture screenshot: Delivered state
+  await page.screenshot({
+    path: path.join(EVIDENCE_DIR, '04-kds-kanban-delivered-after-confirm.png'),
+    fullPage: true,
+  });
+
+  // ---------------------------------------------------------------------
+  // Test Step E: Backward drag (Delivered -> Preparing)
+  // Backward moves stay one-touch: NO confirmation dialog
+  // ---------------------------------------------------------------------
+  await dragCard(cardIn(deliveredCol), preparingCol, 'Delivered -> Preparing (backward)');
+  await expect(page.getByRole('heading', { name: 'Skip a stage?' })).toHaveCount(0);
+  await expect(cardIn(preparingCol)).toBeVisible();
+  await expect(cardIn(preparingCol)).not.toHaveClass(/pointer-events-none/);
+  await expect(cardIn(deliveredCol)).toHaveCount(0);
+
+  await page.screenshot({
+    path: path.join(EVIDENCE_DIR, '05-kds-kanban-backward-drag-no-modal.png'),
+    fullPage: true,
+  });
+
+  // ---------------------------------------------------------------------
+  // Test Step F: Backward drag to Waiting, then skip drag from Waiting -> Ready (skipping Preparing)
+  // ---------------------------------------------------------------------
+  await dragCard(cardIn(preparingCol), waitingCol, 'Preparing -> Waiting (backward)');
+  await expect(cardIn(waitingCol)).toBeVisible();
+  await expect(cardIn(waitingCol)).not.toHaveClass(/pointer-events-none/);
+
+  await dragCard(cardIn(waitingCol), readyCol, 'Waiting -> Ready (skips Preparing)');
+  await expect(dialogTitle).toBeVisible();
+  await expect(page.getByText('This will mark the item as Ready and skip the stages in between.')).toBeVisible();
+  const confirmReadyBtn = page.getByRole('button', { name: 'Mark as Ready' });
+  await expect(confirmReadyBtn).toBeVisible();
+
+  await page.screenshot({
+    path: path.join(EVIDENCE_DIR, '06-kds-kanban-skip-to-ready-modal.png'),
+    fullPage: true,
+  });
+
+  await confirmReadyBtn.click();
+  await expect(dialogTitle).toHaveCount(0);
+  await expect(cardIn(readyCol)).toBeVisible();
+  await expect(cardIn(readyCol)).not.toHaveClass(/pointer-events-none/);
+  await expect(cardIn(waitingCol)).toHaveCount(0);
+
+  await page.screenshot({
+    path: path.join(EVIDENCE_DIR, '07-kds-kanban-ready-after-confirm.png'),
+    fullPage: true,
+  });
+});

--- a/frontend/e2e/kds-kanban-skip-confirm.spec.ts
+++ b/frontend/e2e/kds-kanban-skip-confirm.spec.ts
@@ -1,7 +1,4 @@
 import { test, expect, type Locator } from '@playwright/test';
-import path from 'path';
-
-const EVIDENCE_DIR = '/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04C9425M4HQACRQR7J9VQ0X';
 
 test('KDS kanban requires confirmation when skipping preparation stages', async ({ page }) => {
   // Set generous desktop viewport
@@ -62,14 +59,8 @@ test('KDS kanban requires confirmation when skipping preparation stages', async 
   await expect(cardIn(waitingCol)).toBeVisible();
   await expect(cardIn(waitingCol)).not.toHaveClass(/pointer-events-none/);
 
-  // Capture screenshot: Initial Waiting state
-  await page.screenshot({
-    path: path.join(EVIDENCE_DIR, '01-kds-kanban-initial-waiting.png'),
-    fullPage: true,
-  });
-
   // Helper for dnd-kit pointer drag and drop from card header
-  const dragCard = async (sourceCard: Locator, targetColumn: Locator, desc: string = '') => {
+  const dragCard = async (sourceCard: Locator, targetColumn: Locator, desc = '') => {
     console.log(`\n[Drag] ${desc}`);
     await expect(sourceCard).toBeVisible();
     await expect(sourceCard).not.toHaveClass(/pointer-events-none/);
@@ -95,7 +86,7 @@ test('KDS kanban requires confirmation when skipping preparation stages', async 
   };
 
   // -------------------------------------------------------------
-  // Test Step A: Single-step forward move (Waiting -> Preparing)
+  // Step A: Single-step forward move (Waiting -> Preparing)
   // Single-step moves stay one-touch: NO confirmation dialog shown
   // -------------------------------------------------------------
   await dragCard(cardIn(waitingCol), preparingCol, 'Waiting -> Preparing (single-step)');
@@ -105,13 +96,8 @@ test('KDS kanban requires confirmation when skipping preparation stages', async 
   await expect(cardIn(preparingCol)).not.toHaveClass(/pointer-events-none/);
   await expect(cardIn(waitingCol)).toHaveCount(0);
 
-  await page.screenshot({
-    path: path.join(EVIDENCE_DIR, '02-kds-kanban-single-step-preparing.png'),
-    fullPage: true,
-  });
-
   // ---------------------------------------------------------------------
-  // Test Step B: Multi-step forward move (Preparing -> Delivered, skipping Ready)
+  // Step B: Multi-step forward move (Preparing -> Delivered, skipping Ready)
   // Accidental completion protection: MUST require explicit confirmation
   // ---------------------------------------------------------------------
   await dragCard(cardIn(preparingCol), deliveredCol, 'Preparing -> Delivered (skips Ready)');
@@ -124,14 +110,8 @@ test('KDS kanban requires confirmation when skipping preparation stages', async 
   await expect(cancelBtn).toBeVisible();
   await expect(confirmDeliveredBtn).toBeVisible();
 
-  // Capture screenshot: Skip stage confirmation modal
-  await page.screenshot({
-    path: path.join(EVIDENCE_DIR, '03-kds-kanban-skip-stage-modal.png'),
-    fullPage: true,
-  });
-
   // ---------------------------------------------------------------------
-  // Test Step C: Cancel confirmation -> card remains in Preparing
+  // Step C: Cancel confirmation -> card remains in Preparing
   // ---------------------------------------------------------------------
   await cancelBtn.click();
   await expect(dialogTitle).toHaveCount(0);
@@ -140,7 +120,7 @@ test('KDS kanban requires confirmation when skipping preparation stages', async 
   await expect(cardIn(deliveredCol)).toHaveCount(0);
 
   // ---------------------------------------------------------------------
-  // Test Step D: Drag again and Confirm -> card commits transition to Delivered
+  // Step D: Drag again and Confirm -> card commits transition to Delivered
   // ---------------------------------------------------------------------
   await dragCard(cardIn(preparingCol), deliveredCol, 'Preparing -> Delivered (confirm)');
   await expect(dialogTitle).toBeVisible();
@@ -151,14 +131,8 @@ test('KDS kanban requires confirmation when skipping preparation stages', async 
   await expect(cardIn(deliveredCol)).not.toHaveClass(/pointer-events-none/);
   await expect(cardIn(preparingCol)).toHaveCount(0);
 
-  // Capture screenshot: Delivered state
-  await page.screenshot({
-    path: path.join(EVIDENCE_DIR, '04-kds-kanban-delivered-after-confirm.png'),
-    fullPage: true,
-  });
-
   // ---------------------------------------------------------------------
-  // Test Step E: Backward drag (Delivered -> Preparing)
+  // Step E: Backward drag (Delivered -> Preparing)
   // Backward moves stay one-touch: NO confirmation dialog
   // ---------------------------------------------------------------------
   await dragCard(cardIn(deliveredCol), preparingCol, 'Delivered -> Preparing (backward)');
@@ -167,13 +141,8 @@ test('KDS kanban requires confirmation when skipping preparation stages', async 
   await expect(cardIn(preparingCol)).not.toHaveClass(/pointer-events-none/);
   await expect(cardIn(deliveredCol)).toHaveCount(0);
 
-  await page.screenshot({
-    path: path.join(EVIDENCE_DIR, '05-kds-kanban-backward-drag-no-modal.png'),
-    fullPage: true,
-  });
-
   // ---------------------------------------------------------------------
-  // Test Step F: Backward drag to Waiting, then skip drag from Waiting -> Ready (skipping Preparing)
+  // Step F: Backward drag to Waiting, then skip drag Waiting -> Ready (skipping Preparing)
   // ---------------------------------------------------------------------
   await dragCard(cardIn(preparingCol), waitingCol, 'Preparing -> Waiting (backward)');
   await expect(cardIn(waitingCol)).toBeVisible();
@@ -185,19 +154,9 @@ test('KDS kanban requires confirmation when skipping preparation stages', async 
   const confirmReadyBtn = page.getByRole('button', { name: 'Mark as Ready' });
   await expect(confirmReadyBtn).toBeVisible();
 
-  await page.screenshot({
-    path: path.join(EVIDENCE_DIR, '06-kds-kanban-skip-to-ready-modal.png'),
-    fullPage: true,
-  });
-
   await confirmReadyBtn.click();
   await expect(dialogTitle).toHaveCount(0);
   await expect(cardIn(readyCol)).toBeVisible();
   await expect(cardIn(readyCol)).not.toHaveClass(/pointer-events-none/);
   await expect(cardIn(waitingCol)).toHaveCount(0);
-
-  await page.screenshot({
-    path: path.join(EVIDENCE_DIR, '07-kds-kanban-ready-after-confirm.png'),
-    fullPage: true,
-  });
 });

--- a/frontend/src/components/kds/KdsKanbanBoard.tsx
+++ b/frontend/src/components/kds/KdsKanbanBoard.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/hooks/useKdsConnection';
 import { ORDER_TYPE_LABEL_KEYS } from '@/lib/order-types';
 import { useI18n } from '@/hooks/useI18n';
+import { useConfirm } from '@/hooks/use-confirm';
 import { parseDbTimestamp } from '@/lib/utils';
 
 export interface KdsKanbanBoardProps {
@@ -51,6 +52,8 @@ export function KdsKanbanBoard({ orders, updating, updateItemStatus }: KdsKanban
   const resolvedModalItem = modalItem
     ? { ...modalItem, item: orders.flatMap((order) => order.items || []).find((item) => item.id === modalItem.item.id) || modalItem.item }
     : null;
+  const { t } = useI18n();
+  const { confirm, ConfirmDialog } = useConfirm();
 
   // Group by status, then by order. Default rendering matches the tabs view:
   // one card per order, with the order header and a list of items in that status.
@@ -97,8 +100,24 @@ export function KdsKanbanBoard({ orders, updating, updateItemStatus }: KdsKanban
     if (!event.operation.target || !sourceData || !targetData) return;
     if (sourceData.fromStatus === targetData.status) return;
 
+    const sourceIdx = STATUS_ORDER.indexOf(sourceData.fromStatus as BoardStatus);
+    const targetIdx = STATUS_ORDER.indexOf(targetData.status as BoardStatus);
+    // A forward drag that jumps over one or more stages (e.g. preparing →
+    // served) can accidentally complete an order, so require an explicit
+    // confirmation before committing (issue #301). Backward and single-step
+    // moves stay one-touch.
+    const skipsStage = sourceIdx >= 0 && targetIdx > sourceIdx + 1;
+    if (skipsStage) {
+      const targetLabel = t(STATUS_CONFIG[targetData.status].labelKey);
+      const proceed = await confirm(
+        t('kds.skipStageMessage', { status: targetLabel }),
+        { title: t('kds.skipStageTitle'), confirmLabel: t('kds.markAs', { status: targetLabel }) },
+      );
+      if (!proceed) return;
+    }
+
     const results = await Promise.all(sourceData.itemIds.map((id) =>
-      updateItemStatus(id, targetData.status, { silent: true, expectedStatus: sourceData.fromStatus }),
+      updateItemStatus(id, targetData.status, { silent: !skipsStage, expectedStatus: sourceData.fromStatus }),
     ));
     const failed = results.filter((result) => !result).length;
     if (failed > 0) {
@@ -165,6 +184,8 @@ export function KdsKanbanBoard({ orders, updating, updateItemStatus }: KdsKanban
           )}
         </div>
       </DragDropProvider>
+
+      {ConfirmDialog}
 
       {resolvedModalItem && (
         <KdsItemModal

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1137,6 +1137,8 @@
   "kds.viewTabs": "Tabs",
   "kds.emptyColumn": "—",
   "kds.wsConnected": "WebSocket connected",
+  "kds.skipStageTitle": "Skip a stage?",
+  "kds.skipStageMessage": "This will mark the item as {status} and skip the stages in between.",
   "nav.collapse": "Collapse",
   "nav.confirmLogout": "Are you sure you want to log out?",
   "nav.heapLabel": "Heap: ",

--- a/frontend/src/lib/i18n/es.json
+++ b/frontend/src/lib/i18n/es.json
@@ -1136,6 +1136,8 @@
   "kds.viewTabs": "Pestañas",
   "kds.emptyColumn": "—",
   "kds.wsConnected": "WebSocket conectado",
+  "kds.skipStageTitle": "¿Saltar una etapa?",
+  "kds.skipStageMessage": "Esto marcará el ítem como {status} y saltará las etapas intermedias.",
   "nav.collapse": "Contraer",
   "nav.confirmLogout": "¿Estás seguro de que quieres cerrar la sesión?",
   "nav.heapLabel": "Memoria: ",

--- a/frontend/src/lib/i18n/fa.json
+++ b/frontend/src/lib/i18n/fa.json
@@ -1137,6 +1137,8 @@
   "kds.viewTabs": "زبانه‌ها",
   "kds.emptyColumn": "—",
   "kds.wsConnected": "WebSocket پیوند داده شد",
+  "kds.skipStageTitle": "پرش از یک مرحله؟",
+  "kds.skipStageMessage": "این کالا به وضعیت {status} تغییر می‌کند و مراحل میانی نادیده گرفته می‌شوند.",
   "nav.collapse": "جمع کردن",
   "nav.confirmLogout": "آیا از خروج مطمئن هستید؟",
   "nav.heapLabel": "حافظه: ",

--- a/frontend/src/lib/i18n/pt.json
+++ b/frontend/src/lib/i18n/pt.json
@@ -1136,6 +1136,8 @@
   "kds.viewTabs": "Abas",
   "kds.emptyColumn": "—",
   "kds.wsConnected": "WebSocket conectado",
+  "kds.skipStageTitle": "Pular uma etapa?",
+  "kds.skipStageMessage": "Isso marcará o item como {status} e pulará as etapas intermediárias.",
   "nav.collapse": "Recolher",
   "nav.confirmLogout": "Tem certeza de que deseja sair?",
   "nav.heapLabel": "Heap: ",


### PR DESCRIPTION
## Intent

Add a confirmation dialog in the KDS Kanban board before a drag skips preparation stages, preventing accidental silent order completion (#301)

## What Changed

- Added a confirmation prompt in `KdsKanbanBoard` when dragging an item forward across multiple stages, while allowing single-step and backward transitions to proceed without confirmation.
- Added `kds.skipStageTitle` and `kds.skipStageMessage` localization strings to English, Spanish, Persian, and Portuguese translation dictionaries.
- Added Playwright end-to-end tests in `frontend/e2e/kds-kanban-skip-confirm.spec.ts` verifying confirmation dialog appearance, cancellation, stage skip confirmation, and single-step/backward drag behavior.

## Risk Assessment

✅ Low: The change is a clean and well-bounded enhancement that introduces a confirmation dialog when skipping KDS Kanban preparation stages, complete with multi-language i18n support and comprehensive E2E test coverage.

## Testing

Executed i18n translation integrity checks, backend KDS integration and contract suites, and the Playwright end-to-end test suite (`e2e/kds-kanban-skip-confirm.spec.ts`), capturing 8 visual screenshot artifacts demonstrating the confirmation modal, cancel retention, and commit behaviors on stage skipping with all checks passing.

- Evidence: Initial KDS Kanban Board (Waiting column) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04DWM8DM58T67SWM2T6SSC8/01_kanban_board_initial_waiting.png</code>)
- Evidence: Single-step forward drag (Waiting -&gt; Preparing, one-touch without dialog) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04DWM8DM58T67SWM2T6SSC8/02_single_step_moved_to_preparing.png</code>)
- Evidence: Confirmation dialog on stage skip (Preparing -&gt; Delivered) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04DWM8DM58T67SWM2T6SSC8/03_skip_stage_confirmation_dialog.png</code>)
- Evidence: Cancelled confirmation retains item in Preparing stage (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04DWM8DM58T67SWM2T6SSC8/04_cancelled_card_retained_in_preparing.png</code>)
- Evidence: Confirmed transition moves item to Delivered stage (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04DWM8DM58T67SWM2T6SSC8/05_confirmed_card_moved_to_delivered.png</code>)
- Evidence: Backward drag (Delivered -&gt; Preparing) stays one-touch without dialog (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04DWM8DM58T67SWM2T6SSC8/06_backward_drag_to_preparing_no_dialog.png</code>)
- Evidence: Confirmation dialog on stage skip (Waiting -&gt; Ready) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04DWM8DM58T67SWM2T6SSC8/07_skip_waiting_to_ready_confirmation_dialog.png</code>)
- Evidence: Confirmed transition moves item to Ready stage (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M04DWM8DM58T67SWM2T6SSC8/08_confirmed_card_in_ready.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d26a64fd1f3ad45f6b94f4cc02876d38211cd1aa","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:translations`
- `node tests/run-electron-node-test.cjs tests/kds-integration.test.ts`
- `node tests/run-electron-node-test.cjs tests/kds-contract.test.ts`
- `cd frontend && npx playwright test e2e/kds-kanban-skip-confirm.spec.ts`
- `Playwright end-to-end interactive Kanban drag-and-drop verification capturing visual screenshots for initial board state, single-step transitions, stage-skip confirmation modal, cancellation retention, confirmation commit, and backward one-touch drag`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
