### PR TITLE
feat(i18n): drive region locale preferences from country profile

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -13,7 +13,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from '@/components/ui/button';
 import api from '@/lib/api';
 import toast from 'react-hot-toast';
-import { COUNTRIES, countryName, type CurrencyDisplay, type DigitMode, type CalendarMode } from '@/lib/countries';
+import { COUNTRIES, countryName, getCountryByCode, type CurrencyDisplay, type DigitMode, type CalendarMode } from '@/lib/countries';
 import { dialCodeFor, normalizeOptionalPhone } from '@/lib/phone';
 import { useConfirm } from '@/hooks/use-confirm';
 import { MasterPinPrompt } from '@/components/settings/MasterPinPrompt';
@@ -22,6 +22,7 @@ import { InitializeDatabaseDialog } from '@/components/settings/InitializeDataba
 import { WhatsAppEnableCard } from '@/components/settings/WhatsAppEnableCard';
 import { TaxConfigurationPanel } from '@/components/settings/TaxConfigurationPanel';
 import { PaymentMethodsSettings } from '@/components/settings/PaymentMethodsSettings';
+import { LocalePreferencesPanel } from '@/components/settings/LocalePreferencesPanel';
 import type { HealthCheckReport } from '@/types/electron';
 import { useI18n } from '@/hooks/useI18n';
 import { Ltr } from '@/components/layout/Ltr';
@@ -2251,61 +2252,19 @@ export default function SettingsPage() {
                     </div>
                   )}
                 </div>
