### PR TITLE
feat(tax): show installed tax plugin version and check for updates

### DIFF
--- a/frontend/src/components/settings/TaxConfigurationPanel.tsx
+++ b/frontend/src/components/settings/TaxConfigurationPanel.tsx
@@ -9,6 +9,7 @@ import {
   CheckCircle2,
   ChevronDown,
   Clock3,
+  Download,
   History,
   Lock,
   Plus,
@@ -99,6 +100,18 @@ type PackDetail = {
   rules: TaxRule[];
   overrides: TaxOverride[];
   targets: { products: OverrideTarget[]; addons: OverrideTarget[] };
+};
+
+type TaxPackUpdate = {
+  // The catalog's current id — pass this to catalog/install.
+  packId: string;
+  // The id actually installed for this store (may predate a catalog rename).
+  installedPackId: string;
+  country: string;
+  publisher: string;
+  currentVersion: string;
+  latestVersion: string;
+  entry: { version: string; publishedAt: string; minFloVersion: string };
 };
 
 type AuditRow = {
@@ -243,6 +256,9 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
   const [taxesEnabled, setTaxesEnabled] = useState(false);
   const [pluginRequested, setPluginRequested] = useState(false);
   const [showAdvancedTools, setShowAdvancedTools] = useState(false);
+  const [packUpdate, setPackUpdate] = useState<TaxPackUpdate | null>(null);
+  const [checkingUpdate, setCheckingUpdate] = useState(false);
+  const [installingUpdate, setInstallingUpdate] = useState(false);
 
   const [manualStarter] = useState(() => {
     const category = newManualCategory('Standard');
@@ -434,6 +450,11 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
   // actually activated (enableCountryTaxes / saveManualConfig / turnTaxesOff).
   const taxMode: 'off' | 'official' | 'manual' = !taxesEnabled ? 'off' : activePackPublisher === 'local' ? 'manual' : 'official';
   const manualBuilderVisible = manualBuilderOpen || taxMode === 'manual';
+  // Only meaningful while an official (non-local) pack is active — gate at
+  // render time rather than resetting packUpdate from an effect, so a stale
+  // result from a previously active pack never leaks into a different mode.
+  const pluginUpdateApplicable = taxMode === 'official' && detail?.pack.publisher !== 'local';
+  const activePluginUpdate = pluginUpdateApplicable ? packUpdate : null;
   // The segment control's *displayed* selection: opening the manual editor
   // is its own state even before anything is saved, so it must outrank
   // taxMode here — otherwise "Turn Off Tax" (or "Official") stays lit at the
@@ -450,6 +471,72 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
     () => new Map((detail?.categories || []).map((category) => [category.category_id, category.label])),
     [detail?.categories],
   );
+
+  async function checkForPluginUpdates(announce: boolean) {
+    const packId = detail?.pack.id;
+    if (!pluginUpdateApplicable || !packId) {
+      if (announce) toast.error('No installed tax plugin to check for updates');
+      return;
+    }
+    setCheckingUpdate(true);
+    try {
+      const response = await api.get('/tax-packs/updates');
+      const updates = (response.data?.updates || []) as TaxPackUpdate[];
+      const match = updates.find((update) => update.installedPackId === packId) || null;
+      setPackUpdate(match);
+      if (announce) toast.success(match ? `Update available: v${match.latestVersion}` : 'Tax plugin is up to date');
+    } catch (error) {
+      if (announce) toast.error(apiMessage(error, 'Could not check for tax plugin updates'));
+    } finally {
+      setCheckingUpdate(false);
+    }
+  }
+
+  // Silent, best-effort check whenever the active official pack changes —
+  // e.g. right after the settings page loads. Never surfaces an error toast;
+  // a failed/offline check just leaves the update banner hidden.
+  useEffect(() => {
+    if (!pluginUpdateApplicable || !detail?.pack.id) return;
+    let cancelled = false;
+    const packId = detail.pack.id;
+    api.get('/tax-packs/updates')
+      .then((response) => {
+        if (cancelled) return;
+        const updates = (response.data?.updates || []) as TaxPackUpdate[];
+        setPackUpdate(updates.find((update) => update.installedPackId === packId) || null);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [pluginUpdateApplicable, detail?.pack.id]);
+
+  async function installPluginUpdate() {
+    const update = activePluginUpdate;
+    if (!update || !isOwner) return;
+    setInstallingUpdate(true);
+    try {
+      const installResponse = await api.post('/tax-packs/catalog/install', {
+        pack_id: update.packId,
+        version: update.latestVersion,
+      });
+      const installed = installResponse.data.installed as { packId: string; versionId: string };
+      await api.post(
+        `/tax-packs/${encodeURIComponent(installed.packId)}/versions/${encodeURIComponent(installed.versionId)}/activate`,
+      );
+      toast.success(`Tax plugin updated to v${update.latestVersion}`);
+      setPackUpdate(null);
+      // installed.packId can differ from the pack that was active before
+      // (e.g. a catalog rename, official-in -> official-india) — switch the
+      // selection explicitly rather than relying on loadList's "keep current
+      // selection if it still exists" default, which would keep showing the
+      // now-inactive old pack.
+      setSelectedPackId(installed.packId);
+      await Promise.all([loadList(), loadAudit(), loadDetail(installed.packId)]);
+    } catch (error) {
+      toast.error(apiMessage(error, 'Could not install the tax plugin update'));
+    } finally {
+      setInstallingUpdate(false);
+    }
+  }
 
   function resetOverrideForm() {
     setEditingOverrideId(null);
@@ -800,6 +887,39 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
             from the FloCafe team and will build it soon. Taxes remain off until it is ready.
             {pluginRequested && ' Your request is queued for the team.'}
           </p>
+        )}
+        {taxMode === 'official' && detail?.active_version && detail.pack.publisher !== 'local' && (
+          <div className="mt-3 flex flex-wrap items-center gap-3 rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-700">
+            <span>
+              Tax plugin version <span className="font-mono font-medium">v{detail.active_version.version}</span>
+              <span className="ms-1 text-gray-400">({detail.pack.trust_status})</span>
+            </span>
+            <button
+              type="button"
+              onClick={() => void checkForPluginUpdates(true)}
+              disabled={checkingUpdate}
+              className="ms-auto flex items-center gap-1 font-medium text-brand disabled:opacity-50"
+            >
+              <RefreshCw size={13} className={checkingUpdate ? 'animate-spin' : ''} />
+              {checkingUpdate ? 'Checking…' : 'Check for updates'}
+            </button>
+          </div>
+        )}
+        {activePluginUpdate && (
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-brand/30 bg-brand/5 px-3 py-2 text-sm">
+            <span className="flex items-center gap-1.5">
+              <Download size={14} className="text-brand" />
+              Plugin update available: <span className="font-mono font-medium">v{activePluginUpdate.latestVersion}</span>
+              <span className="text-gray-500">(current v{activePluginUpdate.currentVersion})</span>
+            </span>
+            {isOwner ? (
+              <Button size="sm" disabled={installingUpdate} onClick={() => void installPluginUpdate()}>
+                {installingUpdate ? 'Installing…' : 'Install & activate'}
+              </Button>
+            ) : (
+              <span className="text-xs text-gray-500">Ask an owner to install this update.</span>
+            )}
+          </div>
         )}
       </section>
 

--- a/main/index.ts
+++ b/main/index.ts
@@ -3,7 +3,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { Bonjour } from 'bonjour-service';
-import { initDatabase, closeDatabase, waitForDatabaseRequests, beginDatabaseShutdown, SchemaVersionMismatchError } from './db';
+import { getDatabase, initDatabase, closeDatabase, waitForDatabaseRequests, beginDatabaseShutdown, SchemaVersionMismatchError } from './db';
+import { computeTaxPackUpdates, fetchRemoteTaxPackCatalog } from './tax-packs/catalog';
 import { startServer, stopServer, getLocalIP, isServerRunning, getServerPort } from './server';
 import { cloudSync } from './services/cloud-sync';
 import { telemetry, sendEvent as sendTelemetryEvent } from './services/telemetry';
@@ -168,6 +169,37 @@ function checkForUpdates(): void {
   } else {
     log.debug('[Update] Skipping update check in dev mode');
     mainWindow?.webContents.send('update-status', { status: 'dev-mode' });
+  }
+}
+
+// Separate from the app self-updater above: tax packs are the only plugin
+// type FloCafe currently supports, installed from the FloCafe-Plugins GitHub
+// Releases catalog rather than through electron-updater. This is a
+// best-effort, network-optional check — a store must keep working offline,
+// so a failure here only logs and never blocks startup.
+async function checkTaxPackUpdatesOnStartup(): Promise<void> {
+  try {
+    const remote = await fetchRemoteTaxPackCatalog();
+    const installedRows = getDatabase().prepare(`
+      SELECT pack.id AS pack_id, pack.country, pack.publisher, version.version
+      FROM country_packs AS pack
+      JOIN country_pack_versions AS version ON version.id = pack.active_version_id
+      WHERE pack.status = 'active'
+    `).all() as Array<{ pack_id: string; country: string; publisher: string; version: string }>;
+    const updates = computeTaxPackUpdates(
+      installedRows.map((row) => (
+        { packId: row.pack_id, country: row.country, publisher: row.publisher, version: row.version }
+      )),
+      remote.catalog,
+    );
+    if (updates.length > 0) {
+      const summary = updates.map((update) => `${update.packId} ${update.currentVersion} -> ${update.latestVersion}`).join(', ');
+      console.log(`[Tax Packs] ${updates.length} plugin update(s) available: ${summary}`);
+    } else {
+      console.log('[Tax Packs] Plugin update check: all installed tax packs are up to date');
+    }
+  } catch (error) {
+    console.warn('[Tax Packs] Startup plugin update check skipped (offline or catalog unavailable):', error);
   }
 }
 
@@ -689,6 +721,7 @@ async function initialize(): Promise<void> {
       setupAutoUpdater();
       setTimeout(() => checkForUpdates(), 5000);
     }
+    setTimeout(() => { void checkTaxPackUpdatesOnStartup(); }, 5000);
 
     console.log('[Flo] Ready!');
   } catch (error) {

--- a/main/routes/tax-packs.ts
+++ b/main/routes/tax-packs.ts
@@ -7,6 +7,7 @@ import { TaxEngine } from '../services/tax-engine';
 import type { CountryPack, PluginPrintTemplate, TaxBehavior, TaxCategory, TaxRule } from '../tax-packs/types';
 import { BUNDLED_COUNTRY_PACKS } from '../tax-packs/bundled';
 import {
+  computeTaxPackUpdates,
   downloadAndVerifyTaxPack,
   fetchRemoteTaxPackCatalog,
   verifyTaxPackSignature,
@@ -750,6 +751,28 @@ router.get('/catalog', requireRole('owner', 'manager'), asyncHandler(async (req:
   } catch (error: any) {
     console.error('[Tax Packs] Catalog fetch failed:', error);
     res.status(502).json({ error: error.message || 'Could not check the tax pack catalog' });
+  }
+}));
+
+router.get('/updates', requireRole('owner', 'manager'), asyncHandler(async (req: Request, res: Response) => {
+  try {
+    const remote = await fetchRemoteTaxPackCatalog(fetch, getHttpRequestSignal(req));
+    const installedRows = getDatabase().prepare(`
+      SELECT pack.id AS pack_id, pack.country, pack.publisher, version.version
+      FROM country_packs AS pack
+      JOIN country_pack_versions AS version ON version.id = pack.active_version_id
+      WHERE pack.status = 'active'
+    `).all() as Array<{ pack_id: string; country: string; publisher: string; version: string }>;
+    const updates = computeTaxPackUpdates(
+      installedRows.map((row) => (
+        { packId: row.pack_id, country: row.country, publisher: row.publisher, version: row.version }
+      )),
+      remote.catalog,
+    );
+    res.json({ checked_at: now(), release_tag: remote.releaseTag, updates });
+  } catch (error: any) {
+    console.error('[Tax Packs] Update check failed:', error);
+    res.status(502).json({ error: error.message || 'Could not check for tax plugin updates' });
   }
 }));
 

--- a/main/tax-packs/catalog.ts
+++ b/main/tax-packs/catalog.ts
@@ -44,6 +44,73 @@ export interface VerifiedTaxPackArtifact {
   printTemplates: PluginPrintTemplate[];
 }
 
+export interface InstalledTaxPackVersion {
+  packId: string;
+  country: string;
+  publisher: string;
+  version: string;
+}
+
+export interface TaxPackUpdate {
+  // The catalog's current id — pass this to catalog/install, not installedPackId.
+  packId: string;
+  // The id actually stored in country_packs.id for this store, which predates
+  // a rename for legacy installs (see LEGACY_TAX_PACK_ID_ALIASES below).
+  installedPackId: string;
+  country: string;
+  publisher: string;
+  currentVersion: string;
+  latestVersion: string;
+  entry: TaxPackCatalogEntry;
+}
+
+// Pack ids renamed by commit 3a75876, before the public catalog existed —
+// see LEGACY_TRUSTED_PACK_DIGESTS in routes/tax-packs.ts for the matching
+// signature-trust concern. Stores that installed one of these before the
+// rename still carry the pre-rename id in country_packs.id; the catalog only
+// lists the current id, so update checks must resolve through this alias or
+// a renamed pack looks like "no updates" forever.
+const LEGACY_TAX_PACK_ID_ALIASES: Record<string, string> = {
+  'official-in': 'official-india',
+  'official-th': 'official-thailand',
+};
+
+function currentTaxPackId(packId: string): string {
+  return LEGACY_TAX_PACK_ID_ALIASES[packId] || packId;
+}
+
+function newerVersion(a: string, b: string): boolean {
+  return a.localeCompare(b, undefined, { numeric: true }) > 0;
+}
+
+export function computeTaxPackUpdates(
+  installed: InstalledTaxPackVersion[],
+  catalog: TaxPackCatalog,
+): TaxPackUpdate[] {
+  const updates: TaxPackUpdate[] = [];
+  for (const row of installed) {
+    const catalogId = currentTaxPackId(row.packId);
+    const newest = catalog.packs
+      .filter((entry) => entry.id === catalogId)
+      .reduce<TaxPackCatalogEntry | null>(
+        (best, entry) => (!best || newerVersion(entry.version, best.version) ? entry : best),
+        null,
+      );
+    if (newest && newerVersion(newest.version, row.version)) {
+      updates.push({
+        packId: catalogId,
+        installedPackId: row.packId,
+        country: row.country,
+        publisher: row.publisher,
+        currentVersion: row.version,
+        latestVersion: newest.version,
+        entry: newest,
+      });
+    }
+  }
+  return updates;
+}
+
 interface GitHubReleaseAsset {
   name?: unknown;
   browser_download_url?: unknown;

--- a/tests/tax-pack-catalog.test.ts
+++ b/tests/tax-pack-catalog.test.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  computeTaxPackUpdates,
   downloadAndVerifyTaxPack,
   fetchRemoteTaxPackCatalog,
   parseTaxPackCatalog,
@@ -53,6 +54,89 @@ function signedFixture() {
   };
   return { privateKey, publicKey, pack, packJson, signature, entry, catalog };
 }
+
+function catalogEntry(overrides: Partial<TaxPackCatalogEntry>): TaxPackCatalogEntry {
+  return {
+    id: 'official-testland',
+    publisher: 'FreeOpenSourcePOS',
+    country: 'ZZ',
+    jurisdiction: '*',
+    version: '1.0.0',
+    publishedAt: '2026-01-01',
+    minFloVersion: '2.4.0',
+    downloadUrl: `${releaseBase}/official-testland-v1.0.0.json`,
+    signatureUrl: `${releaseBase}/official-testland-v1.0.0.json.sig`,
+    digest: '0'.repeat(64),
+    ...overrides,
+  };
+}
+
+test('computeTaxPackUpdates flags only installed packs with a newer catalog version', () => {
+  const catalog: TaxPackCatalog = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-01T00:00:00.000Z',
+    packs: [
+      catalogEntry({ id: 'official-testland', version: '1.2.0' }),
+      catalogEntry({ id: 'official-otherland', country: 'YY', version: '1.0.0' }),
+    ],
+  };
+  const updates = computeTaxPackUpdates(
+    [
+      { packId: 'official-testland', country: 'ZZ', publisher: 'FreeOpenSourcePOS', version: '1.0.0' },
+      { packId: 'official-otherland', country: 'YY', publisher: 'FreeOpenSourcePOS', version: '1.0.0' },
+    ],
+    catalog,
+  );
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].packId, 'official-testland');
+  assert.equal(updates[0].installedPackId, 'official-testland');
+  assert.equal(updates[0].currentVersion, '1.0.0');
+  assert.equal(updates[0].latestVersion, '1.2.0');
+});
+
+test('computeTaxPackUpdates resolves a pre-rename installed id (official-in) against the current catalog id (official-india)', () => {
+  const catalog: TaxPackCatalog = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-14T20:42:36.442Z',
+    packs: [catalogEntry({ id: 'official-india', country: 'IN', version: '1.0.4' })],
+  };
+  const updates = computeTaxPackUpdates(
+    [{ packId: 'official-in', country: 'IN', publisher: 'FreeOpenSourcePOS', version: '1.0.0' }],
+    catalog,
+  );
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].installedPackId, 'official-in');
+  assert.equal(updates[0].packId, 'official-india');
+  assert.equal(updates[0].currentVersion, '1.0.0');
+  assert.equal(updates[0].latestVersion, '1.0.4');
+});
+
+test('computeTaxPackUpdates treats a double-digit minor version as newer, not a string comparison', () => {
+  const catalog: TaxPackCatalog = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-01T00:00:00.000Z',
+    packs: [catalogEntry({ id: 'official-testland', version: '1.10.0' })],
+  };
+  const updates = computeTaxPackUpdates(
+    [{ packId: 'official-testland', country: 'ZZ', publisher: 'FreeOpenSourcePOS', version: '1.9.0' }],
+    catalog,
+  );
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].latestVersion, '1.10.0');
+});
+
+test('computeTaxPackUpdates returns nothing when the installed version is already current', () => {
+  const catalog: TaxPackCatalog = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-01T00:00:00.000Z',
+    packs: [catalogEntry({ id: 'official-testland', version: '1.0.0' })],
+  };
+  const updates = computeTaxPackUpdates(
+    [{ packId: 'official-testland', country: 'ZZ', publisher: 'FreeOpenSourcePOS', version: '1.0.0' }],
+    catalog,
+  );
+  assert.equal(updates.length, 0);
+});
 
 test('catalog discovery finds the newest tax-pack release and verifies its detached signature', async () => {
   const fixture = signedFixture();


### PR DESCRIPTION
## Summary
- Show the installed tax plugin's version and trust status directly in Settings → Tax Config, plus a manual "Check for updates" action.
- Check for tax plugin updates on FloCafe startup (best-effort, logs only, never blocks offline startup).
- Fix update detection for stores that installed a country pack before the `official-in`→`official-india` / `official-th`→`official-thailand` rename (commit 3a75876) — the catalog only lists the current id, so update checks now resolve through a legacy-id alias before matching.

## Test plan
- [x] `npx tsc --noEmit` (root and frontend)
- [x] `npx eslint` on changed files
- [x] `npm run test:tax-pack-catalog` (8/8, including new regression tests)
- [x] `npm run test:tax-pack-management` (138/138)
- [x] `npm run build`
- [x] Live end-to-end check against the real FloCafe-Plugins GitHub catalog confirming `official-in v1.0.0` correctly resolves to `official-india v1.0.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)