### PR TITLE
ci: shard core test suite across parallel runner jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,45 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: 1
 
-      - name: Core test suite (Includes smoke & kds integration)
-        run: npm test
+  # 4b. Linux Core Test Suite (sharded)
+  # `npm test` runs ~90 suites serially (~3.5 min) and dominated the PR critical
+  # path. Run the same suites as two round-robin shards on separate runners —
+  # they run in parallel with the build/lint job above, cutting merge-ready time
+  # instead of just the job's own wall time. Shards MUST be separate runners:
+  # several auth suites interfere when run concurrently on one machine.
+  linux-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.kds == 'true' || needs.changes.outputs.db == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild native modules
+        run: npx @electron/rebuild -f -w better-sqlite3
+
+      - name: Payment method split checks (npm pretest)
+        if: matrix.shard == 0
+        run: bash tests/run-test.sh npm run test:payment-methods-split
+
+      - name: Core test suite (shard ${{ matrix.shard }})
+        # The suite list is derived from package.json's "test" script at run
+        # time, so shard coverage cannot drift from a hand-maintained list.
+        run: |
+          SHARD_TOTAL=2 SHARD_INDEX=${{ matrix.shard }} node scripts/ci/run-test-shard.cjs
 
   # 5. Playwright E2E
   e2e-playwright:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,12 +140,19 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
 
       - name: Install dependencies
         run: npm ci
 
       - name: Rebuild native modules
         run: npx @electron/rebuild -f -w better-sqlite3
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
 
       - name: Payment method split checks (npm pretest)
         if: matrix.shard == 0

