### PR TITLE
fix(tax): reinstall an installed tax plugin to repair a missing billing template

### DIFF
--- a/frontend/src/components/settings/TaxConfigurationPanel.tsx
+++ b/frontend/src/components/settings/TaxConfigurationPanel.tsx
@@ -259,6 +259,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
   const [packUpdate, setPackUpdate] = useState<TaxPackUpdate | null>(null);
   const [checkingUpdate, setCheckingUpdate] = useState(false);
   const [installingUpdate, setInstallingUpdate] = useState(false);
+  const [reinstallingPlugin, setReinstallingPlugin] = useState(false);
 
   const [manualStarter] = useState(() => {
     const category = newManualCategory('Standard');
@@ -535,6 +536,33 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       toast.error(apiMessage(error, 'Could not install the tax plugin update'));
     } finally {
       setInstallingUpdate(false);
+    }
+  }
+
+  // Re-downloads the currently-active plugin version in place and re-derives
+  // its categories, rules, and bundled billing template. For the case where a
+  // plugin shows as installed/active but its billing template never appeared
+  // under Printers > Bill Template (e.g. after a database restore) — the
+  // version number doesn't change, so the normal update flow has nothing to
+  // offer here.
+  async function reinstallPlugin() {
+    const packId = detail?.pack.id;
+    const versionId = detail?.active_version?.id;
+    if (!isOwner || !pluginUpdateApplicable || !packId || !versionId) return;
+    if (!window.confirm('Re-download this tax plugin and rebuild its categories, rules, and billing template? This will not change the installed version.')) {
+      return;
+    }
+    setReinstallingPlugin(true);
+    try {
+      await api.post(
+        `/tax-packs/${encodeURIComponent(packId)}/versions/${encodeURIComponent(versionId)}/reinstall`,
+      );
+      toast.success('Tax plugin reinstalled — its billing template should now appear under Printers > Bill Template');
+      await Promise.all([loadList(), loadAudit(), loadDetail(packId)]);
+    } catch (error) {
+      toast.error(apiMessage(error, 'Could not reinstall the tax plugin'));
+    } finally {
+      setReinstallingPlugin(false);
     }
   }
 
@@ -894,15 +922,29 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
               Tax plugin version <span className="font-mono font-medium">v{detail.active_version.version}</span>
               <span className="ms-1 text-gray-400">({detail.pack.trust_status})</span>
             </span>