-                {form.countryCode === 'IR' && (
-                  <div className="md:col-span-2 space-y-4 rounded-lg border border-gray-100 bg-gray-50/60 p-4">
-                    <p className="text-sm font-medium text-gray-700">{t('settings.iranLocaleTitle')}</p>
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                      <div>
-                        <label className="block text-sm text-gray-500 mb-1">{t('settings.iranCurrencyDisplay')}</label>
-                        {isAdmin ? (
-                          <select
-                            value={form.currencyDisplay}
-                            onChange={(e) => setForm((p) => ({ ...p, currencyDisplay: e.target.value as CurrencyDisplay }))}
-                            className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
-                          >
-                            <option value="rial">{t('settings.iranCurrencyDisplayRial')}</option>
-                            <option value="toman">{t('settings.iranCurrencyDisplayToman')}</option>
-                            <option value="toman_short">{t('settings.iranCurrencyDisplayTomanShort')}</option>
-                          </select>
-                        ) : (
-                          <p className="font-medium text-gray-900">{form.currencyDisplay === 'toman' ? t('settings.iranCurrencyDisplayToman') : form.currencyDisplay === 'toman_short' ? t('settings.iranCurrencyDisplayTomanShort') : t('settings.iranCurrencyDisplayRial')}</p>
-                        )}
-                      </div>
-                      <div>
-                        <label className="block text-sm text-gray-500 mb-1">{t('settings.iranNumberDigits')}</label>
-                        {isAdmin ? (
-                          <select
-                            value={form.numberDigits}
-                            onChange={(e) => setForm((p) => ({ ...p, numberDigits: e.target.value as DigitMode }))}
-                            className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
-                          >
-                            <option value="locale">{t('settings.iranNumberDigitsLocale')}</option>
-                            <option value="latin">{t('settings.iranNumberDigitsLatin')}</option>
-                          </select>
-                        ) : (
-                          <p className="font-medium text-gray-900">{form.numberDigits === 'latin' ? t('settings.iranNumberDigitsLatin') : t('settings.iranNumberDigitsLocale')}</p>
-                        )}
-                      </div>
-                      <div>
-                        <label className="block text-sm text-gray-500 mb-1">{t('settings.iranCalendar')}</label>
-                        {isAdmin ? (
-                          <select
-                            value={form.calendar}
-                            onChange={(e) => setForm((p) => ({ ...p, calendar: e.target.value as CalendarMode }))}
-                            className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
-                          >
-                            <option value="locale">{t('settings.iranCalendarLocale')}</option>
-                            <option value="persian">{t('settings.iranCalendarPersian')}</option>
-                            <option value="gregorian">{t('settings.iranCalendarGregorian')}</option>
-                          </select>
-                        ) : (
-                          <p className="font-medium text-gray-900">{form.calendar === 'persian' ? t('settings.iranCalendarPersian') : form.calendar === 'gregorian' ? t('settings.iranCalendarGregorian') : t('settings.iranCalendarLocale')}</p>
-                        )}
-                      </div>
-                    </div>
-                    <p className="text-xs text-gray-400">{t('settings.iranLocaleHint')}</p>
-                  </div>
-                )}
+                <LocalePreferencesPanel
+                  options={getCountryByCode(form.countryCode)?.localeOptions}
+                  currencyDisplay={form.currencyDisplay}
+                  digits={form.numberDigits}
+                  calendar={form.calendar}
+                  isAdmin={isAdmin}
+                  onChange={(patch) => setForm((p) => ({
+                    ...p,
+                    ...(patch.currencyDisplay !== undefined ? { currencyDisplay: patch.currencyDisplay } : {}),
+                    ...(patch.digits !== undefined ? { numberDigits: patch.digits } : {}),
+                    ...(patch.calendar !== undefined ? { calendar: patch.calendar } : {}),
+                  }))}
+                />
                 <div>
                   <label className="block text-sm text-gray-500 mb-1">{t('settings.billingType')}</label>
                   {isAdmin ? (

--- a/frontend/src/components/settings/LocalePreferencesPanel.tsx
+++ b/frontend/src/components/settings/LocalePreferencesPanel.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useI18n } from '@/hooks/useI18n';
+import type { CountryLocaleOptions, CurrencyDisplay, DigitMode, CalendarMode } from '@/lib/countries';
+
+interface Props {
+  options?: CountryLocaleOptions;
+  currencyDisplay: CurrencyDisplay;
+  digits: DigitMode;
+  calendar: CalendarMode;
+  isAdmin: boolean;
+  onChange: (patch: { currencyDisplay?: CurrencyDisplay; digits?: DigitMode; calendar?: CalendarMode }) => void;
+}
+
+// Option labels keyed by value. The panel itself is region-agnostic: which
+// controls (and which options within them) are rendered is driven entirely by
+// the country profile's `localeOptions`, so a region without locale options
+// never sees this panel.
+const CURRENCY_DISPLAY_LABELS: Record<CurrencyDisplay, string> = {
+  rial: 'settings.iranCurrencyDisplayRial',
+  toman: 'settings.iranCurrencyDisplayToman',
+  toman_short: 'settings.iranCurrencyDisplayTomanShort',
+};
+
+const DIGIT_LABELS: Record<DigitMode, string> = {
+  locale: 'settings.iranNumberDigitsLocale',
+  latin: 'settings.iranNumberDigitsLatin',
+};
+
+const CALENDAR_LABELS: Record<CalendarMode, string> = {
+  locale: 'settings.iranCalendarLocale',
+  persian: 'settings.iranCalendarPersian',
+  gregorian: 'settings.iranCalendarGregorian',
+};
+
+export function LocalePreferencesPanel({ options, currencyDisplay, digits, calendar, isAdmin, onChange }: Props) {
+  const { t } = useI18n();
+
+  const hasAny = Boolean(
+    options?.currencyDisplay?.length || options?.digits?.length || options?.calendar?.length,
+  );
+  if (!hasAny) return null;
+
+  return (
+    <div className="md:col-span-2 space-y-4 rounded-lg border border-gray-100 bg-gray-50/60 p-4">
+      <p className="text-sm font-medium text-gray-700">{t('settings.iranLocaleTitle')}</p>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {options?.currencyDisplay?.length ? (
+          <div>
+            <label className="block text-sm text-gray-500 mb-1">{t('settings.iranCurrencyDisplay')}</label>
+            {isAdmin ? (
+              <select
+                value={currencyDisplay}
+                onChange={(e) => onChange({ currencyDisplay: e.target.value as CurrencyDisplay })}
+                className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
+              >
+                {options!.currencyDisplay!.map((mode) => (
+                  <option key={mode} value={mode}>{t(CURRENCY_DISPLAY_LABELS[mode])}</option>
+                ))}
+              </select>
+            ) : (
+              <p className="font-medium text-gray-900">{t(CURRENCY_DISPLAY_LABELS[currencyDisplay])}</p>
+            )}
+          </div>
+        ) : null}
+
+        {options?.digits?.length ? (
+          <div>
+            <label className="block text-sm text-gray-500 mb-1">{t('settings.iranNumberDigits')}</label>
+            {isAdmin ? (
+              <select
+                value={digits}
+                onChange={(e) => onChange({ digits: e.target.value as DigitMode })}
+                className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
+              >
+                {options!.digits!.map((mode) => (
+                  <option key={mode} value={mode}>{t(DIGIT_LABELS[mode])}</option>
+                ))}
+              </select>
+            ) : (
+              <p className="font-medium text-gray-900">{t(DIGIT_LABELS[digits])}</p>
+            )}
+          </div>
+        ) : null}
+
+        {options?.calendar?.length ? (
+          <div>
+            <label className="block text-sm text-gray-500 mb-1">{t('settings.iranCalendar')}</label>
+            {isAdmin ? (
+              <select
+                value={calendar}
+                onChange={(e) => onChange({ calendar: e.target.value as CalendarMode })}
+                className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
+              >
+                {options!.calendar!.map((mode) => (
+                  <option key={mode} value={mode}>{t(CALENDAR_LABELS[mode])}</option>
+                ))}
+              </select>
+            ) : (
+              <p className="font-medium text-gray-900">{t(CALENDAR_LABELS[calendar])}</p>
+            )}
+          </div>
+        ) : null}
+      </div>
+      <p className="text-xs text-gray-400">{t('settings.iranLocaleHint')}</p>
+    </div>
+  );
+}

--- a/frontend/src/lib/countries.ts
+++ b/frontend/src/lib/countries.ts
@@ -11,6 +11,7 @@ export {
   formatDateForTenant,
   countryName,
   type Country,
+  type CountryLocaleOptions,
   type LocalePreferences,
   type CurrencyDisplay,
   type DigitMode,

--- a/main/countries.ts
+++ b/main/countries.ts
@@ -6,6 +6,17 @@ export interface TaxIdFormat {
   description: string;
 }
 
+/**
+ * Which locale display preferences a country supports. The Settings UI only
+ * renders these controls when a country's profile declares them, so
+ * region-specific options never appear (or bloat) other regions' UI.
+ */
+export interface CountryLocaleOptions {
+  currencyDisplay?: ('rial' | 'toman' | 'toman_short')[];
+  digits?: ('locale' | 'latin')[];
+  calendar?: ('locale' | 'persian' | 'gregorian')[];
+}
+
 export interface Country {
   code: string;
   name: string;
@@ -20,6 +31,8 @@ export interface Country {
   // for countries we haven't verified a format for; unset means no format
   // is enforced, never "reject everything".
   taxIdFormat?: TaxIdFormat;
+  // Locale display preferences available for this country (undefined = none).
+  localeOptions?: CountryLocaleOptions;
 }
 
 const dn = new Intl.DisplayNames(['en'], { type: 'region' });
@@ -31,6 +44,7 @@ interface Row {
   taxIdLabel?: string;
   taxName?: string;
   taxIdFormat?: TaxIdFormat;
+  localeOptions?: CountryLocaleOptions;
 }
 
 const SUPPORTED: Record<string, Row> = {
@@ -74,7 +88,12 @@ const SUPPORTED: Record<string, Row> = {
   EG: { locale: 'ar-EG', currency: 'EGP', tz: 'Africa/Cairo',                    taxIdLabel: 'TIN',   taxName: 'VAT' },
   IL: { locale: 'he-IL', currency: 'ILS', tz: 'Asia/Jerusalem',                                                      taxName: 'VAT' },
   TR: { locale: 'tr-TR', currency: 'TRY', tz: 'Europe/Istanbul',                 taxIdLabel: 'VKN',   taxName: 'KDV' },
-  IR: { locale: 'fa-IR', currency: 'IRR', tz: 'Asia/Tehran',                     taxIdLabel: 'Economic Code', taxName: 'VAT' },
+  IR: { locale: 'fa-IR', currency: 'IRR', tz: 'Asia/Tehran',                     taxIdLabel: 'Economic Code', taxName: 'VAT',
+    localeOptions: {
+      currencyDisplay: ['rial', 'toman', 'toman_short'],
+      digits: ['locale', 'latin'],
+      calendar: ['locale', 'persian', 'gregorian'],
+    } },
 };
 
 function build(code: string): Country {
@@ -89,6 +108,7 @@ function build(code: string): Country {
     taxIdLabel: r.taxIdLabel,
     taxName: r.taxName,
     taxIdFormat: r.taxIdFormat,
+    localeOptions: r.localeOptions,
   };
 }
 

--- a/tests/locale-iran.test.ts
+++ b/tests/locale-iran.test.ts
@@ -42,6 +42,27 @@ test('IR profile resolves fa-IR / IRR / Asia/Tehran', () => {
   assert.equal(ir.timezone, 'Asia/Tehran');
 });
 
+test('IR profile exposes locale display options (data-driven UI)', () => {
+  const ir = getCountryByCode('IR');
+  assert.ok(ir?.localeOptions, 'expected IR to declare localeOptions');
+  assert.deepEqual(ir.localeOptions.currencyDisplay, ['rial', 'toman', 'toman_short']);
+  assert.deepEqual(ir.localeOptions.digits, ['locale', 'latin']);
+  assert.deepEqual(ir.localeOptions.calendar, ['locale', 'persian', 'gregorian']);
+});
+
+test('non-IR profiles expose no localeOptions (no Settings UI bloat)', () => {
+  for (const code of ['IN', 'US', 'BR', 'AR', 'EG', 'TR', 'ZZ']) {
+    const profile = getCountryByCode(code);
+    if (profile) {
+      assert.equal(
+        profile.localeOptions,
+        undefined,
+        `expected no localeOptions for ${code}, got: ${JSON.stringify(profile.localeOptions)}`,
+      );
+    }
+  }
+});
+
 test('formatCurrency: IR renders Rial with Persian digits and no decimals', () => {
   const out = formatCurrency(6000000, 'IRR', 'fa-IR');
   assert.ok(out.includes('ریال'), `expected the Rial token, got: ${out}`);


### PR DESCRIPTION
## Intent

Make Iran-specific locale display settings (currency display unit Rial/Toman/Toman-shorthand, digit style Persian/Latin, calendar Shamsi/Gregorian) data-driven so they appear only when the IR country is selected and never clutter other regions' UI. The user approved the 'data-driven country profile' approach: declare a localeOptions field on the IR country profile, render controls through a generic LocalePreferencesPanel that only shows when a profile declares options, with no hard-coded country conditionals in the Settings JSX and no behavior change for EN/ES/PT or any non-Iran tenant. Storage stays raw IRR (never converted); these are display-only preferences. Keep the country-based visibility trigger (currency is read-only derived from country) while formatters already key off currency === IRR. No DB migration, no new backend route. Add regression tests that IR exposes localeOptions and non-IR profiles expose none.

## What Changed

- Added `CountryLocaleOptions` to country types and declared `localeOptions` on the Iran (`IR`) country profile for currency display, digit mode, and calendar options.
- Replaced hard-coded Iran conditional markup in `SettingsPage` with a dynamic `LocalePreferencesPanel` that only renders when a country profile defines locale options.
- Added tests verifying that the `IR` profile exposes locale display options and non-IR country profiles define none.

## Risk Assessment

✅ Low: The change is a clean, well-bounded refactor that drives Iran locale display preferences through country profile data and a generic panel with no hard-coded country conditionals and full test coverage.

## Testing

Executed targeted automated test suites for currency and locale formatting, verified successful TypeScript compilation and Next.js static export build, and performed end-to-end browser validation capturing full visual evidence of dynamic Iran locale display preferences in both editable admin, read-only non-admin, and RTL modes.

- Evidence: Settings UI with US selected (no Iran locale panel rendered) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M08HBND6XXQKN9ZGSF5F14FV/01-settings-non-iran-us.png</code>)
- Evidence: Settings UI with Iran selected in Admin mode (Locale Preferences Panel rendered with dropdowns) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M08HBND6XXQKN9ZGSF5F14FV/02-settings-iran-admin.png</code>)
- Evidence: Settings UI with configured Iran preferences (Toman, Latin digits, Gregorian calendar) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M08HBND6XXQKN9ZGSF5F14FV/03-settings-iran-admin-selected-options.png</code>)
- Evidence: Settings UI switched to India (Iran locale preferences panel cleanly unmounted) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M08HBND6XXQKN9ZGSF5F14FV/04-settings-switched-back-to-india.png</code>)
- Evidence: Settings UI in Persian (fa) RTL language with Iran display preferences (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M08HBND6XXQKN9ZGSF5F14FV/05-settings-iran-persian-rtl.png</code>)
- Evidence: Settings UI with Iran preferences in Non-Admin read-only mode (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M08HBND6XXQKN9ZGSF5F14FV/06-settings-iran-readonly.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3e7f74bc1fdae6dfb89c815c8a36f4984caa83f0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm run test:currency` (`tests/currency.test.ts`, `tests/country-profile.test.ts`, `tests/locale-iran.test.ts`)</code>
- `npx ts-node --transpile-only -P tests/tsconfig.json tests/rtl-setup-auth-settings.test.ts`
- `npx ts-node --transpile-only -P tests/tsconfig.json tests/translations.test.ts`
- `npm run build`
- `npm run build:frontend`
- <code>Playwright E2E UI verification: dynamic visibility of `LocalePreferencesPanel` when switching between non-IR (US/IN) and IR, admin option modifications, non-admin read-only presentation, and Persian (`fa`) RTL layout</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
