### PR TITLE
fix(ci): accept single-quoted AppX identity attributes in Windows verify step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -419,35 +419,6 @@ jobs:
           # (mirrors release-mac; see #168, electron-userland/electron-builder#7515).
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
-      - name: TEMP debug - dump AppX manifests
-        # Diagnostic only — investigating a 3.2.1 release-windows failure
-        # ("AppX publisher ... does not match the configured Store publisher"
-        # for the arm64 package). Remove once root-caused.
-        shell: pwsh
-        run: |
-          $expectedIdentity = node -p "require('./package.json').build.appx.identityName"
-          $expectedPublisher = node -p "require('./package.json').build.appx.publisher"
-          $expectedVersion = "$(node -p "require('./package.json').version").0"
-          Write-Host "expectedIdentity=$expectedIdentity"
-          Write-Host "expectedPublisher=$expectedPublisher"
-          Write-Host "expectedVersion=$expectedVersion"
-          Add-Type -AssemblyName System.IO.Compression.FileSystem
-          $appxFiles = @(Get-ChildItem release\*.appx -ErrorAction SilentlyContinue)
-          foreach ($appx in $appxFiles) {
-            Write-Host "---- $($appx.Name) ----"
-            $zip = [System.IO.Compression.ZipFile]::OpenRead($appx.FullName)
-            try {
-              $entry = $zip.GetEntry("AppxManifest.xml")
-              $reader = New-Object System.IO.StreamReader($entry.Open())
-              try { $manifest = $reader.ReadToEnd() } finally { $reader.Dispose() }
-            } finally { $zip.Dispose() }
-            if ($manifest -match '<Identity\s+([^>]+?)/?>') {
-              Write-Host "Identity attrs: $($Matches[1])"
-            } else {
-              Write-Host "NO <Identity> MATCH FOUND"
-            }
-          }
-
       - name: Verify Windows release assets
         # Same class of bug as macOS's missing latest-mac.yml: electron-updater's
         # NSIS updater needs latest.yml + the installer's .blockmap to check for
@@ -492,21 +463,27 @@ jobs:
               Write-Error "Identity element is missing from AppxManifest.xml in $($appx.Name)"
               exit 1
             }
+            # Attribute values may be single- or double-quoted (both are
+            # valid XML) — electron-builder 26.15.3 emits Publisher with
+            # single quotes while Name/ProcessorArchitecture/Version use
+            # double quotes. A double-quote-only pattern here false-positives
+            # "does not match" even when the value is correct (see the 3.2.1
+            # release-windows failure this was found from).
             $identityAttrs = $Matches[1]
-            if ($identityAttrs -notmatch 'ProcessorArchitecture="([^"]+)"') {
+            if ($identityAttrs -notmatch 'ProcessorArchitecture=["'']([^"'']+)["'']') {
               Write-Error "ProcessorArchitecture is missing from AppxManifest.xml in $($appx.Name)"
               exit 1
             }
             $architectures[$Matches[1]] = $true
-            if ($identityAttrs -notmatch 'Name="([^"]+)"' -or $Matches[1] -ne $expectedIdentity) {
+            if ($identityAttrs -notmatch 'Name=["'']([^"'']+)["'']' -or $Matches[1] -ne $expectedIdentity) {
               Write-Error "AppX identity in $($appx.Name) does not match expected '$expectedIdentity'"
               exit 1
             }
-            if ($identityAttrs -notmatch 'Publisher="([^"]+)"' -or $Matches[1] -ne $expectedPublisher) {
+            if ($identityAttrs -notmatch 'Publisher=["'']([^"'']+)["'']' -or $Matches[1] -ne $expectedPublisher) {
               Write-Error "AppX publisher in $($appx.Name) does not match the configured Store publisher"
               exit 1
             }
-            if ($identityAttrs -notmatch 'Version="([^"]+)"' -or $Matches[1] -ne $expectedVersion) {
+            if ($identityAttrs -notmatch 'Version=["'']([^"'']+)["'']' -or $Matches[1] -ne $expectedVersion) {
               Write-Error "AppX version in $($appx.Name) does not match package.json version '$expectedVersion'"
               exit 1
             }


### PR DESCRIPTION
## Summary
- Fixes the root cause of the 3.2.1 `release-windows` job failure: electron-builder 26.15.3 emits the AppxManifest.xml `Identity` element's `Publisher` attribute with single quotes while `Name`/`ProcessorArchitecture`/`Version` use double quotes (both valid XML). The verify step's regexes were double-quote-only, so `Publisher` never matched and the step reported "AppX publisher ... does not match the configured Store publisher" even though the value was exactly correct.
- Broadens all four identity-attribute regexes to accept either quote style.
- Confirmed locally against the actual failing manifest content (dumped via a temporary debug step in #345, now removed) using `pwsh` — the fixed regex correctly extracts and matches `CN=34AFD24D-EC88-44B8-B309-08BB8A6BB5F7`.

No product code changed — this only affects the release pipeline's Windows verification step.

## Test plan
- [x] Verified the fixed regex against the real failing manifest content locally via `pwsh`
- CI-only change; product test suites don't cover this file