-            <button
-              type="button"
-              onClick={() => void checkForPluginUpdates(true)}
-              disabled={checkingUpdate}
-              className="ms-auto flex items-center gap-1 font-medium text-brand disabled:opacity-50"
-            >
-              <RefreshCw size={13} className={checkingUpdate ? 'animate-spin' : ''} />
-              {checkingUpdate ? 'Checking…' : 'Check for updates'}
-            </button>
+            <span className="ms-auto flex items-center gap-3">
+              {isOwner && (
+                <button
+                  type="button"
+                  onClick={() => void reinstallPlugin()}
+                  disabled={reinstallingPlugin}
+                  title="Re-download this plugin and rebuild its categories, rules, and billing template"
+                  className="flex items-center gap-1 font-medium text-gray-600 hover:text-gray-800 disabled:opacity-50"
+                >
+                  <Wrench size={13} className={reinstallingPlugin ? 'animate-spin' : ''} />
+                  {reinstallingPlugin ? 'Reinstalling…' : 'Reinstall plugin'}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => void checkForPluginUpdates(true)}
+                disabled={checkingUpdate}
+                className="flex items-center gap-1 font-medium text-brand disabled:opacity-50"
+              >
+                <RefreshCw size={13} className={checkingUpdate ? 'animate-spin' : ''} />
+                {checkingUpdate ? 'Checking…' : 'Check for updates'}
+              </button>
+            </span>
           </div>
         )}
         {activePluginUpdate && (

--- a/main/routes/tax-packs.ts
+++ b/main/routes/tax-packs.ts
@@ -126,6 +126,23 @@ function persistPackArtifacts(
     version.effective_from, version.effective_to, version.min_flo_version, version.published_at,
     installedAt,
   );
+  persistPackContent(version, definition, installedAt, printTemplates);
+}
+
+// Re-derivable content for a version row that already exists in
+// country_pack_versions: categories, rules, and bundled print templates.
+// Split out from persistPackArtifacts so reinstallPackVersion can clear and
+// re-run just this part for a version whose row is present but whose
+// dependent rows (most commonly installed_print_templates, e.g. after a
+// restored/desynced database) went missing without needing to fight the
+// (pack_id, version) UNIQUE constraint on country_pack_versions.
+function persistPackContent(
+  version: VersionRow,
+  definition: CountryPack,
+  installedAt: string,
+  printTemplates: PluginPrintTemplate[] = [],
+): void {
+  const db = getDatabase();
   const insertCategory = db.prepare(`
     INSERT INTO tax_categories (
       id, pack_version_id, category_id, label, default_behavior, definition_json, created_at
@@ -678,6 +695,64 @@ export async function installCatalogEntry(
     versionId,
     version: artifact.pack.version,
     validation,
+  };
+}
+
+export async function reinstallPackVersion(
+  packId: string,
+  versionId: string,
+  options: InstallCatalogEntryOptions,
+): Promise<{ packId: string; versionId: string; version: string; templateCount: number }> {
+  const db = getDatabase();
+  const pack = db.prepare('SELECT * FROM country_packs WHERE id = ?').get(packId) as PackRow | undefined;
+  const version = db.prepare(
+    'SELECT * FROM country_pack_versions WHERE id = ? AND pack_id = ?'
+  ).get(versionId, packId) as VersionRow | undefined;
+  if (!pack || !version) {
+    throw Object.assign(new Error('Installed tax pack version not found'), { statusCode: 404 });
+  }
+  if (pack.publisher === 'local') {
+    throw Object.assign(new Error('Manually-built tax configurations do not need reinstalling'), { statusCode: 400 });
+  }
+  const fetchImpl = options.fetchImpl || fetch;
+  const publicKey = options.publicKey || TRUSTED_TAX_PACK_SIGNING_PUBLIC_KEY;
+  const remote = await fetchRemoteTaxPackCatalog(fetchImpl, options.signal);
+  const entry = remote.catalog.packs.find(
+    (candidate) => candidate.id === pack.id && candidate.version === version.version,
+  );
+  if (!entry) {
+    throw Object.assign(
+      new Error('This tax plugin version is no longer available in the plugin catalog'),
+      { statusCode: 404 },
+    );
+  }
+  const artifact = await downloadAndVerifyTaxPack(entry, fetchImpl, publicKey, options.signal);
+  if (artifact.pack.id !== pack.id || artifact.pack.version !== version.version) {
+    throw Object.assign(new Error('Downloaded artifact does not match the installed pack version'), { statusCode: 409 });
+  }
+  const validation = validationChecklist(version, publicKey);
+  if (!validation.valid) {
+    throw Object.assign(new Error('Tax plugin failed reinstall validation'), { statusCode: 400, validation });
+  }
+  const installedAt = now();
+  withTxn(() => {
+    db.prepare('DELETE FROM tax_categories WHERE pack_version_id = ?').run(version.id);
+    db.prepare('DELETE FROM tax_rules WHERE pack_version_id = ?').run(version.id);
+    db.prepare('DELETE FROM installed_print_templates WHERE pack_version_id = ?').run(version.id);
+    persistPackContent(version, artifact.pack, installedAt, artifact.printTemplates);
+    audit('reinstall_pack', options.actorUserId, pack.id, version.id, null, {
+      source: 'github_release',
+      version: artifact.pack.version,
+      digest: entry.digest,
+      downloadUrl: entry.downloadUrl,
+      templateCount: artifact.printTemplates.length,
+    });
+  });
+  return {
+    packId: pack.id,
+    versionId: version.id,
+    version: version.version,
+    templateCount: artifact.printTemplates.length,
   };
 }
 
@@ -1352,6 +1427,29 @@ router.post('/:packId/versions/:versionId/activate', requireRole('owner'), (req:
     res.status(500).json({ error: 'Could not activate pack version' });
   }
 });
+
+// Re-downloads an already-installed version and re-derives its categories,
+// rules, and bundled print templates in place. Repairs a pack that shows as
+// installed/active but is missing dependent rows (most visibly, its billing
+// template not appearing under Printers > Bill Template) — e.g. after a
+// database restore or an interrupted prior install — without needing to
+// bump the version number, which the normal install path requires.
+router.post('/:packId/versions/:versionId/reinstall', requireRole('owner'), asyncHandler(async (req: Request, res: Response) => {
+  try {
+    const requestSignal = getHttpRequestSignal(req);
+    const result = await reinstallPackVersion(String(req.params.packId), String(req.params.versionId), {
+      actorUserId: actorUserId(req),
+      signal: requestSignal,
+    });
+    res.json({ reinstalled: result });
+  } catch (error: any) {
+    const statusCode = error.statusCode || 502;
+    res.status(statusCode).json({
+      error: error.message || 'Could not reinstall tax plugin version',
+      ...(error.validation ? { validation: error.validation } : {}),
+    });
+  }
+}));
 
 router.post('/:packId/rollback', requireRole('owner'), (req: Request, res: Response) => {
   try {

--- a/tests/tax-pack-management.test.ts
+++ b/tests/tax-pack-management.test.ts
@@ -42,6 +42,7 @@ const { registerRoutes } = require('../main/routes/index');
 const { calculateConfiguredChargeTaxes } = require('../main/services/tax');
 const {
   installCatalogEntry,
+  reinstallPackVersion,
   validationChecklist,
 } = require('../main/routes/tax-packs');
 const {
@@ -763,6 +764,86 @@ async function main() {
       const contentLines = receipt.split('\n').filter((line) => line.length > 0);
       assert(contentLines.every((line) => line.length <= columns), `plugin renderer keeps ${columns}-column profile within printable width`);
     }
+
+    console.log('\n8b. Reinstalling a plugin repairs a missing billing template without changing its version');
+    db.prepare('DELETE FROM installed_print_templates WHERE pack_version_id = ?').run(wrappedInstalled.versionId);
+    assertEqual(
+      db.prepare('SELECT COUNT(*) AS count FROM installed_print_templates WHERE pack_version_id = ?')
+        .get(wrappedInstalled.versionId).count,
+      0,
+      'simulated desync: the billing template row is gone even though the pack version is still installed',
+    );
+    const missingTemplateRes = await api(baseUrl, '/api/settings/bill-templates', { headers: manager.authHeader });
+    assert(
+      !missingTemplateRes.data.plugins.some((entry: any) => entry.id === 'in.gst.tax-invoice.v1'),
+      'billing template is not exposed to settings while its row is missing',
+    );
+
+    const reinstallCatalog = {
+      schemaVersion: 1,
+      generatedAt: '2026-08-01T00:00:00.000Z',
+      packs: [wrappedEntry],
+    };
+    const reinstallCatalogUrl = `${wrappedBase}/reinstall-catalog.json`;
+    const reinstallReleasesUrl = 'https://api.github.com/repos/FreeOpenSourcePOS/FloCafe-Plugins/releases?per_page=100&page=1';
+    const reinstallFetch = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === reinstallReleasesUrl) {
+        return new Response(JSON.stringify([{
+          tag_name: wrappedTag,
+          html_url: `https://github.com/FreeOpenSourcePOS/FloCafe-Plugins/releases/tag/${wrappedTag}`,
+          draft: false,
+          assets: [{ name: 'catalog.json', browser_download_url: reinstallCatalogUrl }],
+        }]), { status: 200 });
+      }
+      if (url === reinstallCatalogUrl) return new Response(JSON.stringify(reinstallCatalog), { status: 200 });
+      if (url === wrappedEntry.downloadUrl) return new Response(wrappedArtifactJson, { status: 200 });
+      if (url === wrappedEntry.signatureUrl) return new Response(wrappedSignature, { status: 200 });
+      return new Response('', { status: 404 });
+    };
+    const reinstalled = await reinstallPackVersion(
+      wrappedInstalled.packId,
+      wrappedInstalled.versionId,
+      { actorUserId: owner.userId, fetchImpl: reinstallFetch, publicKey },
+    );
+    assertEqual(reinstalled.version, '1.3.0', 'reinstall keeps the same installed version, it does not upgrade');
+    assertEqual(reinstalled.templateCount, 1, 'reinstall reports the restored template count');
+    const repairedTemplateRow = db.prepare(
+      'SELECT * FROM installed_print_templates WHERE template_id = ?'
+    ).get('in.gst.tax-invoice.v1');
+    assert(!!repairedTemplateRow, 'reinstall re-creates the missing billing template row');
+    assertEqual(repairedTemplateRow.pack_version_id, wrappedInstalled.versionId, 'restored template is keyed to the same pack version');
+    const repairedChildren = db.prepare(`
+      SELECT
+        (SELECT COUNT(*) FROM tax_categories WHERE pack_version_id = ?) AS categories,
+        (SELECT COUNT(*) FROM tax_rules WHERE pack_version_id = ?) AS rules
+    `).get(wrappedInstalled.versionId, wrappedInstalled.versionId);
+    assertEqual(repairedChildren.categories, wrappedPack.categories.length, 'reinstall does not duplicate categories');
+    assertEqual(repairedChildren.rules, wrappedPack.rules.length, 'reinstall does not duplicate rules');
+    const repairedTemplateListRes = await api(baseUrl, '/api/settings/bill-templates', { headers: manager.authHeader });
+    const repairedPluginTemplate = repairedTemplateListRes.data.plugins.find((entry: any) => entry.id === 'in.gst.tax-invoice.v1');
+    assert(!!repairedPluginTemplate, 'billing template is exposed to settings again after reinstall');
+    const reinstallAudit = db.prepare(`
+      SELECT action, actor_user_id FROM tax_config_audit
+      WHERE pack_version_id = ? AND action = 'reinstall_pack'
+    `).get(wrappedInstalled.versionId);
+    assert(!!reinstallAudit, 'reinstall is audited');
+    assertEqual(reinstallAudit.actor_user_id, owner.userId, 'reinstall audit identifies the acting user');
+
+    const genericPack = db.prepare(
+      "SELECT active_version_id FROM country_packs WHERE id = 'local-generic'"
+    ).get() as { active_version_id: string };
+    let manualReinstallRejected = false;
+    try {
+      await reinstallPackVersion('local-generic', genericPack.active_version_id, {
+        actorUserId: owner.userId,
+        fetchImpl: reinstallFetch,
+        publicKey,
+      });
+    } catch (error: any) {
+      manualReinstallRejected = error.statusCode === 400;
+    }
+    assert(manualReinstallRejected, 'reinstalling a local/manual pack is rejected, it has nothing to redownload');
 
     db.prepare("UPDATE country_pack_versions SET status = 'revoked' WHERE id = ?").run(wrappedInstalled.versionId);
     const rejectRevokedTemplate = await api(baseUrl, '/api/settings/bill_template', {


### PR DESCRIPTION
## Summary
- A tax pack can be "installed and active" while its billing template is missing from Printers > Bill Template — e.g. after a database restore or interrupted install left a `country_pack_versions` row without a matching `installed_print_templates` row. The install path's duplicate-version guard short-circuits before the template is ever (re-)written, and neither activation nor the update-checker can repair it.
- Adds `POST /tax-packs/:packId/versions/:versionId/reinstall`: re-downloads and re-verifies the exact installed version from the catalog and re-derives its categories, rules, and print templates in place, without bumping the version.
- Adds an owner-only "Reinstall plugin" button next to "Check for updates" in Settings > Tax Config.

## Test plan
- [x] `node tests/run-electron-node-test.cjs tests/tax-pack-management.test.ts` — 150/150 passing, including new coverage: simulated missing-template desync, reinstall repairs it without duplicating categories/rules, reinstall is audited, local/manual packs are rejected.
- [x] `node tests/run-electron-node-test.cjs tests/tax-pack-catalog.test.ts` — 8/8 passing.
- [x] `npx tsc --noEmit`, `npm run lint` (0 errors), `npm run build`, `npm run build:frontend` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)