### PR TITLE
refactor(i18n): migrate POS components and web-print to use-intl

### DIFF
--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -27,7 +27,7 @@ import PosTopbar from '@/components/pos/PosTopbar';
 import { usePrinterStore } from '@/hooks/usePrinter';
 import { showPrintWarningsToast } from '@/lib/printer/warnings-toast';
 import { useBarcodeScanner } from '@/hooks/useBarcodeScanner';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useSupportTicketStatus } from '@/hooks/useSupportTicketStatus';
@@ -78,7 +78,8 @@ export default function POSPage() {
   const heldOrders = useHeldOrdersStore();
   const { customerMandatory, autoPrintKot, autoPrintBill, billingType, tablesRequired, kotPrintingEnabled, setBillingType, setTablesRequired, setKotPrintingEnabled } = usePosSettingsStore();
   const { open: leftSidebarOpen } = useSidebar();
-  const { t } = useI18n();
+  const t = useTranslations('pos');
+  const tSupport = useTranslations('support');
   const currencyFmt = useFormatCurrency();
   const { confirm, ConfirmDialog } = useConfirm();
 
@@ -268,10 +269,10 @@ export default function POSPage() {
       const code = `print.kot.${msg.toLowerCase().includes('spool') ? 'spooler_timeout' : 'failed'}`;
       setSupportError({
         code,
-        message: t('pos.kotPrintFailed'),
+        message: t('kotPrintFailed'),
         payload: { event_code: code, message: msg, category: 'printer', diagnostics: { order_id: order.id, stage: 'kot_print' } },
       });
-      toast.error(t('pos.kotPrintFailed'));
+      toast.error(t('kotPrintFailed'));
     }
   };
 
@@ -293,10 +294,10 @@ export default function POSPage() {
       const code = 'print.receipt.failed';
       setSupportError({
         code,
-        message: t('pos.receiptPrintFailed'),
+        message: t('receiptPrintFailed'),
         payload: { event_code: code, message: msg, category: 'printer', diagnostics: { bill_id: bill.id, stage: 'receipt_print' } },
       });
-      toast.error(t('pos.receiptPrintFailed'));
+      toast.error(t('receiptPrintFailed'));
     }
   };
 
@@ -338,10 +339,10 @@ export default function POSPage() {
       addItemsAttemptRef.current = null;
       // Do not clear cart or checkout state that may have been started while
       // recovery was in flight. A reload starts empty; any current UI is newer.
-      toast.success(t('pos.itemsAddedToOrder', { number: pendingAttempt!.orderNumber || pendingAttempt!.orderId }));
+      toast.success(t('itemsAddedToOrder', { number: pendingAttempt!.orderNumber || pendingAttempt!.orderId }));
       refreshTables();
     }).catch(() => {
-      toast.error(t('pos.addItemsFailed'));
+      toast.error(t('addItemsFailed'));
     });
   // The recovery runs once per authenticated renderer and intentionally uses
   // the persisted attempt rather than the transient cart state.
@@ -387,7 +388,7 @@ export default function POSPage() {
           await heldOrders.fetchHeldOrders();
         }
       } catch {
-        toast.error(t('pos.menuLoadFailed'));
+        toast.error(t('menuLoadFailed'));
       }
     };
     fetchData();
