### PR TITLE
release: prepare 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Flo Cafe are documented here. Dates are release dates, not commit dates. Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [3.2.1] - 2026-08-17
+## [3.2.2] - 2026-08-17
 
 ### Added
 - Added full Persian (Farsi) RTL layout support across the Setup wizard, auth screens, Settings, Dashboard, POS, and shared UI components, with logical direction utilities and isolated LTR islands for technical values (order numbers, phone numbers, URLs, IDs).
@@ -16,6 +16,7 @@ All notable changes to Flo Cafe are documented here. Dates are release dates, no
 - Bounded email and tax-ID input validation to prevent ReDoS.
 - Repaired databases that never created the `revoked_tokens` table because of a migration version-number collision shipped in release 2.9.0. Affected installs were failing every authenticated request closed; a new migration (v71) idempotently restores the table on upgrade.
 - Tax plugin update checks now resolve a pre-rename installed pack id (e.g. `official-in`) against the current catalog id (`official-india`), so stores that installed before the rename correctly see real updates instead of "up to date" forever.
+- Windows release verification no longer false-positives on the AppX manifest's `Publisher` identity attribute, which electron-builder emits with single quotes rather than double quotes.
 
 ### Changed
 - CI test suite now shards across two parallel runners to speed up merge-ready checks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -204,7 +204,11 @@ function run() {
     'release-windows job must verify and upload the .appx Microsoft Store package'
   );
   assert.ok(
-    winJob.includes('ProcessorArchitecture="([^"]+)"') &&
+    // Quote-agnostic: electron-builder emits some AppX Identity attributes
+    // (e.g. Publisher) with single quotes and others with double quotes —
+    // both are valid XML — so this must not lock in one quote style. The
+    // doubled '' is PowerShell's single-quoted-string escape for a literal '.
+    winJob.includes(`ProcessorArchitecture=["'']([^"'']+)["'']`) &&
     winJob.includes('@("x64", "arm64")'),
     'release-windows job must inspect AppX manifests and require both x64 and arm64 packages'
   );


### PR DESCRIPTION
## Summary
- Bumps `package.json`/`package-lock.json` to `3.2.2` and renames the prepared `[3.2.1]` changelog entry to `[3.2.2]`.
- `3.2.1` was tagged, hit a release-windows failure (AppX manifest quote-parsing bug, fixed in #346), and was deleted (tag + GitHub release) before completing — Linux and macOS artifacts it did publish are functionally identical to what `3.2.2` will ship, just under the correct version now that Windows/Store publishing will actually succeed.

## Test plan
- [x] `git diff --check`
- Version/changelog bump only, no product code changed beyond what's already on `main` (merged via #343/#344/#346).