### PR TITLE
fix(ui): mirror sidebar, drawers, and tab navigation in RTL layout and update nightly CI

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,8 +1,12 @@
 name: Full Cross-Platform Matrix
 
+# Runs nightly and on demand only. It deliberately does NOT trigger on every
+# push to main: with `concurrency.cancel-in-progress: true` below, a burst of
+# merges (e.g. dependency bumps) would cancel each other's in-flight matrix
+# builds mid-package — wasting ~30 min of runner time per kill and losing the
+# per-commit packaging result. The nightly run always covers the latest main,
+# and release.yml already builds tagged releases per platform.
 on:
-  push:
-    branches: [main]
   schedule:
     - cron: '0 0 * * *' # Nightly
   workflow_dispatch:

--- a/frontend/e2e/rtl-dashboard-pos-common.spec.ts
+++ b/frontend/e2e/rtl-dashboard-pos-common.spec.ts
@@ -68,6 +68,14 @@ async function setLanguage(page: Page, value: string): Promise<void> {
     data: { value },
   });
   expect(res.ok(), `setting language=${value} should succeed (status ${res.status()})`).toBeTruthy();
+  await page.evaluate((lang) => {
+    try {
+      const raw = localStorage.getItem('pos-settings');
+      const parsed = raw ? JSON.parse(raw) : { state: {} };
+      parsed.state = { ...parsed.state, language: lang };
+      localStorage.setItem('pos-settings', JSON.stringify(parsed));
+    } catch {}
+  }, value);
 }
 
 async function assertNoHorizontalOverflow(page: Page, label: string): Promise<void> {
@@ -168,6 +176,77 @@ test('Dashboard, POS, and orders screens render LTR in English and RTL in Persia
     await expect(page.locator('h1')).toBeVisible();
     await assertNoHorizontalOverflow(page, 'tables screen');
     await captureScreenshot(page, 'tables-rtl-fa.png');
+
+    // ── Persian (RTL) on the staff screen & modal ──────────────────────────
+    await page.goto(`${BASE}/staff`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.locator('h1')).toBeVisible();
+    await assertNoHorizontalOverflow(page, 'staff screen');
+    const addStaffBtn = page.locator('button', { has: page.locator('svg') }).filter({ hasText: /افزودن|Add/i }).first();
+    if (await addStaffBtn.isVisible()) {
+      await addStaffBtn.click();
+      const roleSelect = page.locator('select').first();
+      await roleSelect.selectOption('manager');
+      const pinInput = page.locator('input[placeholder*="PIN"], input[placeholder*="پین"], input[inputmode="numeric"]').first();
+      await expect(pinInput).toBeVisible();
+      const togglePinBtn = page.locator('button[aria-label="Toggle PIN visibility"]').first();
+      await expect(togglePinBtn).toBeVisible();
+      const pinBox = await pinInput.boundingBox();
+      const toggleBox = await togglePinBtn.boundingBox();
+      expect(pinBox).not.toBeNull();
+      expect(toggleBox).not.toBeNull();
+      // In RTL, end-3 is on the left half of the input.
+      expect(toggleBox!.x + toggleBox!.width).toBeLessThan(pinBox!.x + pinBox!.width / 2);
+      await captureScreenshot(page, 'staff-modal-rtl-fa.png');
+      const closeFormBtn = page.locator('button:has(svg.lucide-x)').first();
+      if (await closeFormBtn.isVisible()) {
+        await closeFormBtn.click();
+      } else {
+        await page.keyboard.press('Escape');
+      }
+    }
+
+    // ── Persian (RTL) on addon-groups, print-test, support, customer-display ─
+    await page.goto(`${BASE}/addon-groups`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await assertNoHorizontalOverflow(page, 'addon-groups screen');
+    await captureScreenshot(page, 'addon-groups-rtl-fa.png');
+
+    await page.goto(`${BASE}/print-test`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await assertNoHorizontalOverflow(page, 'print-test screen');
+    await captureScreenshot(page, 'print-test-rtl-fa.png');
+
+    await page.goto(`${BASE}/support`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await assertNoHorizontalOverflow(page, 'support screen');
+    await captureScreenshot(page, 'support-rtl-fa.png');
+
+    await page.goto(`${BASE}/customer-display`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await assertNoHorizontalOverflow(page, 'customer-display screen');
+    await captureScreenshot(page, 'customer-display-rtl-fa.png');
+
+    // ── Mobile layout & SidebarTrigger on Persian dashboard ─────────────────
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto(`${BASE}/dashboard`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    const mobileTrigger = page.locator('button[aria-label="Open navigation"]');
+    await expect(mobileTrigger).toBeVisible();
+    await captureScreenshot(page, 'mobile-dashboard-appbar-rtl-fa.png');
+
+    await mobileTrigger.click();
+    const sheetContent = page.locator('[data-mobile="true"]');
+    await expect(sheetContent).toBeVisible();
+    const sheetBox = await sheetContent.boundingBox();
+    expect(sheetBox).not.toBeNull();
+    // In RTL, side="left" (inline-start) is pinned to the right edge.
+    expect(sheetBox!.x + sheetBox!.width).toBeGreaterThan(360);
+    await captureScreenshot(page, 'mobile-sidebar-sheet-rtl-fa.png');
+    await page.keyboard.press('Escape');
+
+    // Restore desktop viewport
+    await page.setViewportSize({ width: 1280, height: 720 });
   } finally {
     // Restore English so the shared server does not leak Persian into other specs.
     await setLanguage(page, 'en');

--- a/frontend/e2e/rtl-dashboard-pos-common.spec.ts
+++ b/frontend/e2e/rtl-dashboard-pos-common.spec.ts
@@ -80,6 +80,24 @@ async function assertNoHorizontalOverflow(page: Page, label: string): Promise<vo
   );
 }
 
+/**
+ * The fixed app sidebar rail must sit at the inline-start: left edge in LTR,
+ * right edge in RTL (Persian). Regression coverage for the physical left-0
+ * pinning that kept it stuck on the left in RTL (Refs #241).
+ */
+async function assertSidebarSide(page: Page, expected: 'left' | 'right'): Promise<void> {
+  const container = page.locator('[data-slot="sidebar-container"]');
+  await expect(container).toBeVisible();
+  const box = await container.boundingBox();
+  expect(box, 'sidebar container must have a bounding box').not.toBeNull();
+  const vw = page.viewportSize()?.width ?? 0;
+  if (expected === 'left') {
+    expect(box!.x, 'sidebar must be pinned to the left edge in LTR').toBeLessThan(5);
+  } else {
+    expect(box!.x + box!.width, 'sidebar must be pinned to the right edge in RTL').toBeGreaterThan(vw - 5);
+  }
+}
+
 test('Dashboard, POS, and orders screens render LTR in English and RTL in Persian with LTR phone input, mirrored arrows, and no overflow', async ({ page }) => {
   // Owner account: the dashboard page redirects non-owner roles to /pos, and
   // one login keeps the suite within the shared server's login rate limit.
@@ -91,6 +109,7 @@ test('Dashboard, POS, and orders screens render LTR in English and RTL in Persia
   await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
   await expect(page.getByTestId('pos-product-grid')).toBeVisible();
   await expect(page.getByText('E2E Coffee')).toBeVisible();
+  await assertSidebarSide(page, 'left');
   await captureScreenshot(page, 'pos-ltr-en.png');
 
   // ── Persian (RTL) on the POS screen ──────────────────────────────────────
@@ -100,6 +119,7 @@ test('Dashboard, POS, and orders screens render LTR in English and RTL in Persia
     await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
     await expect(page.getByTestId('pos-product-grid')).toBeVisible();
     await expect(page.getByText('E2E Coffee')).toBeVisible();
+    await assertSidebarSide(page, 'right');
 
     // The customer-search phone input is naturally LTR and must stay dir="ltr" inside RTL.
     const phoneInput = page.locator('input[type="tel"]').first();

--- a/frontend/e2e/rtl-setup-auth-settings.spec.ts
+++ b/frontend/e2e/rtl-setup-auth-settings.spec.ts
@@ -61,6 +61,14 @@ async function setLanguage(page: Page, value: string): Promise<void> {
     data: { value },
   });
   expect(res.ok(), `setting language=${value} should succeed`).toBeTruthy();
+  await page.evaluate((lang) => {
+    try {
+      const raw = localStorage.getItem('pos-settings');
+      const parsed = raw ? JSON.parse(raw) : { state: {} };
+      parsed.state = { ...parsed.state, language: lang };
+      localStorage.setItem('pos-settings', JSON.stringify(parsed));
+    } catch {}
+  }, value);
 }
 
 async function logout(page: Page): Promise<void> {

--- a/frontend/e2e/rtl-setup-auth-settings.spec.ts
+++ b/frontend/e2e/rtl-setup-auth-settings.spec.ts
@@ -231,6 +231,15 @@ test('settings renders RTL without horizontal overflow, mirrors toggles and tabs
     await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
     await expect(page.locator('nav')).toBeVisible();
 
+    // The Settings left nav mirrors to the inline-end in RTL: radix Tabs must
+    // follow the document direction instead of forcing dir="ltr" (Refs #241).
+    await expect(page.locator('[data-slot="tabs"]')).toHaveAttribute('dir', 'rtl');
+    const settingsNavBox = await page.locator('nav').boundingBox();
+    expect(settingsNavBox, 'settings nav must have a bounding box').not.toBeNull();
+    expect(settingsNavBox!.x, 'settings nav must sit on the right side in RTL').toBeGreaterThan(
+      (page.viewportSize()?.width ?? 0) / 2
+    );
+
     // Verify language dropdown in Settings offers en, es, pt, and fa
     const languageSelect = page.locator('select').filter({ has: page.locator('option[value="en"]') }).first();
     await expect(languageSelect).toBeVisible();

--- a/frontend/src/app/(dashboard)/addon-groups/page.tsx
+++ b/frontend/src/app/(dashboard)/addon-groups/page.tsx
@@ -194,7 +194,7 @@ export default function AddonGroupsPage() {
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold text-gray-900">{t('addonGroups.title')}</h1>
         <Button onClick={() => { resetForm(); setShowForm(true); }}>
-          <Plus size={16} className="mr-1" /> {t('addonGroups.addGroup')}
+          <Plus size={16} className="me-1" /> {t('addonGroups.addGroup')}
         </Button>
       </div>
 
@@ -207,7 +207,7 @@ export default function AddonGroupsPage() {
               <div className="flex items-center justify-between p-4">
                 <button
                   onClick={() => setExpandedGroup(isExpanded ? null : group.id)}
-                  className="flex items-center gap-3 flex-1 text-left"
+                  className="flex items-center gap-3 flex-1 text-start"
                 >
                   {isExpanded ? <ChevronDown size={18} className="text-gray-400" /> : <ChevronRight size={18} className="text-gray-400" />}
                   <div>

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -3,7 +3,7 @@
 import { usePathname } from 'next/navigation';
 import AppSidebar from '@/components/layout/Sidebar';
 import AuthGuard from '@/components/layout/AuthGuard';
-import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
+import { SidebarProvider, SidebarInset, SidebarTrigger } from '@/components/ui/sidebar';
 import StatusBar from '@/components/layout/StatusBar';
 import GlobalNotifications from '@/components/layout/GlobalNotifications';
 
@@ -16,6 +16,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       <SidebarProvider defaultOpen>
         <AppSidebar />
         <SidebarInset className="h-screen overflow-hidden flex flex-col">
+          {/* Mobile-only app bar: below md the sidebar renders as a Sheet with
+              no opener, so expose the trigger here (Refs #241). */}
+          <div className="md:hidden flex items-center px-2 py-1.5 border-b border-gray-200 bg-white shrink-0">
+            <SidebarTrigger className="size-8" aria-label="Open navigation" />
+          </div>
           {!isPos && <GlobalNotifications />}
           <div className={isPos
             ? 'flex-1 min-h-0 flex flex-col overflow-hidden p-4'

--- a/frontend/src/app/(dashboard)/print-test/page.tsx
+++ b/frontend/src/app/(dashboard)/print-test/page.tsx
@@ -275,7 +275,7 @@ export default function PrintTestPage() {
               variant="outline"
               size="lg"
             >
-              <Download size={18} className="mr-2" />
+              <Download size={18} className="me-2" />
               {t('printTest.downloadHtml')}
             </Button>
           )}

--- a/frontend/src/app/(dashboard)/staff/page.tsx
+++ b/frontend/src/app/(dashboard)/staff/page.tsx
@@ -167,7 +167,7 @@ export default function StaffPage() {
     <div>
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold text-gray-900">{t('staff.title')}</h1>
-        <Button onClick={openAdd}><Plus size={16} className="mr-1" /> {t('staff.addButton')}</Button>
+        <Button onClick={openAdd}><Plus size={16} className="me-1" /> {t('staff.addButton')}</Button>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -187,10 +187,10 @@ export default function StaffPage() {
             </div>
             <div className="flex flex-wrap gap-2 mt-3">
               <Button variant="outline" size="sm" onClick={() => openEdit(s)}>
-                <Edit size={14} className="mr-1" /> {t('common.edit')}
+                <Edit size={14} className="me-1" /> {t('common.edit')}
               </Button>
               <Button variant="outline" size="sm" onClick={() => openResetPw(s)}>
-                <RotateCcw size={14} className="mr-1" /> {t('staff.resetPwButton')}
+                <RotateCcw size={14} className="me-1" /> {t('staff.resetPwButton')}
               </Button>
               <Button
                 variant="ghost"
@@ -230,10 +230,10 @@ export default function StaffPage() {
                   type={showPassword ? 'text' : 'password'} placeholder={editingStaff ? t('staff.newPasswordPlaceholder') : t('staff.passwordPlaceholder')}
                   value={form.password}
                   onChange={(e) => setForm({ ...form, password: e.target.value })}
-                  className="w-full px-3 py-2 pr-10 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
+                  className="w-full px-3 py-2 pe-10 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
                   required={!editingStaff}
                 />
-                <button type="button" aria-label="Toggle password visibility" title="Toggle password visibility" onClick={() => setShowPassword(!showPassword)} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700">
+                <button type="button" aria-label="Toggle password visibility" title="Toggle password visibility" onClick={() => setShowPassword(!showPassword)} className="absolute end-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700">
                   {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                 </button>
               </div>
@@ -262,12 +262,12 @@ export default function StaffPage() {
                       type={showPin ? 'text' : 'password'} placeholder={editingStaff ? t('staff.pinPlaceholderEdit') : t('staff.pinPlaceholderAdd')}
                       value={form.pin}
                       onChange={(e) => setForm({ ...form, pin: e.target.value.replace(/\D/g, '').slice(0, 6) })}
-                      className="w-full px-3 py-2 pr-10 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
+                      className="w-full px-3 py-2 pe-10 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
                       maxLength={6}
                       pattern="[0-9]*"
                       inputMode="numeric"
                     />
-                    <button type="button" aria-label="Toggle PIN visibility" title="Toggle PIN visibility" onClick={() => setShowPin(!showPin)} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700">
+                    <button type="button" aria-label="Toggle PIN visibility" title="Toggle PIN visibility" onClick={() => setShowPin(!showPin)} className="absolute end-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700">
                       {showPin ? <EyeOff size={16} /> : <Eye size={16} />}
                     </button>
                   </div>
@@ -293,9 +293,9 @@ export default function StaffPage() {
                 <input
                   type={showResetPassword ? 'text' : 'password'} placeholder={t('staff.newPasswordPlaceholder')} value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
-                  className="w-full px-3 py-2 pr-10 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
+                  className="w-full px-3 py-2 pe-10 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
                 />
-                <button type="button" aria-label="Toggle password visibility" title="Toggle password visibility" onClick={() => setShowResetPassword(!showResetPassword)} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700">
+                <button type="button" aria-label="Toggle password visibility" title="Toggle password visibility" onClick={() => setShowResetPassword(!showResetPassword)} className="absolute end-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700">
                   {showResetPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                 </button>
               </div>

--- a/frontend/src/app/(dashboard)/support/page.tsx
+++ b/frontend/src/app/(dashboard)/support/page.tsx
@@ -145,7 +145,7 @@ export default function SupportPage() {
             <div className="space-y-2">
               <Label htmlFor="support-message">{t('support.description')}</Label>
               <textarea id="support-message" value={message} onChange={(e) => setMessage(e.target.value)} maxLength={20000} rows={10} className="w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50" placeholder={t('support.descriptionPlaceholder')} required />
-              <p className="text-right text-xs text-muted-foreground">{fmtNum(message.length)} / 20,000</p>
+              <p className="text-end text-xs text-muted-foreground">{fmtNum(message.length)} / 20,000</p>
             </div>
             <Button type="submit" disabled={loading || submitting || !subject.trim() || !message.trim()} className="w-full sm:w-auto">
               {submitting ? <Loader2 className="animate-spin" /> : <LifeBuoy />}{submitting ? t('support.submitting') : t('support.submit')}

--- a/frontend/src/app/customer-display/page.tsx
+++ b/frontend/src/app/customer-display/page.tsx
@@ -77,7 +77,7 @@ export default function CustomerDisplayPage() {
           <div className="text-2xl md:text-3xl font-bold tracking-tight">{currentTenant.business_name}</div>
           <div className="text-slate-400 mt-1 text-sm md:text-base">Order status</div>
         </div>
-        <div className="text-right text-xs text-slate-500">
+        <div className="text-end text-xs text-slate-500">
           {error ? 'Connection problem — retrying…' : lastUpdated ? `Updated ${lastUpdated.toLocaleTimeString()}` : 'Connecting…'}
         </div>
       </header>

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -59,8 +59,10 @@ function DrawerContent({
           "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
           "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
           "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
-          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
-          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          // Logical inline positioning mirrors the side drawers in RTL (Persian),
+          // matching the Sheet treatment: "right" = inline-end, "left" = inline-start.
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:end-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-s data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:start-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-e data-[vaul-drawer-direction=left]:sm:max-w-sm",
           className
         )}
         {...props}

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -61,10 +61,12 @@ function SheetContent({
         data-slot="sheet-content"
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          // Inline-start/end positioning mirrors the sheet in RTL (Persian);
+          // the slide-in animations are physical so they flip too via `rtl:`.
           side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right rtl:data-[state=closed]:slide-out-to-left rtl:data-[state=open]:slide-in-from-left inset-y-0 end-0 h-full w-3/4 border-s sm:max-w-sm",
           side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left rtl:data-[state=closed]:slide-out-to-right rtl:data-[state=open]:slide-in-from-right inset-y-0 start-0 h-full w-3/4 border-e sm:max-w-sm",
           side === "top" &&
             "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
           side === "bottom" &&

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -226,14 +226,16 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[inset-inline-start,inset-inline-end,width] duration-200 ease-linear md:flex",
+          // Logical inline positioning keeps the rail on the inline-start
+          // side in both directions: `left` in LTR, `right` in RTL (Persian).
           side === "left"
-            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
-            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+            ? "start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]"
+            : "end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
-            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-e group-data-[side=right]:border-s",
           className
         )}
         {...props}
@@ -288,12 +290,14 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
-        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-end-4 group-data-[side=right]:start-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+        // The rail hugs the content-facing edge; mirror the centering shift in RTL.
+        "rtl:group-data-[side=left]:translate-x-1/2",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize rtl:in-data-[side=left]:cursor-e-resize rtl:in-data-[side=right]:cursor-w-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize rtl:[[data-side=left][data-state=collapsed]_&]:cursor-w-resize rtl:[[data-side=right][data-state=collapsed]_&]:cursor-e-resize",
         "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-end-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-start-2",
         className
       )}
       {...props}
@@ -307,7 +311,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
       data-slot="sidebar-inset"
       className={cn(
         "bg-background relative flex w-full flex-1 flex-col",
-        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2",
         className
       )}
       {...props}
@@ -634,7 +638,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-s px-2.5 py-0.5",
+        "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-s px-2.5 py-0.5 rtl:-translate-x-px",
         "group-data-[collapsible=icon]:hidden",
         className
       )}
@@ -677,7 +681,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 rtl:translate-x-px",
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -5,17 +5,27 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { Tabs as TabsPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
+import { usePosSettingsStore } from "@/store/pos-settings"
+import { getLanguageDirection } from "@/lib/i18n"
 
 function Tabs({
   className,
   orientation = "horizontal",
+  dir,
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  // Radix defaults `dir` to "ltr", which pins tab layouts (and their flex
+  // columns, e.g. the Settings left nav) to LTR even inside RTL (Persian)
+  // documents. Follow the active UI language direction instead so the tabs
+  // mirror with the rest of the page. An explicit `dir` prop still wins.
+  const language = usePosSettingsStore((s) => s.language);
+  const direction = dir ?? getLanguageDirection(language);
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
       orientation={orientation}
+      dir={direction}
       className={cn(
         "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
         className


### PR DESCRIPTION
## Intent

Fix the remaining RTL (Persian) layout bugs found in the #241 acceptance visual audit, and stop the nightly cross-platform matrix CI from canceling itself. User wants all of it in one PR. Deliberate decisions from the audit: (1) the shadcn Sidebar and mobile Sheet pinned with physical left-0/border-r classes, so in RTL the app sidebar stayed on the physical left while content mirrored right — convert to logical start/end/border-s/e positioning with rtl: variants only where no logical utility exists (rail translate-x, sheet slide animations, cursors); (2) radix Tabs forces dir=ltr on its root, which pinned the Settings tab nav to LTR and also broke the ON-state Toggle knob (rtl:-translate-x-5 applied against an ltr tabs root, shoving the knob off the track) — make the shared Tabs component pass getLanguageDirection() as the dir prop so tabs follow the active UI language; (3) staff add/edit modal password/PIN visibility toggles used pr-10 + absolute right-3, staying pinned right in RTL — switch to pe-10 + end-3; (4) the mobile sidebar Sheet had no visible opener (SidebarTrigger never rendered; only Ctrl/Cmd+B worked) so touch-device cashiers could not reach Orders/Settings — add a mobile-only (md:hidden) app bar with SidebarTrigger in the dashboard layout; (5) drawer.tsx left/right side variants use physical positioning — convert to logical start/end; (6) cosmetic mr-1 -> me-1 / text-right -> text-end on addon-groups, print-test, support, customer-display; (7) nightly-release.yml (Full Cross-Platform Matrix) had on: push: branches: [main] plus concurrency cancel-in-progress: true, so every push to main canceled the previous in-flight matrix build (24m wasted, e.g. the build canceled right when #385 merged) — remove the push trigger so it runs nightly + workflow_dispatch only, with a comment explaining why. KDS standalone kanban buckets were verified already flowing right-to-left via flex (no change). Verified surfaces: all 10 dashboard routes + 17 settings tabs + key modals + mobile viewport in EN and FA, full Playwright e2e (16/16, 1 worker), all 4 RTL backend suites, lint, build:frontend. Keep existing English/Spanish/Portuguese behavior unchanged. No co-author footers in commits.

## What Changed

- Converted sidebar, sheet, drawer, and staff form components from physical left/right and border styles to logical `start`/`end` and `border-s`/`border-e` positioning, and updated radix `Tabs` to derive its direction from the active UI language.
- Added a mobile-only dashboard app bar with a `SidebarTrigger` button to enable navigation drawer access on small viewports, along with logical alignment adjustments across addon groups, print test, support, and customer display views.
- Removed the `push` branch trigger from `nightly-release.yml` so cross-platform matrix builds run only on schedule or manual dispatch, and added E2E assertions for RTL sidebar positioning, staff toggles, and settings tab direction.

## Risk Assessment

✅ Low: The changes cleanly resolve RTL visual and layout defects using standard logical CSS properties and UI direction props without introducing regressions or breaking changes.

## Testing

Validated the RTL (Persian) visual layout and workflow trigger fixes across 4 backend test suites and the full 16-test Playwright E2E suite, capturing 28 visual evidence screenshots covering all 10 dashboard routes, 17 settings tabs, staff modal eye toggles, and mobile viewport with sidebar trigger.

- Evidence: POS screen (English LTR baseline) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/pos-ltr-en.png</code>)
- Evidence: POS screen (Persian RTL with sidebar on right and LTR phone input) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/pos-rtl-fa.png</code>)
- Evidence: Dashboard (Persian RTL with sidebar on inline-start and mirrored cards) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/dashboard-rtl-fa.png</code>)
- Evidence: Orders screen (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/orders-rtl-fa.png</code>)
- Evidence: Products screen (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/products-rtl-fa.png</code>)
- Evidence: Customers screen (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/customers-rtl-fa.png</code>)
- Evidence: Tables screen (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/tables-rtl-fa.png</code>)
- Evidence: Staff Add Modal (Persian RTL with PIN/password toggles at inline-end) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/staff-modal-rtl-fa.png</code>)
- Evidence: Addon Groups screen (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/addon-groups-rtl-fa.png</code>)
- Evidence: Print Test screen (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/print-test-rtl-fa.png</code>)
- Evidence: Support screen (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/support-rtl-fa.png</code>)
- Evidence: Customer Display screen (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/customer-display-rtl-fa.png</code>)
- Evidence: Mobile Dashboard Viewport with SidebarTrigger app bar (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/mobile-dashboard-appbar-rtl-fa.png</code>)
- Evidence: Mobile Sidebar Sheet open on inline-start right edge (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/mobile-sidebar-sheet-rtl-fa.png</code>)
- Evidence: Settings Store Tab (English LTR baseline) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/settings-store-ltr-en.png</code>)
- Evidence: Settings Store Tab (Persian RTL with Radix tabs &amp; toggles mirrored) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/settings-store-rtl-fa.png</code>)
- Evidence: Settings Account Tab (Persian RTL with LTR email island) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/settings-account-rtl-fa.png</code>)
- Evidence: Settings Taxes Tab (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/settings-taxes-rtl-fa.png</code>)
- Evidence: Settings Health Check Dialog (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/settings-health-check-dialog-rtl-fa.png</code>)
- Evidence: Auth Login (English LTR baseline) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/auth-login-ltr-en.png</code>)
- Evidence: Auth Login (Persian RTL with LTR email &amp; end-aligned toggle) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/auth-login-rtl-fa.png</code>)
- Evidence: Auth Recover Password (English LTR baseline) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/auth-recover-ltr-en.png</code>)
- Evidence: Auth Recover Password (Persian RTL with rtl-flip back arrow) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/auth-recover-rtl-fa.png</code>)
- Evidence: Setup Step 1 (English LTR baseline) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/setup-step1-ltr-en.png</code>)
- Evidence: Setup Step 1 (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/setup-step1-rtl-fa.png</code>)
- Evidence: Setup Step 1 Persian Option for fa browser locale (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/setup-step1-fa-locale-fa-option.png</code>)
- Evidence: Setup Step 2 Master PIN (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/setup-step2-master-pin-rtl-fa.png</code>)
- Evidence: Setup Step 3 Owner Account (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0987DXE6GC0K39YZBKW8ANW/setup-step3-owner-account-rtl-fa.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3254f9ddff1f57535f89cbe2c64126c008a0f0b4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:rtl-foundation`
- `npm run test:rtl-setup-auth-settings`
- `npm run test:rtl-dashboard-pos-common`
- `npm run test:rtl-kds-server-whatsapp`
- `cd frontend && npx playwright test --workers=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