@@ -419,13 +420,13 @@ export default function POSPage() {
     if (product) {
       handleProductClick(product);
     } else {
-      toast.error(t('pos.barcodeNotFound', { code }));
+      toast.error(t('barcodeNotFound', { code }));
     }
   }, !anyModalOpen);
 
   const handlePlaceOrder = async () => {
     if (cart.items.length === 0) {
-      toast.error(t('pos.cartEmpty'));
+      toast.error(t('cartEmpty'));
       return;
     }
     if (customerMandatory && !cart.customerId) {
@@ -476,7 +477,7 @@ export default function POSPage() {
           { items: newItems, special_instructions: specialInstructions },
           { headers: { 'Idempotency-Key': itemAttempt.idempotencyKey } },
         );
-        toast.success(t('pos.itemsAddedToOrder', { number: pendingOrder.order_number }));
+        toast.success(t('itemsAddedToOrder', { number: pendingOrder.order_number }));
         orderForKot = data.order as Order;
         if (!clearAppendAttempt(storage, itemAttempt)) throw new Error('Unable to clear append retry state');
         addItemsAttemptRef.current = null;
@@ -502,12 +503,12 @@ export default function POSPage() {
         const orderAttempt: PostpaidAttempt = priorOrderAttempt?.userId === activeUserId && priorOrderAttempt.fingerprint === orderFingerprint
           ? priorOrderAttempt
           : { userId: activeUserId || '', fingerprint: orderFingerprint, idempotencyKey: newIdempotencyKey() };
-        if (!savePostpaidAttempt(orderAttempt)) throw new Error(t('pos.placeOrderFailed'));
+        if (!savePostpaidAttempt(orderAttempt)) throw new Error(t('placeOrderFailed'));
         const { data } = orderAttempt.order
           ? { data: { order: orderAttempt.order } }
           : await api.post('/orders', orderPayload, { headers: { 'Idempotency-Key': orderAttempt.idempotencyKey } });
         if (!orderAttempt.order) savePostpaidAttempt({ ...orderAttempt, order: data.order as Order });
-        toast.success(t('pos.orderPlaced', { number: data.order.order_number }));
+        toast.success(t('orderPlaced', { number: data.order.order_number }));
         orderForKot = data.order as Order;
         clearPostpaidAttempt();
       }
@@ -528,7 +529,7 @@ export default function POSPage() {
 
       await printKotIfEnabled(orderForKot);
     } catch {
-      toast.error(t('pos.placeOrderFailed'));
+      toast.error(t('placeOrderFailed'));
     } finally {
       setSubmitting(false);
     }
@@ -598,7 +599,7 @@ export default function POSPage() {
     // order response if this renderer loses the response or restarts.
     if (!savePrepaidAttempt(attempt)) {
       clearPrepaidAttempt();
-      toast.error(t('pos.processOrderFailed'));
+      toast.error(t('processOrderFailed'));
       setSubmitting(false);
       return;
     }
@@ -704,15 +705,15 @@ export default function POSPage() {
         : 0;
 
       if (paidBill.payment_status !== 'paid') {
-        toast.error(t('pos.paymentIncomplete', {
+        toast.error(t('paymentIncomplete', {
           amount: currencyFmt(Number(paidBill.balance) || 0),
         }));
         return;
       }
 
       const successMsg = pointsEarned > 0
-        ? t('pos.orderPaidWithPoints', { number: orderData.order.order_number, points: pointsEarned })
-        : t('pos.orderPaid', { number: orderData.order.order_number });
+        ? t('orderPaidWithPoints', { number: orderData.order.order_number, points: pointsEarned })
+        : t('orderPaid', { number: orderData.order.order_number });
       toast.success(successMsg);
       if (cart.tableId) {
         try {
@@ -732,7 +733,7 @@ export default function POSPage() {
 
       await printBillForTenant(paidBill, isPrepaidCheckout);
     } catch {
-      toast.error(t('pos.processOrderFailed'));
+      toast.error(t('processOrderFailed'));
     } finally {
       setSubmitting(false);
     }
@@ -750,7 +751,7 @@ export default function POSPage() {
   const handleSelectOccupiedTable = async (table: Table) => {
     const activeOrder = table.current_order || table.activeOrder || null;
     const activeCustomerId = activeOrder?.customer_id;
-    const activeCustomerName = activeOrder?.customer?.name || t('pos.anotherCustomer');
+    const activeCustomerName = activeOrder?.customer?.name || t('anotherCustomer');
 
     if (
       cart.customerId != null &&
@@ -758,10 +759,10 @@ export default function POSPage() {
       String(cart.customerId) !== String(activeCustomerId)
     ) {
       const shouldProceed = await confirm(
-        t('pos.customerMismatchWarning', { customer: activeCustomerName }),
+        t('customerMismatchWarning', { customer: activeCustomerName }),
         {
-          title: t('pos.customerMismatchTitle'),
-          confirmLabel: t('pos.proceedAnyway'),
+          title: t('customerMismatchTitle'),
+          confirmLabel: t('proceedAnyway'),
         },
       );
 
@@ -780,10 +781,10 @@ export default function POSPage() {
         cart.setOrderType('dine_in');
       } else {
         await heldOrders.fetchHeldOrders();
-        toast.error(t('pos.loadOrderFailed'));
+        toast.error(t('loadOrderFailed'));
       }
     } catch {
-      toast.error(t('pos.loadOrderFailed'));
+      toast.error(t('loadOrderFailed'));
     } finally {
       setShowTablePicker(false);
       await refreshTables();
@@ -792,7 +793,7 @@ export default function POSPage() {
 
   const handleHoldTable = async (tableId: string) => {
     if (cart.items.length === 0) {
-      toast.error(t('pos.cartEmpty'));
+      toast.error(t('cartEmpty'));
       return;
     }
     const tableName = tables.find((t) => t.id === tableId)?.name || tableId;
@@ -800,10 +801,10 @@ export default function POSPage() {
       await heldOrders.holdOrder(tableId, cart.items, cart.customerId, cart.guestCount, cart.orderNotes);
       cart.clearCart();
       setShowTablePicker(false);
-      toast.success(t('pos.orderHeld', { tableName }));
+      toast.success(t('orderHeld', { tableName }));
       await refreshTables();
     } catch {
-      toast.error(t('pos.holdOrderFailed'));
+      toast.error(t('holdOrderFailed'));
     }
   };
 
@@ -814,13 +815,13 @@ export default function POSPage() {
     cart.setGuestCount(order.guest_count || 1);
     cart.setOrderNotes(order.special_instructions || '');
     setPendingOrder(order);
-    toast(`${t('pos.addingItemsToOrder', { number: order.order_number })} ${t('pos.placeOrderReady')}`, { icon: 'ℹ️' });
+    toast(`${t('addingItemsToOrder', { number: order.order_number })} ${t('placeOrderReady')}`, { icon: 'ℹ️' });
   };
 
   // Add cart items directly to existing order
   const handleAddCartToOrder = async (table: Table, order: Order) => {
     if (cart.items.length === 0) {
-      toast.error(t('pos.cartEmpty'));
+      toast.error(t('cartEmpty'));
       return;
     }
     setSubmitting(true);
@@ -854,12 +855,12 @@ export default function POSPage() {
       // attempt through all network errors so a lost response can replay it.
       if (!clearAppendAttempt(storage, itemAttempt)) throw new Error('Unable to clear append retry state');
       addItemsAttemptRef.current = null;
-      toast.success(t('pos.itemsAddedToOrder', { number: order.order_number }));
+      toast.success(t('itemsAddedToOrder', { number: order.order_number }));
       cart.clearCart();
       setCheckoutTable(null);
       refreshTables();
     } catch {
-      toast.error(t('pos.addItemsFailed'));
+      toast.error(t('addItemsFailed'));
     } finally {
       setSubmitting(false);
     }
@@ -875,7 +876,7 @@ export default function POSPage() {
       try {
         await printBillForTenant(await fetchLatestBill(bill.id));
       } catch {
-        toast.error(t('pos.receiptPrintFailed'));
+        toast.error(t('receiptPrintFailed'));
       }
     }
   };
@@ -898,27 +899,27 @@ export default function POSPage() {
         <div className="fixed bottom-4 start-4 z-50 w-[min(28rem,calc(100vw-2rem))] rounded-xl border border-red-200 bg-white p-4 shadow-xl">
           {sentTicketId ? (
             <>
-              <p className="font-semibold text-red-800">{t('support.requestQueued')}</p>
+              <p className="font-semibold text-red-800">{tSupport('requestQueued')}</p>
               {delivery.status === 'delivered' && delivery.supportCode ? (
                 <>
-                  <p className="mt-1 text-sm font-semibold text-gray-800">{t('support.supportCode')}: <Ltr as="span" className="font-mono">{delivery.supportCode}</Ltr></p>
-                  <p className="mt-0.5 text-xs text-gray-500">{t('support.supportCodeHint')}</p>
+                  <p className="mt-1 text-sm font-semibold text-gray-800">{tSupport('supportCode')}: <Ltr as="span" className="font-mono">{delivery.supportCode}</Ltr></p>
+                  <p className="mt-0.5 text-xs text-gray-500">{tSupport('supportCodeHint')}</p>
                 </>
               ) : (
                 <p className="mt-1 text-xs text-gray-500">
-                  {delivery.status === 'failed' ? t('support.stillQueuedLocally') : t('support.confirmingDelivery')}
+                  {delivery.status === 'failed' ? tSupport('stillQueuedLocally') : tSupport('confirmingDelivery')}
                 </p>
               )}
               <div className="mt-3">
-                <button className="rounded border px-3 py-2 text-sm" onClick={() => { setSupportError(null); setSentTicketId(null); }}>{t('support.dismiss')}</button>
+                <button className="rounded border px-3 py-2 text-sm" onClick={() => { setSupportError(null); setSentTicketId(null); }}>{tSupport('dismiss')}</button>
               </div>
             </>
           ) : (
             <>
-              <p className="font-semibold text-red-800">{t('pos.printingFailed')}</p>
+              <p className="font-semibold text-red-800">{t('printingFailed')}</p>
               <p className="mt-1 text-sm text-gray-600">{supportError.message}</p>
               <details className="mt-2 text-xs text-gray-500">
-                <summary className="cursor-pointer">{t('support.showPayload')}</summary>
+                <summary className="cursor-pointer">{tSupport('showPayload')}</summary>
                 <Ltr as="pre" className="mt-2 max-h-32 overflow-auto rounded bg-gray-50 p-2">{JSON.stringify(
                   diagnosticsPreview
                     ? { ...supportError.payload, diagnostics: { ...(supportError.payload.diagnostics as Record<string, unknown> | undefined), ...diagnosticsPreview } }
@@ -938,14 +939,14 @@ export default function POSPage() {
                         correlation_id: crypto.randomUUID(),
                         client_ticket_id: clientTicketId,
                       });
-                      toast.success(t('support.queued'));
+                      toast.success(tSupport('queued'));
                       setSentTicketId(clientTicketId);
                     } catch {
-                      toast.error(t('pos.supportRequestQueueFailed'));
+                      toast.error(t('supportRequestQueueFailed'));
                     }
                   }}
-                >{t('support.getHelp')}</button>
-                <button className="rounded border px-3 py-2 text-sm" onClick={() => setSupportError(null)}>{t('support.dismiss')}</button>
+                >{tSupport('getHelp')}</button>
+                <button className="rounded border px-3 py-2 text-sm" onClick={() => setSupportError(null)}>{tSupport('dismiss')}</button>
               </div>
             </>
           )}
@@ -1057,12 +1058,12 @@ export default function POSPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-2xl p-5 w-full max-w-sm">
             <div className="flex justify-between items-center mb-4">
-              <h3 className="text-lg font-bold">{t('pos.selectCustomer')}</h3>
+              <h3 className="text-lg font-bold">{t('selectCustomer')}</h3>
               <button onClick={() => setShowCustomerPrompt(false)} className="text-gray-400 hover:text-gray-600">
                 <X size={20} />
               </button>
             </div>
-            <p className="text-sm text-gray-500 mb-4">{t('pos.customerRequiredBeforeOrder')}</p>
+            <p className="text-sm text-gray-500 mb-4">{t('customerRequiredBeforeOrder')}</p>
             <CustomerSearch onSelected={() => setShowCustomerPrompt(false)} />
           </div>
         </div>

--- a/frontend/src/components/pos/AddonModal.tsx
+++ b/frontend/src/components/pos/AddonModal.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { X, Plus, Minus } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { Button } from '@/components/ui/button';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import type { Product, Addon, AddonGroup } from '@/lib/types';
 
@@ -33,7 +33,7 @@ export default function AddonModal({
   product, onAdd, onClose,
   initialQuantity = 1, initialAddons = [], initialInstructions = '', mode = 'add',
 }: Props) {
-  const { t } = useI18n();
+  const t = useTranslations('pos');
   const fmt = useFormatCurrency();
   const [selected, setSelected] = useState<Record<string | number, Addon[]>>(() => groupInitialAddons(initialAddons));
   const [quantity, setQuantity] = useState(initialQuantity);
@@ -61,7 +61,7 @@ export default function AddonModal({
       const newGroupTotal = currentGroupTotal + delta;
       const max = group.max_selection || 999;
       if (delta > 0 && newGroupTotal > max) {
-        toast.error(t('pos.maxSelectionReached', { count: max }));
+        toast.error(t('maxSelectionReached', { count: max }));
         return;
       }
 
@@ -134,7 +134,7 @@ export default function AddonModal({
                   <h3 className="font-semibold text-sm text-gray-900">{group.name}</h3>
                   <span className="flex items-center gap-2">
                     {Boolean(group.is_required) && (
-                      <span className="text-xs text-red-500 font-medium">{t('pos.required')}</span>
+                      <span className="text-xs text-red-500 font-medium">{t('required')}</span>
                     )}
                     {group.max_selection ? (() => {
                       const remaining = Math.max(0, group.max_selection - count);
@@ -145,7 +145,7 @@ export default function AddonModal({
                             ? 'text-sm text-amber-500'
                             : 'text-xs text-sky-500'
                         }`}>
-                          {isZero ? t('pos.selectionComplete') : t('pos.remainingCount', { count: remaining })}
+                          {isZero ? t('selectionComplete') : t('remainingCount', { count: remaining })}
                         </span>
                       );
                     })() : null}
@@ -170,7 +170,7 @@ export default function AddonModal({
                           <div className="flex items-center gap-2">
                             <span className="font-medium">{addon.name}</span>
                             <span className={`text-xs ${isSel ? 'text-brand font-semibold' : 'text-gray-500'}`}>
-                              {Number(addon.price) === 0 ? t('pos.freeAddon') : `+${fmt(Number(addon.price))}`}
+                              {Number(addon.price) === 0 ? t('freeAddon') : `+${fmt(Number(addon.price))}`}
                             </span>
                           </div>
                           <div className="flex items-center gap-2">
@@ -218,7 +218,7 @@ export default function AddonModal({
                         <div className="flex items-center gap-2">
                           <span className="font-medium">{addon.name}</span>
                           <span className={`text-xs ${isSel ? 'text-brand font-semibold' : 'text-gray-500'}`}>
-                            {Number(addon.price) === 0 ? t('pos.freeAddon') : `+${fmt(Number(addon.price))}`}
+                            {Number(addon.price) === 0 ? t('freeAddon') : `+${fmt(Number(addon.price))}`}
                           </span>
                         </div>
                         <div className="flex items-center gap-2">
@@ -258,7 +258,7 @@ export default function AddonModal({
                   const requiredMin = Boolean(group.is_required) ? Math.max(1, group.min_selection || 1) : (group.min_selection || 0);
                   if (requiredMin > 0 && count < requiredMin) {
                     return (
-                      <p className="text-xs text-red-500 mt-1">{t('pos.selectAtLeast', { count: requiredMin })}</p>
+                      <p className="text-xs text-red-500 mt-1">{t('selectAtLeast', { count: requiredMin })}</p>
                     );
                   }
                   return null;
@@ -268,12 +268,12 @@ export default function AddonModal({
           })}
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">{t('pos.specialInstructions')}</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t('specialInstructions')}</label>
             <input
               type="text"
               value={instructions}
               onChange={(e) => setInstructions(e.target.value.slice(0, 100))}
-              placeholder={t('pos.specialInstructionsPlaceholder')}
+              placeholder={t('specialInstructionsPlaceholder')}
               maxLength={100}
               className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand"
             />
@@ -299,8 +299,8 @@ export default function AddonModal({
           </div>
           <Button onClick={handleAdd} disabled={!isValid} className="w-full" size="lg">
             {mode === 'edit'
-              ? t('pos.saveItemChanges', { total: fmt(itemTotal), defaultValue: 'Save changes — {total}' })
-              : t('pos.addToCart', { total: fmt(itemTotal) })}
+              ? t('saveItemChanges', { total: fmt(itemTotal), defaultValue: 'Save changes — {total}' })
+              : t('addToCart', { total: fmt(itemTotal) })}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/pos/CartPanel.tsx
+++ b/frontend/src/components/pos/CartPanel.tsx
@@ -10,7 +10,7 @@ import { useCartStore } from '@/store/cart';
 import { useHeldOrdersStore } from '@/store/held-orders';
 import { useAuthStore } from '@/store/auth';
 import { usePosSettingsStore } from '@/store/pos-settings';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import toast from 'react-hot-toast';
 import type { Table, Order, OrderItem, CartItem } from '@/lib/types';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
@@ -37,27 +37,28 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
   const heldOrders = useHeldOrdersStore();
   const { currentTenant } = useAuthStore();
   const billingType = usePosSettingsStore((s) => s.billingType);
-  const { t } = useI18n();
+  const t = useTranslations('pos');
+  const tCommon = useTranslations('common');
   const isRestaurant = (currentTenant?.business_type ?? 'restaurant') === 'restaurant';
   const fmt = useFormatCurrency();
   const canHold = isRestaurant && cart.orderType === 'dine_in' && cart.tableId && cart.items.length > 0 && billingType === 'postpaid';
 
   const handleHold = async () => {
     if (!cart.tableId) {
-      toast.error(t('pos.selectTableFirst'));
+      toast.error(t('selectTableFirst'));
       return;
     }
     if (cart.items.length === 0) {
-      toast.error(t('pos.cartEmpty'));
+      toast.error(t('cartEmpty'));
       return;
     }
     const tableName = tables.find((t) => t.id === cart.tableId)?.name || cart.tableId;
     try {
       await heldOrders.holdOrder(cart.tableId, cart.items, cart.customerId, cart.guestCount, cart.orderNotes);
       cart.clearCart();
-      toast.success(t('pos.orderHeldFor', { table: tableName }));
+      toast.success(t('orderHeldFor', { table: tableName }));
     } catch {
-      toast.error(t('pos.holdOrderFailed'));
+      toast.error(t('holdOrderFailed'));
     }
   };
 
@@ -76,7 +77,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
             .filter((type) => isRestaurant || type !== 'dine_in')
             .map((type) => {
               const Icon = orderTypeIcons[type];
-              const label = type === 'dine_in' ? t('pos.orderTypeDineIn') : type === 'takeaway' ? t('pos.orderTypeTakeaway') : t('pos.orderTypeDelivery');
+              const label = type === 'dine_in' ? t('orderTypeDineIn') : type === 'takeaway' ? t('orderTypeTakeaway') : t('orderTypeDelivery');
               return (
                 <button
                   key={type}
@@ -96,11 +97,11 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
 
         {cart.orderType === 'dine_in' && (
           <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-3 py-2">
-            <div className="flex items-center gap-2 text-sm text-gray-600"><Users size={15} /><span>{t('pos.pax', { defaultValue: 'Pax' })}</span></div>
+            <div className="flex items-center gap-2 text-sm text-gray-600"><Users size={15} /><span>{t('pax', { defaultValue: 'Pax' })}</span></div>
             <div className="flex items-center gap-2">
-              <button type="button" aria-label={t('pos.decreasePax', { defaultValue: 'Decrease pax' })} onClick={() => cart.setGuestCount(Math.max(1, cart.guestCount - 1))} className="size-7 rounded-full bg-gray-100 flex items-center justify-center"><Minus size={13} /></button>
-              <input aria-label={t('pos.pax', { defaultValue: 'Pax' })} type="number" min="1" max="99" value={cart.guestCount} onChange={(e) => cart.setGuestCount(Math.min(99, Math.max(1, Number(e.target.value) || 1)))} className="w-10 text-center text-sm font-semibold border-0 outline-none" />
-              <button type="button" aria-label={t('pos.increasePax', { defaultValue: 'Increase pax' })} onClick={() => cart.setGuestCount(Math.min(99, cart.guestCount + 1))} className="size-7 rounded-full bg-gray-100 flex items-center justify-center"><Plus size={13} /></button>
+              <button type="button" aria-label={t('decreasePax', { defaultValue: 'Decrease pax' })} onClick={() => cart.setGuestCount(Math.max(1, cart.guestCount - 1))} className="size-7 rounded-full bg-gray-100 flex items-center justify-center"><Minus size={13} /></button>
+              <input aria-label={t('pax', { defaultValue: 'Pax' })} type="number" min="1" max="99" value={cart.guestCount} onChange={(e) => cart.setGuestCount(Math.min(99, Math.max(1, Number(e.target.value) || 1)))} className="w-10 text-center text-sm font-semibold border-0 outline-none" />
+              <button type="button" aria-label={t('increasePax', { defaultValue: 'Increase pax' })} onClick={() => cart.setGuestCount(Math.min(99, cart.guestCount + 1))} className="size-7 rounded-full bg-gray-100 flex items-center justify-center"><Plus size={13} /></button>
             </div>
           </div>
         )}
@@ -113,7 +114,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
               type="text"
               value={cart.deliveryAddress}
               onChange={(e) => cart.setDeliveryAddress(e.target.value)}
-              placeholder={t('pos.deliveryAddress')}
+              placeholder={t('deliveryAddress')}
               className="flex-1 px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand focus:border-brand outline-none"
             />
           </div>
@@ -125,7 +126,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
         {/* Previously ordered items (add-items mode) */}
         {existingOrder && existingOrder.items && existingOrder.items.filter((i: OrderItem) => i.status !== 'cancelled').length > 0 && (
           <div className="mb-3 pb-3 border-b border-dashed border-gray-200">
-            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">{t('pos.alreadyOrdered')}</p>
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">{t('alreadyOrdered')}</p>
             <div className="space-y-1.5">
               {existingOrder.items.filter((i: OrderItem) => i.status !== 'cancelled').map((item: OrderItem) => (
                 <div key={item.id} className="flex justify-between items-center">
@@ -140,7 +141,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
         {cart.items.length === 0 ? (
           <div className={`flex flex-col items-center justify-center text-gray-400 ${existingOrder ? 'py-4' : isDrawer ? 'py-8' : 'h-full'}`}>
             <ShoppingCart size={existingOrder ? 24 : 40} />
-            <p className="mt-2 text-sm">{existingOrder ? t('pos.addNewItemsAbove') : t('pos.cartEmpty')}</p>
+            <p className="mt-2 text-sm">{existingOrder ? t('addNewItemsAbove') : t('cartEmpty')}</p>
           </div>
         ) : (
           <div className="space-y-3">
@@ -163,7 +164,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
                         className="shrink-0 flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 hover:bg-amber-200 text-xs font-medium transition-colors"
                       >
                         <SquarePen size={12} />
-                        {t('common.edit')}
+                        {tCommon('edit')}
                       </button>
                     )}
                   </div>
@@ -212,7 +213,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
             <textarea
               value={cart.orderNotes}
               onChange={(e) => cart.setOrderNotes(e.target.value.slice(0, 200))}
-              placeholder={t('pos.orderNotesPlaceholder')}
+              placeholder={t('orderNotesPlaceholder')}
               rows={2}
               maxLength={200}
               className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-brand/30 focus:border-brand"
@@ -221,11 +222,11 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
           </div>
         )}
         <div className="flex justify-between mb-1 text-sm">
-          <span className="text-gray-500">{t('pos.items')}</span>
+          <span className="text-gray-500">{t('items')}</span>
           <span className="font-medium">{cart.itemCount()}</span>
         </div>
         <div className="flex justify-between mb-4 text-lg">
-          <span className="font-semibold text-gray-900">{t('pos.subtotal')}</span>
+          <span className="font-semibold text-gray-900">{t('subtotal')}</span>
           <span className="font-bold text-brand">
             {fmt(cart.subtotal())}
           </span>
@@ -233,7 +234,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
         <div className="flex gap-2">
           {canHold && (
             <Button variant="outline" onClick={handleHold} className="flex-1">
-              <Pause size={14} className="me-1" /> {t('pos.holdButton')}
+              <Pause size={14} className="me-1" /> {t('holdButton')}
             </Button>
           )}
           <Button
@@ -242,7 +243,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
             className="flex-1"
             size="lg"
           >
-            {submitting ? t('pos.placing') : t('pos.placeOrderButton')}
+            {submitting ? t('placing') : t('placeOrderButton')}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/pos/CustomerSearch.tsx
+++ b/frontend/src/components/pos/CustomerSearch.tsx
@@ -13,7 +13,7 @@ import type { Customer } from '@/lib/types';
 import EditCustomerModal from './EditCustomerModal';
 import { Ltr } from '@/components/layout/Ltr';
 
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 
 interface Props {
   onSelected?: () => void;
@@ -40,14 +40,15 @@ function phoneMatchesInput(customerPhoneDigits: string | null | undefined, input
   return customerPhoneDigits.includes(inputDigits);
 }
 
-function TagBadges({ counts, t }: { counts: Record<string, number>; t: (k: string, p?: Record<string, string | number>) => string }) {
+function TagBadges({ counts }: { counts: Record<string, number> }) {
+  const t = useTranslations('pos');
   const entries = Object.entries(counts).filter(([, n]) => n > 0);
   if (entries.length === 0) return null;
   return (
     <div className="flex flex-wrap gap-1">
       {entries.map(([tag, count]) => (
         <span key={tag} className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${tagColor(tag)}`}>
-          {t('pos.tagCount', { tag, count })}
+          {t('tagCount', { tag, count })}
         </span>
       ))}
     </div>
@@ -58,7 +59,8 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
   const cart = useCartStore();
   const { currentTenant } = useAuthStore();
   const enforcePhoneLength = usePosSettingsStore((s) => s.enforcePhoneLength);
-  const { t } = useI18n();
+  const t = useTranslations('pos');
+  const tCommon = useTranslations('common');
   const country = currentTenant?.country ?? 'IN';
   const dialCode = dialCodeFor(country);
   const [phone, setPhone] = useState('');
@@ -172,7 +174,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
     if (!name.trim() || !phone.trim()) return;
     const parsed = parsePhone(phone, country);
     if (!parsed) {
-      toast.error(t('pos.invalidPhone', { country: countryName(country) }));
+      toast.error(t('invalidPhone', { country: countryName(country) }));
       return;
     }
     setCreating(true);
@@ -180,10 +182,10 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
       const { data } = await api.post('/customers', { name: name.trim(), phone: parsed.e164, country_code: parsed.countryCode });
       cart.setCustomer(data.customer);
       setPhone(''); setName(''); setMatched(null); setSearched(false);
-      toast.success(t('pos.customerCreated'));
+      toast.success(t('customerCreated'));
       onSelected?.();
     } catch {
-      toast.error(t('pos.createCustomerFailed'));
+      toast.error(t('createCustomerFailed'));
     } finally {
       setCreating(false);
     }
@@ -213,7 +215,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
           <div className="h-10 flex items-center gap-2 px-3 bg-brand-light rounded-lg min-w-0 w-full">
             <button
               onClick={() => setEditingCustomer(true)}
-              title={t('pos.editCustomer', { defaultValue: 'Edit name / phone' })}
+              title={t('editCustomer', { defaultValue: 'Edit name / phone' })}
               className="flex-1 min-w-0 flex items-center gap-x-2 flex-wrap text-start group"
             >
               <span className="font-semibold text-brand text-sm truncate group-hover:underline">{customer.name}</span>
@@ -222,10 +224,10 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
               {!!loyaltyPoints && loyaltyPoints > 0 && (
                 <span className="flex items-center gap-0.5 text-xs font-medium text-brand bg-white/70 rounded-full px-1.5 py-0.5 shrink-0">
                   <Gift size={11} />
-                  {t('pos.loyaltyPointsShort', { count: loyaltyPoints, defaultValue: '{count} pts' })}
+                  {t('loyaltyPointsShort', { count: loyaltyPoints, defaultValue: '{count} pts' })}
                 </span>
               )}
-              {hasTags && <TagBadges counts={customer.tag_counts!} t={t} />}
+              {hasTags && <TagBadges counts={customer.tag_counts!} />}
             </button>
             <button onClick={handleClear} className="text-brand hover:text-brand-hover shrink-0 ms-auto">
               <X size={14} />
@@ -257,10 +259,10 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
         {!!loyaltyPoints && loyaltyPoints > 0 && (
           <span className="inline-flex items-center gap-0.5 text-xs font-medium text-brand bg-brand-light rounded-full px-1.5 py-0.5">
             <Gift size={11} />
-            {t('pos.loyaltyPointsShort', { count: loyaltyPoints, defaultValue: '{count} pts' })}
+            {t('loyaltyPointsShort', { count: loyaltyPoints, defaultValue: '{count} pts' })}
           </span>
         )}
-        {hasTags && <TagBadges counts={customer.tag_counts!} t={t} />}
+        {hasTags && <TagBadges counts={customer.tag_counts!} />}
         {editingCustomer && (
           <EditCustomerModal
             customer={customer}
@@ -284,7 +286,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
             value={phone}
             onChange={handlePhoneChange}
             onKeyDown={handlePhoneKeyDown}
-            placeholder={dialCode ? `${dialCode} ${t('pos.phone')}` : t('pos.phone')}
+            placeholder={dialCode ? `${dialCode} ${t('phone')}` : t('phone')}
             className="h-10 w-48 shrink-0 px-3 text-sm border border-amber-400 bg-amber-50 placeholder:text-amber-600/70 rounded-lg focus:ring-2 focus:ring-amber-200 focus:border-amber-500 outline-none"
             dir="ltr"
           />
@@ -299,7 +301,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
               else handleCreate();
             }}
             readOnly={!!matched}
-            placeholder={searched ? (matched ? '' : t('pos.enterName')) : t('pos.nameAutoFills')}
+            placeholder={searched ? (matched ? '' : t('enterName')) : t('nameAutoFills')}
             className={`h-10 w-48 shrink-0 px-3 text-sm border rounded-lg focus:ring-2 outline-none transition-colors duration-150 ${
               matched
                 ? 'border-gray-200 bg-gray-50 cursor-pointer focus:ring-brand/20 focus:border-brand'
@@ -312,7 +314,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
               onClick={handleSelectMatched}
               className="h-10 shrink-0 px-3 bg-brand text-white text-xs rounded-lg hover:bg-brand-hover whitespace-nowrap"
             >
-              {t('pos.select')}
+              {t('select')}
             </button>
           )}
           {isNew && name.trim() && (
@@ -321,7 +323,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
               disabled={creating}
               className="h-10 shrink-0 px-3 bg-brand text-white text-xs rounded-lg hover:bg-brand-hover disabled:opacity-50 whitespace-nowrap"
             >
-              {creating ? t('pos.loadingEllipsis') : t('common.add')}
+              {creating ? t('loadingEllipsis') : tCommon('add')}
             </button>
           )}
         </div>
@@ -329,9 +331,9 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
         {searched && (
           <div className="absolute start-0 top-full mt-1 z-20 rounded-md border border-gray-100 bg-white px-2 py-1 shadow-sm">
             {matched ? (
-              <span className="text-xs text-green-600 font-medium">{t('pos.customerFound')}</span>
+              <span className="text-xs text-green-600 font-medium">{t('customerFound')}</span>
             ) : (
-              <span className="text-xs text-red-500 font-medium">{t('pos.newCustomerEnterName')}</span>
+              <span className="text-xs text-red-500 font-medium">{t('newCustomerEnterName')}</span>
             )}
           </div>
         )}
@@ -351,7 +353,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
             value={phone}
             onChange={handlePhoneChange}
             onKeyDown={handlePhoneKeyDown}
-            placeholder={dialCode ? `${dialCode} ${t('pos.phone')}` : t('pos.phone')}
+            placeholder={dialCode ? `${dialCode} ${t('phone')}` : t('phone')}
             className={`${baseInput} flex-1 py-2`}
             dir="ltr"
           />
@@ -367,7 +369,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
             else handleCreate();
           }}
           readOnly={!!matched}
-          placeholder={searched ? (matched ? '' : t('pos.enterName')) : t('pos.nameAutoFills')}
+          placeholder={searched ? (matched ? '' : t('enterName')) : t('nameAutoFills')}
           className={`${baseInput} w-full py-2 ${matched ? 'bg-gray-50 cursor-pointer' : ''}`}
           onClick={matched ? handleSelectMatched : undefined}
         />
@@ -377,25 +379,25 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
         <div className="space-y-1.5">
           {matched ? (
             <>
-              <p className="text-xs text-green-600 font-medium">{t('pos.customerFoundClick')}</p>
-              {matched.tag_counts && <TagBadges counts={matched.tag_counts} t={t} />}
+              <p className="text-xs text-green-600 font-medium">{t('customerFoundClick')}</p>
+              {matched.tag_counts && <TagBadges counts={matched.tag_counts} />}
               <button
                 onClick={handleSelectMatched}
                 className="w-full py-1.5 bg-brand text-white text-sm rounded-lg hover:bg-brand-hover"
               >
-                {t('pos.selectName', { name: matched.name })}
+                {t('selectName', { name: matched.name })}
               </button>
             </>
           ) : (
             <>
-              <p className="text-xs text-red-500 font-medium">{t('pos.newCustomerEnterName')}</p>
+              <p className="text-xs text-red-500 font-medium">{t('newCustomerEnterName')}</p>
               {name.trim() && (
                 <button
                   onClick={handleCreate}
                   disabled={creating}
                   className="w-full py-1.5 bg-brand text-white text-sm rounded-lg hover:bg-brand-hover disabled:opacity-50"
                 >
-                  {creating ? t('pos.creating') : t('pos.addName', { name: name.trim() })}
+                  {creating ? t('creating') : t('addName', { name: name.trim() })}
                 </button>
               )}
             </>

--- a/frontend/src/components/pos/DietaryBadge.tsx
+++ b/frontend/src/components/pos/DietaryBadge.tsx
@@ -1,4 +1,4 @@
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 
 // Normalise a raw tag string to its canonical key used in TAG_CONFIG.
 // Handles case, spaces, hyphens, underscores and common spelling variants so
@@ -41,15 +41,52 @@ const TAG_CONFIG: Record<string, { color: string; bg: string; dot: string }> = {
   limited:        { color: 'text-rose-700',   bg: 'bg-rose-100',    dot: 'bg-rose-500' },
 };
 
+// Exhaustively typed leaf-key map for known tags (use-intl resolves leaf keys
+// within the `pos` namespace scope, so no template-literal dynamic keys).
+type PosKey = keyof AppConfig['Messages']['pos'];
+
+type KnownDietaryTag =
+  | 'veg'
+  | 'vegan'
+  | 'egg'
+  | 'non_veg'
+  | 'spicy'
+  | 'contains_nuts'
+  | 'gluten_free'
+  | 'dairy_free'
+  | 'new_arrival'
+  | 'bestseller'
+  | 'organic'
+  | 'fragrance_free'
+  | 'limited';
+
+const DIETARY_TAG_KEYS = {
+  veg: 'tagVeg',
+  vegan: 'tagVegan',
+  egg: 'tagEgg',
+  non_veg: 'tagNonVeg',
+  spicy: 'tagSpicy',
+  contains_nuts: 'tagContainsNuts',
+  gluten_free: 'tagGlutenFree',
+  dairy_free: 'tagDairyFree',
+  new_arrival: 'tagNewArrival',
+  bestseller: 'tagBestseller',
+  organic: 'tagOrganic',
+  fragrance_free: 'tagFragranceFree',
+  limited: 'tagLimited',
+} as const satisfies Record<KnownDietaryTag, PosKey>;
+
+/** Title-cases a normalized tag for display when it has no translation key. */
+function formatTagName(canonical: string): string {
+  return canonical.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// Legacy dotted-key helper retained for the unmigrated products page (#380)
+// which still calls `t(tagLabel(tag))` through the compatibility bridge.
 export function tagLabel(tag: string): string {
   const canonical = normalizeTag(tag);
-  const map: Record<string, string> = {
-    veg: 'pos.tagVeg', vegan: 'pos.tagVegan', egg: 'pos.tagEgg', non_veg: 'pos.tagNonVeg',
-    spicy: 'pos.tagSpicy', contains_nuts: 'pos.tagContainsNuts', gluten_free: 'pos.tagGlutenFree',
-    dairy_free: 'pos.tagDairyFree', new_arrival: 'pos.tagNewArrival', bestseller: 'pos.tagBestseller',
-    organic: 'pos.tagOrganic', fragrance_free: 'pos.tagFragranceFree', limited: 'pos.tagLimited',
-  };
-  return map[canonical] ?? canonical.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  const key = (DIETARY_TAG_KEYS as Record<string, PosKey | undefined>)[canonical];
+  return key ? `pos.${key}` : formatTagName(canonical);
 }
 
 // First tag's bg colour for card background tinting
@@ -59,12 +96,16 @@ export function firstTagBg(tags: string[] | null | undefined): string {
 }
 
 export default function TagBadge({ tag }: { tag: string }) {
-  const { t } = useI18n();
-  const cfg = TAG_CONFIG[normalizeTag(tag)] ?? { color: 'text-gray-600', bg: 'bg-gray-100', dot: 'bg-gray-400' };
+  const t = useTranslations('pos');
+  const canonical = normalizeTag(tag);
+  const cfg = TAG_CONFIG[canonical] ?? { color: 'text-gray-600', bg: 'bg-gray-100', dot: 'bg-gray-400' };
+  // Known tags translate through the typed map; custom tags render their
+  // formatted name directly without an unchecked runtime translation key.
+  const key = (DIETARY_TAG_KEYS as Record<string, PosKey | undefined>)[canonical];
   return (
     <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase ${cfg.color} ${cfg.bg}`}>
       <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${cfg.dot}`} />
-      {t(tagLabel(tag))}
+      {key ? t(key) : formatTagName(canonical)}
     </span>
   );
 }

--- a/frontend/src/components/pos/EditCustomerModal.tsx
+++ b/frontend/src/components/pos/EditCustomerModal.tsx
@@ -6,7 +6,7 @@ import toast from 'react-hot-toast';
 import api from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { useAuthStore } from '@/store/auth';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { dialCodeFor, normalizeOptionalPhone } from '@/lib/phone';
 import type { Customer } from '@/lib/types';
 
@@ -18,7 +18,8 @@ interface Props {
 
 export default function EditCustomerModal({ customer, onClose, onSaved }: Props) {
   const { currentTenant } = useAuthStore();
-  const { t } = useI18n();
+  const t = useTranslations('pos');
+  const tCommon = useTranslations('common');
   const country = currentTenant?.country ?? 'IN';
   const dialCode = dialCodeFor(country);
   const [name, setName] = useState(customer.name);
@@ -27,13 +28,13 @@ export default function EditCustomerModal({ customer, onClose, onSaved }: Props)
 
   const handleSave = async () => {
     if (!name.trim()) {
-      toast.error(t('pos.nameRequired', { defaultValue: 'Name is required' }));
+      toast.error(t('nameRequired', { defaultValue: 'Name is required' }));
       return;
     }
 
     const norm = normalizeOptionalPhone(phone.trim(), country);
     if (!norm.valid) {
-      toast.error(t('pos.invalidPhone', { country, defaultValue: 'Invalid phone number' }));
+      toast.error(t('invalidPhone', { country, defaultValue: 'Invalid phone number' }));
       return;
     }
 
@@ -45,10 +46,10 @@ export default function EditCustomerModal({ customer, onClose, onSaved }: Props)
         country_code: norm.countryCode ?? '',
       });
       onSaved(data.customer);
-      toast.success(t('pos.customerUpdated', { defaultValue: 'Customer updated' }));
+      toast.success(t('customerUpdated', { defaultValue: 'Customer updated' }));
       onClose();
     } catch {
-      toast.error(t('pos.customerUpdateFailed', { defaultValue: 'Failed to update customer' }));
+      toast.error(t('customerUpdateFailed', { defaultValue: 'Failed to update customer' }));
     } finally {
       setSaving(false);
     }
@@ -58,14 +59,14 @@ export default function EditCustomerModal({ customer, onClose, onSaved }: Props)
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-2xl w-full max-w-sm p-5">
         <div className="flex justify-between items-center mb-4">
-          <h3 className="text-lg font-bold text-gray-900">{t('pos.editCustomer', { defaultValue: 'Edit Customer' })}</h3>
+          <h3 className="text-lg font-bold text-gray-900">{t('editCustomer', { defaultValue: 'Edit Customer' })}</h3>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
             <X size={20} />
           </button>
         </div>
         <div className="space-y-3">
           <div>
-            <label className="block text-xs font-medium text-gray-500 mb-1">{t('pos.customerName', { defaultValue: 'Name' })}</label>
+            <label className="block text-xs font-medium text-gray-500 mb-1">{t('customerName', { defaultValue: 'Name' })}</label>
             <input
               type="text"
               value={name}
@@ -75,7 +76,7 @@ export default function EditCustomerModal({ customer, onClose, onSaved }: Props)
             />
           </div>
           <div>
-            <label className="block text-xs font-medium text-gray-500 mb-1">{t('pos.phone')}</label>
+            <label className="block text-xs font-medium text-gray-500 mb-1">{t('phone')}</label>
             <input
               type="tel"
               inputMode="tel"
@@ -88,9 +89,9 @@ export default function EditCustomerModal({ customer, onClose, onSaved }: Props)
           </div>
         </div>
         <div className="flex gap-2 mt-5">
-          <Button variant="outline" onClick={onClose} className="flex-1">{t('common.cancel')}</Button>
+          <Button variant="outline" onClick={onClose} className="flex-1">{tCommon('cancel')}</Button>
           <Button onClick={handleSave} disabled={saving} className="flex-1">
-            {saving ? t('pos.loadingEllipsis') : t('common.save')}
+            {saving ? t('loadingEllipsis') : tCommon('save')}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/pos/PaymentModal.tsx
+++ b/frontend/src/components/pos/PaymentModal.tsx
@@ -10,7 +10,7 @@ import TaxBreakdown from '@/components/pos/TaxBreakdown';
 import { resolveTaxComponents } from '@/lib/printer/tax-components';
 import { useCartStore } from '@/store/cart';
 import { useConfirm } from '@/hooks/use-confirm';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import { PAYMENT_METHODS, type CustomPaymentMethod } from '@/lib/payment-methods';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useFormatNumber } from '@/hooks/useFormatNumber';
@@ -44,13 +44,39 @@ interface Payment {
 // Must match LOYALTY_REDEMPTION_RATE in main/routes/bills.ts.
 const LOYALTY_REDEMPTION_RATE = 100;
 
+type PosKey = keyof AppConfig['Messages']['pos'];
+
+// Built-in payment method label keys (PAYMENT_METHODS keeps dotted keys for the
+// unmigrated dashboard page, so this maps them to the typed `pos` leaf keys).
+const BUILT_IN_PAYMENT_KEYS = {
+  cash: 'methodCash',
+  card: 'methodCard',
+} as const satisfies Record<'cash' | 'card', PosKey>;
+
 export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Props) {
   const remaining = Number(bill.balance);
   const cartCustomerId = useCartStore((s) => s.customerId);
   const cartCustomer = useCartStore((s) => s.customer);
   const effectiveCustomerId = bill.customer_id || cartCustomerId || null;
   const { confirm, ConfirmDialog } = useConfirm();
-  const { t } = useI18n();
+  const t = useTranslations('pos');
+  const tCommon = useTranslations('common');
+  const tOrders = useTranslations('orders');
+  const tWhatsappSend = useTranslations('whatsapp.send');
+
+  // sendBillViaFlo (shared with the not-yet-migrated orders page) still takes a
+  // legacy dotted-key translator; bridge the typed `whatsapp.send` namespace to
+  // that contract without reintroducing the legacy global `t()`.
+  const whatsappSendT = (key: string): string =>
+    tWhatsappSend(
+      key.replace(/^whatsapp\.send\./, '') as
+        | 'success'
+        | 'failed'
+        | 'error.notConnected'
+        | 'error.notOnWhatsapp'
+        | 'error.blocked'
+        | 'error.rateLimited',
+    );
   const { currentTenant } = useAuthStore();
   const isWhatsAppReady = useWhatsAppReady();
   const unitAdapter = useCurrencyUnitAdapter();
@@ -190,16 +216,16 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
     if (applyingDiscount) return;
     const val = customVal !== undefined ? customVal : parseFloat(discountValue);
     if (customVal === undefined && (isNaN(val) || val < 0)) {
-      toast.error(t('pos.discountInvalid'));
+      toast.error(t('discountInvalid'));
       return;
     }
     // Check if PIN is required
     if (discountRequiresApproval && val > 0 && !discountPin) {
-      toast.error(t('pos.managerPinRequired'));
+      toast.error(t('managerPinRequired'));
       return;
     }
     if (val > 0 && !isDiscountTypeAllowed(discountMode, discountType)) {
-      toast.error(t('pos.discountInvalid'));
+      toast.error(t('discountInvalid'));
       return;
     }
     setApplyingDiscount(true);
@@ -211,7 +237,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
         discount_reason: val > 0 ? discountReason || undefined : undefined,
         override_pin: discountRequiresApproval && val > 0 ? discountPin : undefined,
       });
-      toast.success(val === 0 ? t('pos.discountRemoved') : t('pos.discountUpdated'));
+      toast.success(val === 0 ? t('discountRemoved') : t('discountUpdated'));
       setDiscountPin('');
       if (val === 0) {
         setShowDiscount(false);
@@ -224,7 +250,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
         onBillUpdate(data.bill);
       }
     } catch {
-      toast.error(t('pos.failedToUpdateDiscount'));
+      toast.error(t('failedToUpdateDiscount'));
       // Clear the PIN on any failure (wrong PIN or rate-limited) so a stale/rejected
       // PIN doesn't sit in the field looking like it might still work on retry.
       setDiscountPin('');
@@ -239,22 +265,22 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
       !PAYMENT_METHODS.some((allowed) => allowed.key === p.method)
       && !customMethods.some((method) => method.id === p.payment_method_id)
     ) || !amountIsValid(p.amount))) {
-      toast.error(t('pos.paymentFailed'));
+      toast.error(t('paymentFailed'));
       return;
     }
     if (walletAmount.trim() && !/^\d+(?:\.\d{1,4})?$/.test(walletAmount.trim())) {
-      toast.error(t('pos.paymentFailed'));
+      toast.error(t('paymentFailed'));
       return;
     }
     const nonCashTotal = payments
       .filter((p) => p.method !== 'cash')
       .reduce((sum, p) => sum + toStoredUnit(Number(p.amount) || 0), 0) + walletAmt;
     if (nonCashTotal > remaining + 0.000001) {
-      toast.error(t('pos.paymentAboveBalance'));
+      toast.error(t('paymentAboveBalance'));
       return;
     }
     if (totalPayment < remaining - 0.01) {
-      toast.error(t('pos.paymentBelowBalance'));
+      toast.error(t('paymentBelowBalance'));
       return;
     }
     // Validate wallet amount against available balance (convert currency to points for comparison)
@@ -263,7 +289,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
       const walletPointsRequired = walletAmt * redemptionRate;
       if (walletPointsRequired > walletBalance) {
         const maxCurrency = Math.floor(walletBalance / redemptionRate);
-        toast.error(t('pos.walletMaxAmount', { max: currencyFmt(maxCurrency) }));
+        toast.error(t('walletMaxAmount', { max: currencyFmt(maxCurrency) }));
         return;
       }
     }
@@ -296,7 +322,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
         // new request and must not reuse the completed request's hash.
         if (updatedBill) idempotencyKeyRef.current = null;
         if (updatedBill && onBillUpdate) onBillUpdate(updatedBill);
-        toast.error(t('pos.paymentIncomplete', {
+        toast.error(t('paymentIncomplete', {
           amount: currencyFmt(Number(updatedBill?.balance) || 0),
         }));
         return;
@@ -304,20 +330,20 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
       const earned = res.data?.loyaltyPointsEarned > 0 ? res.data.loyaltyPointsEarned : 0;
       setPointsEarned(earned);
       if (earned > 0) {
-        toast.success(t('pos.paymentRecordedWithPoints', { points: earned }));
+        toast.success(t('paymentRecordedWithPoints', { points: earned }));
       } else {
-        toast.success(t('pos.paymentRecorded'));
+        toast.success(t('paymentRecorded'));
       }
       setJustPaid(true);
     } catch {
-      toast.error(t('pos.paymentFailed'));
+      toast.error(t('paymentFailed'));
     } finally {
       setProcessing(false);
     }
   };
 
   const tenantForShare = {
-    business_name: currentTenant?.business_name || t('common.businessNameFallback'),
+    business_name: currentTenant?.business_name || tCommon('businessNameFallback'),
     currency: currentTenant?.currency || 'INR',
     country: currentTenant?.country || 'IN',
   };
@@ -325,12 +351,12 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
   const handleSendWhatsApp = async () => {
     const phone = cartCustomer?.phone;
     if (!phone) {
-      toast.error(t('whatsapp.send.customerPhoneRequired'));
+      toast.error(tWhatsappSend('customerPhoneRequired'));
       return;
     }
     setSendingWa(true);
     try {
-      await sendBillViaFlo(bill, phone, tenantForShare, t, { pointsEarned });
+      await sendBillViaFlo(bill, phone, tenantForShare, whatsappSendT, { pointsEarned });
     } finally {
       setSendingWa(false);
     }
@@ -338,7 +364,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
 
   const handleShareWhatsApp = () => {
     if (!cartCustomer?.phone) {
-      toast.error(t('whatsapp.send.customerPhoneRequired'));
+      toast.error(tWhatsappSend('customerPhoneRequired'));
       return;
     }
     try {
@@ -349,7 +375,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
         { pointsEarned }
       );
     } catch {
-      toast.error(t('orders.whatsappFailed'));
+      toast.error(tOrders('whatsappFailed'));
     }
   };
 
@@ -360,8 +386,8 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
         {/* Header */}
         <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-gray-100">
           <div>
-            <h2 className="text-lg font-bold text-gray-900">{t('pos.payment')}</h2>
-            <p className="text-xs text-gray-400 mt-0.5">{t('pos.billNumber', { number: bill.bill_number })}</p>
+            <h2 className="text-lg font-bold text-gray-900">{t('payment')}</h2>
+            <p className="text-xs text-gray-400 mt-0.5">{t('billNumber', { number: bill.bill_number })}</p>
           </div>
           <button
             onClick={onClose}
@@ -377,7 +403,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
           <div className="bg-gradient-to-br from-slate-800 to-slate-900 rounded-2xl px-5 py-4 text-white">
             <div className="flex items-start justify-between mb-3">
               <div>
-                <p className="text-xs font-medium text-slate-400 uppercase tracking-widest">{t('pos.totalDue')}</p>
+                <p className="text-xs font-medium text-slate-400 uppercase tracking-widest">{t('totalDue')}</p>
                 <p className="text-4xl font-bold mt-1 tracking-tight">{currencyFmt(remaining)}</p>
               </div>
               {cartCustomer && (
@@ -392,12 +418,12 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
 
             <div className="border-t border-white/10 pt-3 space-y-1.5 text-xs">
               <div className="flex justify-between text-slate-300">
-                <span>{t('pos.subtotal')}</span>
+                <span>{t('subtotal')}</span>
                 <span>{currencyFmt(Number(bill.subtotal))}</span>
               </div>
               {Number(bill.discount_amount) > 0 && (
                 <div className="flex justify-between text-emerald-400 font-medium">
-                  <span>{t('pos.discount')}</span>
+                  <span>{t('discount')}</span>
                   <span>− {currencyFmt(Number(bill.discount_amount))}</span>
                 </div>
               )}
@@ -407,24 +433,24 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
               }))} />
               {Number(bill.delivery_charge) > 0 && (
                 <div className="flex justify-between text-slate-300">
-                  <span>{t('pos.delivery')}</span>
+                  <span>{t('delivery')}</span>
                   <span>{currencyFmt(Number(bill.delivery_charge))}</span>
                 </div>
               )}
               {Number(bill.packaging_charge) > 0 && (
                 <div className="flex justify-between text-slate-300">
-                  <span>{t('pos.packaging')}</span>
+                  <span>{t('packaging')}</span>
                   <span>{currencyFmt(Number(bill.packaging_charge))}</span>
                 </div>
               )}
               {Number(bill.round_off) !== 0 && (
                 <div className="flex justify-between text-slate-300">
-                  <span>{t('pos.roundOff')}</span>
+                  <span>{t('roundOff')}</span>
                   <span>{Number(bill.round_off) > 0 ? '+' : ''}{currencyFmt(Number(bill.round_off))}</span>
                 </div>
               )}
               <div className="flex justify-between text-white font-semibold border-t border-white/10 pt-1.5 mt-1">
-                <span>{t('pos.total')}</span>
+                <span>{t('total')}</span>
                 <span>{currencyFmt(Number(bill.total))}</span>
               </div>
             </div>
@@ -435,10 +461,10 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
             <div className="flex items-center gap-2 px-3.5 py-2.5 bg-gray-50 border border-gray-200 rounded-xl">
               <Sparkles size={13} className="text-gray-400 shrink-0" />
               <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs">
-                <span className="text-gray-700 font-medium">{t('pos.loyalty')}</span>
+                <span className="text-gray-700 font-medium">{t('loyalty')}</span>
                 <span className="font-semibold text-gray-700">
                   {walletBalance !== null
-                    ? t('pos.pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / (LOYALTY_REDEMPTION_RATE))) })
+                    ? t('pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / (LOYALTY_REDEMPTION_RATE))) })
                     : '…'}
                 </span>
               </div>
@@ -450,8 +476,8 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
             <button type="button" onClick={() => setShowDiscount((open) => !open)} className="w-full flex items-center justify-between gap-3 px-3 py-2.5 bg-gray-50 text-start">
               <span className="text-sm font-medium text-gray-700">
                 {Number(bill.discount_amount) > 0
-                  ? `${t('pos.discount')}: -${currencyFmt(Number(bill.discount_amount))}`
-                  : t('pos.applyDiscount')}
+                  ? `${t('discount')}: -${currencyFmt(Number(bill.discount_amount))}`
+                  : t('applyDiscount')}
               </span>
               <ChevronDown size={16} className={`text-gray-400 transition-transform ${showDiscount ? 'rotate-180' : ''}`} />
             </button>
@@ -465,7 +491,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                       className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors ${discountType === 'percentage' ? 'bg-purple-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                     >
                       <Percent size={14} />
-                      {t('pos.percentage')}
+                      {t('percentage')}
                     </button>
                   )}
                   {isDiscountTypeAllowed(discountMode, 'amount') && (
@@ -473,7 +499,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                       onClick={() => { setDiscountType('amount'); }}
                       className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors ${discountType === 'amount' ? 'bg-purple-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                     >
-                      {t('pos.flatAmount')}
+                      {t('flatAmount')}
                     </button>
                   )}
                 </div>
@@ -496,7 +522,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   type="text"
                   value={discountReason}
                   onChange={(e) => setDiscountReason(e.target.value)}
-                  placeholder={t('pos.discountReasonPlaceholder')}
+                  placeholder={t('discountReasonPlaceholder')}
                   className="w-full px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-white"
                 />
                 {discountRequiresApproval && parseFloat(discountValue) > 0 && (
@@ -504,7 +530,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                     type="password"
                     value={discountPin}
                     onChange={(e) => setDiscountPin(e.target.value)}
-                    placeholder={t('pos.managerPin')}
+                    placeholder={t('managerPin')}
                     maxLength={6}
                     className="w-full px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-white"
                   />
@@ -516,14 +542,14 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   className="w-full bg-purple-600 hover:bg-purple-700 text-white"
                 >
                   {applyingDiscount
-                    ? t('pos.applyingDiscount')
-                    : Number(bill.discount_amount) > 0 ? t('pos.updateDiscount') : t('pos.applyDiscount')}
+                    ? t('applyingDiscount')
+                    : Number(bill.discount_amount) > 0 ? t('updateDiscount') : t('applyDiscount')}
                 </Button>
                 {Number(bill.discount_amount) > 0 && (
                   <Button variant="outline" size="sm" className="w-full" onClick={async () => {
-                    if (await confirm(t('pos.removeDiscountConfirm'), { destructive: true, confirmLabel: t('pos.remove') })) void handleApplyDiscount(0);
+                    if (await confirm(t('removeDiscountConfirm'), { destructive: true, confirmLabel: t('remove') })) void handleApplyDiscount(0);
                   }}>
-                    {t('pos.remove')}
+                    {t('remove')}
                   </Button>
                 )}
               </div>
@@ -534,7 +560,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
             {payments.map((payment, idx) => {
               const builtIn = PAYMENT_METHODS.find((method) => method.key === payment.method && payment.payment_method_id === undefined);
               const custom = customMethods.find((method) => method.id === payment.payment_method_id);
-              const label = builtIn ? t(builtIn.labelKey) : custom?.name || t('common.unknown');
+              const label = builtIn ? t(BUILT_IN_PAYMENT_KEYS[builtIn.key]) : custom?.name || tCommon('unknown');
               const Icon = builtIn?.icon;
               const active = (parseFloat(payment.amount) || 0) > 0;
               return <div key={payment.payment_method_id === undefined ? payment.method : `custom:${payment.payment_method_id}`} className="flex h-11">
@@ -577,7 +603,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                 <span className={`text-sm font-semibold ${
                   change > 0 ? 'text-emerald-800' : 'text-gray-400'
                 }`}>
-                  {t('pos.changeReturned')}
+                  {t('changeReturned')}
                 </span>
               </div>
               <span className={`text-xl font-bold tabular-nums ${
@@ -599,7 +625,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   const dueDisplay = toDisplayUnit(dueStored);
                   setWalletAmount(dueDisplay > 0 ? String(dueDisplay) : '');
                 }} className={`w-36 shrink-0 rounded-s-xl border px-3 flex items-center gap-2 text-sm font-semibold ${walletAmt > 0 ? 'bg-purple-600 text-white border-purple-600' : 'bg-purple-50 text-purple-800 border-purple-200 disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200'}`}>
-                  <Wallet size={15} /><span className="truncate">{t('pos.loyaltyWallet')}</span>
+                  <Wallet size={15} /><span className="truncate">{t('loyaltyWallet')}</span>
                 </button>
                 <div className="flex flex-1 items-center border border-s-0 border-purple-200 rounded-e-xl bg-white focus-within:ring-2 focus-within:ring-purple-400">
                   <span className="ps-3 text-gray-400 text-xs">{inputCurrencyLabel}</span>
@@ -622,7 +648,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   />
                 </div>
               </div>
-              <p className="px-1 text-[11px] text-gray-400 text-end">{walletBalance > 0 ? t('pos.pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE)) }) : t('pos.noBalance')}</p>
+              <p className="px-1 text-[11px] text-gray-400 text-end">{walletBalance > 0 ? t('pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE)) }) : t('noBalance')}</p>
             </div>
           )}
         </div>
@@ -639,7 +665,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                     size="lg"
                   >
                     <Send size={16} className="me-2" />
-                    {sendingWa ? t('pos.processingPayment') : t('pos.sendViaWhatsApp')}
+                    {sendingWa ? t('processingPayment') : t('sendViaWhatsApp')}
                   </Button>
                 ) : (
                   <Button
@@ -649,17 +675,17 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                     size="lg"
                   >
                     <Send size={16} className="me-2" />
-                    {t('common.shareViaWhatsApp')}
+                    {tCommon('shareViaWhatsApp')}
                   </Button>
                 )
               )}
               <Button onClick={onPaid} variant="outline" className="w-full" size="lg">
-                {t('common.done')}
+                {tCommon('done')}
               </Button>
             </>
           ) : (
             <Button onClick={handlePay} disabled={processing || totalPayment < remaining - 0.01} className="w-full" size="lg">
-              {processing ? t('pos.processingPayment') : `${t('pos.pay')} ${currencyFmt(totalPayment)}`}
+              {processing ? t('processingPayment') : `${t('pay')} ${currencyFmt(totalPayment)}`}
             </Button>
           )}
         </div>

--- a/frontend/src/components/pos/PosTopbar.tsx
+++ b/frontend/src/components/pos/PosTopbar.tsx
@@ -7,7 +7,7 @@ import { useAuthStore } from '@/store/auth';
 import { usePosSettingsStore } from '@/store/pos-settings';
 import { LayoutGrid } from 'lucide-react';
 import type { Table } from '@/lib/types';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 
 interface Props {
   tables: Table[];
@@ -18,7 +18,7 @@ export default function PosTopbar({ tables, onShowTablePicker }: Props) {
   const cart = useCartStore();
   const { currentTenant } = useAuthStore();
   const tablesRequired = usePosSettingsStore((s) => s.tablesRequired);
-  const { t } = useI18n();
+  const t = useTranslations('pos');
   const isRestaurant = (currentTenant?.business_type ?? 'restaurant') === 'restaurant';
   const showTableBtn = isRestaurant && cart.orderType === 'dine_in' && tablesRequired;
 
@@ -40,8 +40,8 @@ export default function PosTopbar({ tables, onShowTablePicker }: Props) {
         >
           <LayoutGrid size={14} />
           {cart.tableId
-            ? t('pos.tableLabel', { name: tables.find(t => t.id === cart.tableId)?.name || cart.tableId })
-            : t('pos.selectTable')}
+            ? t('tableLabel', { name: tables.find(t => t.id === cart.tableId)?.name || cart.tableId })
+            : t('selectTable')}
         </button>
       )}
 

--- a/frontend/src/components/pos/PrepaidCheckoutModal.tsx
+++ b/frontend/src/components/pos/PrepaidCheckoutModal.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import api from '@/lib/api';
 import { useCartStore } from '@/store/cart';
 import { useTaxPreview } from '@/hooks/use-tax-preview';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import TaxBreakdown from '@/components/pos/TaxBreakdown';
 import toast from 'react-hot-toast';
 import { PAYMENT_METHODS, type CustomPaymentMethod } from '@/lib/payment-methods';
@@ -48,6 +48,25 @@ interface Props {
 // Must match LOYALTY_REDEMPTION_RATE in main/routes/bills.ts.
 const LOYALTY_REDEMPTION_RATE = 100;
 
+type PosKey = keyof AppConfig['Messages']['pos'];
+
+type OrderType = 'dine_in' | 'takeaway' | 'delivery' | 'online';
+
+// Exhaustively typed lookup for the order-type suffix (no template-literal keys).
+const ORDER_TYPE_SUFFIX_KEYS = {
+  dine_in: 'orderTypeSuffix_dine_in',
+  takeaway: 'orderTypeSuffix_takeaway',
+  delivery: 'orderTypeSuffix_delivery',
+  online: 'orderTypeSuffix_online',
+} as const satisfies Record<OrderType, PosKey>;
+
+// Built-in payment method label keys (PAYMENT_METHODS keeps dotted keys for the
+// unmigrated dashboard page, so this maps them to the typed `pos` leaf keys).
+const BUILT_IN_PAYMENT_KEYS = {
+  cash: 'methodCash',
+  card: 'methodCard',
+} as const satisfies Record<'cash' | 'card', PosKey>;
+
 interface Payment {
   method: string;
   payment_method_id?: number;
@@ -57,7 +76,8 @@ interface Payment {
 export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
   const cart = useCartStore();
   const customer = cart.customer;
-  const { t } = useI18n();
+  const t = useTranslations('pos');
+  const tCommon = useTranslations('common');
   const currencyFmt = useFormatCurrency();
   const fmtNum = useFormatNumber();
   const unitAdapter = useCurrencyUnitAdapter();
@@ -218,38 +238,38 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
       !PAYMENT_METHODS.some((allowed) => allowed.key === p.method)
       && !customMethods.some((method) => method.id === p.payment_method_id)
     ) || !amountIsValid(p.amount))) {
-      toast.error(t('pos.paymentFailed'));
+      toast.error(t('paymentFailed'));
       return;
     }
     if (walletAmount.trim() && !/^\d+(?:\.\d{1,4})?$/.test(walletAmount.trim())) {
-      toast.error(t('pos.paymentFailed'));
+      toast.error(t('paymentFailed'));
       return;
     }
     const nonCashTotal = payments
       .filter((p) => p.method !== 'cash')
       .reduce((sum, p) => sum + toStoredUnit(Number(p.amount) || 0), 0) + walletAmt;
     if (nonCashTotal > remaining + 0.000001) {
-      toast.error(t('pos.paymentAboveBalance'));
+      toast.error(t('paymentAboveBalance'));
       return;
     }
     if (totalPayment < remaining - 0.01) {
-      toast.error(t('pos.paymentBelowBalance'));
+      toast.error(t('paymentBelowBalance'));
       return;
     }
     if (walletAmt > 0 && walletBalance !== null) {
       const walletPointsRequired = walletAmt * LOYALTY_REDEMPTION_RATE;
       if (walletPointsRequired > walletBalance) {
         const maxCurrency = Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE);
-        toast.error(t('pos.walletMaxAmount', { max: currencyFmt(maxCurrency) }));
+        toast.error(t('walletMaxAmount', { max: currencyFmt(maxCurrency) }));
         return;
       }
     }
     if (preview.discountAmount > 0 && discountRequiresApproval && !discountPin) {
-      toast.error(t('pos.managerPinRequired'));
+      toast.error(t('managerPinRequired'));
       return;
     }
     if (preview.discountAmount > 0 && !isDiscountTypeAllowed(discountMode, discountType)) {
-      toast.error(t('pos.discountInvalid'));
+      toast.error(t('discountInvalid'));
       return;
     }
 
@@ -281,9 +301,9 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
         {/* Header */}
         <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-gray-100">
           <div>
-            <h2 className="text-lg font-bold text-gray-900">{t('pos.checkout')}</h2>
+            <h2 className="text-lg font-bold text-gray-900">{t('checkout')}</h2>
             <p className="text-xs text-gray-400 mt-0.5 capitalize">
-              {t(`pos.orderTypeSuffix_${cart.orderType}` as 'pos.orderTypeSuffix_dine_in' | 'pos.orderTypeSuffix_takeaway' | 'pos.orderTypeSuffix_delivery' | 'pos.orderTypeSuffix_online')}
+              {t(ORDER_TYPE_SUFFIX_KEYS[cart.orderType])}
             </p>
           </div>
           <button
@@ -301,7 +321,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
             <div className="flex items-start justify-between">
               <div className="flex-1">
                 <p className="text-xs font-medium text-slate-400 uppercase tracking-widest">
-                  {taxLoading ? t('pos.subtotal') : t('pos.totalDue')}
+                  {taxLoading ? t('subtotal') : t('totalDue')}
                 </p>
                 {taxLoading || !preview ? (
                   <div className="h-10 w-32 bg-white/10 rounded animate-pulse mt-1" />
@@ -311,30 +331,30 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   </p>
                 )}
                 <p className="text-xs text-slate-400 mt-1.5">
-                  {t('pos.itemCount', { count: cart.itemCount() })}
+                  {t('itemCount', { count: cart.itemCount() })}
                 </p>
                 {!taxLoading && preview && (
                   <div className="mt-2 space-y-1">
                     <div className="flex justify-between text-xs text-slate-300">
-                      <span>{t('pos.subtotal')}</span>
+                      <span>{t('subtotal')}</span>
                       <span>{currencyFmt(preview.subtotal)}</span>
                     </div>
                     {preview.discountAmount > 0 && (
                       <div className="flex justify-between text-xs text-emerald-400 font-medium">
-                        <span>{t('pos.discount')}</span>
+                        <span>{t('discount')}</span>
                         <span>− {currencyFmt(preview.discountAmount)}</span>
                       </div>
                     )}
                     <TaxBreakdown taxAmount={preview.taxAmount} taxBreakdown={preview.taxBreakdown} />
                     {preview.packagingCharge > 0 && (
                       <div className="flex justify-between text-xs text-slate-300">
-                        <span>{t('pos.packaging')}</span>
+                        <span>{t('packaging')}</span>
                         <span>{currencyFmt(preview.packagingCharge)}</span>
                       </div>
                     )}
                     {preview.roundOff !== 0 && (
                       <div className="flex justify-between text-xs text-slate-300">
-                        <span>{t('pos.roundOff')}</span>
+                        <span>{t('roundOff')}</span>
                         <span>{preview.roundOff > 0 ? '+' : ''}{currencyFmt(preview.roundOff)}</span>
                       </div>
                     )}
@@ -357,10 +377,10 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
             <div className="flex items-center gap-2 px-3.5 py-2.5 bg-gray-50 border border-gray-200 rounded-xl">
               <Sparkles size={13} className="text-gray-400 shrink-0" />
               <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs">
-                <span className="text-gray-700 font-medium">{t('pos.loyalty')}</span>
+                <span className="text-gray-700 font-medium">{t('loyalty')}</span>
                 <span className="font-semibold text-gray-700">
                   {walletBalance !== null
-                    ? t('pos.pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE)) })
+                    ? t('pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE)) })
                     : '…'}
                 </span>
               </div>
@@ -371,7 +391,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
           <div className="rounded-xl border border-gray-200 overflow-hidden">
             <button type="button" onClick={() => setDiscountOpen((open) => !open)} className="w-full flex items-center justify-between gap-3 px-3 py-2.5 bg-gray-50 text-start">
               <span className="text-sm font-medium text-gray-700">
-                {preview?.discountAmount ? `${t('pos.discount')}: -${currencyFmt(preview.discountAmount)}` : t('pos.applyDiscount')}
+                {preview?.discountAmount ? `${t('discount')}: -${currencyFmt(preview.discountAmount)}` : t('applyDiscount')}
               </span>
               <ChevronDown size={16} className={`text-gray-400 transition-transform ${discountOpen ? 'rotate-180' : ''}`} />
             </button>
@@ -385,7 +405,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                       className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors ${discountType === 'percentage' ? 'bg-purple-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                     >
                       <Percent size={14} />
-                      {t('pos.percentage')}
+                      {t('percentage')}
                     </button>
                   )}
                   {isDiscountTypeAllowed(discountMode, 'amount') && (
@@ -393,7 +413,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                       onClick={() => setDiscountType('amount')}
                       className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors ${discountType === 'amount' ? 'bg-purple-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                     >
-                      {t('pos.flatAmount')}
+                      {t('flatAmount')}
                     </button>
                   )}
                 </div>
@@ -416,7 +436,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   type="text"
                   value={discountReason}
                   onChange={(e) => setDiscountReason(e.target.value)}
-                  placeholder={t('pos.discountReasonPlaceholder')}
+                  placeholder={t('discountReasonPlaceholder')}
                   className="w-full px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-white"
                 />
                 {discountRequiresApproval && parseFloat(discountValue) > 0 && (
@@ -424,7 +444,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                     type="password"
                     value={discountPin}
                     onChange={(e) => setDiscountPin(e.target.value)}
-                    placeholder={t('pos.managerPin')}
+                    placeholder={t('managerPin')}
                     maxLength={6}
                     className="w-full px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-white"
                   />
@@ -436,7 +456,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                     setDiscountPin('');
                     setPaymentsTouched(false);
                   }}>
-                    {t('pos.remove')}
+                    {t('remove')}
                   </Button>
                 )}
               </div>
@@ -448,7 +468,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
             {payments.map((payment, idx) => {
               const builtIn = PAYMENT_METHODS.find((method) => method.key === payment.method && payment.payment_method_id === undefined);
               const custom = customMethods.find((method) => method.id === payment.payment_method_id);
-              const label = builtIn ? t(builtIn.labelKey) : custom?.name || t('common.unknown');
+              const label = builtIn ? t(BUILT_IN_PAYMENT_KEYS[builtIn.key]) : custom?.name || tCommon('unknown');
               const Icon = builtIn?.icon;
               const active = (parseFloat(payment.amount) || 0) > 0;
               return <div key={payment.payment_method_id === undefined ? payment.method : `custom:${payment.payment_method_id}`} className="flex h-11">
@@ -491,7 +511,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                 <span className={`text-sm font-semibold ${
                   change > 0 ? 'text-emerald-800' : 'text-gray-400'
                 }`}>
-                  {t('pos.changeReturned')}
+                  {t('changeReturned')}
                 </span>
               </div>
               <span className={`text-xl font-bold tabular-nums ${
@@ -513,7 +533,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   const dueDisplay = toDisplayUnit(dueStored);
                   setWalletAmount(dueDisplay > 0 ? String(dueDisplay) : '');
                 }} className={`w-36 shrink-0 rounded-s-xl border px-3 flex items-center gap-2 text-sm font-semibold ${walletAmt > 0 ? 'bg-purple-600 text-white border-purple-600' : 'bg-purple-50 text-purple-800 border-purple-200 disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200'}`}>
-                  <Wallet size={15} /><span className="truncate">{t('pos.loyaltyWallet')}</span>
+                  <Wallet size={15} /><span className="truncate">{t('loyaltyWallet')}</span>
                 </button>
                 <div className="flex flex-1 items-center border border-s-0 border-purple-200 rounded-e-xl bg-white focus-within:ring-2 focus-within:ring-purple-400">
                   <span className="ps-3 text-gray-400 text-xs">{inputCurrencyLabel}</span>
@@ -536,7 +556,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   />
                 </div>
               </div>
-              <p className="px-1 text-[11px] text-gray-400 text-end">{walletBalance > 0 ? t('pos.pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE)) }) : t('pos.noBalance')}</p>
+              <p className="px-1 text-[11px] text-gray-400 text-end">{walletBalance > 0 ? t('pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE)) }) : t('noBalance')}</p>
             </div>
           )}
         </div>
@@ -549,7 +569,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
             className="w-full h-12 text-base font-semibold rounded-xl"
             size="lg"
           >
-            {taxLoading ? t('pos.calculatingTax') : processing ? t('pos.processingPayment') : t('pos.confirmPaymentAmount', { amount: currencyFmt(remaining) })}
+            {taxLoading ? t('calculatingTax') : processing ? t('processingPayment') : t('confirmPaymentAmount', { amount: currencyFmt(remaining) })}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/pos/PrinterStatus.tsx
+++ b/frontend/src/components/pos/PrinterStatus.tsx
@@ -35,30 +35,32 @@ import {
 import { usePrinterStore, usePrinterStatusSync } from '@/hooks/usePrinter';
 import type { PrinterStatus } from '@/lib/printer/PrinterService';
 import toast from 'react-hot-toast';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
+
+type PosKey = keyof AppConfig['Messages']['pos'];
 
 const STATUS_CONFIG: Record<
   PrinterStatus,
-  { labelKey: string; color: string; Icon: React.ElementType }
+  { labelKey: PosKey; color: string; Icon: React.ElementType }
 > = {
   disconnected: {
-    labelKey: 'pos.printerNoPrinter',
+    labelKey: 'printerNoPrinter',
     color: 'text-gray-400',
     Icon: Printer,
   },
   connecting: {
-    labelKey: 'pos.printerConnecting',
+    labelKey: 'printerConnecting',
     color: 'text-amber-500',
     Icon: Loader2,
   },
   connected: {
-    labelKey: 'pos.printerReady',
+    labelKey: 'printerReady',
     color: 'text-green-600',
     Icon: PrinterCheck,
   },
   error: {
-    labelKey: 'pos.printerError',
+    labelKey: 'printerError',
     color: 'text-red-500',
     Icon: PrinterX,
   },
@@ -72,7 +74,7 @@ export default function PrinterStatus() {
     connect, disconnect, clearError,
     printMethod, hardwarePrinter,
   } = usePrinterStore();
-  const { t } = useI18n();
+  const t = useTranslations('pos');
   const router = useRouter();
 
   const effectiveStatus: PrinterStatus = hardwarePrinter ? 'connected' : status;
@@ -84,21 +86,21 @@ export default function PrinterStatus() {
     try {
       await connect();
       if (usePrinterStore.getState().status === 'connected') {
-        toast.success(t('pos.printerConnected'));
+        toast.success(t('printerConnected'));
       } else if (usePrinterStore.getState().lastError) {
-        toast.error(t('pos.printerError'));
+        toast.error(t('printerError'));
       }
     } catch {
-      toast.error(t('pos.printerError'));
+      toast.error(t('printerError'));
     }
   };
 
   const handleDisconnect = async () => {
     try {
       await disconnect();
-      toast(t('pos.printerDisconnected'));
+      toast(t('printerDisconnected'));
     } catch {
-      toast.error(t('pos.printerError'));
+      toast.error(t('printerError'));
     }
   };
 
@@ -126,7 +128,7 @@ export default function PrinterStatus() {
 
       <DropdownMenuContent align="end" className="w-52">
         <DropdownMenuLabel className="text-xs text-gray-500">
-          {t('pos.printerSectionLabel')}
+          {t('printerSectionLabel')}
         </DropdownMenuLabel>
 
         {hardwarePrinter && (
@@ -148,7 +150,7 @@ export default function PrinterStatus() {
         {isConnected && deviceInfo && (
           <div className="px-2 py-1.5 text-xs text-gray-500 border-b border-gray-100">
             <p className="font-medium text-gray-700 truncate">
-              {deviceInfo.productName ?? t('pos.printerUnknownDevice')}
+              {deviceInfo.productName ?? t('printerUnknownDevice')}
             </p>
             <p><Ltr>{deviceInfo.manufacturerName ?? `VID:${deviceInfo.vendorId.toString(16).toUpperCase()}`}</Ltr></p>
           </div>
@@ -156,7 +158,7 @@ export default function PrinterStatus() {
 
         {lastError && (
           <div className="px-2 py-1.5 text-xs text-red-600 bg-red-50 rounded mx-1 my-1">
-            {t('pos.printerError')}
+            {t('printerError')}
           </div>
         )}
 
@@ -171,7 +173,7 @@ export default function PrinterStatus() {
                 className="text-sm cursor-pointer"
               >
                 <Printer size={14} className="me-2" />
-                {isConnecting ? t('pos.printerConnecting') : t('pos.printerConnectUsb')}
+                {isConnecting ? t('printerConnecting') : t('printerConnectUsb')}
               </DropdownMenuItem>
             )}
 
@@ -181,7 +183,7 @@ export default function PrinterStatus() {
                 className="text-sm cursor-pointer text-red-600 focus:text-red-600"
               >
                 <Unplug size={14} className="me-2" />
-{t('pos.printerDisconnect')}
+{t('printerDisconnect')}
               </DropdownMenuItem>
             )}
           </>
@@ -189,7 +191,7 @@ export default function PrinterStatus() {
 
         {printMethod === 'browser' && (
           <div className="px-2 py-1.5 text-xs text-gray-500">
-            {t('pos.printerBrowserMode')}
+            {t('printerBrowserMode')}
           </div>
         )}
 
@@ -200,7 +202,7 @@ export default function PrinterStatus() {
           className="text-sm cursor-pointer"
         >
           <Settings size={14} className="me-2" />
-          {t('pos.printerSettings')}
+          {t('printerSettings')}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/frontend/src/components/pos/ProductGrid.tsx
+++ b/frontend/src/components/pos/ProductGrid.tsx
@@ -8,7 +8,7 @@ import { usePosSettingsStore } from '@/store/pos-settings';
 import { nameToColor } from '@/lib/image-utils';
 import TagBadge from './DietaryBadge';
 import api from '@/lib/api';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { parseDbTimestamp } from '@/lib/utils';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 
@@ -59,7 +59,7 @@ export default function ProductGrid({
 }: Props) {
   const cart = useCartStore();
   const { showProductImages } = usePosSettingsStore();
-  const { t } = useI18n();
+  const t = useTranslations('pos');
   const fmt = useFormatCurrency();
   const cartQuantities = useMemo(() => {
     const quantities = new Map<Product['id'], number>();
@@ -96,7 +96,7 @@ export default function ProductGrid({
                 setSearch('');
               }
             }}
-            placeholder={t('pos.searchProducts')}
+            placeholder={t('searchProducts')}
             className="w-full ps-9 pe-4 py-2 bg-white border border-gray-200 rounded-xl focus:border-brand outline-none transition-colors text-sm"
           />
         </div>
@@ -107,7 +107,7 @@ export default function ProductGrid({
               !selectedCategory ? 'bg-brand text-white' : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50'
             }`}
           >
-            {t('pos.allCategories')}
+            {t('allCategories')}
           </button>
           {categories.filter((cat) => cat.id != null).map((cat) => {
             const colorClasses = getCategoryColorClasses(cat.color);
@@ -154,11 +154,11 @@ export default function ProductGrid({
                   <>
                     {product.stock_quantity <= 0 ? (
                       <span className="absolute top-2 start-2 bg-red-100 text-red-700 text-[10px] font-bold px-2 py-0.5 rounded-full z-10 shadow-sm border border-red-200 pointer-events-none">
-                        {t('pos.outOfStock')}
+                        {t('outOfStock')}
                       </span>
                     ) : product.stock_quantity <= (product.low_stock_threshold || 0) ? (
                       <span className="absolute top-2 start-2 bg-orange-100 text-orange-700 text-[10px] font-bold px-2 py-0.5 rounded-full z-10 shadow-sm border border-orange-200 pointer-events-none">
-                        {t('pos.lowStock')}
+                        {t('lowStock')}
                       </span>
                     ) : null}
                   </>
@@ -217,7 +217,7 @@ export default function ProductGrid({
                           onProductClick(product);
                         }}
                         className="text-gray-400 hover:text-gray-600 transition-colors"
-                        title={t('pos.customisable')}
+                        title={t('customisable')}
                       >
                         <SlidersHorizontal size={12} />
                       </button>

--- a/frontend/src/components/pos/SplitCheckModal.tsx
+++ b/frontend/src/components/pos/SplitCheckModal.tsx
@@ -5,12 +5,13 @@ import { Minus, Plus, X } from 'lucide-react';
 import api from '@/lib/api';
 import toast from 'react-hot-toast';
 import { Button } from '@/components/ui/button';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import type { Bill, Order, OrderItem } from '@/lib/types';
 
 export function SplitCheckModal({ bill, order, onClose, onSplit }: { bill: Bill; order: Order; onClose: () => void; onSplit: (bills: Bill[]) => void }) {
-  const { t } = useI18n();
+  const t = useTranslations('pos');
+  const tCommon = useTranslations('common');
   const fmt = useFormatCurrency();
   const items = (order.items || []).filter((item) => !['cancelled', 'voided', 'void_adjustment'].includes(item.status));
   const initialCount = Math.min(8, Math.max(2, order.guest_count || 2));
@@ -41,7 +42,7 @@ export function SplitCheckModal({ bill, order, onClose, onSplit }: { bill: Bill;
   const submit = async () => {
     const invalid = items.some((item) => (allocations[item.id] || []).reduce((sum, value) => sum + value, 0) !== item.quantity)
       || Array.from({ length: count }, (_, check) => items.every((item) => !(allocations[item.id]?.[check] > 0))).some(Boolean);
-    if (invalid) return toast.error(t('pos.allocateAllItems', { defaultValue: 'Allocate every item and leave no guest check empty' }));
+    if (invalid) return toast.error(t('allocateAllItems', { defaultValue: 'Allocate every item and leave no guest check empty' }));
     setSaving(true);
     try {
       const checks = Array.from({ length: count }, (_, checkIndex) => ({
@@ -54,14 +55,14 @@ export function SplitCheckModal({ bill, order, onClose, onSplit }: { bill: Bill;
       const { data } = await api.post(`/bills/${bill.id}/split-check`, { checks });
       onSplit(data.bills);
     } catch {
-      toast.error(t('pos.splitCheckFailed', { defaultValue: 'Unable to split check' }));
+      toast.error(t('splitCheckFailed', { defaultValue: 'Unable to split check' }));
     } finally { setSaving(false); }
   };
 
   return <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[70] p-4"><div className="bg-white rounded-2xl w-full max-w-5xl max-h-[90vh] flex flex-col">
-    <div className="p-5 border-b flex items-center justify-between"><div><h2 className="text-lg font-bold">{t('pos.splitCheck', { defaultValue: 'Split check' })}</h2><p className="text-sm text-gray-500">{t('pos.splitCheckHint', { defaultValue: 'Assign whole item quantities to each guest check.' })}</p></div><button onClick={onClose}><X size={20} /></button></div>
-    <div className="p-5 border-b flex items-center gap-3"><span className="text-sm text-gray-600">{t('pos.numberOfChecks', { defaultValue: 'Number of checks' })}</span><button onClick={() => resize(count - 1)} className="size-7 rounded-full bg-gray-100 flex items-center justify-center"><Minus size={13} /></button><strong>{count}</strong><button onClick={() => resize(count + 1)} className="size-7 rounded-full bg-gray-100 flex items-center justify-center"><Plus size={13} /></button></div>
-    <div className="overflow-auto p-5"><table className="w-full text-sm"><thead><tr><th className="text-start p-2 sticky start-0 bg-white">{t('pos.items')}</th>{Array.from({ length: count }, (_, i) => <th key={i} className="p-2 min-w-28"><input value={labels[i]} onChange={(e) => setLabels((old) => old.map((label, n) => n === i ? e.target.value.slice(0, 40) : label))} className="w-full text-center border rounded px-2 py-1" /></th>)}</tr></thead><tbody>{items.map((item: OrderItem) => <tr key={item.id} className="border-t"><td className="p-2 sticky start-0 bg-white"><div className="font-medium">{item.product_name}</div><div className="text-xs text-gray-400">{item.quantity} × {fmt(Number(item.total) / item.quantity)}</div></td>{Array.from({ length: count }, (_, i) => <td key={i} className="p-2"><input type="number" min="0" max={item.quantity} value={allocations[item.id]?.[i] || 0} onChange={(e) => { const value = Math.min(item.quantity, Math.max(0, Number(e.target.value) || 0)); setAllocations((old) => ({ ...old, [item.id]: old[item.id].map((qty, n) => n === i ? value : qty) })); }} className="w-full text-center border rounded px-2 py-1" /></td>)}</tr>)}</tbody><tfoot><tr className="border-t font-semibold"><td className="p-2">{t('pos.estimatedItemsTotal', { defaultValue: 'Items total' })}</td>{totals.map((total, i) => <td key={i} className="p-2 text-center">{fmt(total)}</td>)}</tr></tfoot></table></div>
-    <div className="p-5 border-t flex justify-end gap-2"><Button variant="outline" onClick={onClose}>{t('common.cancel')}</Button><Button onClick={submit} disabled={saving}>{saving ? t('common.saving') : t('pos.createChecks', { defaultValue: 'Create checks' })}</Button></div>
+    <div className="p-5 border-b flex items-center justify-between"><div><h2 className="text-lg font-bold">{t('splitCheck', { defaultValue: 'Split check' })}</h2><p className="text-sm text-gray-500">{t('splitCheckHint', { defaultValue: 'Assign whole item quantities to each guest check.' })}</p></div><button onClick={onClose}><X size={20} /></button></div>
+    <div className="p-5 border-b flex items-center gap-3"><span className="text-sm text-gray-600">{t('numberOfChecks', { defaultValue: 'Number of checks' })}</span><button onClick={() => resize(count - 1)} className="size-7 rounded-full bg-gray-100 flex items-center justify-center"><Minus size={13} /></button><strong>{count}</strong><button onClick={() => resize(count + 1)} className="size-7 rounded-full bg-gray-100 flex items-center justify-center"><Plus size={13} /></button></div>
+    <div className="overflow-auto p-5"><table className="w-full text-sm"><thead><tr><th className="text-start p-2 sticky start-0 bg-white">{t('items')}</th>{Array.from({ length: count }, (_, i) => <th key={i} className="p-2 min-w-28"><input value={labels[i]} onChange={(e) => setLabels((old) => old.map((label, n) => n === i ? e.target.value.slice(0, 40) : label))} className="w-full text-center border rounded px-2 py-1" /></th>)}</tr></thead><tbody>{items.map((item: OrderItem) => <tr key={item.id} className="border-t"><td className="p-2 sticky start-0 bg-white"><div className="font-medium">{item.product_name}</div><div className="text-xs text-gray-400">{item.quantity} × {fmt(Number(item.total) / item.quantity)}</div></td>{Array.from({ length: count }, (_, i) => <td key={i} className="p-2"><input type="number" min="0" max={item.quantity} value={allocations[item.id]?.[i] || 0} onChange={(e) => { const value = Math.min(item.quantity, Math.max(0, Number(e.target.value) || 0)); setAllocations((old) => ({ ...old, [item.id]: old[item.id].map((qty, n) => n === i ? value : qty) })); }} className="w-full text-center border rounded px-2 py-1" /></td>)}</tr>)}</tbody><tfoot><tr className="border-t font-semibold"><td className="p-2">{t('estimatedItemsTotal', { defaultValue: 'Items total' })}</td>{totals.map((total, i) => <td key={i} className="p-2 text-center">{fmt(total)}</td>)}</tr></tfoot></table></div>
+    <div className="p-5 border-t flex justify-end gap-2"><Button variant="outline" onClick={onClose}>{tCommon('cancel')}</Button><Button onClick={submit} disabled={saving}>{saving ? tCommon('saving') : t('createChecks', { defaultValue: 'Create checks' })}</Button></div>
   </div></div>;
 }

--- a/frontend/src/components/pos/TableCheckoutModal.tsx
+++ b/frontend/src/components/pos/TableCheckoutModal.tsx
@@ -5,7 +5,7 @@ import { X, ShoppingCart, Users } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import TaxBreakdown from '@/components/pos/TaxBreakdown';
 import api from '@/lib/api';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import toast from 'react-hot-toast';
 import type { Table, Order, Bill, OrderItem } from '@/lib/types';
@@ -30,7 +30,7 @@ export default function TableCheckoutModal({
   onPayment,
   onAddCartToOrder
 }: Props) {
-  const { t } = useI18n();
+  const t = useTranslations('pos');
   const fmt = useFormatCurrency();
   const formatItemTotal = (value: unknown, fallback: unknown) => {
     const total = Number(value);
@@ -58,7 +58,7 @@ export default function TableCheckoutModal({
         }
       } catch {
         if (controller.signal.aborted) return;
-        toast.error(t('pos.loadOrderFailed'));
+        toast.error(t('loadOrderFailed'));
       } finally {
         setLoading(false);
       }
@@ -82,7 +82,7 @@ export default function TableCheckoutModal({
       const { data } = await api.post('/bills/generate', { order_id: order.id });
       onPayment(data.bill);
     } catch {
-      toast.error(t('pos.generateBillFailed'));
+      toast.error(t('generateBillFailed'));
     } finally {
       setGenerating(false);
     }
@@ -95,7 +95,7 @@ export default function TableCheckoutModal({
       const bill = order.bill || (await api.post('/bills/generate', { order_id: order.id })).data.bill;
       setSplitBill(bill);
     } catch {
-      toast.error(t('pos.generateBillFailed'));
+      toast.error(t('generateBillFailed'));
     }
     finally { setGenerating(false); }
   };
@@ -106,7 +106,7 @@ export default function TableCheckoutModal({
     try {
       await onAddCartToOrder(table, order);
     } catch {
-      toast.error(t('pos.addItemsFailed'));
+      toast.error(t('addItemsFailed'));
     } finally {
       setAddingItems(false);
     }
@@ -126,8 +126,8 @@ export default function TableCheckoutModal({
     return (
       <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
         <div className="bg-white rounded-2xl p-6 w-full max-w-md">
-          <p className="text-gray-500 text-center py-4">{t('pos.noActiveOrder')}</p>
-          <Button onClick={onClose} variant="outline" className="w-full">{t('pos.close')}</Button>
+          <p className="text-gray-500 text-center py-4">{t('noActiveOrder')}</p>
+          <Button onClick={onClose} variant="outline" className="w-full">{t('close')}</Button>
         </div>
       </div>
     );
@@ -150,10 +150,10 @@ export default function TableCheckoutModal({
                   ? 'bg-green-100 text-green-700' 
                   : 'bg-orange-100 text-orange-700'
               }`}>
-                {order.bill?.payment_status === 'paid' ? t('pos.paid') : t('pos.unpaid')}
+                {order.bill?.payment_status === 'paid' ? t('paid') : t('unpaid')}
               </span>
             </div>
-            <p className="text-sm text-gray-500">{t('pos.orderNumber', { number: order.order_number })}</p>
+            <p className="text-sm text-gray-500">{t('orderNumber', { number: order.order_number })}</p>
           </div>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
             <X size={20} />
@@ -163,7 +163,7 @@ export default function TableCheckoutModal({
         <div className="flex-1 overflow-y-auto p-5">
           {/* Existing order items - shown as disabled/reference */}
           <div className="mb-3">
-            <p className="text-xs text-gray-400 uppercase tracking-wider mb-2">{t('pos.previousItems')}</p>
+            <p className="text-xs text-gray-400 uppercase tracking-wider mb-2">{t('previousItems')}</p>
             <div className="space-y-1">
               {activeItems.map((item) => (
                 <div key={item.id} className="flex justify-between items-start py-1.5 px-2 bg-gray-50 rounded-lg">
@@ -186,7 +186,7 @@ export default function TableCheckoutModal({
 
         <div className="p-5 border-t border-gray-100 space-y-3">
           <div className="flex justify-between text-sm">
-            <span className="text-gray-500">{t('pos.subtotal')}</span>
+            <span className="text-gray-500">{t('subtotal')}</span>
             <span>{fmt(Number(order.subtotal))}</span>
           </div>
           <TaxBreakdown
@@ -195,20 +195,20 @@ export default function TableCheckoutModal({
             theme="light"
           />
           <div className="flex justify-between text-lg font-bold">
-            <span>{t('pos.total')}</span>
+            <span>{t('total')}</span>
             <span className="text-brand">{fmt(Number(order.total))}</span>
           </div>
           {order.bill && order.bill.payment_status !== 'paid' && Number(order.bill.balance) > 0 && (
             <div className="flex justify-between text-sm font-medium">
-              <span className="text-orange-600">{t('pos.balanceDue')}</span>
+              <span className="text-orange-600">{t('balanceDue')}</span>
               <span className="text-orange-600">{fmt(Number(order.bill.balance))}</span>
             </div>
           )}
 
-          {splitBills.length > 0 && <div className="space-y-2">{splitBills.map((bill) => <div key={bill.id} className="flex items-center justify-between rounded-lg border p-2"><div><p className="text-sm font-medium">{bill.split_label}</p><p className="text-xs text-gray-500">{fmt(Number(bill.total))} · {bill.payment_status}</p></div>{bill.payment_status !== 'paid' && <Button size="sm" onClick={() => onPayment(bill)}>{t('pos.pay', { defaultValue: 'Pay' })}</Button>}</div>)}</div>}
+          {splitBills.length > 0 && <div className="space-y-2">{splitBills.map((bill) => <div key={bill.id} className="flex items-center justify-between rounded-lg border p-2"><div><p className="text-sm font-medium">{bill.split_label}</p><p className="text-xs text-gray-500">{fmt(Number(bill.total))} · {bill.payment_status}</p></div>{bill.payment_status !== 'paid' && <Button size="sm" onClick={() => onPayment(bill)}>{t('pay', { defaultValue: 'Pay' })}</Button>}</div>)}</div>}
 
           {/* Show different buttons based on cart state */}
-          {splitBills.length === 0 && splitChecksEnabled && order.type === 'dine_in' && order.bill?.payment_status !== 'paid' && <Button variant="outline" onClick={handleSplitCheck} disabled={generating} className="w-full"><Users size={15} className="me-2" />{t('pos.splitCheck', { defaultValue: 'Split check' })}</Button>}
+          {splitBills.length === 0 && splitChecksEnabled && order.type === 'dine_in' && order.bill?.payment_status !== 'paid' && <Button variant="outline" onClick={handleSplitCheck} disabled={generating} className="w-full"><Users size={15} className="me-2" />{t('splitCheck', { defaultValue: 'Split check' })}</Button>}
           {cartItemCount > 0 ? (
             // Cart has items - show "Add items to order" option
             <div className="space-y-2">
@@ -219,20 +219,20 @@ export default function TableCheckoutModal({
                 size="lg"
               >
                 <ShoppingCart size={16} className="me-2" />
-                {addingItems ? t('pos.adding') : t('pos.addToOrder', { count: cartItemCount })}
+                {addingItems ? t('adding') : t('addToOrder', { count: cartItemCount })}
               </Button>
               <Button onClick={handleCheckout} variant="outline" className="w-full" disabled={generating}>
-                {generating ? t('pos.generating') : t('pos.checkoutInstead')}
+                {generating ? t('generating') : t('checkoutInstead')}
               </Button>
             </div>
           ) : splitBills.length === 0 ? (
             // Cart empty - show both options
             <div className="grid grid-cols-2 gap-3">
               <Button variant="outline" onClick={() => onAddItems(table, order)}>
-                {t('pos.addItems')}
+                {t('addItems')}
               </Button>
               <Button onClick={handleCheckout} disabled={generating}>
-                {generating ? t('pos.generating') : t('pos.checkout')}
+                {generating ? t('generating') : t('checkout')}
               </Button>
             </div>
           ) : null}

--- a/frontend/src/components/pos/TablePickerModal.tsx
+++ b/frontend/src/components/pos/TablePickerModal.tsx
@@ -3,7 +3,7 @@
 import { X } from 'lucide-react';
 import type { Table } from '@/lib/types';
 import { useHeldOrdersStore } from '@/store/held-orders';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 
 interface Props {
   tables: Table[];
@@ -16,19 +16,21 @@ interface Props {
   onClose: () => void;
 }
 
-const statusStyles: Record<string, { border: string; badge: string; badgeKey: string | null }> = {
+type PosKey = keyof AppConfig['Messages']['pos'];
+
+const statusStyles: Record<string, { border: string; badge: string; badgeKey: PosKey | null }> = {
   available: { border: 'border-gray-200 hover:border-brand/40', badge: '', badgeKey: null },
-  occupied: { border: 'border-orange-300 bg-orange-50', badge: 'bg-orange-500', badgeKey: 'pos.tableOccupied' },
-  reserved: { border: 'border-yellow-300 bg-yellow-50', badge: 'bg-yellow-500', badgeKey: 'pos.tableReserved' },
-  cleaning: { border: 'border-gray-300 bg-gray-100', badge: 'bg-gray-500', badgeKey: 'pos.tableCleaning' },
-  held: { border: 'border-blue-400 bg-blue-50', badge: 'bg-blue-500', badgeKey: 'pos.tableHeld' },
+  occupied: { border: 'border-orange-300 bg-orange-50', badge: 'bg-orange-500', badgeKey: 'tableOccupied' },
+  reserved: { border: 'border-yellow-300 bg-yellow-50', badge: 'bg-yellow-500', badgeKey: 'tableReserved' },
+  cleaning: { border: 'border-gray-300 bg-gray-100', badge: 'bg-gray-500', badgeKey: 'tableCleaning' },
+  held: { border: 'border-blue-400 bg-blue-50', badge: 'bg-blue-500', badgeKey: 'tableHeld' },
 };
 
 export default function TablePickerModal({
   tables, selectedTableId, onSelectAvailable, onSelectOccupied, onSelectHeld, onPlaceOrder, onHoldTable, onClose,
 }: Props) {
   const heldOrders = useHeldOrdersStore();
-  const { t } = useI18n();
+  const t = useTranslations('pos');
 
   const handleClick = (table: Table) => {
     if (heldOrders.hasHeldOrder(table.id)) {
@@ -52,7 +54,7 @@ export default function TablePickerModal({
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-2xl p-6 w-full max-w-lg max-h-[80vh] overflow-y-auto">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-bold">{t('pos.selectTable')}</h2>
+          <h2 className="text-lg font-bold">{t('selectTable')}</h2>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
             <X size={20} />
           </button>
@@ -80,7 +82,7 @@ export default function TablePickerModal({
               >
                 {isHeld && (
                   <span className="absolute -top-2 -end-2 bg-blue-500 text-white text-[10px] px-1.5 py-0.5 rounded-full font-bold">
-                    {t('pos.tableHeld')}
+                    {t('tableHeld')}
                   </span>
                 )}
                 {!isHeld && style.badgeKey && (
@@ -89,7 +91,7 @@ export default function TablePickerModal({
                   </span>
                 )}
                 <p className="font-bold text-gray-900">{table.name}</p>
-                <p className="text-xs text-gray-500">{t('pos.tableSeats', { count: table.capacity })}</p>
+                <p className="text-xs text-gray-500">{t('tableSeats', { count: table.capacity })}</p>
                 {table.status === 'occupied' && (table.current_order || table.activeOrder) && (
                   <p className="text-xs text-orange-600 font-medium mt-1">
                     #{(table.current_order || table.activeOrder)?.order_number}
@@ -101,7 +103,7 @@ export default function TablePickerModal({
         </div>
 
         {tables.length === 0 && (
-          <p className="text-center text-gray-500 py-8">{t('pos.noTablesFound')}</p>
+          <p className="text-center text-gray-500 py-8">{t('noTablesFound')}</p>
         )}
 
         {selectedTableId && (
@@ -110,7 +112,7 @@ export default function TablePickerModal({
               onClick={() => onHoldTable(selectedTableId)}
               className="flex-1 px-4 py-3 rounded-xl border-2 border-gray-200 text-gray-700 font-medium hover:bg-gray-50 transition-colors"
             >
-              {t('pos.holdTable')}
+              {t('holdTable')}
             </button>
             <button
               onClick={() => {
@@ -119,7 +121,7 @@ export default function TablePickerModal({
               }}
               className="flex-1 px-4 py-3 rounded-xl bg-brand text-white font-medium hover:bg-brand/90 transition-colors"
             >
-              {t('pos.placeOrderButton')}
+              {t('placeOrderButton')}
             </button>
           </div>
         )}

--- a/frontend/src/components/pos/TaxBreakdown.tsx
+++ b/frontend/src/components/pos/TaxBreakdown.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { formatCurrencyForTenant } from '@/lib/countries';
 import { useAuthStore } from '@/store/auth';
 
@@ -19,7 +19,7 @@ interface Props {
 }
 
 export default function TaxBreakdown({ taxAmount, taxBreakdown, theme = 'dark' }: Props) {
-  const { t } = useI18n();
+  const t = useTranslations('pos');
   const currentTenant = useAuthStore((s) => s.currentTenant);
   const tenantCountry = currentTenant?.country;
   const tenantCurrency = currentTenant?.currency ?? 'INR';
@@ -42,7 +42,7 @@ export default function TaxBreakdown({ taxAmount, taxBreakdown, theme = 'dark' }
             ? <ChevronDown size={12} className={theme === 'light' ? 'text-gray-400' : 'text-slate-400'} />
             : <ChevronRight size={12} className={`rtl-flip ${theme === 'light' ? 'text-gray-400' : 'text-slate-400'}`} />
         )}
-        <span className={`text-xs ${theme === 'light' ? 'text-gray-500' : 'text-slate-300'}`}>{t('pos.tax')}</span>
+        <span className={`text-xs ${theme === 'light' ? 'text-gray-500' : 'text-slate-300'}`}>{t('tax')}</span>
         <span className="flex-1" />
         <span className={`text-xs ${theme === 'light' ? 'text-gray-500' : 'text-slate-300'}`}>{fmt(taxAmount)}</span>
       </button>
@@ -54,7 +54,7 @@ export default function TaxBreakdown({ taxAmount, taxBreakdown, theme = 'dark' }
             const amount = typeof line?.amount === 'number' ? line.amount : 0;
             return (
               <div key={`${title}_${rate}_${i}`} className={`flex justify-between text-xs ${theme === 'light' ? 'text-gray-400' : 'text-slate-400'}`}>
-                <span>{t('pos.taxLine', { title, rate })}</span>
+                <span>{t('taxLine', { title, rate })}</span>
                 <span>{fmt(amount)}</span>
               </div>
             );

--- a/frontend/src/lib/printer/web-print.ts
+++ b/frontend/src/lib/printer/web-print.ts
@@ -22,7 +22,9 @@ import {
 } from '@/lib/countries';
 import { formatTaxComponentLabel, resolveTaxComponents } from './tax-components';
 import { RECEIPT_BRANDING_NAME, RECEIPT_BRANDING_URL } from './branding';
-import { t as translate, getLanguageDirection, type Language } from '@/lib/i18n';
+import { createTranslator } from 'use-intl/core';
+import { getCachedMessages } from '@/lib/i18n/loader';
+import { LANGUAGES, getLanguageDirection, type Language } from '@/lib/i18n/languages';
 import { usePosSettingsStore } from '@/store/pos-settings';
 import { parseDbTimestamp } from '@/lib/utils';
 
@@ -82,31 +84,47 @@ function resolveLanguage(language?: Language): Language {
   }
 }
 
+/**
+ * Synchronous receipt translator backed by the shared locale loader cache.
+ * English is primed at module load; other languages resolve once their bundle
+ * has been loaded on demand (#375). Falls back to English so a receipt always
+ * renders without raw keys.
+ */
+function getReceiptTranslator(lang: Language): (key: string) => string {
+  const locale = LANGUAGES[lang]?.locale ?? 'en';
+  const messages = getCachedMessages(lang) ?? getCachedMessages('en') ?? {};
+  // `createTranslator` resolves dotted keys against the whole message tree;
+  // the cached messages are untyped (Record<string, unknown>), so the returned
+  // translator accepts arbitrary string keys at runtime.
+  return createTranslator({ locale, messages }) as unknown as (key: string) => string;
+}
+
 /** Static receipt labels in the active UI language. */
 function receiptLabels(lang: Language) {
+  const t = getReceiptTranslator(lang);
   return {
-    billNumber: translate('receipt.billNumber', lang),
-    date: translate('receipt.date', lang),
-    table: translate('receipt.table', lang),
-    customer: translate('pos.customer', lang),
-    customerNo: translate('receipt.customerNo', lang),
-    phone: translate('receipt.phone', lang),
-    item: translate('receipt.item', lang),
-    qty: translate('receipt.qty', lang),
-    rate: translate('receipt.rate', lang),
-    amount: translate('receipt.amount', lang),
-    taxDetails: translate('receipt.taxDetails', lang),
-    subtotal: translate('pos.subtotal', lang),
-    discount: translate('pos.discount', lang),
-    totalTax: translate('receipt.totalTax', lang),
-    serviceCharge: translate('receipt.serviceCharge', lang),
-    deliveryCharge: translate('receipt.deliveryCharge', lang),
-    grandTotal: translate('receipt.grandTotal', lang),
-    payments: translate('receipt.payments', lang),
-    thankYou: translate('receipt.thankYou', lang),
-    taxIncluded: translate('receipt.taxIncluded', lang),
-    printBill: translate('receipt.printBill', lang),
-    reprint: translate('receipt.reprint', lang),
+    billNumber: t('receipt.billNumber'),
+    date: t('receipt.date'),
+    table: t('receipt.table'),
+    customer: t('pos.customer'),
+    customerNo: t('receipt.customerNo'),
+    phone: t('receipt.phone'),
+    item: t('receipt.item'),
+    qty: t('receipt.qty'),
+    rate: t('receipt.rate'),
+    amount: t('receipt.amount'),
+    taxDetails: t('receipt.taxDetails'),
+    subtotal: t('pos.subtotal'),
+    discount: t('pos.discount'),
+    totalTax: t('receipt.totalTax'),
+    serviceCharge: t('receipt.serviceCharge'),
+    deliveryCharge: t('receipt.deliveryCharge'),
+    grandTotal: t('receipt.grandTotal'),
+    payments: t('receipt.payments'),
+    thankYou: t('receipt.thankYou'),
+    taxIncluded: t('receipt.taxIncluded'),
+    printBill: t('receipt.printBill'),
+    reprint: t('receipt.reprint'),
   };
 }
 
@@ -116,7 +134,7 @@ function receiptLabels(lang: Language) {
  * localized so a Persian receipt doesn't show an English phrase.
  */
 function resolveTaxIdLabel(country: string | undefined, lang: Language): string {
-  if (country?.toUpperCase() === 'IR') return translate('receipt.economicCode', lang);
+  if (country?.toUpperCase() === 'IR') return getReceiptTranslator(lang)('receipt.economicCode');
   return getCountryByCode(country ?? 'IN')?.taxIdLabel || 'Tax ID';
 }
 
@@ -128,7 +146,7 @@ const PAYMENT_METHOD_KEYS: Record<string, string> = {
 
 function resolvePaymentMethodLabel(method: string, lang: Language): string {
   const key = PAYMENT_METHOD_KEYS[method.toLowerCase()];
-  if (key) return translate(key, lang);
+  if (key) return getReceiptTranslator(lang)(key);
   return method.charAt(0).toUpperCase() + method.slice(1);
 }
 


### PR DESCRIPTION
## Intent

Migrate the POS page, its 14 components, and the web-print helper from the legacy useI18n()/t() flat-key API to use-intl useTranslations()/createTranslator, completing Phase 3 batch 5B (issue #377) of the i18n migration epic (#372).

Scope is exactly 16 files: pos/page.tsx plus the 14 POS components (AddonModal, CartPanel, CustomerSearch, DietaryBadge, EditCustomerModal, PaymentModal, PosTopbar, PrepaidCheckoutModal, PrinterStatus, ProductGrid, SplitCheckModal, TableCheckoutModal, TablePickerModal, TaxBreakdown) and lib/printer/web-print.ts.

Key decisions: React components use useTranslations(namespace) with typed leaf keys; multi-namespace files split into t / tCommon / tSupport / tOrders / tWhatsappSend as needed. DietaryBadge uses a typed KnownDietaryTag plus DIETARY_TAG_KEYS map for known tags while custom tags render the canonical name directly, and its existing tagLabel() helper must keep returning dotted keys because the unmigrated products page (batch 5E) still consumes it. PrepaidCheckoutModal uses a typed OrderType plus ORDER_TYPE_SUFFIX_KEYS map to replace the pos.orderTypeSuffix template-literal cast. Payment-method labels: PAYMENT_METHODS.labelKey stays dotted (dashboard batch 5C still consumes it), so both payment modals use a local typed BUILT_IN_PAYMENT_KEYS map. PaymentModal sendBillViaFlo is shared with the unmigrated orders page and still takes a dotted-key callback, bridged with a typed whatsapp.send adapter rather than reintroducing legacy t(). web-print.ts (non-React) uses createTranslator from use-intl/core with cached messages, keeping generateBillHtml/printWebBill synchronous so the receipt-printing and browser-receipts tests stay intact.

Constraints: no wording, logic, or behavior changes beyond the mechanical i18n API migration; no new dependencies, migrations, or schema changes; the legacy useI18n bridge must remain for other unmigrated batches (its removal is owned by #381); PaymentModal recently gained a dynamic currency-unit adapter (#387) whose behavior must be preserved.

## What Changed

- Migrated the POS page and 14 POS components from the legacy `useI18n` flat-key API to `useTranslations` with scoped namespace lookups.
- Added typed leaf-key maps for dynamic translation keys (`DIETARY_TAG_KEYS`, `ORDER_TYPE_SUFFIX_KEYS`, and `BUILT_IN_PAYMENT_KEYS`) while preserving compatibility interfaces for unmigrated modules.
- Converted `web-print.ts` to `createTranslator` from `use-intl/core` backed by cached locale messages for synchronous receipt label translation.

## Risk Assessment

✅ Low: The mechanical migration of POS components and web-print to use-intl is clean, type-safe, preserves backward-compatibility bridges, and introduces no regressions or missing translation keys.

## Testing

Validated Phase 3 Batch 5B i18n migration across all 16 scoped files: translation integrity checks confirmed 100% key and ICU parity without untranslated leaves; Next.js frontend export compiled successfully; browser web receipt generation verified synchronous translations in EN, ES, PT, and Persian RTL; Playwright e2e validated rendered POS UI in both English LTR and Persian RTL; and currency/payment split test suites passed with zero failures. Captured rendered UI screenshots and receipt HTML/PNG evidence in the designated evidence directory.

- Evidence: POS Screen English LTR UI (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D3DF5HBETVQHFX32CEADPS/pos-ltr-en.png</code>)
- Evidence: POS Screen Persian RTL UI (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D3DF5HBETVQHFX32CEADPS/pos-rtl-fa.png</code>)
- Evidence: Persian RTL Web Receipt (Rial &amp; Persian Digits) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D3DF5HBETVQHFX32CEADPS/01_persian_receipt_rial_persian_digits.png</code>)
<details>
<summary>Evidence: Persian RTL Web Receipt HTML (Rial)</summary>

```text
<!DOCTYPE html>
<html lang="fa" dir="rtl">
<head>
  <meta charset="utf-8">
  <title>رسید # BILL-IR-0089</title>
  <style>
    
    * { box-sizing: border-box; margin: 0; padding: 0; }
    body { font-family: -apple-system, 'Segoe UI', Tahoma, 'Noto Naskh Arabic', 'Helvetica Neue', Arial, sans-serif; font-size: 12px; line-height: 1.4; color: #333; }
    .bill-container { max-width: 100%; margin: 0 auto; }
    .reprint-banner { text-align: center; font-size: 22px; font-weight: bold; letter-spacing: 2px; color: #c00; border: 3px solid #c00; padding: 6px; margin-bottom: 15px; }
    .header { text-align: center; margin-bottom: 20px; padding-bottom: 10px; border-bottom: 1px solid #ccc; }
    .header h1 { font-size: 24px; margin-bottom: 5px; }
    .bill-details { margin-bottom: 15px; }
    .bill-details table { width: 100%; }
    .items-table { width: 100%; border-collapse: collapse; margin-bottom: 15px; }
    .items-table th, .items-table td { padding: 8px; border-bottom: 1px solid #eee; text-align: start; }
    .items-table th { background: #f5f5f5; font-weight: bold; }
    .tax-table, .payments-table { width: 50%; margin-inline-start: 50%; border-collapse: collapse; margin-bottom: 15px; }
    .tax-table th, .tax-table td, .payments-table th, .payments-table td { padding: 6px 8px; }
    .tax-table th, .payments-table th { background: #f9f9f9; text-align: start; }
    .totals-table { width: 100%; border-collapse: collapse; margin-bottom: 15px; }
    .totals-table td { padding: 6px 8px; }
    .total-row { border-top: 2px solid #333; font-size: 16px; }
    .footer { text-align: center; margin-top: 30px; padding-top: 15px; border-top: 1px solid #ccc; }
    .powered-by { font-size: 10px; margin-top: 8px; color: #555; }
    .text-end { text-align: end !important; }
    .num { unicode-bidi: isolate; white-space: nowrap; }
    .ltr { direction: ltr; unicode-bidi: isolate; }
    .text-muted { color: #666; }
    .text-italic { font-style: italic; color: #888; }
  
        .bill-container { padding: 10px; max-width: 80mm; font-size: 11px; }
        .header h1 { font-size: 16px; }
      
    @media print {
      .no-print { display: none !important; }
      body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
    }
  </style>
</head>
<body>
  <div class="bill-container">
    
    <!-- Header -->
    <div class="header">
      <h1>کافه کتاب تهران (Tehran Book Cafe)</h1>
      <p>تهران، خیابان انقلاب، پلاک ۱۲</p>
      <p>تلفن: <span class="ltr" dir="ltr">+98 21 6644 1234</span></p>
      <p>کد اقتصادی: <span class="ltr" dir="ltr">411123456789</span></p>
    </div>

    <!-- Bill Details -->
    <div class="bill-details">
      <table>
        <tr>
          <td><strong>رسید #</strong> <span class="ltr" dir="ltr">BILL-IR-0089</span></td>
          <td class="text-end"><strong>تاریخ</strong> ۲۶ مرداد ۱۴۰۵، ۱۸:۰۰</td>
        </tr>
        <tr><td><strong>میز</strong> میز ۱۲ (Table 12)</td><td></td></tr>
        <tr><td><strong>مشتری</strong> رضا حسینی (Reza Hosseini)</td><td></td></tr>
        <tr><td><strong>شماره مشتری</strong> <span class="ltr" dir="ltr">+98 912 345 6789</span></td><td></td></tr>
      </table>
    </div>

    <!-- Items Table -->
    <table class="items-table">
      <thead>
        <tr>
          <th>اقلام</th>
          <th class="text-end">تعداد</th>
          <th class="text-end">نرخ</th>
          <th class="text-end">مبلغ</th>
        </tr>
      </thead>
      <tbody>
        
          <tr>
            <td>
              چای زعفرانی (Saffron Tea)
              <br><small class="text-muted">+ هل اضافه</small>
              <br><small class="text-italic">کم شیرین</small>
            </td>
            <td class="text-end num">۲</td>
            <td class="text-end num">‎ریال ۳۰۰٬۰۰۰</td>
            <td class="text-end num">‎ریال ۶۶۰٬۰۰۰</td>
          </tr>
        
          <tr>
            <td>
              باقلوا یزدی (Baklava)
              
              
            </td>
            <td class="text-end num">۱</td>
            <td class="text-end num">‎ریال ۳۰۰٬۰۰۰</td>
            <td class="text-end num">‎ریال ۳۳۰٬۰۰۰</td>
          </tr>
        
      </tbody>
    </table>

    <!-- Tax Breakdown -->
    
    <table class="tax-table">
      <thead>
        <tr><th colspan="2">جزئیات مالیات</th></tr>
      </thead>
      <tbody>
        
          <tr><td>ارزش افزوده (VAT) @10%</td><td class="text-end num">‎ریال ۹۰٬۰۰۰</td></tr>
        
      </tbody>
    </table>
    

    <!-- Totals -->
    <table class="totals-table">
      <tr><td>جمع جزء</td><td class="text-end num">‎ریال ۹۰۰٬۰۰۰</td></tr>
      
      <tr><td>مالیات کل</td><td class="text-end num">‎ریال ۹۰٬۰۰۰</td></tr>
      
      
      <tr class="total-row"><td><strong>جمع کل</strong></td><td class="text-end num"><strong>‎ریال ۹۹۰٬۰۰۰</strong></td></tr>
    </table>

    <!-- Payments -->
    
    <table class="payments-table">
      <thead>
        <tr><th colspan="2">پرداخت‌ها</th></tr>
      </thead>
      <tbody>
        
          <tr><td>کارت</td><td class="text-end num">‎ریال ۹۹۰٬۰۰۰</td></tr>
        
      </tbody>
    </table>
    

    <!-- Footer -->
    <div class="footer">
      <p>از بازدید شما سپاسگزاریم!</p>
      <p>مالیات در صورت اعمال، شامل شده است</p>
      <p class="powered-by">Powered by FloPOS<br>https://flopos.com</p>
    </div>
  </div>

  <div class="no-print" style="text-align:center;margin-top:20px;">
    <button onclick="window.print()" style="padding:10px 20px;font-size:16px;cursor:pointer;">چاپ رسید</button>
  </div>
</body>
</html>
  
```
</details>
- Evidence: Persian RTL Web Receipt (Toman &amp; Persian Digits) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D3DF5HBETVQHFX32CEADPS/02_persian_receipt_toman_persian_digits.png</code>)
- Evidence: Persian RTL Web Receipt (Toman Short &amp; Latin Digits) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D3DF5HBETVQHFX32CEADPS/03_persian_receipt_toman_short_latin_digits.png</code>)
- Evidence: English Baseline Web Receipt (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D3DF5HBETVQHFX32CEADPS/05_english_receipt_baseline.png</code>)
- Evidence: Spanish Reprint Web Receipt (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D3DF5HBETVQHFX32CEADPS/06_spanish_receipt_reprint.png</code>)
- Evidence: Portuguese Brazil Web Receipt (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D3DF5HBETVQHFX32CEADPS/07_portuguese_receipt_brazil.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0b756fec55d19c47dd7fb7a29835e10ce4046fac","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:translations`
- `npm run test:locale-chunks`
- `npm run test:rtl-dashboard-pos-common`
- `npm run test:receipt-printing`
- `npm run test:bills-print-api`
- `npm run test:currency`
- `npm run test:payment-methods-split`
- `npm run build:frontend`
- `npm run build`
- `npx ts-node --transpile-only -P tests/tsconfig.json tests/browser-receipts.test.ts`
- `cd frontend && EVIDENCE_DIR=/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D3DF5HBETVQHFX32CEADPS npx playwright test e2e/rtl-dashboard-pos-common.spec.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