--- a/scripts/ci/run-test-shard.cjs
+++ b/scripts/ci/run-test-shard.cjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/*
+ * CI test sharding for the FloCafe "Core test suite" (`npm test`).
+ *
+ * The canonical, ordered suite list lives in package.json's "test" script as a
+ * chain of `bash tests/run-test.sh npm run test:<name>` invocations. This helper
+ * reads that script at run time (so there is no second list to drift), assigns
+ * suites to shards round-robin by position, and runs this shard's subset with
+ * the same `run-test.sh` wrapper that `npm test` uses.
+ *
+ * Usage:
+ *   SHARD_TOTAL=2 SHARD_INDEX=0 node scripts/ci/run-test-shard.cjs
+ *
+ * The `pretest` hook (test:payment-methods-split) is intentionally NOT run here;
+ * CI runs it as its own step before the shards, mirroring `npm test`'s pretest.
+ */
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function parseIntEnv(name, value, fallback, min) {
+  if (value === undefined || value === '') return fallback;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < min) {
+    console.error(`Invalid ${name}=${value}: expected an integer >= ${min}.`);
+    process.exit(2);
+  }
+  return n;
+}
+
+const total = parseIntEnv('SHARD_TOTAL', process.env.SHARD_TOTAL, 2, 1);
+const index = parseIntEnv('SHARD_INDEX', process.env.SHARD_INDEX, 0, 0);
+if (index >= total) {
+  console.error(`Invalid SHARD_INDEX=${index}: must be < SHARD_TOTAL=${total}.`);
+  process.exit(2);
+}
+
+const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const testScript = pkg.scripts && pkg.scripts.test;
+if (typeof testScript !== 'string' || testScript.length === 0) {
+  console.error('package.json has no "test" script to shard.');
+  process.exit(2);
+}
+
+const suitePattern = /(?:bash\s+tests\/run-test\.sh\s+)?npm\s+run\s+(test:[\w-]+)/g;
+const suites = [];
+let match;
+while ((match = suitePattern.exec(testScript)) !== null) {
+  if (!suites.includes(match[1])) suites.push(match[1]);
+}
+
+if (suites.length === 0) {
+  console.error('Could not extract any test suites from package.json "test" script.');
+  process.exit(2);
+}
+
+const mine = suites.filter((_, i) => i % total === index);
+console.log(
+  `[test-shard] shard ${index}/${total}: ${mine.length}/${suites.length} suites (total across shards).`,
+);
+
+let failed = false;
+for (const suite of mine) {
+  console.log(`\n=== [shard ${index}] ${suite} ===`);
+  const result = spawnSync('bash', ['tests/run-test.sh', 'npm', 'run', suite], {
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.error || result.signal || result.status !== 0) {
+    console.error(`[shard ${index}] FAILED: ${suite}`);
+    failed = true;
+    break;
+  }
+}
+
+process.exit(failed ? 1 : 0);

--- a/tests/dev-tooling-scripts.test.ts
+++ b/tests/dev-tooling-scripts.test.ts
@@ -173,6 +173,175 @@ function runTest() {
 
   console.log('✓ nuclear reset Electron cache paths verified');
 
+  console.log('Testing scripts/ci/run-test-shard.cjs parameter validation and sharding behavior...');
+
+  const shardScript = path.join(rootDir, 'scripts/ci/run-test-shard.cjs');
+
+  // Parameter validation checks
+  const invalidCases = [
+    { env: { SHARD_TOTAL: '0', SHARD_INDEX: '0' }, expectedErr: /Invalid SHARD_TOTAL=0: expected an integer >= 1/ },
+    { env: { SHARD_TOTAL: '-2', SHARD_INDEX: '0' }, expectedErr: /Invalid SHARD_TOTAL=-2: expected an integer >= 1/ },
+    { env: { SHARD_TOTAL: 'abc', SHARD_INDEX: '0' }, expectedErr: /Invalid SHARD_TOTAL=abc: expected an integer >= 1/ },
+    { env: { SHARD_TOTAL: '2.5', SHARD_INDEX: '0' }, expectedErr: /Invalid SHARD_TOTAL=2.5: expected an integer >= 1/ },
+    { env: { SHARD_TOTAL: '2', SHARD_INDEX: '-1' }, expectedErr: /Invalid SHARD_INDEX=-1: expected an integer >= 0/ },
+    { env: { SHARD_TOTAL: '2', SHARD_INDEX: '2' }, expectedErr: /Invalid SHARD_INDEX=2: must be < SHARD_TOTAL=2/ },
+    { env: { SHARD_TOTAL: '2', SHARD_INDEX: '5' }, expectedErr: /Invalid SHARD_INDEX=5: must be < SHARD_TOTAL=2/ },
+  ];
+
+  for (const tc of invalidCases) {
+    const res = spawnSync('node', [shardScript], {
+      encoding: 'utf8',
+      cwd: rootDir,
+      env: { ...process.env, ...tc.env },
+    });
+    assert.strictEqual(res.status, 2, `Expected exit status 2 for env ${JSON.stringify(tc.env)}`);
+    assert.match(res.stderr, tc.expectedErr, `Expected stderr to match ${tc.expectedErr}`);
+  }
+
+  console.log('✓ run-test-shard.cjs parameter validation verified');
+
+  // Execution and partition behavior using temporary fixture
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-shard-test-'));
+  try {
+    fs.mkdirSync(path.join(fixtureDir, 'scripts/ci'), { recursive: true });
+    fs.mkdirSync(path.join(fixtureDir, 'tests'), { recursive: true });
+
+    // Copy run-test-shard.cjs
+    fs.copyFileSync(shardScript, path.join(fixtureDir, 'scripts/ci/run-test-shard.cjs'));
+
+    // Create mock tests/run-test.sh
+    const runTestSh = `#!/usr/bin/env bash
+shift # skip 'npm'
+shift # skip 'run'
+suite="$1"
+echo "RUNNING_MOCK_SUITE:$suite"
+if [[ "$suite" == "test:failing-suite" ]]; then
+  exit 1
+fi
+exit 0
+`;
+    fs.writeFileSync(path.join(fixtureDir, 'tests/run-test.sh'), runTestSh, { mode: 0o755 });
+
+    // Create fixture package.json
+    const fixturePkg = {
+      name: 'fixture-app',
+      scripts: {
+        'test:suite-1': 'node -e ""',
+        'test:suite-2': 'node -e ""',
+        'test:suite-3': 'node -e ""',
+        'test:suite-4': 'node -e ""',
+        'test:suite-5': 'node -e ""',
+        'test:failing-suite': 'node -e ""',
+        test: 'bash tests/run-test.sh npm run test:suite-1 && bash tests/run-test.sh npm run test:suite-2 && bash tests/run-test.sh npm run test:suite-3 && bash tests/run-test.sh npm run test:suite-4 && bash tests/run-test.sh npm run test:suite-5',
+        'test-with-fail': 'bash tests/run-test.sh npm run test:suite-1 && bash tests/run-test.sh npm run test:failing-suite && bash tests/run-test.sh npm run test:suite-3',
+      },
+    };
+    fs.writeFileSync(path.join(fixtureDir, 'package.json'), JSON.stringify(fixturePkg, null, 2));
+
+    // Test Shard 0 execution (suites 1, 3, 5)
+    const shard0 = spawnSync('node', ['scripts/ci/run-test-shard.cjs'], {
+      encoding: 'utf8',
+      cwd: fixtureDir,
+      env: { ...process.env, SHARD_TOTAL: '2', SHARD_INDEX: '0' },
+    });
+    assert.strictEqual(shard0.status, 0, `Expected shard 0 to pass: ${shard0.stderr}`);
+    assert.match(shard0.stdout, /RUNNING_MOCK_SUITE:test:suite-1/);
+    assert.match(shard0.stdout, /RUNNING_MOCK_SUITE:test:suite-3/);
+    assert.match(shard0.stdout, /RUNNING_MOCK_SUITE:test:suite-5/);
+    assert.doesNotMatch(shard0.stdout, /RUNNING_MOCK_SUITE:test:suite-2/);
+    assert.doesNotMatch(shard0.stdout, /RUNNING_MOCK_SUITE:test:suite-4/);
+
+    // Test Shard 1 execution (suites 2, 4)
+    const shard1 = spawnSync('node', ['scripts/ci/run-test-shard.cjs'], {
+      encoding: 'utf8',
+      cwd: fixtureDir,
+      env: { ...process.env, SHARD_TOTAL: '2', SHARD_INDEX: '1' },
+    });
+    assert.strictEqual(shard1.status, 0, `Expected shard 1 to pass: ${shard1.stderr}`);
+    assert.match(shard1.stdout, /RUNNING_MOCK_SUITE:test:suite-2/);
+    assert.match(shard1.stdout, /RUNNING_MOCK_SUITE:test:suite-4/);
+    assert.doesNotMatch(shard1.stdout, /RUNNING_MOCK_SUITE:test:suite-1/);
+    assert.doesNotMatch(shard1.stdout, /RUNNING_MOCK_SUITE:test:suite-3/);
+    assert.doesNotMatch(shard1.stdout, /RUNNING_MOCK_SUITE:test:suite-5/);
+
+    // Test Fail-fast on failing suite
+    fixturePkg.scripts.test = fixturePkg.scripts['test-with-fail'];
+    fs.writeFileSync(path.join(fixtureDir, 'package.json'), JSON.stringify(fixturePkg, null, 2));
+
+    const failingShard = spawnSync('node', ['scripts/ci/run-test-shard.cjs'], {
+      encoding: 'utf8',
+      cwd: fixtureDir,
+      env: { ...process.env, SHARD_TOTAL: '2', SHARD_INDEX: '1' }, // failing-suite is at index 1
+    });
+    assert.strictEqual(failingShard.status, 1, 'Expected failing suite to exit with code 1');
+    assert.match(failingShard.stdout, /RUNNING_MOCK_SUITE:test:failing-suite/);
+    assert.match(failingShard.stderr, /\[shard 1\] FAILED: test:failing-suite/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+
+  console.log('✓ run-test-shard.cjs round-robin execution and fail-fast verified');
+
+  // Real package.json test suite partition & coverage invariance
+  const realPkg = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+  const testScript = realPkg.scripts?.test;
+  assert.ok(typeof testScript === 'string' && testScript.length > 0, 'package.json must define a "test" script');
+
+  const suitePattern = /(?:bash\s+tests\/run-test\.sh\s+)?npm\s+run\s+(test:[\w-]+)/g;
+  const allSuites: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = suitePattern.exec(testScript)) !== null) {
+    if (!allSuites.includes(match[1])) allSuites.push(match[1]);
+  }
+
+  assert.strictEqual(allSuites.length, 90, `Expected 90 test suites in "test" script, got ${allSuites.length}`);
+
+  for (const suiteName of allSuites) {
+    assert.ok(
+      suiteName in realPkg.scripts,
+      `Suite "${suiteName}" extracted from "test" script must exist in package.json scripts`,
+    );
+  }
+
+  const shard0Suites = allSuites.filter((_, i) => i % 2 === 0);
+  const shard1Suites = allSuites.filter((_, i) => i % 2 === 1);
+  assert.strictEqual(shard0Suites.length, 45, 'Shard 0 must have exactly 45 suites');
+  assert.strictEqual(shard1Suites.length, 45, 'Shard 1 must have exactly 45 suites');
+
+  // Ensure 0 overlap and 100% union coverage
+  const intersection = shard0Suites.filter((s) => shard1Suites.includes(s));
+  assert.strictEqual(intersection.length, 0, 'Shards must not share any duplicate suites');
+
+  const reconstructed = [];
+  for (let i = 0; i < allSuites.length; i++) {
+    reconstructed.push(i % 2 === 0 ? shard0Suites[i / 2] : shard1Suites[(i - 1) / 2]);
+  }
+  assert.deepStrictEqual(reconstructed, allSuites, 'Round-robin shards must reconstruct the exact original suite list in order');
+
+  console.log('✓ package.json test suite sharding coverage invariance (90 suites, 45 per shard) verified');
+
+  // CI Workflow schema and configuration assertions
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const yaml = require('js-yaml');
+  const ciWorkflow = yaml.load(fs.readFileSync(path.join(rootDir, '.github/workflows/ci.yml'), 'utf8'));
+
+  assert.ok(ciWorkflow.jobs['linux-tests'], 'ci.yml must define a "linux-tests" job');
+  const linuxTestsJob = ciWorkflow.jobs['linux-tests'];
+  assert.strictEqual(linuxTestsJob['runs-on'], 'ubuntu-latest', 'linux-tests must run on ubuntu-latest');
+  assert.strictEqual(linuxTestsJob?.strategy?.['fail-fast'], false, 'linux-tests strategy.fail-fast must be false');
+  assert.deepStrictEqual(linuxTestsJob?.strategy?.matrix?.shard, [0, 1], 'linux-tests matrix.shard must be [0, 1]');
+
+  const steps = linuxTestsJob.steps || [];
+  const pretestStep = steps.find((s: any) => s.name?.includes('Payment method split checks'));
+  assert.ok(pretestStep, 'linux-tests must include payment method split pretest step');
+  assert.strictEqual(pretestStep.if, 'matrix.shard == 0', 'Payment method split check must run only on shard 0');
+
+  const shardStep = steps.find((s: any) => s.name?.includes('Core test suite (shard'));
+  assert.ok(shardStep, 'linux-tests must include Core test suite shard step');
+  assert.match(shardStep.run, /SHARD_TOTAL=2\s+SHARD_INDEX=\${{\s*matrix\.shard\s*}}\s+node\s+scripts\/ci\/run-test-shard\.cjs/);
+
+  console.log('✓ CI workflow linux-tests matrix and sharding configuration verified');
+
   console.log('All dev tooling script tests passed cleanly!');
 }
 

--- a/tests/dev-tooling-scripts.test.ts
+++ b/tests/dev-tooling-scripts.test.ts
@@ -336,6 +336,11 @@ exit 0
   assert.ok(pretestStep, 'linux-tests must include payment method split pretest step');
   assert.strictEqual(pretestStep.if, 'matrix.shard == 0', 'Payment method split check must run only on shard 0');
 
+  const frontendDepsStep = steps.find((s: any) => s.name?.includes('Install frontend dependencies'));
+  assert.ok(frontendDepsStep, 'linux-tests must include frontend dependencies installation step');
+  assert.strictEqual(frontendDepsStep['working-directory'], 'frontend');
+  assert.strictEqual(frontendDepsStep.run, 'npm ci');
+
   const shardStep = steps.find((s: any) => s.name?.includes('Core test suite (shard'));
   assert.ok(shardStep, 'linux-tests must include Core test suite shard step');
   assert.match(shardStep.run, /SHARD_TOTAL=2\s+SHARD_INDEX=\${{\s*matrix\.shard\s*}}\s+node\s+scripts\/ci\/run-test-shard\.cjs/);


### PR DESCRIPTION
## Intent

Shard the CI core test suite (~90 serial suites) into two parallel runner jobs to cut PR merge-ready time, without removing any test coverage. Update branch protection to require the new shard checks.

## What Changed

- Added `scripts/ci/run-test-shard.cjs` to dynamically parse test suites from `package.json` and execute round-robin partitions based on `SHARD_TOTAL` and `SHARD_INDEX`.
- Updated `.github/workflows/ci.yml` to run the core test suite across a two-runner matrix job (`linux-tests`) with payment method split prechecks on shard 0.
- Added tests in `tests/dev-tooling-scripts.test.ts` covering shard script parameter validation, round-robin partitioning, fail-fast behavior, and CI workflow configuration.

## Risk Assessment

✅ Low: The change cleanly shards the CI core test suites across two matrix runners using a dynamic runner script without modifying local test scripts or reducing test coverage.

## Testing

Exercised scripts/ci/run-test-shard.cjs CLI error validation, round-robin distribution, fail-fast error handling on failing suites, and suite coverage invariance on the repository package.json (all 90 suites partitioned into 45 suites per shard with 100% coverage and zero overlaps). Validated .github/workflows/ci.yml linux-tests matrix shard setup and pretest execution. All automated checks passed cleanly.

<details>
<summary>Evidence: CI Core Test Suite Sharding Validation Evidence</summary>

```text
# CI Core Test Suite Sharding Validation Evidence

## Summary
- **Total Test Suites in `npm test`**: 90 suites
- **Shard 0 Suite Count**: 45 suites
- **Shard 1 Suite Count**: 45 suites
- **Overlap**: 0 suites (completely disjoint)
- **Coverage Preserved**: 100% (45 + 45 = 90 suites, exact original order preserved)

## GitHub Actions CI Workflow Configuration (`.github/workflows/ci.yml`)
- **Job Name**: `linux-tests`
- **Runner OS**: `ubuntu-latest`
- **Matrix Strategy**: `shard: [0,1]`
- **Fail Fast**: `false`
- **Execution Command**: `SHARD_TOTAL=2 SHARD_INDEX=${{ matrix.shard }} node scripts/ci/run-test-shard.cjs`
- **Pretest Hook**: `Payment method split checks` executed conditionally on `matrix.shard == 0`
- **Required Status Checks for Branch Protection**: `linux-tests (0)` and `linux-tests (1)`

## Shard 0 Test Suites (45 Suites - Index 0, 2, 4, ...)

| # | Global Index | Suite Target | Command Definition |
|---|---|---|---|
| 1 | 0 | `test:smoke` | `node tests/run-electron-node-test.cjs tests/smoke-test.test.ts` |
| 2 | 2 | `test:kds-integration` | `node tests/run-electron-node-test.cjs tests/kds-integration.test.ts` |
| 3 | 4 | `test:kds-frontend-conflict` | `ts-node --transpile-only -P tests/tsconfig.json tests/kds-frontend-conflict.test.ts` |
| 4 | 6 | `test:cors` | `ts-node --transpile-only -P tests/tsconfig.json tests/cors-security.test.ts` |
| 5 | 8 | `test:release-config` | `ts-node --transpile-only -P tests/tsconfig.json tests/release-config.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/verify-electron-runtime-xattr.test.ts` |
| 6 | 10 | `test:first-run` | `node tests/run-electron-node-test.cjs tests/first-run-setup.test.ts && node tests/run-electron-node-test.cjs tests/setup-failure-recovery.test.ts` |
| 7 | 12 | `test:staff-authz` | `node tests/run-electron-node-test.cjs tests/staff-authz.test.ts` |
| 8 | 14 | `test:authz-phase3` | `node tests/run-electron-node-test.cjs tests/authz-matrix-phase3.test.ts` |
| 9 | 16 | `test:customer-auth` | `node tests/run-electron-node-test.cjs tests/customer-auth.test.ts` |
| 10 | 18 | `test:backup` | `ts-node --transpile-only -P tests/tsconfig.json tests/backup-restore.test.ts && node tests/run-electron-node-test.cjs tests/backup-restore-production.test.ts && node tests/run-electron-node-test.cjs tests/restore-managed-path.test.ts` |
| 11 | 20 | `test:cloud-account-status` | `node tests/run-electron-node-test.cjs tests/cloud-account-status.test.ts` |
| 12 | 22 | `test:printer-width-refresh` | `node tests/run-electron-node-test.cjs tests/printer-width-refresh.test.ts` |
| 13 | 24 | `test:translations` | `ts-node --transpile-only -P tests/tsconfig.json tests/translations.test.ts` |
| 14 | 26 | `test:currency` | `ts-node --transpile-only -P tests/tsconfig.json tests/currency.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/country-profile.test.ts` |
| 15 | 28 | `test:tax-components` | `ts-node --transpile-only -P tests/tsconfig.json tests/tax-components.test.ts` |
| 16 | 30 | `test:tax-pack-management` | `node tests/run-electron-node-test.cjs tests/tax-pack-management.test.ts` |
| 17 | 32 | `test:legacy-tax-pack-digest` | `node tests/run-electron-node-test.cjs tests/legacy-tax-pack-digest.test.ts` |
| 18 | 34 | `test:customer-phone-search` | `node tests/run-electron-node-test.cjs tests/customer-phone-search.test.ts` |
| 19 | 36 | `test:receipt-column-width` | `ts-node --transpile-only -P tests/tsconfig.json tests/receipt-column-width.test.ts` |
| 20 | 38 | `test:receipt-printing` | `ts-node --transpile-only -P tests/tsconfig.json tests/receipt-printing.test.ts` |
| 21 | 40 | `test:kitchen-addons` | `node tests/run-electron-node-test.cjs tests/kitchen-addons-parsing.test.ts` |
| 22 | 42 | `test:issue-125-addon-reads` | `node tests/run-electron-node-test.cjs tests/issue-125-addon-read-paths.test.ts` |
| 23 | 44 | `test:reports-insights` | `node tests/run-electron-node-test.cjs tests/reports-insights.test.ts` |
| 24 | 46 | `test:integration-happy` | `node tests/run-electron-node-test.cjs tests/integration-happy-path.test.ts` |
| 25 | 48 | `test:integration-payments` | `node tests/run-electron-node-test.cjs tests/integration-payments.test.ts` |
| 26 | 50 | `test:issue-214-auth` | `node tests/run-electron-node-test.cjs tests/issue-214-auth-migration.test.ts` |
| 27 | 52 | `test:integration-lifecycle` | `node tests/run-electron-node-test.cjs tests/integration-order-lifecycle.test.ts` |
| 28 | 54 | `test:integration-loyalty` | `node tests/run-electron-node-test.cjs tests/integration-loyalty.test.ts` |
| 29 | 56 | `test:loyalty-toggle` | `node tests/run-electron-node-test.cjs tests/loyalty-toggle.test.ts` |
| 30 | 58 | `test:integration-discount-settings` | `node tests/run-electron-node-test.cjs tests/integration-discount-settings.test.ts` |
| 31 | 60 | `test:issue-248-csv` | `node tests/run-electron-node-test.cjs tests/issue-248-menu-csv.test.ts && node tests/run-electron-node-test.cjs tests/menu-csv-formula-export.test.ts` |
| 32 | 62 | `test:bills-print-api` | `ts-node --transpile-only -P tests/tsconfig.json tests/bills-print-api.test.ts` |
| 33 | 64 | `test:issue-134-routing` | `node tests/run-electron-node-test.cjs tests/issue-134-station-routing.test.ts` |
| 34 | 66 | `test:issue-137-barcode` | `node tests/run-electron-node-test.cjs tests/issue-137-barcode.test.ts` |
| 35 | 68 | `test:issue-250-catalog-perf` | `node tests/run-electron-node-test.cjs tests/issue-250-catalog-perf.test.ts` |
| 36 | 70 | `test:issue-265-morocco-profile` | `node tests/run-electron-node-test.cjs tests/issue-265-morocco-profile.test.ts` |
| 37 | 72 | `test:tables-string-ids` | `node tests/run-electron-node-test.cjs tests/tables-string-ids.test.ts` |
| 38 | 74 | `test:schema-health` | `node tests/run-electron-node-test.cjs tests/schema-health.test.ts` |
| 39 | 76 | `test:migration-v56-v57` | `node tests/run-electron-node-test.cjs tests/migration-v56-to-v57.test.ts` |
| 40 | 78 | `test:google-drive` | `node tests/run-electron-node-test.cjs tests/google-drive.test.ts` |
| 41 | 80 | `test:phone-validation` | `node tests/run-electron-node-test.cjs tests/phone-validation.test.ts` |
| 42 | 82 | `test:issue-133-kds-kot-toggles` | `node tests/run-electron-node-test.cjs tests/issue-133-kds-kot-toggles.test.ts` |
| 43 | 84 | `test:whatsapp-service` | `ts-node --transpile-only -P tests/tsconfig.json tests/whatsapp-service.test.ts` |
| 44 | 86 | `test:issue-127-password-recovery` | `node tests/run-electron-node-test.cjs tests/issue-127-password-recovery.test.ts` |
| 45 | 88 | `test:windows-uninstaller` | `node tests/run-windows-uninstaller-tests.cjs` |

## Shard 1 Test Suites (45 Suites - Index 1, 3, 5, ...)

| # | Global Index | Suite Target | Command Definition |
|---|---|---|---|
| 1 | 1 | `test:server-port-collision` | `node tests/run-electron-node-test.cjs tests/server-port-collision.test.ts` |
| 2 | 3 | `test:kds-contract` | `node tests/run-electron-node-test.cjs tests/kds-contract.test.ts` |
| 3 | 5 | `test:kds-window-hardening` | `ts-node --transpile-only -P tests/tsconfig.json tests/kds-window-hardening.test.ts` |
| 4 | 7 | `test:csp-lan` | `ts-node --transpile-only -P tests/tsconfig.json tests/csp-lan-header.test.ts` |
| 5 | 9 | `test:telemetry` | `node tests/run-electron-node-test.cjs tests/telemetry-delivery.test.ts` |
| 6 | 11 | `test:security` | `node tests/run-electron-node-test.cjs tests/security-hardening.test.ts` |
| 7 | 13 | `test:orders-authz` | `node tests/run-electron-node-test.cjs tests/orders-authz.test.ts` |
| 8 | 15 | `test:auth-ui-deterministic` | `ts-node --transpile-only -P tests/tsconfig.json tests/auth-ui-deterministic.test.ts` |
| 9 | 17 | `test:customer-pagination` | `node tests/run-electron-node-test.cjs tests/customer-pagination.test.ts` |
| 10 | 19 | `test:recovery-cloud` | `node tests/run-electron-node-test.cjs tests/recovery-legacy-fk.test.ts && node tests/run-electron-node-test.cjs tests/cloud-deletion-recovery.test.ts` |
| 11 | 21 | `test:printer` | `ts-node --transpile-only -P tests/tsconfig.json tests/printer.test.ts && npm run test:printer-api` |
| 12 | 23 | `test:printer-migrations` | `node tests/run-electron-node-test.cjs tests/printer-usb-device-path-migration.test.ts` |
| 13 | 25 | `test:phone` | `ts-node --transpile-only -P tests/tsconfig.json tests/phone.test.ts` |
| 14 | 27 | `test:tax-engine` | `ts-node --transpile-only -P tests/tsconfig.json tests/tax-engine.test.ts` |
| 15 | 29 | `test:tax-pack-catalog` | `ts-node --transpile-only -P tests/tsconfig.json tests/tax-pack-catalog.test.ts` |
| 16 | 31 | `test:manual-tax-config` | `node tests/run-electron-node-test.cjs tests/manual-tax-config.test.ts` |
| 17 | 33 | `test:support-ticket` | `node tests/run-electron-node-test.cjs tests/support-ticket.test.ts` |
| 18 | 35 | `test:phone-search-integration` | `node tests/run-electron-node-test.cjs tests/phone-search-integration.test.ts` |
| 19 | 37 | `test:notes-validation` | `ts-node --transpile-only -P tests/tsconfig.json tests/order-notes-validation.test.ts` |
| 20 | 39 | `test:cancel-override` | `node tests/run-electron-node-test.cjs tests/cancel-override.test.ts && node tests/run-electron-node-test.cjs tests/manager-pin-rate-limit-bypass.test.ts` |
| 21 | 41 | `test:order-item-addons` | `node tests/run-electron-node-test.cjs tests/order-item-addons.test.ts && node tests/run-electron-node-test.cjs tests/addon-price-integrity.test.ts` |
| 22 | 43 | `test:windows-country-code-crash` | `node tests/run-electron-node-test.cjs tests/issue-windows-country-code-crash.test.ts` |
| 23 | 45 | `test:sequence` | `node tests/run-electron-node-test.cjs tests/sequence-generation.test.ts` |
| 24 | 47 | `test:integration-tax` | `node tests/run-electron-node-test.cjs tests/integration-tax.test.ts` |
| 25 | 49 | `test:issue-214` | `node tests/run-electron-node-test.cjs tests/issue-214-payment-integrity.test.ts` |
| 26 | 51 | `test:issue-214-migration` | `node tests/run-electron-node-test.cjs tests/issue-214-migration-integrity.test.ts` |
| 27 | 53 | `test:integration-reconciliation` | `node tests/run-electron-node-test.cjs tests/integration-bill-reconciliation.test.ts` |
| 28 | 55 | `test:integration-discount` | `node tests/run-electron-node-test.cjs tests/integration-discount-edge.test.ts` |
| 29 | 57 | `test:discount-system` | `node tests/run-electron-node-test.cjs tests/discount-system.test.ts` |
| 30 | 59 | `test:integration-loyalty-global` | `node tests/run-electron-node-test.cjs tests/integration-loyalty-global-rate.test.ts` |
| 31 | 61 | `test:integration-loyalty-redemption` | `node tests/run-electron-node-test.cjs tests/integration-loyalty-redemption.test.ts` |
| 32 | 63 | `test:issue-24` | `node tests/run-electron-node-test.cjs tests/issue-24-cancel-item-checkout.test.ts` |
| 33 | 65 | `test:issue-134-mgmt` | `node tests/run-electron-node-test.cjs tests/issue-134-station-management.test.ts` |
| 34 | 67 | `test:issue-244-product-addon-links` | `node tests/run-electron-node-test.cjs tests/issue-244-product-addon-links.test.ts` |
| 35 | 69 | `test:issue-258-bill-pagination` | `node tests/run-electron-node-test.cjs tests/issue-258-bill-pagination.test.ts` |
| 36 | 71 | `test:issue-266-currency-symbol-print` | `node tests/run-electron-node-test.cjs tests/issue-266-currency-symbol-print.test.ts` |
| 37 | 73 | `test:held-orders` | `node tests/run-electron-node-test.cjs tests/held-orders.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/held-orders-store.test.ts` |
| 38 | 75 | `test:upgrade-path` | `node tests/run-electron-node-test.cjs tests/upgrade-path.test.ts` |
| 39 | 77 | `test:master-pin` | `node tests/run-electron-node-test.cjs tests/master-pin.test.ts` |
| 40 | 79 | `test:database-tools-api` | `node tests/run-electron-node-test.cjs tests/database-tools-api.test.ts && node tests/run-electron-node-test.cjs tests/database-maintenance-lock.test.ts` |
| 41 | 81 | `test:phone-migration` | `node tests/run-electron-node-test.cjs tests/phone-migration.test.ts` |
| 42 | 83 | `test:whatsapp-schema` | `node tests/run-electron-node-test.cjs tests/whatsapp-schema.test.ts` |
| 43 | 85 | `test:whatsapp-middleware` | `node tests/run-electron-node-test.cjs tests/whatsapp-middleware.test.ts` |
| 44 | 87 | `test:dev-tooling` | `ts-node --transpile-only -P tests/tsconfig.json tests/dev-tooling-scripts.test.ts && npm run test:phase2 && npm run test:url-allowlist && npm run test:static-routes` |
| 45 | 89 | `test:shutdown-lifecycle` | `npm run build && node tests/run-electron-node-test.cjs tests/shutdown-lifecycle.test.ts` |
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"361fdab2fce5739dd3ae763b8c69cc15a93b61d4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npx ts-node --transpile-only -P tests/tsconfig.json tests/dev-tooling-scripts.test.ts`
- `npm run test:dev-tooling`
- `npm run test:release-config`
- <code>`node scripts/ci/run-test-shard.cjs` parameter validation and fail-fast checks</code>
- <code>CI workflow `.github/workflows/ci.yml` matrix and runner isolation schema verification</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
