### PR TITLE
ci: harden Microsoft Store publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,6 +430,15 @@ jobs:
           $appxFiles = @(Get-ChildItem release\*.appx -ErrorAction SilentlyContinue)
           if ($appxFiles.Count -eq 0) { Write-Error "no .appx in release\ — Microsoft Store submission package is missing"; exit 1 }
 
+          # Identity/publisher must match Partner Center's listing exactly or
+          # Store submission is rejected; version must match package.json or
+          # a stale/wrong build could be silently submitted. Check both here,
+          # before anything is uploaded, rather than finding out from Partner
+          # Center after the fact.
+          $expectedIdentity = node -p "require('./package.json').build.appx.identityName"
+          $expectedPublisher = node -p "require('./package.json').build.appx.publisher"
+          $expectedVersion = "$(node -p "require('./package.json').version").0"
+
           Add-Type -AssemblyName System.IO.Compression.FileSystem
           $architectures = @{}
           foreach ($appx in $appxFiles) {
@@ -446,11 +455,32 @@ jobs:
             } finally {
               $zip.Dispose()
             }
-            if ($manifest -notmatch 'ProcessorArchitecture="([^"]+)"') {
+            # Scope attribute extraction to the <Identity> element itself —
+            # DisplayName/PublisherDisplayName elsewhere in the manifest also
+            # contain the substring 'Name="...\"', so matching against the
+            # whole manifest could grab the wrong attribute.
+            if ($manifest -notmatch '<Identity\s+([^>]+?)/?>') {
+              Write-Error "Identity element is missing from AppxManifest.xml in $($appx.Name)"
+              exit 1
+            }
+            $identityAttrs = $Matches[1]
+            if ($identityAttrs -notmatch 'ProcessorArchitecture="([^"]+)"') {
               Write-Error "ProcessorArchitecture is missing from AppxManifest.xml in $($appx.Name)"
               exit 1
             }
             $architectures[$Matches[1]] = $true
+            if ($identityAttrs -notmatch 'Name="([^"]+)"' -or $Matches[1] -ne $expectedIdentity) {
+              Write-Error "AppX identity in $($appx.Name) does not match expected '$expectedIdentity'"
+              exit 1
+            }
+            if ($identityAttrs -notmatch 'Publisher="([^"]+)"' -or $Matches[1] -ne $expectedPublisher) {
+              Write-Error "AppX publisher in $($appx.Name) does not match the configured Store publisher"
+              exit 1
+            }
+            if ($identityAttrs -notmatch 'Version="([^"]+)"' -or $Matches[1] -ne $expectedVersion) {
+              Write-Error "AppX version in $($appx.Name) does not match package.json version '$expectedVersion'"
+              exit 1
+            }
           }
           foreach ($requiredArch in @("x64", "arm64")) {
             if (-not $architectures.ContainsKey($requiredArch)) {
@@ -467,9 +497,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Setup Microsoft Store Developer CLI
-        uses: microsoft/microsoft-store-apppublisher@v1.1
+        # Tag-only: workflow_dispatch can run this job against arbitrary
+        # branch code, so it must never be allowed to reach Partner Center.
+        # Pinned to v1.4 by commit SHA rather than the mutable v1.1 tag
+        # (matches this repo's pinning convention for third-party actions).
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
 
       - name: Publish Windows AppX packages to Microsoft Store
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         shell: pwsh
         env:
           AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
@@ -477,7 +513,19 @@ jobs:
           AZURE_AD_APPLICATION_SECRET: ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
           SELLER_ID: ${{ secrets.SELLER_ID }}
           MICROSOFT_STORE_PRODUCT_ID: ${{ vars.MICROSOFT_STORE_PRODUCT_ID }}
+          # Optional: set MSSTORE_NO_COMMIT=true (repo/environment variable)
+          # to leave a submission as a draft, or MSSTORE_FLIGHT_ID to submit
+          # to a Partner Center flight instead of production, for a
+          # dry-run validation. Remove both once validated.
+          MSSTORE_FLIGHT_ID: ${{ vars.MSSTORE_FLIGHT_ID }}
+          MSSTORE_NO_COMMIT: ${{ vars.MSSTORE_NO_COMMIT }}
         run: |
+          # msstore is a native CLI, not a PowerShell cmdlet — a failing call
+          # doesn't throw a terminating error or fail the step on its own, so
+          # without an explicit $LASTEXITCODE check this step reports success
+          # even when the Store submission itself failed.
+          $ErrorActionPreference = 'Stop'
+
           $missing = @()
           foreach ($name in @("AZURE_AD_TENANT_ID", "AZURE_AD_APPLICATION_CLIENT_ID", "AZURE_AD_APPLICATION_SECRET", "SELLER_ID", "MICROSOFT_STORE_PRODUCT_ID")) {
             if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
@@ -494,8 +542,17 @@ jobs:
             --sellerId "$env:SELLER_ID" `
             --clientId "$env:AZURE_AD_APPLICATION_CLIENT_ID" `
             --clientSecret "$env:AZURE_AD_APPLICATION_SECRET"
+          if ($LASTEXITCODE -ne 0) { throw "msstore reconfigure failed with exit code $LASTEXITCODE." }
 
           # The Store CLI accepts the app/project path and discovers the package
           # candidates from the release directory for Electron projects; appId
           # keeps CI non-interactive.
-          msstore publish "${{ github.workspace }}\release" --appId "$env:MICROSOFT_STORE_PRODUCT_ID"
+          $publishArgs = @("${{ github.workspace }}\release", '--appId', "$env:MICROSOFT_STORE_PRODUCT_ID")
+          if (-not [string]::IsNullOrWhiteSpace($env:MSSTORE_FLIGHT_ID)) {
+            $publishArgs += @('--flightId', $env:MSSTORE_FLIGHT_ID)
+          }
+          if ($env:MSSTORE_NO_COMMIT -eq 'true') {
+            $publishArgs += '--noCommit'
+          }
+          msstore publish @publishArgs
+          if ($LASTEXITCODE -ne 0) { throw "Microsoft Store publish failed with exit code $LASTEXITCODE." }

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -209,8 +209,16 @@ function run() {
     'release-windows job must inspect AppX manifests and require both x64 and arm64 packages'
   );
   assert.ok(
-    winJob.includes('microsoft/microsoft-store-apppublisher@v1.1'),
-    'release-windows job must install the official Microsoft Store Developer CLI action'
+    winJob.includes('microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0'),
+    'release-windows job must install the official Microsoft Store Developer CLI action pinned by commit SHA'
+  );
+  assert.ok(
+    (winJob.match(/if: github\.event_name == 'push' && startsWith\(github\.ref, 'refs\/tags\/'\)/g) || []).length >= 2,
+    'the Store CLI setup and publish steps must be gated to tag pushes so workflow_dispatch can never reach Partner Center'
+  );
+  assert.ok(
+    /msstore reconfigure[\s\S]+?if \(\$LASTEXITCODE -ne 0\)/.test(winJob),
+    'release-windows job must check msstore reconfigure exit code — a failing native CLI call does not fail a pwsh step on its own'
   );
   for (const required of [
     'AZURE_AD_TENANT_ID',
@@ -229,8 +237,10 @@ function run() {
     'release-windows job must configure msstore with Partner Center credentials'
   );
   assert.ok(
-    /msstore publish "\$\{\{ github\.workspace \}\}\\release" --appId "\$env:MICROSOFT_STORE_PRODUCT_ID"/.test(winJob),
-    'release-windows job must publish the built AppX packages to the configured Microsoft Store product'
+    /\$publishArgs = @\("\$\{\{ github\.workspace \}\}\\release", '--appId', "\$env:MICROSOFT_STORE_PRODUCT_ID"\)/.test(winJob) &&
+    /msstore publish @publishArgs/.test(winJob) &&
+    /if \(\$LASTEXITCODE -ne 0\) \{ throw "Microsoft Store publish failed/.test(winJob),
+    'release-windows job must publish the built AppX packages to the configured Microsoft Store product and check the exit code'
   );
 
   console.log('✅ Release config + workflow integrity checks passed');


### PR DESCRIPTION
## Summary

PR #260 (`feat/microsoft-store-publishing`, opened 2026-08-11 by @khaira777) implemented Microsoft Store publishing with several safety properties that #327's simpler version — which merged directly to `main` instead — doesn't have. #260 was never merged and its branch is based on old (~3.0.5-era) `main`, so a raw merge isn't viable; this ports the relevant hardening onto the current `release-windows` job (which already builds x64+arm64, unlike #260's x64-only version):

- **Tag-only gating** on both Store steps (`if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')`). Without this, `workflow_dispatch` on any branch could reach Partner Center.
- **Explicit exit-code checks** on `msstore reconfigure`/`msstore publish`. They're native CLI calls, not PowerShell cmdlets, so a failure doesn't fail the step on its own — the step could report green while the Store submission actually failed.
- **SHA-pinned action**: `microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4` instead of the mutable `@v1.1` tag, matching this repo's pinning convention elsewhere in the file.
- **Identity/publisher/version validation** for each built AppX against `package.json`, folded into the existing per-architecture manifest check, before anything is uploaded or submitted.
- **Draft/flight support** via optional `MSSTORE_FLIGHT_ID`/`MSSTORE_NO_COMMIT` repo variables, for validating a submission without committing it to production.

**Not ported**: the `production-release` GitHub Environment approval gate from #260. That needs a maintainer to create the environment, add required reviewers, and restrict it to release tags in **Settings → Environments** — I can't do that from here. Recommend setting it up before relying on this for unattended releases.

Once this merges, PR #260 and #261 (the follow-on macOS App Store PR stacked on top of it) become fully superseded and their branches can be deleted.

## Test plan
- [x] `npm run test:release-config` (updated its assertions to match the new checks)
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [x] `actionlint .github/workflows/release.yml` — no new findings