### PR TITLE
release: prepare 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Flo Cafe are documented here. Dates are release dates, not commit dates. Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [3.2.3] - 2026-08-17
+
+### Added
+- Settings → Tax Config now has an owner-only "Reinstall plugin" action that re-downloads an already-installed tax plugin and rebuilds its categories, rules, and billing template in place, repairing a pack that shows as installed/active but is missing its billing template (e.g. after a database restore or an interrupted prior install) without requiring a version change.
+
 ## [3.2.2] - 2026-08-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- Bumps version to 3.2.3.
- Adds the CHANGELOG entry for the tax-plugin reinstall feature landed in #349.
- No other code changes — this release is #349 (billing-template repair) on top of #346 (Windows AppX manifest verification fix), both already on `main`.

## Test plan
- [x] `npm run test:release-config` passes.
- [x] `npm run lint`, `npm run build`, `npm run build:frontend` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)