### PR TITLE
refactor(i18n): migrate orders, tables, customers, and dashboard to use-intl

### DIFF
--- a/frontend/e2e/i18n-batch-5c.spec.ts
+++ b/frontend/e2e/i18n-batch-5c.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, Page } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+const BASE = 'http://localhost:3001';
+const EVIDENCE_DIR =
+  process.env.EVIDENCE_DIR ||
+  path.join(os.tmpdir(), 'no-mistakes-evidence', '01M0D6PY3HABMDFH71W637DKE8');
+
+async function captureScreenshot(page: Page, filename: string): Promise<void> {
+  if (!fs.existsSync(EVIDENCE_DIR)) {
+    fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  }
+  await page.screenshot({ path: path.join(EVIDENCE_DIR, filename), fullPage: true });
+}
+
+async function login(page: Page, email: string): Promise<void> {
+  await page.goto(`${BASE}/auth/login`);
+  await page.locator('#email').fill(email);
+  await page.locator('#password').fill('E2ePass123!');
+  await page.locator('button[type="submit"]').click();
+  await page.waitForURL('**/pos/**', { timeout: 20000 });
+  await page.waitForFunction(() => !!localStorage.getItem('token'));
+}
+
+async function setLanguage(page: Page, value: string): Promise<void> {
+  const token = await page.evaluate(() => localStorage.getItem('token'));
+  expect(token, 'auth token must be present before changing language').toBeTruthy();
+  const res = await page.request.put(`${BASE}/api/settings/language`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { value },
+  });
+  expect(res.ok(), `setting language=${value} should succeed (status ${res.status()})`).toBeTruthy();
+  await page.evaluate((lang) => {
+    try {
+      const raw = localStorage.getItem('pos-settings');
+      const parsed = raw ? JSON.parse(raw) : { state: {} };
+      parsed.state = { ...parsed.state, language: lang };
+      localStorage.setItem('pos-settings', JSON.stringify(parsed));
+    } catch {}
+  }, value);
+}
+
+test('Batch 5C Pages (Dashboard, Orders, Tables, Customers, OrderHistoryGrid) render correctly in English and Persian', async ({ page }) => {
+  await login(page, 'owner@flo.local');
+
+  // ==========================================
+  // 1. ENGLISH (EN) BASELINE
+  // ==========================================
+  await setLanguage(page, 'en');
+
+  // 1a. Dashboard (EN)
+  await page.goto(`${BASE}/dashboard`);
+  await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Dashboard');
+  await expect(page.getByText("Today's Sales")).toBeVisible();
+  await expect(page.getByText('Running Orders')).toBeVisible();
+  await captureScreenshot(page, 'dashboard-en.png');
+
+  // 1b. Orders (EN)
+  await page.goto(`${BASE}/orders`);
+  await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Orders');
+  await expect(page.getByPlaceholder('Search by order number…')).toBeVisible();
+  await captureScreenshot(page, 'orders-en.png');
+
+  // 1c. Tables (EN)
+  await page.goto(`${BASE}/tables`);
+  await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Tables');
+  await expect(page.getByText('Add Table')).toBeVisible();
+  await captureScreenshot(page, 'tables-en.png');
+
+  // 1d. Customers (EN)
+  await page.goto(`${BASE}/customers`);
+  await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Customers');
+  await expect(page.getByText('Add Customer')).toBeVisible();
+  await captureScreenshot(page, 'customers-en.png');
+
+  // 1e. Order History Demo (OrderHistoryGrid) (EN)
+  await page.goto(`${BASE}/order-history-demo`);
+  await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Order History');
+  await expect(page.getByText('Dine In').first()).toBeVisible();
+  await expect(page.getByText('Subtotal').first()).toBeVisible();
+  await expect(page.getByText('Print Receipt').first()).toBeVisible();
+  await captureScreenshot(page, 'order-history-grid-en.png');
+
+  // ==========================================
+  // 2. PERSIAN (FA) RTL
+  // ==========================================
+  try {
+    await setLanguage(page, 'fa');
+
+    // 2a. Dashboard (FA)
+    await page.goto(`${BASE}/dashboard`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('پیشخوان');
+    await expect(page.getByText('فروش امروز')).toBeVisible();
+    await expect(page.getByText('سفارش‌های در جریان')).toBeVisible();
+    await captureScreenshot(page, 'dashboard-fa.png');
+
+    // 2b. Orders (FA)
+    await page.goto(`${BASE}/orders`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('سفارش‌ها');
+    await expect(page.getByPlaceholder('بر پایه شماره سفارش جستجو کنید…')).toBeVisible();
+    await captureScreenshot(page, 'orders-fa.png');
+
+    // 2c. Tables (FA)
+    await page.goto(`${BASE}/tables`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('میزها');
+    await expect(page.getByText('افزودن میز')).toBeVisible();
+    await captureScreenshot(page, 'tables-fa.png');
+
+    // 2d. Customers (FA)
+    await page.goto(`${BASE}/customers`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('مشتریان');
+    await expect(page.getByText('افزودن مشتری').first()).toBeVisible();
+    await captureScreenshot(page, 'customers-fa.png');
+
+    // 2e. Order History Demo (OrderHistoryGrid) (FA)
+    await page.goto(`${BASE}/order-history-demo`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('پیشینه سفارش‌ها');
+    await expect(page.getByText('خوردن در محل').first()).toBeVisible();
+    await expect(page.getByText('جمع جزء').first()).toBeVisible();
+    await expect(page.getByText('چاپ رسید').first()).toBeVisible();
+    await captureScreenshot(page, 'order-history-grid-fa.png');
+
+  } finally {
+    await setLanguage(page, 'en');
+  }
+});

--- a/frontend/src/app/(dashboard)/customers/page.tsx
+++ b/frontend/src/app/(dashboard)/customers/page.tsx
@@ -13,7 +13,7 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import type { Customer } from '@/lib/types';
 import { countryName } from '@/lib/countries';
 import { dialCodeFor, normalizeOptionalPhone } from '@/lib/phone';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useFormatDate } from '@/hooks/useFormatDate';
@@ -26,7 +26,11 @@ function SortIcon({ field, sortField, sortOrder }: { field: string; sortField: s
 
 export default function CustomersPage() {
   const { currentTenant } = useAuthStore();
-  const { t } = useI18n();
+  const tCustomer = useTranslations('customer');
+  const tCustomers = useTranslations('customers');
+  const tPos = useTranslations('pos');
+  const tNav = useTranslations('nav');
+  const tCommon = useTranslations('common');
   const fmt = useFormatCurrency();
   const { formatDate } = useFormatDate();
   const fmtNum = useFormatNumber();
@@ -59,7 +63,7 @@ export default function CustomersPage() {
       const { data } = await api.get(`/customers/${c.id}/wallet`);
       setLedgerData(data);
     } catch {
-      toast.error(t('customer.ledgerLoadFailed'));
+      toast.error(tCustomer('ledgerLoadFailed'));
     } finally {
       setLedgerLoading(false);
     }
@@ -76,7 +80,7 @@ export default function CustomersPage() {
     api.get('/customers', { params, signal: controller.signal })
       .then(({ data }) => setCustomers(data.data || []))
       .catch((err: unknown) => {
-        if (!(err instanceof Error && (err.name === 'CanceledError' || err.name === 'AbortError'))) toast.error(t('customer.loadFailed'));
+        if (!(err instanceof Error && (err.name === 'CanceledError' || err.name === 'AbortError'))) toast.error(tCustomer('loadFailed'));
       })
       .finally(() => { setLoading(false); });
     }, 250);
@@ -102,26 +106,26 @@ export default function CustomersPage() {
     e.preventDefault();
     const norm = normalizeOptionalPhone(form.phone, defaultCountry);
     if (!norm.valid) {
-      toast.error(t('pos.invalidPhone', { country: countryName(defaultCountry) }));
+      toast.error(tPos('invalidPhone', { country: countryName(defaultCountry) }));
       return;
     }
     if (!editingCustomer && !norm.e164) {
-      toast.error(t('pos.invalidPhone', { country: countryName(defaultCountry) }));
+      toast.error(tPos('invalidPhone', { country: countryName(defaultCountry) }));
       return;
     }
     const payload = { ...form, phone: norm.e164 ?? '', country_code: norm.countryCode ?? '' };
     try {
       if (editingCustomer) {
         await api.put(`/customers/${editingCustomer.id}`, payload);
-        toast.success(t('customer.updated'));
+        toast.success(tCustomer('updated'));
       } else {
         await api.post('/customers', payload);
-        toast.success(t('customer.added'));
+        toast.success(tCustomer('added'));
       }
       setShowForm(false);
       setRefreshKey((k) => k + 1);
     } catch {
-      toast.error(t('customer.saveFailed'));
+      toast.error(tCustomer('saveFailed'));
     }
   };
 
@@ -138,24 +142,24 @@ export default function CustomersPage() {
     <div>
       <div className="flex justify-between items-center mb-6">
         <div className="flex items-center gap-4">
-          <h1 className="text-2xl font-bold text-gray-900">{t('nav.customers')}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{tNav('customers')}</h1>
           {filter === 'invalid_phones' && (
             <span className="bg-red-100 text-red-800 text-xs px-2.5 py-1 rounded-full font-medium flex items-center gap-1.5">
-              <AlertCircle size={14} /> {t('customers.actionRequired')}
+              <AlertCircle size={14} /> {tCustomers('actionRequired')}
               <button onClick={() => router.push('/customers')} className="ms-1 text-red-500 hover:text-red-700">
                 <X size={12} />
               </button>
             </span>
           )}
         </div>
-        <Button onClick={openAdd}><Plus size={16} className="me-1" /> {t('customer.add')}</Button>
+        <Button onClick={openAdd}><Plus size={16} className="me-1" /> {tCustomer('add')}</Button>
       </div>
 
       <div className="relative mb-4">
         <Search size={18} className="absolute start-3 top-1/2 -translate-y-1/2 text-gray-400" />
         <input
           type="text" value={search} onChange={(e) => setSearch(e.target.value)}
-          placeholder={t('customer.search')}
+          placeholder={tCustomer('search')}
           className="w-full ps-10 pe-4 py-2.5 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand outline-none"
         />
       </div>
@@ -165,25 +169,25 @@ export default function CustomersPage() {
           <thead className="bg-gray-50">
             <tr>
               <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-100 group transition-colors" onClick={() => onSort('name')}>
-                {t('customers.columnCustomer')} <SortIcon field="name" sortField={sortField} sortOrder={sortOrder} />
+                {tCustomers('columnCustomer')} <SortIcon field="name" sortField={sortField} sortOrder={sortOrder} />
               </th>
               <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-100 group transition-colors" onClick={() => onSort('phone')}>
-                {t('customer.phone')} <SortIcon field="phone" sortField={sortField} sortOrder={sortOrder} />
+                {tCustomer('phone')} <SortIcon field="phone" sortField={sortField} sortOrder={sortOrder} />
               </th>
               <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-100 group transition-colors" onClick={() => onSort('last_visit')}>
-                {t('customers.columnLastVisit')} <SortIcon field="last_visit" sortField={sortField} sortOrder={sortOrder} />
+                {tCustomers('columnLastVisit')} <SortIcon field="last_visit" sortField={sortField} sortOrder={sortOrder} />
               </th>
               <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-100 group transition-colors" onClick={() => onSort('visits')}>
-                {t('customer.visits')} <SortIcon field="visits" sortField={sortField} sortOrder={sortOrder} />
+                {tCustomer('visits')} <SortIcon field="visits" sortField={sortField} sortOrder={sortOrder} />
               </th>
               <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-100 group transition-colors" onClick={() => onSort('spent')}>
-                {t('customer.totalSpent')} <SortIcon field="spent" sortField={sortField} sortOrder={sortOrder} />
+                {tCustomer('totalSpent')} <SortIcon field="spent" sortField={sortField} sortOrder={sortOrder} />
               </th>
               <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-100 group transition-colors" onClick={() => onSort('loyalty')}>
-                {t('customer.loyalty')} <SortIcon field="loyalty" sortField={sortField} sortOrder={sortOrder} />
+                {tCustomer('loyalty')} <SortIcon field="loyalty" sortField={sortField} sortOrder={sortOrder} />
               </th>
-              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('customers.columnActions')}</th>
-              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('customers.columnLedger')}</th>
+              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{tCustomers('columnActions')}</th>
+              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{tCustomers('columnLedger')}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
@@ -214,7 +218,7 @@ export default function CustomersPage() {
                   {Number(c.wallet_balance) > 0 ? (
                     <span className="inline-flex items-center gap-1 text-purple-700 font-semibold text-sm">
                       <Wallet size={13} />
-                      {fmtNum(Number(c.wallet_balance))} {t('customer.ptsSuffix')}
+                      {fmtNum(Number(c.wallet_balance))} {tCustomer('ptsSuffix')}
                     </span>
                   ) : (
                     <span className="text-gray-400 text-sm">—</span>
@@ -226,7 +230,7 @@ export default function CustomersPage() {
                   </Button>
                 </td>
                 <td className="p-4 text-center">
-                  <Button variant="ghost" size="sm" onClick={() => openLedger(c)} title={t('customer.viewLedgerTitle')}>
+                  <Button variant="ghost" size="sm" onClick={() => openLedger(c)} title={tCustomer('viewLedgerTitle')}>
                     <History size={14} />
                   </Button>
                 </td>
@@ -234,8 +238,8 @@ export default function CustomersPage() {
             ))}
           </tbody>
         </table>
-        {customers.length === 0 && <p className="text-center text-gray-500 py-12">{t('customers.empty')}</p>}
-        {customers.length >= 200 && <p className="text-center text-xs text-gray-400 py-3">{t('customers.first200')}</p>}
+        {customers.length === 0 && <p className="text-center text-gray-500 py-12">{tCustomers('empty')}</p>}
+        {customers.length >= 200 && <p className="text-center text-xs text-gray-400 py-3">{tCustomers('first200')}</p>}
       </div>
 
       {/* Loyalty Ledger Modal */}
@@ -244,7 +248,7 @@ export default function CustomersPage() {
           <div className="bg-white rounded-2xl w-full max-w-lg max-h-[85vh] flex flex-col shadow-xl">
             <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-gray-100">
               <div>
-                <h2 className="text-lg font-bold text-gray-900">{t('customers.loyaltyLedger')}</h2>
+                <h2 className="text-lg font-bold text-gray-900">{tCustomers('loyaltyLedger')}</h2>
                 <p className="text-sm text-gray-500">{ledgerCustomer.name}</p>
               </div>
               <button onClick={() => setLedgerCustomer(null)} className="w-8 h-8 flex items-center justify-center rounded-full bg-gray-100 hover:bg-gray-200">
@@ -253,29 +257,29 @@ export default function CustomersPage() {
             </div>
 
             {ledgerLoading ? (
-              <div className="flex-1 flex items-center justify-center py-12 text-gray-400">{t('customer.loadingLedger')}</div>
+              <div className="flex-1 flex items-center justify-center py-12 text-gray-400">{tCustomer('loadingLedger')}</div>
             ) : ledgerData ? (
               <>
                 {/* Summary row */}
                 <div className="flex items-center gap-6 px-6 py-4 bg-gray-50 border-b border-gray-100">
                   <div>
-                    <p className="text-xs text-gray-500 mb-0.5">{t('customers.totalBalance')}</p>
-                    <p className="text-2xl font-bold text-gray-900">{ledgerData.balance} <span className="text-sm font-normal text-gray-500">{t('customer.ptsSuffix')}</span></p>
+                    <p className="text-xs text-gray-500 mb-0.5">{tCustomers('totalBalance')}</p>
+                    <p className="text-2xl font-bold text-gray-900">{ledgerData.balance} <span className="text-sm font-normal text-gray-500">{tCustomer('ptsSuffix')}</span></p>
                   </div>
                 </div>
 
                 {/* Ledger table */}
                 <div className="flex-1 overflow-y-auto">
                   {ledgerData.transactions.length === 0 ? (
-                    <p className="text-center text-gray-400 py-12">{t('customers.noTransactions')}</p>
+                    <p className="text-center text-gray-400 py-12">{tCustomers('noTransactions')}</p>
                   ) : (
                     <table className="w-full text-sm">
                       <thead className="bg-gray-50 sticky top-0">
                         <tr>
-                          <th className="text-start px-4 py-2.5 text-xs font-medium text-gray-500">{t('customers.columnDate')}</th>
-                          <th className="text-start px-4 py-2.5 text-xs font-medium text-gray-500">{t('customers.columnDescription')}</th>
-                          <th className="text-end px-4 py-2.5 text-xs font-medium text-gray-500">{t('customers.columnPoints')}</th>
-                          <th className="text-end px-4 py-2.5 text-xs font-medium text-gray-500">{t('customers.columnExpires')}</th>
+                          <th className="text-start px-4 py-2.5 text-xs font-medium text-gray-500">{tCustomers('columnDate')}</th>
+                          <th className="text-start px-4 py-2.5 text-xs font-medium text-gray-500">{tCustomers('columnDescription')}</th>
+                          <th className="text-end px-4 py-2.5 text-xs font-medium text-gray-500">{tCustomers('columnPoints')}</th>
+                          <th className="text-end px-4 py-2.5 text-xs font-medium text-gray-500">{tCustomers('columnExpires')}</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-gray-50">
@@ -312,19 +316,19 @@ export default function CustomersPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-2xl p-6 w-full max-w-sm">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-bold">{editingCustomer ? t('customer.edit') : t('customer.add')}</h2>
+              <h2 className="text-lg font-bold">{editingCustomer ? tCustomer('edit') : tCustomer('add')}</h2>
               <button onClick={() => setShowForm(false)}><X size={20} className="text-gray-400" /></button>
             </div>
             <form onSubmit={handleSave} className="space-y-4">
-              <input type="text" placeholder={t('customer.name')} value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })}
+              <input type="text" placeholder={tCustomer('name')} value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })}
                 className="w-full px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand" required />
               <div className="flex items-stretch gap-2">
-                <input type="tel" placeholder={dialCode ? `${dialCode} ${t('customer.phone')}` : t('customer.phone')} value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })}
+                <input type="tel" placeholder={dialCode ? `${dialCode} ${tCustomer('phone')}` : tCustomer('phone')} value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })}
                   className="flex-1 px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand" required={!editingCustomer} />
               </div>
-              <input type="email" placeholder={`${t('customer.email')} (${t('common.optional')})`} value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })}
+              <input type="email" placeholder={`${tCustomer('email')} (${tCommon('optional')})`} value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })}
                 className="w-full px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand" />
-              <Button type="submit" className="w-full">{editingCustomer ? t('customer.update') : t('customer.add')}</Button>
+              <Button type="submit" className="w-full">{editingCustomer ? tCustomer('update') : tCustomer('add')}</Button>
             </form>
           </div>
         </div>

--- a/frontend/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/page.tsx
@@ -6,12 +6,13 @@ import Link from 'next/link';
 import { useAuthStore } from '@/store/auth';
 import api from '@/lib/api';
 import { Banknote, ChefHat, Clock, LayoutGrid, TrendingUp, ClipboardList, ArrowRight, Timer, Trophy, Tags, BarChart3, Wallet } from 'lucide-react';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
 import toast from 'react-hot-toast';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { getCountryByCode } from '@/lib/countries';
 import { PAYMENT_METHODS } from '@/lib/payment-methods';
+import { ORDER_STATUS_LABEL_KEYS } from '@/lib/i18n-enums';
 
 interface PaymentMethodBreakdown {
   method: string | null;
@@ -121,13 +122,22 @@ const orderStatusColor: Record<string, string> = {
   cancelled: 'text-red-500',
 };
 
-function localizeTemplate(template: string, vars: Record<string, string | number>): string {
-  return template.replace(/\{(\w+)\}/g, (_m, k) => String(vars[k] ?? `{${k}}`));
-}
+type OrdersKey = keyof AppConfig['Messages']['orders'];
+type PosKey = keyof AppConfig['Messages']['pos'];
+
+// Built-in payment method label keys (PAYMENT_METHODS keeps dotted keys for the
+// not-yet-migrated files, so the dashboard maps them to typed `pos` leaf keys).
+const BUILT_IN_PAYMENT_KEYS = {
+  cash: 'methodCash',
+  card: 'methodCard',
+} as const satisfies Record<'cash' | 'card', PosKey>;
 
 export default function DashboardPage() {
   const { currentTenant } = useAuthStore();
-  const { t } = useI18n();
+  const t = useTranslations('dashboard');
+  const tCommon = useTranslations('common');
+  const tPos = useTranslations('pos');
+  const tOrders = useTranslations('orders');
   const router = useRouter();
   const [stats, setStats] = useState<DailyStats | null>(null);
   const [daySummary, setDaySummary] = useState<DaySummary | null>(null);
@@ -178,7 +188,7 @@ export default function DashboardPage() {
       })
       .catch((err: unknown) => {
         if (err instanceof Error && (err.name === 'CanceledError' || err.name === 'AbortError')) return;
-        toast.error(t('common.somethingWrong'));
+        toast.error(tCommon('somethingWrong'));
       })
       .finally(() => {
         if (!controller.signal.aborted) setLoading(false);
@@ -199,7 +209,7 @@ export default function DashboardPage() {
   const dateScopedTiles = isToday
     ? [
         {
-          label: t('dashboard.runningOrders'),
+          label: t('runningOrders'),
           value: stats?.runningOrders ?? 0,
           icon: ChefHat,
           color: 'bg-blue-50 border-blue-200',
@@ -207,7 +217,7 @@ export default function DashboardPage() {
           href: '/orders',
         },
         {
-          label: t('dashboard.pendingOrders'),
+          label: t('pendingOrders'),
           value: stats?.pendingOrders ?? 0,
           icon: Clock,
           color: 'bg-yellow-50 border-yellow-200',
@@ -215,7 +225,7 @@ export default function DashboardPage() {
           href: '/orders',
         },
         {
-          label: t('dashboard.tablesOccupied'),
+          label: t('tablesOccupied'),
           value: stats?.tablesOccupied ?? 0,
           icon: LayoutGrid,
           color: 'bg-purple-50 border-purple-200',
@@ -225,7 +235,7 @@ export default function DashboardPage() {
       ]
     : [
         {
-          label: t('dashboard.orders'),
+          label: t('orders'),
           value: daySummary?.orders.count ?? 0,
           icon: ChefHat,
           color: 'bg-blue-50 border-blue-200',
@@ -233,7 +243,7 @@ export default function DashboardPage() {
           href: '/orders',
         },
         {
-          label: t('dashboard.newCustomers'),
+          label: t('newCustomers'),
           value: daySummary?.customers.new ?? 0,
           icon: Clock,
           color: 'bg-yellow-50 border-yellow-200',
@@ -244,7 +254,7 @@ export default function DashboardPage() {
 
   const tiles = [
     {
-      label: isToday ? t('dashboard.todaySales') : t('dashboard.sales'),
+      label: isToday ? t('todaySales') : t('sales'),
       value: fmt(isToday ? (stats?.sales ?? 0) : (daySummary?.bills.collected ?? 0)),
       icon: Banknote,
       color: 'bg-green-50 border-green-200',
@@ -253,7 +263,7 @@ export default function DashboardPage() {
     },
     ...dateScopedTiles,
     {
-      label: t('dashboard.aov'),
+      label: t('aov'),
       value: fmt(insights?.aov ?? 0),
       icon: TrendingUp,
       color: 'bg-teal-50 border-teal-200',
@@ -261,8 +271,8 @@ export default function DashboardPage() {
       href: '/orders',
     },
     {
-      label: t('dashboard.avgPrepTime'),
-      value: insights?.avgPrepTimeMinutes != null ? localizeTemplate(t('dashboard.minutesValue'), { minutes: insights.avgPrepTimeMinutes }) : '—',
+      label: t('avgPrepTime'),
+      value: insights?.avgPrepTimeMinutes != null ? t('minutesValue', { minutes: insights.avgPrepTimeMinutes }) : '—',
       icon: Timer,
       color: 'bg-orange-50 border-orange-200',
       iconColor: 'text-orange-600',
@@ -273,14 +283,14 @@ export default function DashboardPage() {
   return (
     <div className="p-6">
       <div className="mb-6 flex items-center justify-between gap-4 flex-wrap">
-        <h1 className="text-2xl font-bold text-gray-900">{t('dashboard.title')}</h1>
+        <h1 className="text-2xl font-bold text-gray-900">{t('title')}</h1>
         <input
           type="date"
           value={selectedDate}
           max={todayLocal}
           onChange={(e) => e.target.value && setSelectedDate(e.target.value)}
           className="px-3 py-1.5 text-sm border border-gray-200 rounded-lg text-gray-700 focus:outline-none focus:ring-2 focus:ring-brand/30"
-          aria-label={t('dashboard.selectDate')}
+          aria-label={t('selectDate')}
         />
       </div>
 
@@ -314,14 +324,14 @@ export default function DashboardPage() {
               <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
                 <h2 className="flex items-center gap-2 font-semibold text-gray-900">
                   <ClipboardList size={16} className="text-gray-400" />
-                  {isToday ? t('dashboard.recentOrders') : t('dashboard.orders')}
+                  {isToday ? t('recentOrders') : t('orders')}
                 </h2>
                 <Link href="/orders" className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover font-medium">
-                  {t('dashboard.viewAll')} <ArrowRight size={12} className="rtl-flip" />
+                  {t('viewAll')} <ArrowRight size={12} className="rtl-flip" />
                 </Link>
               </div>
               {recentOrders.length === 0 ? (
-                <p className="px-4 py-6 text-sm text-gray-400 text-center">{t('dashboard.noOrdersYet')}</p>
+                <p className="px-4 py-6 text-sm text-gray-400 text-center">{t('noOrdersYet')}</p>
               ) : (
                 <div className="divide-y divide-gray-50">
                   {recentOrders.map((order) => (
@@ -334,11 +344,11 @@ export default function DashboardPage() {
                         <div className="flex items-center gap-2">
                           <span className="text-sm font-medium text-gray-900">#<Ltr>{order.order_number}</Ltr></span>
                           <span className={`text-xs font-medium ${orderStatusColor[order.status] || 'text-gray-500'}`}>
-                            {t(`orders.${order.status}` as 'orders.pending' | 'orders.preparing' | 'orders.ready' | 'orders.served' | 'orders.completed' | 'orders.cancelled')}
+                            {(() => { const k = (ORDER_STATUS_LABEL_KEYS as Record<string, OrdersKey | undefined>)[order.status]; return k ? tOrders(k) : order.status; })()}
                           </span>
                         </div>
                         <p className="text-xs text-gray-400 truncate">
-                          {order.customer_name || order.table_name || t('dashboard.walkIn')}
+                          {order.customer_name || order.table_name || t('walkIn')}
                         </p>
                       </div>
                       <span className="text-sm font-semibold text-gray-900 shrink-0">
@@ -355,21 +365,21 @@ export default function DashboardPage() {
               <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
                 <h2 className="flex items-center gap-2 font-semibold text-gray-900">
                   <TrendingUp size={16} className="text-gray-400" />
-                  {t('dashboard.topProductsToday')}
+                  {t('topProductsToday')}
                 </h2>
                 <Link href="/products" className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover font-medium">
-                  {t('dashboard.viewAll')} <ArrowRight size={12} className="rtl-flip" />
+                  {t('viewAll')} <ArrowRight size={12} className="rtl-flip" />
                 </Link>
               </div>
               {topProducts.length === 0 ? (
-                <p className="px-4 py-6 text-sm text-gray-400 text-center">{t('dashboard.noSalesYet')}</p>
+                <p className="px-4 py-6 text-sm text-gray-400 text-center">{t('noSalesYet')}</p>
               ) : (
                 <div className="divide-y divide-gray-50">
                   {topProducts.map((product) => (
                     <div key={product.product_id} className="flex items-center justify-between px-4 py-2.5">
                       <div className="min-w-0">
                         <span className="text-sm font-medium text-gray-900">{product.product_name}</span>
-                        <p className="text-xs text-gray-400">{localizeTemplate(t('dashboard.productSoldOrders'), { quantity: product.total_quantity, orders: product.order_count })}</p>
+                        <p className="text-xs text-gray-400">{t('productSoldOrders', { quantity: product.total_quantity, orders: product.order_count })}</p>
                       </div>
                       <span className="text-sm font-semibold text-gray-900 shrink-0">
                         {fmt(Number(product.total_revenue))}
@@ -387,21 +397,21 @@ export default function DashboardPage() {
               <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
                 <h2 className="flex items-center gap-2 font-semibold text-gray-900">
                   <Trophy size={16} className="text-gray-400" />
-                  {t('dashboard.topStaff')}
+                  {t('topStaff')}
                 </h2>
                 <Link href="/staff" className="flex items-center gap-1 text-xs text-brand hover:text-brand-hover font-medium">
-                  {t('dashboard.viewAll')} <ArrowRight size={12} className="rtl-flip" />
+                  {t('viewAll')} <ArrowRight size={12} className="rtl-flip" />
                 </Link>
               </div>
               {(insights?.topStaff.length ?? 0) === 0 ? (
-                <p className="px-4 py-6 text-sm text-gray-400 text-center">{t('dashboard.noSalesYet')}</p>
+                <p className="px-4 py-6 text-sm text-gray-400 text-center">{t('noSalesYet')}</p>
               ) : (
                 <div className="divide-y divide-gray-50">
                   {insights!.topStaff.map((staff) => (
                     <div key={staff.user_id} className="flex items-center justify-between px-4 py-2.5">
                       <div className="min-w-0">
                         <span className="text-sm font-medium text-gray-900">{staff.name}</span>
-                        <p className="text-xs text-gray-400">{localizeTemplate(t('dashboard.staffOrderCount'), { orders: staff.orderCount })}</p>
+                        <p className="text-xs text-gray-400">{t('staffOrderCount', { orders: staff.orderCount })}</p>
                       </div>
                       <span className="text-sm font-semibold text-gray-900 shrink-0">
                         {fmt(Number(staff.revenue))}
@@ -417,18 +427,18 @@ export default function DashboardPage() {
               <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
                 <h2 className="flex items-center gap-2 font-semibold text-gray-900">
                   <Tags size={16} className="text-gray-400" />
-                  {t('dashboard.topCategories')}
+                  {t('topCategories')}
                 </h2>
               </div>
               {(insights?.topCategories.length ?? 0) === 0 ? (
-                <p className="px-4 py-6 text-sm text-gray-400 text-center">{t('dashboard.noSalesYet')}</p>
+                <p className="px-4 py-6 text-sm text-gray-400 text-center">{t('noSalesYet')}</p>
               ) : (
                 <div className="divide-y divide-gray-50">
                   {insights!.topCategories.map((category) => (
                     <div key={category.category_id ?? category.name} className="flex items-center justify-between px-4 py-2.5">
                       <div className="min-w-0">
                         <span className="text-sm font-medium text-gray-900">{category.name}</span>
-                        <p className="text-xs text-gray-400">{localizeTemplate(t('dashboard.categoryQuantitySold'), { quantity: category.quantity })}</p>
+                        <p className="text-xs text-gray-400">{t('categoryQuantitySold', { quantity: category.quantity })}</p>
                       </div>
                       <span className="text-sm font-semibold text-gray-900 shrink-0">
                         {fmt(Number(category.revenue))}
@@ -444,16 +454,16 @@ export default function DashboardPage() {
           <div className="bg-white rounded-xl border border-gray-100 p-4 mt-4">
             <div className="flex items-center gap-2 mb-4">
               <Wallet size={16} className="text-gray-400" />
-              <h2 className="font-semibold text-gray-900">{t('dashboard.paymentMethods')}</h2>
+              <h2 className="font-semibold text-gray-900">{t('paymentMethods')}</h2>
             </div>
             {paymentMethods.length === 0 ? (
-              <p className="text-sm text-gray-400 text-center py-6">{t('dashboard.noPaymentsYet')}</p>
+              <p className="text-sm text-gray-400 text-center py-6">{t('noPaymentsYet')}</p>
             ) : (
               <div className="space-y-3">
                 {paymentMethods.map((pm) => {
                   const meta = PAYMENT_METHODS.find((m) => m.key === pm.method);
                   const Icon = meta?.icon ?? Wallet;
-                  const label = meta ? t(meta.labelKey) : pm.method === 'wallet' ? t('pos.methodWallet') : String(pm.method || t('common.unknown'));
+                  const label = meta ? tPos(BUILT_IN_PAYMENT_KEYS[meta.key]) : pm.method === 'wallet' ? tPos('methodWallet') : String(pm.method || tCommon('unknown'));
                   const percent = paymentMethodsTotal > 0 ? Math.round((Number(pm.total) / paymentMethodsTotal) * 100) : 0;
                   return (
                     <div key={pm.method ?? 'unknown'}>
@@ -469,7 +479,7 @@ export default function DashboardPage() {
                           <div className="h-full bg-brand rounded-full" style={{ width: `${percent}%` }} />
                         </div>
                         <span className="text-xs text-gray-400 shrink-0">
-                          {localizeTemplate(t('dashboard.paymentMethodCount'), { count: pm.count, percent })}
+                          {t('paymentMethodCount', { count: pm.count, percent })}
                         </span>
                       </div>
                     </div>
@@ -483,46 +493,46 @@ export default function DashboardPage() {
           <div className="bg-white rounded-xl border border-gray-100 p-4 mt-4">
             <div className="flex items-center gap-2 mb-1">
               <BarChart3 size={16} className="text-gray-400" />
-              <h2 className="font-semibold text-gray-900">{t('dashboard.businessPatterns')}</h2>
+              <h2 className="font-semibold text-gray-900">{t('businessPatterns')}</h2>
             </div>
             <p className="text-xs text-gray-400 mb-4">
-              {localizeTemplate(t('dashboard.businessPatternsHint'), { days: insights?.windowDays ?? 30 })}
+              {t('businessPatternsHint', { days: insights?.windowDays ?? 30 })}
             </p>
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
               <div>
-                <p className="text-xs text-gray-500 mb-1">{t('dashboard.busiestHour')}</p>
+                <p className="text-xs text-gray-500 mb-1">{t('busiestHour')}</p>
                 <p className="text-lg font-bold text-gray-900">
-                  {insights?.busiestHour ? formatHourLabel(insights.busiestHour.hour, locale) : t('dashboard.notEnoughData')}
+                  {insights?.busiestHour ? formatHourLabel(insights.busiestHour.hour, locale) : t('notEnoughData')}
                 </p>
                 {insights?.busiestHour && (
-                  <p className="text-xs text-gray-400">{localizeTemplate(t('dashboard.ordersCount'), { count: insights.busiestHour.orderCount })}</p>
+                  <p className="text-xs text-gray-400">{t('ordersCount', { count: insights.busiestHour.orderCount })}</p>
                 )}
               </div>
               <div>
-                <p className="text-xs text-gray-500 mb-1">{t('dashboard.idlestHour')}</p>
+                <p className="text-xs text-gray-500 mb-1">{t('idlestHour')}</p>
                 <p className="text-lg font-bold text-gray-900">
-                  {insights?.idlestHour ? formatHourLabel(insights.idlestHour.hour, locale) : t('dashboard.notEnoughData')}
+                  {insights?.idlestHour ? formatHourLabel(insights.idlestHour.hour, locale) : t('notEnoughData')}
                 </p>
                 {insights?.idlestHour && (
-                  <p className="text-xs text-gray-400">{localizeTemplate(t('dashboard.ordersCount'), { count: insights.idlestHour.orderCount })}</p>
+                  <p className="text-xs text-gray-400">{t('ordersCount', { count: insights.idlestHour.orderCount })}</p>
                 )}
               </div>
               <div>
-                <p className="text-xs text-gray-500 mb-1">{t('dashboard.busiestDay')}</p>
+                <p className="text-xs text-gray-500 mb-1">{t('busiestDay')}</p>
                 <p className="text-lg font-bold text-gray-900">
-                  {insights?.busiestDayOfWeek ? formatWeekdayLabel(insights.busiestDayOfWeek.dayIndex, locale) : t('dashboard.notEnoughData')}
+                  {insights?.busiestDayOfWeek ? formatWeekdayLabel(insights.busiestDayOfWeek.dayIndex, locale) : t('notEnoughData')}
                 </p>
                 {insights?.busiestDayOfWeek && (
-                  <p className="text-xs text-gray-400">{localizeTemplate(t('dashboard.ordersCount'), { count: insights.busiestDayOfWeek.orderCount })}</p>
+                  <p className="text-xs text-gray-400">{t('ordersCount', { count: insights.busiestDayOfWeek.orderCount })}</p>
                 )}
               </div>
               <div>
-                <p className="text-xs text-gray-500 mb-1">{t('dashboard.idlestDay')}</p>
+                <p className="text-xs text-gray-500 mb-1">{t('idlestDay')}</p>
                 <p className="text-lg font-bold text-gray-900">
-                  {insights?.idlestDayOfWeek ? formatWeekdayLabel(insights.idlestDayOfWeek.dayIndex, locale) : t('dashboard.notEnoughData')}
+                  {insights?.idlestDayOfWeek ? formatWeekdayLabel(insights.idlestDayOfWeek.dayIndex, locale) : t('notEnoughData')}
                 </p>
                 {insights?.idlestDayOfWeek && (
-                  <p className="text-xs text-gray-400">{localizeTemplate(t('dashboard.ordersCount'), { count: insights.idlestDayOfWeek.orderCount })}</p>
+                  <p className="text-xs text-gray-400">{t('ordersCount', { count: insights.idlestDayOfWeek.orderCount })}</p>
                 )}
               </div>
             </div>

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -20,11 +20,10 @@ import { useHeldOrdersStore } from '@/store/held-orders';
 import { useRouter } from 'next/navigation';
 import { useCartStore } from '@/store/cart';
 import { usePosSettingsStore } from '@/store/pos-settings';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
 import { useFormatDate } from '@/hooks/useFormatDate';
 import { useWhatsAppReady } from '@/hooks/useWhatsAppReady';
-import { ORDER_TYPE_LABEL_KEYS } from '@/lib/order-types';
 import {
   defaultDiscountTypeForMode,
   isDiscountTypeAllowed,
@@ -43,40 +42,49 @@ import {
 } from '@/lib/append-attempt';
 import { preferChildScopedBill } from '@/lib/printer/tax-components';
 
-const itemStatusConfig: Record<string, { dot: string; color: string; labelKey: string }> = {
-  pending: { dot: 'bg-yellow-400', color: 'text-yellow-700', labelKey: 'orders.itemStatusWaiting' },
-  preparing: { dot: 'bg-blue-500', color: 'text-blue-700', labelKey: 'orders.itemStatusPreparing' },
-  ready: { dot: 'bg-green-500', color: 'text-green-700', labelKey: 'orders.itemStatusReady' },
-  served: { dot: 'bg-purple-500', color: 'text-purple-700', labelKey: 'orders.itemStatusServed' },
-  cancelled: { dot: 'bg-red-400', color: 'text-red-500', labelKey: 'orders.itemStatusCancelled' },
-  voided: { dot: 'bg-red-500', color: 'text-red-600 line-through', labelKey: 'orders.itemStatusVoided' },
-  void_adjustment: { dot: 'bg-red-300', color: 'text-red-500 italic', labelKey: 'orders.itemStatusVoidAdjustment' },
+type OrdersKey = keyof AppConfig['Messages']['orders'];
+
+const itemStatusConfig: Record<OrderItem['status'], { dot: string; color: string; labelKey: OrdersKey }> = {
+  pending: { dot: 'bg-yellow-400', color: 'text-yellow-700', labelKey: 'itemStatusWaiting' },
+  preparing: { dot: 'bg-blue-500', color: 'text-blue-700', labelKey: 'itemStatusPreparing' },
+  ready: { dot: 'bg-green-500', color: 'text-green-700', labelKey: 'itemStatusReady' },
+  served: { dot: 'bg-purple-500', color: 'text-purple-700', labelKey: 'itemStatusServed' },
+  cancelled: { dot: 'bg-red-400', color: 'text-red-500', labelKey: 'itemStatusCancelled' },
+  voided: { dot: 'bg-red-500', color: 'text-red-600 line-through', labelKey: 'itemStatusVoided' },
+  void_adjustment: { dot: 'bg-red-300', color: 'text-red-500 italic', labelKey: 'itemStatusVoidAdjustment' },
 };
 
-const orderStatusBadge: Record<string, { bg: string; text: string; labelKey: string }> = {
-  pending: { bg: 'bg-yellow-100', text: 'text-yellow-700', labelKey: 'orders.pending' },
-  preparing: { bg: 'bg-blue-100', text: 'text-blue-700', labelKey: 'orders.preparing' },
-  ready: { bg: 'bg-green-100', text: 'text-green-700', labelKey: 'orders.ready' },
-  served: { bg: 'bg-purple-100', text: 'text-purple-700', labelKey: 'orders.served' },
-  completed: { bg: 'bg-gray-100', text: 'text-gray-600', labelKey: 'orders.completed' },
-  cancelled: { bg: 'bg-red-100', text: 'text-red-700', labelKey: 'orders.cancelled' },
+const orderStatusBadge: Record<Order['status'], { bg: string; text: string; labelKey: OrdersKey }> = {
+  pending: { bg: 'bg-yellow-100', text: 'text-yellow-700', labelKey: 'pending' },
+  preparing: { bg: 'bg-blue-100', text: 'text-blue-700', labelKey: 'preparing' },
+  ready: { bg: 'bg-green-100', text: 'text-green-700', labelKey: 'ready' },
+  served: { bg: 'bg-purple-100', text: 'text-purple-700', labelKey: 'served' },
+  completed: { bg: 'bg-gray-100', text: 'text-gray-600', labelKey: 'completed' },
+  cancelled: { bg: 'bg-red-100', text: 'text-red-700', labelKey: 'cancelled' },
 };
 
-const paymentStatusBadge: Record<string, { bg: string; text: string; labelKey: string }> = {
-  paid: { bg: 'bg-green-100', text: 'text-green-700', labelKey: 'orders.paid' },
-  partial: { bg: 'bg-amber-100', text: 'text-amber-700', labelKey: 'orders.partiallyPaid' },
-  unpaid: { bg: 'bg-red-100', text: 'text-red-700', labelKey: 'orders.unpaidBadge' },
+const paymentStatusBadge: Record<'paid' | 'partial' | 'unpaid', { bg: string; text: string; labelKey: OrdersKey }> = {
+  paid: { bg: 'bg-green-100', text: 'text-green-700', labelKey: 'paid' },
+  partial: { bg: 'bg-amber-100', text: 'text-amber-700', labelKey: 'partiallyPaid' },
+  unpaid: { bg: 'bg-red-100', text: 'text-red-700', labelKey: 'unpaidBadge' },
 };
 
-const orderTypeLabel = ORDER_TYPE_LABEL_KEYS;
+// Typed leaf-key order-type map. The shared ORDER_TYPE_LABEL_KEYS stays dotted
+// for the not-yet-migrated KDS batch (5D), so this page uses a local map.
+const ORDER_TYPE_KEYS = {
+  dine_in: 'dineIn',
+  takeaway: 'takeaway',
+  delivery: 'delivery',
+  online: 'online',
+} as const satisfies Record<Order['type'], OrdersKey>;
 
 type FilterType = 'all' | 'active' | 'unpaid' | 'held';
 
-const tabLabelKey: Record<FilterType, string> = {
-  all: 'orders.all',
-  active: 'orders.active',
-  unpaid: 'orders.unpaidBadge',
-  held: 'orders.held',
+const tabLabelKey: Record<FilterType, OrdersKey> = {
+  all: 'all',
+  active: 'active',
+  unpaid: 'unpaidBadge',
+  held: 'held',
 };
 
 // Consolidated state types
@@ -115,7 +123,23 @@ export default function OrdersPage() {
   const router = useRouter();
   const cartStore = useCartStore();
   const { setTablesRequired, autoPrintBill, printerUseUnicode } = usePosSettingsStore();
-  const { t } = useI18n();
+  const tOrders = useTranslations('orders');
+  const tCommon = useTranslations('common');
+  const tNav = useTranslations('nav');
+  const tWhatsappSend = useTranslations('whatsapp.send');
+
+  // sendBillViaFlo (shared with PaymentModal) still takes a legacy dotted-key
+  // translator; bridge the typed `whatsapp.send` namespace to that contract.
+  const whatsappSendT = (key: string): string =>
+    tWhatsappSend(
+      key.replace(/^whatsapp\.send\./, '') as
+        | 'success'
+        | 'failed'
+        | 'error.notConnected'
+        | 'error.notOnWhatsapp'
+        | 'error.blocked'
+        | 'error.rateLimited',
+    );
   const { formatTime, formatDateTime } = useFormatDate();
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
@@ -233,7 +257,7 @@ export default function OrdersPage() {
         }
       });
     } catch {
-      toast.error(t('orders.loadOrdersFailed'));
+      toast.error(tOrders('loadOrdersFailed'));
     } finally {
       setLoading(false);
     }
@@ -257,10 +281,10 @@ export default function OrdersPage() {
       if (!clearAppendAttempt(getAppendAttemptStorage(), pendingAttempt!)) throw new Error('Unable to clear append retry state');
       if (addItemsAttemptRef.current?.idempotencyKey !== pendingAttempt!.idempotencyKey) return;
       addItemsAttemptRef.current = null;
-      toast.success(t('orders.itemsAdded', { count: pendingAttempt!.items.length }));
+      toast.success(tOrders('itemsAdded', { count: pendingAttempt!.items.length }));
       fetchOrders();
     }).catch(() => {
-      toast.error(t('orders.addItemsFailed'));
+      toast.error(tOrders('addItemsFailed'));
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeUserId]);
@@ -375,9 +399,9 @@ export default function OrdersPage() {
 
   const getTimeSince = (dateStr: string) => {
     const minutes = Math.floor((now - parseDbTimestamp(dateStr).getTime()) / 60000);
-    if (minutes < 1) return t('common.justNow');
-    if (minutes < 60) return t('common.timeMinutesAgo', { m: minutes });
-    return t('common.timeHoursMinutesAgo', { h: Math.floor(minutes / 60), m: minutes % 60 });
+    if (minutes < 1) return tCommon('justNow');
+    if (minutes < 60) return tCommon('timeMinutesAgo', { m: minutes });
+    return tCommon('timeHoursMinutesAgo', { h: Math.floor(minutes / 60), m: minutes % 60 });
   };
 
   const handleCreateNewOrderForCustomer = async (order: Order) => {
@@ -386,7 +410,7 @@ export default function OrdersPage() {
     // Check for active POS cart items to avoid accidental loss of progress
     if (cartStore.items.length > 0) {
       const proceed = await confirm(
-        t('orders.cartClearConfirm')
+        tOrders('cartClearConfirm')
       );
       if (!proceed) return;
     }
@@ -408,7 +432,7 @@ export default function OrdersPage() {
     }
 
     router.push('/pos');
-    toast.success(t('orders.newOrderStarted', { name: order.customer.name }));
+    toast.success(tOrders('newOrderStarted', { name: order.customer.name }));
   };
 
   const searchCustomersForLink = (query: string) => {
@@ -431,13 +455,13 @@ export default function OrdersPage() {
     setLinkingCustomer(true);
     try {
       await api.patch(`/orders/${orderId}/customer`, { customer_id: customerId });
-      toast.success(t('orders.customerLinked'));
+      toast.success(tOrders('customerLinked'));
       setLinkCustomerOrderId(null);
       setLinkCustomerSearch('');
       setLinkCustomerResults([]);
       fetchOrders();
     } catch {
-      toast.error(t('orders.linkCustomerFailed'));
+      toast.error(tOrders('linkCustomerFailed'));
     } finally {
       setLinkingCustomer(false);
     }
@@ -496,7 +520,7 @@ export default function OrdersPage() {
       const { data } = await api.post('/bills/generate', { order_id: orderId });
       setPaymentBill(data.bill);
     } catch {
-      toast.error(t('orders.generateBillFailed'));
+      toast.error(tOrders('generateBillFailed'));
     } finally {
       setGeneratingBill(null);
     }
@@ -515,7 +539,7 @@ export default function OrdersPage() {
         await printBill(
           latestBill,
           {
-            business_name: currentTenant?.business_name || t('common.businessNameFallback'),
+            business_name: currentTenant?.business_name || tCommon('businessNameFallback'),
             currency: currentTenant?.currency || 'INR',
             country: currentTenant?.country || 'IN',
             timezone: currentTenant?.timezone || 'UTC',
@@ -527,7 +551,7 @@ export default function OrdersPage() {
         );
         await api.post(`/bills/${bill.id}/print`, { print_type: 'receipt' });
       } catch {
-        toast.error(t('orders.receiptPrintFailedHint'));
+        toast.error(tOrders('receiptPrintFailedHint'));
       }
     }
   };
@@ -535,7 +559,7 @@ export default function OrdersPage() {
   const handlePrint = async (billId: number) => {
     const order = orders.find((o) => o.bill?.id === billId);
     if (!order?.bill) {
-      toast.error(t('orders.billNotFound'));
+      toast.error(tOrders('billNotFound'));
       return;
     }
     const isReprint = (printHistory[billId]?.length ?? 0) > 0;
@@ -548,7 +572,7 @@ export default function OrdersPage() {
       const printWarnings = await printBill(
         latestBill,
         {
-          business_name: currentTenant?.business_name || t('common.businessNameFallback'),
+          business_name: currentTenant?.business_name || tCommon('businessNameFallback'),
           currency: currentTenant?.currency || 'INR',
           country: currentTenant?.country || 'IN',
           timezone: currentTenant?.timezone || 'UTC',
@@ -559,11 +583,11 @@ export default function OrdersPage() {
         { isReprint }
       );
       await api.post(`/bills/${billId}/print`, { print_type: isReprint ? 'reprint' : 'receipt' });
-      toast.success(isReprint ? t('orders.printReceiptReprint') : t('orders.printReceipt'));
+      toast.success(isReprint ? tOrders('printReceiptReprint') : tOrders('printReceipt'));
       showPrintWarningsToast(printWarnings);
       fetchPrintHistory(billId);
     } catch {
-      toast.error(t('orders.printReceiptFailed'));
+      toast.error(tOrders('printReceiptFailed'));
     } finally {
       setPrintingBillId(null);
       setConfirmPrintBillId(null);
@@ -591,9 +615,9 @@ export default function OrdersPage() {
       link.download = `receipt-${billId}-${data.columns}cols.txt`;
       link.click();
       URL.revokeObjectURL(url);
-      toast.success(t('orders.printPreviewDownloaded'));
+      toast.success(tOrders('printPreviewDownloaded'));
     } catch {
-      toast.error(t('orders.printPreviewFailed'));
+      toast.error(tOrders('printPreviewFailed'));
     } finally {
       setPreviewingBillId(null);
     }
@@ -601,16 +625,16 @@ export default function OrdersPage() {
 
   const deleteItem = async (orderId: number, itemId: number) => {
     if (!isOwnerOrManager) {
-      toast.error(t('orders.onlyOwnersRemove'));
+      toast.error(tOrders('onlyOwnersRemove'));
       return;
     }
-    if (!await confirm(t('orders.removeItemConfirm'), { destructive: true, confirmLabel: t('common.remove') })) return;
+    if (!await confirm(tOrders('removeItemConfirm'), { destructive: true, confirmLabel: tCommon('remove') })) return;
     try {
-      await api.patch(`/orders/${orderId}/items/${itemId}/cancel`, { reason: t('orders.removedByManager') });
-      toast.success(t('orders.itemRemoved'));
+      await api.patch(`/orders/${orderId}/items/${itemId}/cancel`, { reason: tOrders('removedByManager') });
+      toast.success(tOrders('itemRemoved'));
       fetchOrders();
     } catch {
-      toast.error(t('orders.removeItemFailed'));
+      toast.error(tOrders('removeItemFailed'));
     }
   };
 
@@ -619,14 +643,14 @@ export default function OrdersPage() {
     setVoidingItem(true);
     try {
       await api.patch(`/orders/${voidItemModal.orderId}/items/${voidItemModal.itemId}/cancel`, {
-        reason: t('orders.removedByManager'),
+        reason: tOrders('removedByManager'),
         override_pin: voidItemModal.overridePin || undefined,
       });
-      toast.success(t('orders.itemVoided'));
+      toast.success(tOrders('itemVoided'));
       setVoidItemModal(null);
       fetchOrders();
     } catch {
-      toast.error(t('orders.voidItemFailed'));
+      toast.error(tOrders('voidItemFailed'));
     } finally {
       setVoidingItem(false);
     }
@@ -636,20 +660,20 @@ export default function OrdersPage() {
     if (!isOwnerOrManager) return;
     try {
       await api.patch(`/orders/${orderId}/items/${itemId}/restore`);
-      toast.success(t('orders.itemRestored'));
+      toast.success(tOrders('itemRestored'));
       fetchOrders();
     } catch {
-      toast.error(t('orders.restoreItemFailed'));
+      toast.error(tOrders('restoreItemFailed'));
     }
   };
 
   const handleWhatsAppShare = (order: Order) => {
     if (!order.bill) {
-      toast.error(t('orders.billNotFound'));
+      toast.error(tOrders('billNotFound'));
       return;
     }
     if (!order.customer?.phone) {
-      toast.error(t('orders.customerPhoneMissing'));
+      toast.error(tOrders('customerPhoneMissing'));
       return;
     }
 
@@ -658,24 +682,24 @@ export default function OrdersPage() {
         order.bill,
         { phone: order.customer.phone, country_code: order.customer.country_code },
         {
-          business_name: currentTenant?.business_name || t('common.businessNameFallback'),
+          business_name: currentTenant?.business_name || tCommon('businessNameFallback'),
           currency,
           country: currentTenant?.country || 'IN',
         },
         { pointsEarned: order.bill.points_earned ?? 0 }
       );
     } catch {
-      toast.error(t('orders.whatsappFailed'));
+      toast.error(tOrders('whatsappFailed'));
     }
   };
 
   const handleSendViaFlo = async (order: Order) => {
     if (!order.bill) {
-      toast.error(t('orders.billNotFound'));
+      toast.error(tOrders('billNotFound'));
       return;
     }
     if (!order.customer?.phone) {
-      toast.error(t('whatsapp.send.customerPhoneRequired'));
+      toast.error(tWhatsappSend('customerPhoneRequired'));
       return;
     }
     setSendingWaOrderId(order.id);
@@ -684,11 +708,11 @@ export default function OrdersPage() {
         order.bill,
         order.customer.phone,
         {
-          business_name: currentTenant?.business_name || t('common.businessNameFallback'),
+          business_name: currentTenant?.business_name || tCommon('businessNameFallback'),
           currency: currentTenant?.currency || 'INR',
           country: currentTenant?.country || 'IN',
         },
-        t,
+        whatsappSendT,
         { pointsEarned: order.bill.points_earned ?? 0 }
       );
     } finally {
@@ -701,11 +725,11 @@ export default function OrdersPage() {
 
     // Check if PIN is required
     if (discountRequiresApproval && discountModal.value > 0 && !discountPin) {
-      toast.error(t('orders.managerPinRequired'));
+      toast.error(tOrders('managerPinRequired'));
       return;
     }
     if (discountModal.value > 0 && !isDiscountTypeAllowed(discountMode, discountModal.type)) {
-      toast.error(t('orders.discountFailed'));
+      toast.error(tOrders('discountFailed'));
       return;
     }
 
@@ -716,10 +740,10 @@ export default function OrdersPage() {
         discount_reason: discountModal.reason || undefined,
         override_pin: discountRequiresApproval && discountModal.value > 0 ? discountPin : undefined,
       });
-      toast.success(t('orders.discountApplied'));
+      toast.success(tOrders('discountApplied'));
       fetchOrders();
     } catch {
-      toast.error(t('orders.discountFailed'));
+      toast.error(tOrders('discountFailed'));
     } finally {
       setDiscountModal(null);
       setDiscountPin('');
@@ -731,15 +755,15 @@ export default function OrdersPage() {
   };
 
   const handleConvertToTakeaway = async (order: Order) => {
-    const tableNote = order.table ? t('orders.freeTableSuffix', { name: order.table.name }) : '';
-    if (!await confirm(t('orders.convertToTakeawayConfirm', { number: order.order_number, tableNote }))) return;
+    const tableNote = order.table ? tOrders('freeTableSuffix', { name: order.table.name }) : '';
+    if (!await confirm(tOrders('convertToTakeawayConfirm', { number: order.order_number, tableNote }))) return;
     setConvertingOrderId(order.id);
     try {
       await api.patch(`/orders/${order.id}/convert-to-takeaway`);
-      toast.success(t('orders.orderConvertedTakeaway'));
+      toast.success(tOrders('orderConvertedTakeaway'));
       fetchOrders();
     } catch {
-      toast.error(t('orders.convertOrderFailed'));
+      toast.error(tOrders('convertOrderFailed'));
     } finally {
       setConvertingOrderId(null);
     }
@@ -755,8 +779,8 @@ export default function OrdersPage() {
     if (!addItemsOrder) return;
     api.get('/products', { params: { per_page: 200 } })
       .then(({ data }) => setProducts(data.products || []))
-      .catch(() => toast.error(t('orders.menuLoadFailed')));
-  }, [addItemsOrder, t]);
+      .catch(() => toast.error(tOrders('menuLoadFailed')));
+  }, [addItemsOrder, tOrders]);
 
   const handleAddItemToSelection = (product: Product) => {
     setSelectedItems(prev => {
@@ -808,11 +832,11 @@ export default function OrdersPage() {
       }, { headers: { 'Idempotency-Key': attempt.idempotencyKey } });
       if (!clearAppendAttempt(storage, attempt)) throw new Error('Unable to clear append retry state');
       addItemsAttemptRef.current = null;
-      toast.success(t('orders.itemsAdded', { count: selectedItems.length }));
+      toast.success(tOrders('itemsAdded', { count: selectedItems.length }));
       openAddItemsModal(null);
       fetchOrders();
     } catch {
-      toast.error(t('orders.addItemsFailed'));
+      toast.error(tOrders('addItemsFailed'));
     } finally {
       setAddingItems(false);
     }
@@ -829,10 +853,10 @@ export default function OrdersPage() {
         free_table: cancelModal.freeTable,
         override_pin: cancelModal.overridePin || undefined,
       });
-      toast.success(t('orders.orderCancelled'));
+      toast.success(tOrders('orderCancelled'));
       fetchOrders();
     } catch {
-      toast.error(t('orders.cancelOrderFailed'));
+      toast.error(tOrders('cancelOrderFailed'));
     } finally {
       setCancellingOrderId(null);
       setCancelModal(null);
@@ -857,7 +881,7 @@ export default function OrdersPage() {
     <div className="flex flex-col h-[calc(100vh-4rem)]">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-bold text-gray-900">{t('nav.orders')}</h1>
+        <h1 className="text-2xl font-bold text-gray-900">{tNav('orders')}</h1>
         <div className="flex gap-2">
           {(['all', 'active', 'unpaid', 'held'] as FilterType[]).map((f) => (
             <button
@@ -869,7 +893,7 @@ export default function OrdersPage() {
                   : 'bg-white text-gray-600 border border-gray-200 hover:border-gray-400'
               }`}
             >
-              {t(tabLabelKey[f])}
+              {tOrders(tabLabelKey[f])}
             </button>
           ))}
         </div>
@@ -882,7 +906,7 @@ export default function OrdersPage() {
           <Search size={16} className="absolute start-3 top-1/2 -translate-y-1/2 text-gray-400" />
           <input
             type="text"
-            placeholder={t('orders.search')}
+            placeholder={tOrders('search')}
             value={filters.search}
             onChange={(e) => setFilters(prev => ({ ...prev, search: e.target.value }))}
             className="w-full ps-9 pe-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand/30 focus:border-brand bg-white"
@@ -895,7 +919,7 @@ export default function OrdersPage() {
           onChange={(e) => setFilters(prev => ({ ...prev, table: e.target.value }))}
           className="px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-brand/30 focus:border-brand"
         >
-          <option value="">{t('orders.allTables')}</option>
+          <option value="">{tOrders('allTables')}</option>
           {tables.map((table: Table) => (
             <option key={table.id} value={String(table.id)}>
               {table.name}
@@ -909,11 +933,11 @@ export default function OrdersPage() {
           onChange={(e) => setFilters(prev => ({ ...prev, type: e.target.value }))}
           className="px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-brand/30 focus:border-brand"
         >
-          <option value="">{t('orders.allTypes')}</option>
-          <option value="dine_in">{t('orders.dineIn')}</option>
-          <option value="takeaway">{t('orders.takeaway')}</option>
-          <option value="delivery">{t('orders.delivery')}</option>
-          <option value="online">{t('orders.online')}</option>
+          <option value="">{tOrders('allTypes')}</option>
+          <option value="dine_in">{tOrders('dineIn')}</option>
+          <option value="takeaway">{tOrders('takeaway')}</option>
+          <option value="delivery">{tOrders('delivery')}</option>
+          <option value="online">{tOrders('online')}</option>
         </select>
 
         {/* Status filter */}
@@ -922,10 +946,10 @@ export default function OrdersPage() {
           onChange={(e) => setFilters(prev => ({ ...prev, status: e.target.value }))}
           className="px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-brand/30 focus:border-brand"
         >
-          <option value="">{t('orders.allStatuses')}</option>
-          <option value="active">{t('orders.active')}</option>
-          <option value="completed">{t('orders.completed')}</option>
-          <option value="cancelled">{t('orders.cancelled')}</option>
+          <option value="">{tOrders('allStatuses')}</option>
+          <option value="active">{tOrders('active')}</option>
+          <option value="completed">{tOrders('completed')}</option>
+          <option value="cancelled">{tOrders('cancelled')}</option>
         </select>
       </div>
 
@@ -937,7 +961,7 @@ export default function OrdersPage() {
           </div>
         ) : Object.keys(heldOrdersStore.orders).length === 0 ? (
           <div className="flex items-center justify-center flex-1 text-gray-400">
-            <p>{t('orders.heldEmpty')}</p>
+            <p>{tOrders('heldEmpty')}</p>
           </div>
         ) : (
           <div className="flex-1 overflow-y-auto grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-4 content-start items-start auto-rows-max">
@@ -945,10 +969,10 @@ export default function OrdersPage() {
               <div key={heldOrder.tableId} className="bg-white rounded-xl border border-blue-200 overflow-hidden flex flex-col shadow-sm hover:shadow-md transition-shadow">
                  <div className="p-4 border-b border-gray-100 bg-blue-50/50 flex justify-between items-center">
                    <div>
-                     <p className="font-bold text-gray-900">{tables.find(t => t.id === heldOrder.tableId)?.name || t('common.tableFallback')}</p>
+                     <p className="font-bold text-gray-900">{tables.find(t => t.id === heldOrder.tableId)?.name || tCommon('tableFallback')}</p>
                      <p className="text-xs text-gray-500">{formatTime(heldOrder.heldAt)}</p>
                    </div>
-                   <span className="bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full font-bold tracking-wide">{t('orders.held')}</span>
+                   <span className="bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full font-bold tracking-wide">{tOrders('held')}</span>
                  </div>
                  <div className="p-4 flex-1">
                    {heldOrder.items.map((item, idx) => (
@@ -972,27 +996,27 @@ export default function OrdersPage() {
                           router.push('/pos');
                         } else {
                           await heldOrdersStore.fetchHeldOrders();
-                          toast.error(t('orders.resumeFailed'));
+                          toast.error(tOrders('resumeFailed'));
                         }
                       } catch {
-                        toast.error(t('orders.resumeFailed'));
+                        toast.error(tOrders('resumeFailed'));
                       }
-                    }} variant="default" className="flex-1 bg-brand hover:bg-brand/90 text-white">{t('orders.resumeInPos')}</Button>
+                    }} variant="default" className="flex-1 bg-brand hover:bg-brand/90 text-white">{tOrders('resumeInPos')}</Button>
                     <Button onClick={async () => {
-                      if (await confirm(t('orders.deleteHeldConfirm'), { destructive: true })) {
+                      if (await confirm(tOrders('deleteHeldConfirm'), { destructive: true })) {
                         try {
                           const deleted = await heldOrdersStore.removeHeldOrder(heldOrder.tableId, heldOrder.id);
                           if (deleted) {
-                            toast.success(t('orders.heldOrderRemoved'));
+                            toast.success(tOrders('heldOrderRemoved'));
                           } else {
                             await heldOrdersStore.fetchHeldOrders();
-                            toast.error(t('orders.removeHeldOrderFailed'));
+                            toast.error(tOrders('removeHeldOrderFailed'));
                           }
                         } catch {
-                          toast.error(t('orders.removeHeldOrderFailed'));
+                          toast.error(tOrders('removeHeldOrderFailed'));
                         }
                       }
-                    }} variant="outline" className="flex-1 text-red-600 hover:text-red-700 hover:bg-red-50">{t('orders.delete')}</Button>
+                    }} variant="outline" className="flex-1 text-red-600 hover:text-red-700 hover:bg-red-50">{tOrders('delete')}</Button>
                  </div>
               </div>
             ))}
@@ -1004,7 +1028,7 @@ export default function OrdersPage() {
         </div>
       ) : filteredOrders.length === 0 ? (
         <div className="flex items-center justify-center flex-1 text-gray-400">
-          <p>{t('orders.empty')}</p>
+          <p>{tOrders('empty')}</p>
         </div>
       ) : (
         <div className="flex-1 overflow-y-auto grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-4 content-start items-start auto-rows-max">
@@ -1032,9 +1056,9 @@ export default function OrdersPage() {
                   <div className="flex items-center gap-2 flex-wrap min-w-0">
                     <span className="font-bold text-gray-900">#<Ltr>{order.order_number}</Ltr></span>
                     {(() => { const badge = orderStatusBadge[order.status]; return badge ? (
-                      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${badge.bg} ${badge.text}`}>{t(badge.labelKey)}</span>
+                      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${badge.bg} ${badge.text}`}>{tOrders(badge.labelKey)}</span>
                     ) : null; })()}
-                    <span className="text-sm text-gray-500 capitalize">{t(orderTypeLabel[order.type] ?? order.type)}</span>
+                    <span className="text-sm text-gray-500 capitalize">{tOrders(ORDER_TYPE_KEYS[order.type])}</span>
                     {order.table && (
                       <span className="text-sm text-orange-600 font-medium">{order.table.name}</span>
                     )}
@@ -1046,7 +1070,7 @@ export default function OrdersPage() {
                   <div className="flex items-center gap-2 shrink-0">
                     {payBadge && (
                       <span className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${payBadge.bg} ${payBadge.text}`}>
-                        {t(payBadge.labelKey)}
+                        {tOrders(payBadge.labelKey)}
                       </span>
                     )}
                     {paid && order.customer?.phone && (
@@ -1054,7 +1078,7 @@ export default function OrdersPage() {
                         onClick={() => isWhatsAppReady ? handleSendViaFlo(order) : handleWhatsAppShare(order)}
                         disabled={sendingWaOrderId === order.id}
                         className="p-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white transition-colors disabled:opacity-70"
-                        title={isWhatsAppReady ? t('common.sendViaFlo') : t('common.shareViaWhatsApp')}
+                        title={isWhatsAppReady ? tCommon('sendViaFlo') : tCommon('shareViaWhatsApp')}
                       >
                         {sendingWaOrderId === order.id ? <Loader2 className="size-4 animate-spin" /> : isWhatsAppReady ? <Send size={14} /> : <MessageCircle size={14} />}
                       </button>
@@ -1064,7 +1088,7 @@ export default function OrdersPage() {
                         onClick={() => setConfirmPrintBillId(order.bill!.id)}
                         disabled={printingBillId === order.bill.id}
                         className="p-1.5 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-100 disabled:opacity-50 transition-colors"
-                        title={(printHistory[order.bill.id]?.length ?? 0) > 0 ? t('common.reprint') : t('common.print')}
+                        title={(printHistory[order.bill.id]?.length ?? 0) > 0 ? tCommon('reprint') : tCommon('print')}
                       >
                         <Printer size={14} />
                       </button>
@@ -1094,9 +1118,9 @@ export default function OrdersPage() {
                     <button
                       onClick={() => handleCreateNewOrderForCustomer(order)}
                       className="flex items-center gap-1 text-xs font-semibold text-blue-700 hover:text-blue-900 bg-blue-100 hover:bg-blue-200 px-2.5 py-1 rounded-lg transition-colors shrink-0"
-                      title={t('orders.startNewOrderForCustomer')}
+                      title={tOrders('startNewOrderForCustomer')}
                     >
-                      <Plus size={12} /> {t('orders.newOrder')}
+                      <Plus size={12} /> {tOrders('newOrder')}
                     </button>
                   </div>
                 ) : isOwnerOrManager && !['completed', 'cancelled'].includes(order.status) ? (
@@ -1110,7 +1134,7 @@ export default function OrdersPage() {
                             setLinkCustomerSearch(e.target.value);
                             searchCustomersForLink(e.target.value);
                           }}
-                          placeholder={t('orders.searchCustomer')}
+                          placeholder={tOrders('searchCustomer')}
                           className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
                           autoFocus
                         />
@@ -1131,7 +1155,7 @@ export default function OrdersPage() {
                         className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-600 transition-colors"
                       >
                         <UserPlus size={14} />
-                        {t('orders.linkCustomer')}
+                        {tOrders('linkCustomer')}
                       </button>
                     )}
                     {linkCustomerOrderId === order.id && linkCustomerResults.length > 0 && (
@@ -1149,7 +1173,7 @@ export default function OrdersPage() {
                                 <span className="text-xs text-gray-500 ms-2"><Ltr>{customer.phone}</Ltr></span>
                               )}
                             </div>
-                            {linkingCustomer && <span className="text-xs text-gray-400">{t('orders.linking')}</span>}
+                            {linkingCustomer && <span className="text-xs text-gray-400">{tOrders('linking')}</span>}
                           </button>
                         ))}
                       </div>
@@ -1166,7 +1190,7 @@ export default function OrdersPage() {
                         <div key={item.id} className="py-1.5">
                           <div className="flex items-center justify-between">
                             <div className="flex items-center gap-2 flex-1 min-w-0">
-                              <span className={`w-2 h-2 rounded-full shrink-0 ${config.dot}`} title={t(config.labelKey)} />
+                              <span className={`w-2 h-2 rounded-full shrink-0 ${config.dot}`} title={tOrders(config.labelKey)} />
                               <span className={`text-sm font-medium ${config.color}`}>
                                 {item.quantity}x
                               </span>
@@ -1181,7 +1205,7 @@ export default function OrdersPage() {
                                 <button
                                   onClick={() => deleteItem(order.id, item.id)}
                                   className="p-1 rounded hover:bg-red-50 text-red-400 hover:text-red-600 transition-colors"
-                                  title={t('common.removeItem')}
+                                  title={tCommon('removeItem')}
                                 >
                                   <Trash2 size={14} />
                                 </button>
@@ -1190,7 +1214,7 @@ export default function OrdersPage() {
                                 <button
                                   onClick={() => setVoidItemModal({ orderId: order.id, itemId: item.id, productName: item.product_name, overridePin: '' })}
                                   className="p-1 rounded hover:bg-red-50 text-red-400 hover:text-red-600 transition-colors"
-                                  title={t('orders.voidItem')}
+                                  title={tOrders('voidItem')}
                                 >
                                   <Ban size={14} />
                                 </button>
@@ -1214,29 +1238,29 @@ export default function OrdersPage() {
                   {/* Bill summary */}
                   <div className="mt-3 pt-3 border-t border-dashed border-gray-200 space-y-1">
                     <div className="flex justify-between text-sm">
-                      <span className="text-gray-500">{t('common.subtotal')}</span>
+                      <span className="text-gray-500">{tCommon('subtotal')}</span>
                       <span className="text-gray-700">{fmt(subtotal)}</span>
                     </div>
                     {discount > 0 && (
                       <div className="flex justify-between text-sm">
-                        <span className="text-purple-600">{t('common.discount')}</span>
+                        <span className="text-purple-600">{tCommon('discount')}</span>
                         <span className="text-purple-600">-{fmt(discount)}</span>
                       </div>
                     )}
                     {tax > 0 && (
                       <div className="flex justify-between text-sm">
-                        <span className="text-gray-500">{t('common.tax')}</span>
+                        <span className="text-gray-500">{tCommon('tax')}</span>
                         <span className="text-gray-700">{fmt(tax)}</span>
                       </div>
                     )}
                     <div className="flex justify-between text-base font-bold pt-1 border-t border-gray-100">
-                      <span className="text-gray-900">{t('common.total')}</span>
+                      <span className="text-gray-900">{tCommon('total')}</span>
                       <span className="text-gray-900">{fmt(total)}</span>
                     </div>
                     {bill && payStatus === 'partial' && (
                       <div className="flex justify-between text-xs text-gray-500 pt-0.5">
-                        <span>{t('orders.paid')} {fmt(Number(bill.paid_amount))}</span>
-                        <span>{t('orders.balance')} {fmt(Number(bill.balance))}</span>
+                        <span>{tOrders('paid')} {fmt(Number(bill.paid_amount))}</span>
+                        <span>{tOrders('balance')} {fmt(Number(bill.balance))}</span>
                       </div>
                     )}
                   </div>
@@ -1256,7 +1280,7 @@ export default function OrdersPage() {
                             <button
                               onClick={() => restoreItem(order.id, item.id)}
                               className="p-1 rounded hover:bg-green-50 text-green-400 hover:text-green-600"
-                              title={t('common.restore')}
+                              title={tCommon('restore')}
                             >
                               <RotateCcw size={12} />
                             </button>
@@ -1275,14 +1299,14 @@ export default function OrdersPage() {
                         className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
                       >
                         {printHistoryExpanded[order.bill!.id] ? <ChevronDown size={14} /> : <ChevronRight size={14} className="rtl-flip" />}
-                        {t('orders.printHistory')}
+                        {tOrders('printHistory')}
                       </button>
 
                       {printHistoryExpanded[order.bill!.id] && (
                         <div className="mt-2 ps-4 space-y-1">
                           {printHistory[order.bill!.id].map((print, index) => (
                             <div key={print.id} className="text-xs text-gray-500">
-                              {index + 1}. {t('orders.printHistoryEntry', { printedType: print.print_type === 'reprint' ? t('orders.reprint') : t('orders.printed'), user: print.user_name, time: formatDateTime(print.printed_at) })}
+                              {index + 1}. {tOrders('printHistoryEntry', { printedType: print.print_type === 'reprint' ? tOrders('reprint') : tOrders('printed'), user: print.user_name, time: formatDateTime(print.printed_at) })}
                             </div>
                           ))}
                         </div>
@@ -1301,7 +1325,7 @@ export default function OrdersPage() {
                         className="flex-1 justify-center"
                       >
                         <CreditCard size={14} className="me-1.5" />
-                        {generatingBill === order.id ? t('orders.generating') : t('orders.checkout')}
+                        {generatingBill === order.id ? tOrders('generating') : tOrders('checkout')}
                       </Button>
                     )}
                     {!['completed', 'cancelled'].includes(order.status) && (
@@ -1312,7 +1336,7 @@ export default function OrdersPage() {
                         className="flex-1 justify-center border-green-300 text-green-600 hover:bg-green-50 hover:text-green-700"
                       >
                         <Plus size={14} className="me-1.5" />
-                        {t('orders.addItem')}
+                        {tOrders('addItem')}
                       </Button>
                     )}
                     {order.type === 'dine_in' && !['completed', 'cancelled'].includes(order.status) && (
@@ -1324,7 +1348,7 @@ export default function OrdersPage() {
                         className="flex-1 justify-center border-blue-300 text-blue-600 hover:bg-blue-50 hover:text-blue-700"
                       >
                         <ShoppingBag size={14} className="me-1.5" />
-                        {convertingOrderId === order.id ? t('orders.converting') : t('orders.convertToTakeaway')}
+                        {convertingOrderId === order.id ? tOrders('converting') : tOrders('convertToTakeaway')}
                       </Button>
                     )}
                     {!['completed', 'cancelled'].includes(order.status) && (
@@ -1344,7 +1368,7 @@ export default function OrdersPage() {
                         ) : (
                           <Lock size={14} className="me-1.5" />
                         )}
-                        {cancellingOrderId === order.id ? t('orders.cancelling') : t('common.cancel')}
+                        {cancellingOrderId === order.id ? tOrders('cancelling') : tCommon('cancel')}
                       </Button>
                     )}
                   </div>
@@ -1370,12 +1394,12 @@ export default function OrdersPage() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm mx-4">
             <h2 className="text-lg font-bold text-gray-900 mb-2">
-              {(printHistory[confirmPrintBillId]?.length ?? 0) > 0 ? t('orders.reprintReceiptTitle') : t('orders.printReceiptTitle')}
+              {(printHistory[confirmPrintBillId]?.length ?? 0) > 0 ? tOrders('reprintReceiptTitle') : tOrders('printReceiptTitle')}
             </h2>
             <p className="text-sm text-gray-600 mb-6">
               {(printHistory[confirmPrintBillId]?.length ?? 0) > 0
-                ? t('orders.reprintReceiptWarning')
-                : t('orders.printReceiptConfirm')}
+                ? tOrders('reprintReceiptWarning')
+                : tOrders('printReceiptConfirm')}
             </p>
             <div className="flex justify-end gap-2">
               <Button
@@ -1383,15 +1407,15 @@ export default function OrdersPage() {
                 size="sm"
                 onClick={() => setConfirmPrintBillId(null)}
               >
-                {t('common.cancel')}
+                {tCommon('cancel')}
               </Button>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => handleDownloadPrintPreview(confirmPrintBillId)}
                 disabled={previewingBillId === confirmPrintBillId}
-                title={t('orders.downloadPrintPreview')}
-                aria-label={t('orders.downloadPrintPreview')}
+                title={tOrders('downloadPrintPreview')}
+                aria-label={tOrders('downloadPrintPreview')}
                 className="w-9 px-0"
               >
                 {previewingBillId === confirmPrintBillId
@@ -1405,10 +1429,10 @@ export default function OrdersPage() {
               >
                 <Printer size={14} className="me-1.5" />
                 {printingBillId === confirmPrintBillId
-                  ? t('orders.printing')
+                  ? tOrders('printing')
                   : (printHistory[confirmPrintBillId]?.length ?? 0) > 0
-                    ? t('orders.confirmReprint')
-                    : t('orders.confirmPrint')}
+                    ? tOrders('confirmReprint')
+                    : tOrders('confirmPrint')}
               </Button>
             </div>
           </div>
@@ -1419,19 +1443,19 @@ export default function OrdersPage() {
       {cancelModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm mx-4">
-            <h2 className="text-lg font-bold text-gray-900 mb-4">{t('orders.cancel')} #<Ltr>{cancelModal.order.order_number}</Ltr></h2>
+            <h2 className="text-lg font-bold text-gray-900 mb-4">{tOrders('cancel')} #<Ltr>{cancelModal.order.order_number}</Ltr></h2>
 
             <div className="space-y-4">
               <div>
                 <label htmlFor="cancelReason" className="block text-sm font-medium text-gray-700 mb-1">
-                  {t('common.reasonOptional')}
+                  {tCommon('reasonOptional')}
                 </label>
                 <input
                   id="cancelReason"
                   type="text"
                   value={cancelModal.reason}
                   onChange={(e) => updateCancelModal({ reason: e.target.value })}
-                  placeholder={t('orders.cancelReason')}
+                  placeholder={tOrders('cancelReason')}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
                 />
               </div>
@@ -1446,7 +1470,7 @@ export default function OrdersPage() {
                     className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
                   />
                   <label htmlFor="freeTable" className="text-sm text-gray-700">
-                    {t('orders.freeTable', { name: cancelModal.order.table.name })}
+                    {tOrders('freeTable', { name: cancelModal.order.table.name })}
                   </label>
                 </div>
               )}
@@ -1454,14 +1478,14 @@ export default function OrdersPage() {
               {(cancelModal.order.status !== 'pending' || cancelModal.order.items?.some((i) => ['preparing', 'ready', 'served', 'completed'].includes(i.status))) && (
                 <div>
                   <label htmlFor="overridePin" className="block text-sm font-medium text-gray-700 mb-1">
-                    {t('orders.overridePinLabel')}
+                    {tOrders('overridePinLabel')}
                   </label>
                   <input
                     id="overridePin"
                     type="password"
                     value={cancelModal.overridePin}
                     onChange={(e) => updateCancelModal({ overridePin: e.target.value })}
-placeholder={t('orders.managerPin')}
+placeholder={tOrders('managerPin')}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
                   />
                 </div>
@@ -1474,7 +1498,7 @@ placeholder={t('orders.managerPin')}
                 size="sm"
                 onClick={() => setCancelModal(null)}
               >
-                {t('common.cancel')}
+                {tCommon('cancel')}
               </Button>
               <Button
                 size="sm"
@@ -1482,7 +1506,7 @@ placeholder={t('orders.managerPin')}
                 disabled={cancellingOrderId === cancelModal.order.id}
                 className="bg-red-600 hover:bg-red-700 text-white"
               >
-                {cancellingOrderId === cancelModal.order.id ? t('orders.cancelling') : t('orders.confirmCancel')}
+                {cancellingOrderId === cancelModal.order.id ? tOrders('cancelling') : tOrders('confirmCancel')}
               </Button>
             </div>
           </div>
@@ -1493,12 +1517,12 @@ placeholder={t('orders.managerPin')}
       {voidItemModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm mx-4">
-            <h2 className="text-lg font-bold text-gray-900 mb-1">{t('orders.voidItem')}</h2>
-            <p className="text-sm text-gray-500 mb-4">{t('orders.voidItemConfirm', { name: voidItemModal.productName })}</p>
+            <h2 className="text-lg font-bold text-gray-900 mb-1">{tOrders('voidItem')}</h2>
+            <p className="text-sm text-gray-500 mb-4">{tOrders('voidItemConfirm', { name: voidItemModal.productName })}</p>
 
             <div>
               <label htmlFor="voidOverridePin" className="block text-sm font-medium text-gray-700 mb-1">
-                {t('orders.overridePinLabel')}
+                {tOrders('overridePinLabel')}
               </label>
               <input
                 id="voidOverridePin"
@@ -1506,7 +1530,7 @@ placeholder={t('orders.managerPin')}
                 autoFocus
                 value={voidItemModal.overridePin}
                 onChange={(e) => setVoidItemModal({ ...voidItemModal, overridePin: e.target.value })}
-                placeholder={t('orders.managerPin')}
+                placeholder={tOrders('managerPin')}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
               />
             </div>
@@ -1517,7 +1541,7 @@ placeholder={t('orders.managerPin')}
                 size="sm"
                 onClick={() => setVoidItemModal(null)}
               >
-                {t('common.cancel')}
+                {tCommon('cancel')}
               </Button>
               <Button
                 size="sm"
@@ -1525,7 +1549,7 @@ placeholder={t('orders.managerPin')}
                 disabled={voidingItem || !voidItemModal.overridePin}
                 className="bg-red-600 hover:bg-red-700 text-white"
               >
-                {voidingItem ? t('orders.voidingItem') : t('orders.confirmVoidItem')}
+                {voidingItem ? tOrders('voidingItem') : tOrders('confirmVoidItem')}
               </Button>
             </div>
           </div>
@@ -1536,7 +1560,7 @@ placeholder={t('orders.managerPin')}
       {discountModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm mx-4">
-            <h2 className="text-lg font-bold text-gray-900 mb-4">{t('orders.applyDiscountTitle', { number: discountModal.order.order_number })}</h2>
+            <h2 className="text-lg font-bold text-gray-900 mb-4">{tOrders('applyDiscountTitle', { number: discountModal.order.order_number })}</h2>
 
             <div className="space-y-4">
               {/* Discount Type Toggle */}
@@ -1551,7 +1575,7 @@ placeholder={t('orders.managerPin')}
                     }`}
                   >
                     <Percent size={14} />
-                    {t('common.percentage')}
+                    {tCommon('percentage')}
                   </button>
                 )}
                 {isDiscountTypeAllowed(discountMode, 'amount') && (
@@ -1564,7 +1588,7 @@ placeholder={t('orders.managerPin')}
                     }`}
                   >
                     <Banknote size={14} />
-                    {t('common.amount')}
+                    {tCommon('amount')}
                   </button>
                 )}
               </div>
@@ -1572,7 +1596,7 @@ placeholder={t('orders.managerPin')}
               {/* Discount Value */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  {discountModal.type === 'percentage' ? t('orders.discountPercentageLabel') : t('orders.discountAmountLabel')}
+                  {discountModal.type === 'percentage' ? tOrders('discountPercentageLabel') : tOrders('discountAmountLabel')}
                 </label>
                 <div className="relative">
                   <span className="absolute start-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">
@@ -1594,13 +1618,13 @@ placeholder={t('orders.managerPin')}
               {/* Discount Reason */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  {t('common.reasonOptional')}
+                  {tCommon('reasonOptional')}
                 </label>
                 <input
                   type="text"
                   value={discountModal.reason}
                   onChange={(e) => updateDiscountModal({ reason: e.target.value })}
-                  placeholder={t('orders.discountReason')}
+                  placeholder={tOrders('discountReason')}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
                 />
               </div>
@@ -1608,18 +1632,18 @@ placeholder={t('orders.managerPin')}
               {/* Preview */}
               <div className="bg-gray-50 rounded-lg p-3 space-y-1.5">
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-500">{t('common.subtotal')}</span>
+                  <span className="text-gray-500">{tCommon('subtotal')}</span>
                   <span className="text-gray-900">{fmt(Number(discountModal.order.subtotal))}</span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-500">{t('common.tax')}</span>
+                  <span className="text-gray-500">{tCommon('tax')}</span>
                   <span className="text-gray-900">{fmt(Number(discountModal.order.tax_amount || 0))}</span>
                 </div>
                 <div className="flex justify-between text-sm">
                   <span className="text-purple-600">
-                    {t('common.discount')}
+                    {tCommon('discount')}
                     {discountModal.type === 'percentage' && discountModal.value > 0 && (
-                      <span className="text-gray-400 ms-1">{t('orders.percentOnSubtotal', { value: discountModal.value })}</span>
+                      <span className="text-gray-400 ms-1">{tOrders('percentOnSubtotal', { value: discountModal.value })}</span>
                     )}
                   </span>
                   <span className="text-purple-600">
@@ -1631,7 +1655,7 @@ placeholder={t('orders.managerPin')}
                   </span>
                 </div>
                 <div className="border-t border-gray-200 pt-1.5 flex justify-between text-sm font-bold">
-                  <span className="text-gray-900">{t('orders.newTotal')}</span>
+                  <span className="text-gray-900">{tOrders('newTotal')}</span>
                   <span className="text-gray-900">
                     {fmt(
                       discountModal.type === 'percentage'
@@ -1645,12 +1669,12 @@ placeholder={t('orders.managerPin')}
 
             {discountRequiresApproval && discountModal.value > 0 && (
               <div className="mt-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('orders.managerPinLabel')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{tOrders('managerPinLabel')}</label>
                 <input
                   type="password"
                   value={discountPin}
                   onChange={(e) => setDiscountPin(e.target.value)}
-placeholder={t('orders.managerPin')}
+placeholder={tOrders('managerPin')}
                 maxLength={6}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
                 />
@@ -1663,7 +1687,7 @@ placeholder={t('orders.managerPin')}
                 size="sm"
                 onClick={() => setDiscountModal(null)}
               >
-                {t('common.cancel')}
+                {tCommon('cancel')}
               </Button>
               <Button
                 size="sm"
@@ -1672,7 +1696,7 @@ placeholder={t('orders.managerPin')}
                 className="bg-purple-600 hover:bg-purple-700 text-white"
               >
                 <Percent size={14} className="me-1.5" />
-                {t('orders.applyDiscount')}
+                {tOrders('applyDiscount')}
               </Button>
             </div>
           </div>
@@ -1683,14 +1707,14 @@ placeholder={t('orders.managerPin')}
       {addItemsOrder && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-lg mx-4 max-h-[80vh] flex flex-col">
-            <h2 className="text-lg font-bold text-gray-900 mb-4">{t('orders.addItems')} #<Ltr>{addItemsOrder.order_number}</Ltr></h2>
+            <h2 className="text-lg font-bold text-gray-900 mb-4">{tOrders('addItems')} #<Ltr>{addItemsOrder.order_number}</Ltr></h2>
 
             {/* Search */}
             <div className="relative mb-3">
               <Search size={16} className="absolute start-3 top-1/2 -translate-y-1/2 text-gray-400" />
               <input
                 type="text"
-                placeholder={t('orders.searchMenu')}
+                placeholder={tOrders('searchMenu')}
                 value={productSearch}
                 onChange={(e) => setProductSearch(e.target.value)}
                 className="w-full ps-9 pe-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
@@ -1718,21 +1742,21 @@ placeholder={t('orders.managerPin')}
                 ))
               }
               {products.filter(p => !productSearch || p.name.toLowerCase().includes(productSearch.toLowerCase())).length === 0 && (
-                <div className="px-3 py-4 text-sm text-gray-400 text-center">{t('orders.noItemsFound')}</div>
+                <div className="px-3 py-4 text-sm text-gray-400 text-center">{tOrders('noItemsFound')}</div>
               )}
             </div>
 
             {/* Selected items */}
             {selectedItems.length > 0 && (
               <div className="space-y-2 mb-3">
-                <p className="text-xs font-medium text-gray-500 uppercase">{t('orders.selectedItems')}</p>
+                <p className="text-xs font-medium text-gray-500 uppercase">{tOrders('selectedItems')}</p>
                 {selectedItems.map(item => (
                   <div key={item.product_id} className="flex items-center gap-2 bg-gray-50 rounded-lg p-2">
                     <div className="flex-1 min-w-0">
                       <span className="text-sm font-medium text-gray-900 truncate block">{item.product_name}</span>
                       <input
                         type="text"
-                        placeholder={t('orders.notesOptional')}
+                        placeholder={tOrders('notesOptional')}
                         value={item.special_instructions}
                         maxLength={100}
                         onChange={(e) => handleUpdateSelectionNotes(item.product_id, e.target.value.slice(0, 100))}
@@ -1768,7 +1792,7 @@ placeholder={t('orders.managerPin')}
                 size="sm"
                 onClick={() => openAddItemsModal(null)}
               >
-                {t('common.cancel')}
+                {tCommon('cancel')}
               </Button>
               <Button
                 size="sm"
@@ -1777,7 +1801,7 @@ placeholder={t('orders.managerPin')}
                 className="bg-green-600 hover:bg-green-700 text-white"
               >
                 <Plus size={14} className="me-1.5" />
-                {addingItems ? t('orders.adding') : t('orders.addItemsCount', { count: selectedItems.length })}
+                {addingItems ? tOrders('adding') : tOrders('addItemsCount', { count: selectedItems.length })}
               </Button>
             </div>
           </div>

--- a/frontend/src/app/(dashboard)/tables/page.tsx
+++ b/frontend/src/app/(dashboard)/tables/page.tsx
@@ -5,13 +5,13 @@ import api from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import toast from 'react-hot-toast';
 import { Plus, X, Search, UserPlus, RotateCcw } from 'lucide-react';
-import type { Table, Customer, Order } from '@/lib/types';
+import type { Table, Customer, Order, OrderItem } from '@/lib/types';
 import { useAuthStore } from '@/store/auth';
 import { countryName } from '@/lib/countries';
 import { parsePhone, dialCodeFor } from '@/lib/phone';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
-import { ORDER_STATUS_LABEL_KEYS, ITEM_STATUS_LABEL_KEYS } from '@/lib/i18n-enums';
+import { ORDER_STATUS_LABEL_KEYS, ITEM_STATUS_LABEL_KEYS, TABLE_STATUS_LABEL_KEYS } from '@/lib/i18n-enums';
 
 const statusColors: Record<string, string> = {
   available: 'bg-green-500',
@@ -21,13 +21,13 @@ const statusColors: Record<string, string> = {
   held: 'bg-blue-500',
 };
 
-const TABLE_STATUS_LABEL: Record<string, string> = {
-  available: 'tables.statusAvailable',
-  occupied: 'tables.statusOccupied',
-  reserved: 'tables.statusReserved',
-  cleaning: 'tables.statusCleaning',
-  held: 'tables.statusHeld',
-};
+type OrdersKey = keyof AppConfig['Messages']['orders'];
+
+// Runtime-safe item-status lookup keeps the raw-status fallback for the
+// `void_adjustment` status (which has no translation key) while the map
+// itself stays exhaustively typed.
+const itemStatusLabelKey = (status: OrderItem['status']): OrdersKey | undefined =>
+  (ITEM_STATUS_LABEL_KEYS as Record<string, OrdersKey | undefined>)[status];
 
 interface ReserveModalProps {
   table: Table;
@@ -37,7 +37,11 @@ interface ReserveModalProps {
 
 function ReserveModal({ table, onClose, onDone }: ReserveModalProps) {
   const { currentTenant } = useAuthStore();
-  const { t } = useI18n();
+  const tTables = useTranslations('tables');
+  const tPos = useTranslations('pos');
+  const tNav = useTranslations('nav');
+  const tSettings = useTranslations('settings');
+  const tProducts = useTranslations('products');
   const dialCode = dialCodeFor(currentTenant?.country ?? 'IN') || '+91';
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Customer[]>([]);
@@ -66,7 +70,7 @@ function ReserveModal({ table, onClose, onDone }: ReserveModalProps) {
     const country = currentTenant?.country ?? 'IN';
     const parsed = parsePhone(newPhone, country);
     if (!parsed) {
-      toast.error(t('pos.invalidPhone', { country: countryName(country) }));
+      toast.error(tPos('invalidPhone', { country: countryName(country) }));
       return;
     }
     setCreating(true);
@@ -76,9 +80,9 @@ function ReserveModal({ table, onClose, onDone }: ReserveModalProps) {
       setShowCreate(false);
       setQuery('');
       setResults([]);
-      toast.success(t('pos.customerCreated'));
+      toast.success(tPos('customerCreated'));
     } catch {
-      toast.error(t('pos.createCustomerFailed'));
+      toast.error(tPos('createCustomerFailed'));
     } finally {
       setCreating(false);
     }
@@ -94,12 +98,12 @@ function ReserveModal({ table, onClose, onDone }: ReserveModalProps) {
         reservation_customer_phone: selected?.phone ?? null,
       });
       const msg = selected
-        ? t('tables.reservedFor', { name: table.name, customer: selected.name })
-        : t('tables.reservedNoCustomer', { name: table.name });
+        ? tTables('reservedFor', { name: table.name, customer: selected.name })
+        : tTables('reservedNoCustomer', { name: table.name });
       toast.success(msg);
       onDone();
     } catch {
-      toast.error(t('tables.tableReserveFailed'));
+      toast.error(tTables('tableReserveFailed'));
     } finally {
       setSaving(false);
     }
@@ -109,7 +113,7 @@ function ReserveModal({ table, onClose, onDone }: ReserveModalProps) {
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-2xl p-6 w-full max-w-sm">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-bold">{t('nav.tables')} · {table.name}</h2>
+          <h2 className="text-lg font-bold">{tNav('tables')} · {table.name}</h2>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600"><X size={20} /></button>
         </div>
 
@@ -125,14 +129,14 @@ function ReserveModal({ table, onClose, onDone }: ReserveModalProps) {
           </div>
         ) : (
           <div className="mb-4">
-            <p className="text-sm text-gray-500 mb-2">{t('tables.linkCustomer')}</p>
+            <p className="text-sm text-gray-500 mb-2">{tTables('linkCustomer')}</p>
             <div className="relative mb-2">
               <Search size={14} className="absolute start-2.5 top-1/2 -translate-y-1/2 text-gray-400" />
               <input
                 type="text"
                 value={query}
                 onChange={(e) => { setQuery(e.target.value); searchCustomers(e.target.value); }}
-                placeholder={t('tables.searchCustomerPlaceholder')}
+                placeholder={tTables('searchCustomerPlaceholder')}
                 className="w-full ps-8 pe-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand outline-none"
               />
             </div>
@@ -150,23 +154,23 @@ function ReserveModal({ table, onClose, onDone }: ReserveModalProps) {
             {!showCreate ? (
               <button onClick={() => { setShowCreate(true); if (/^\d+$/.test(query.trim())) setNewPhone(query.trim()); }}
                 className="flex items-center gap-1.5 text-sm text-brand font-medium hover:text-brand-hover">
-                <UserPlus size={14} /> {t('tables.newCustomer')}
+                <UserPlus size={14} /> {tTables('newCustomer')}
               </button>
             ) : (
               <div className="space-y-2 border border-gray-200 rounded-xl p-3">
-                <input type="text" placeholder={t('products.nameLabel')} value={newName} onChange={(e) => setNewName(e.target.value)}
+                <input type="text" placeholder={tProducts('nameLabel')} value={newName} onChange={(e) => setNewName(e.target.value)}
                   className="w-full px-3 py-1.5 text-sm border border-gray-200 rounded-lg outline-none focus:ring-1 focus:ring-brand" />
                 <div className="flex items-stretch gap-2">
 
-                  <input type="tel" inputMode="numeric" placeholder={`${dialCode} ${t('settings.phone')}`} value={newPhone}
+                  <input type="tel" inputMode="numeric" placeholder={`${dialCode} ${tSettings('phone')}`} value={newPhone}
                     onChange={(e) => setNewPhone(e.target.value)}
                     className="flex-1 px-3 py-1.5 text-sm border border-gray-200 rounded-lg outline-none focus:ring-1 focus:ring-brand" />
                 </div>
                 <div className="flex gap-2">
-                  <button onClick={() => setShowCreate(false)} className="flex-1 py-1.5 text-sm border border-gray-200 rounded-lg hover:bg-gray-50">{t('tables.cancel')}</button>
+                  <button onClick={() => setShowCreate(false)} className="flex-1 py-1.5 text-sm border border-gray-200 rounded-lg hover:bg-gray-50">{tTables('cancel')}</button>
                   <button onClick={handleCreateCustomer} disabled={creating || !newName.trim() || !newPhone.trim()}
                     className="flex-1 py-1.5 text-sm bg-brand text-white rounded-lg hover:opacity-90 disabled:opacity-50">
-                    {creating ? t('tables.creating') : t('tables.create')}
+                    {creating ? tTables('creating') : tTables('create')}
                   </button>
                 </div>
               </div>
@@ -175,9 +179,9 @@ function ReserveModal({ table, onClose, onDone }: ReserveModalProps) {
         )}
 
         <div className="flex gap-2">
-          <Button variant="outline" onClick={onClose} className="flex-1">{t('tables.cancel')}</Button>
+          <Button variant="outline" onClick={onClose} className="flex-1">{tTables('cancel')}</Button>
           <Button onClick={handleReserve} disabled={saving} className="flex-1">
-            {saving ? t('tables.reserving') : t('tables.reserveTable')}
+            {saving ? tTables('reserving') : tTables('reserveTable')}
           </Button>
         </div>
       </div>
@@ -194,7 +198,8 @@ const itemStatusColors: Record<string, { bg: string; text: string; dot: string }
 };
 
 export default function TablesPage() {
-  const { t } = useI18n();
+  const tTables = useTranslations('tables');
+  const tOrders = useTranslations('orders');
   const [tables, setTables] = useState<Table[]>([]);
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
@@ -220,7 +225,7 @@ export default function TablesPage() {
       const { data } = await api.get('/tables');
       setTables(data.tables || []);
     } catch {
-      toast.error(t('tables.loadFailed'));
+      toast.error(tTables('loadFailed'));
     } finally {
       setLoading(false);
     }
@@ -230,7 +235,7 @@ export default function TablesPage() {
     const load = () => {
       api.get('/tables')
         .then(({ data }) => setTables(data.tables || []))
-        .catch(() => toast.error(t('tables.loadFailed')))
+        .catch(() => toast.error(tTables('loadFailed')))
         .finally(() => setLoading(false));
     };
     load();
@@ -278,12 +283,12 @@ export default function TablesPage() {
     e.preventDefault();
     try {
       await api.post('/tables', { ...form, capacity: Number(form.capacity) });
-      toast.success(t('tables.tableCreated'));
+      toast.success(tTables('tableCreated'));
       setShowForm(false);
       setForm({ name: '', capacity: '4', floor: 'Ground', section: '' });
       fetchTables();
     } catch {
-      toast.error(t('tables.tableCreateFailed'));
+      toast.error(tTables('tableCreateFailed'));
     }
   };
 
@@ -292,7 +297,7 @@ export default function TablesPage() {
       await api.patch(`/tables/${id}/status`, { status });
       fetchTables();
     } catch {
-      toast.error(t('tables.tableUpdateFailed'));
+      toast.error(tTables('tableUpdateFailed'));
     }
   };
 
@@ -301,7 +306,7 @@ export default function TablesPage() {
       await api.post(`/tables/${table.id}/${table.is_active ? 'deactivate' : 'reactivate'}`);
       fetchTables();
     } catch {
-      toast.error(t('tables.updateStatusFailed'));
+      toast.error(tTables('updateStatusFailed'));
     }
   };
 
@@ -316,7 +321,7 @@ export default function TablesPage() {
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t('tables.title')}</h1>
+        <h1 className="text-2xl font-bold text-gray-900">{tTables('title')}</h1>
         <div className="flex items-center gap-3">
           <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
             <input
@@ -325,10 +330,10 @@ export default function TablesPage() {
               onChange={toggleDetails}
               className="w-4 h-4 rounded border-gray-300 text-brand focus:ring-brand"
             />
-            {t('tables.showOrderDetails')}
+            {tTables('showOrderDetails')}
           </label>
           <Button onClick={() => setShowForm(true)}>
-            <Plus size={16} className="me-1" /> {t('tables.addTable')}
+            <Plus size={16} className="me-1" /> {tTables('addTable')}
           </Button>
         </div>
       </div>
@@ -349,9 +354,9 @@ export default function TablesPage() {
                   <div className="flex items-center gap-2">
                     <div className={`w-3 h-3 rounded-full ${statusColors[table.status]}`} />
                     <h3 className="font-bold text-gray-900">{table.name}</h3>
-                    <span className="text-xs text-gray-400">· {t('tables.capacitySeats', { count: table.capacity })}</span>
+                    <span className="text-xs text-gray-400">· {tTables('capacitySeats', { count: table.capacity })}</span>
                   </div>
-                  <span className="text-xs text-gray-400">{t(TABLE_STATUS_LABEL[table.status] ?? table.status)}</span>
+                  <span className="text-xs text-gray-400">{tTables(TABLE_STATUS_LABEL_KEYS[table.status])}</span>
                 </div>
 
                 {/* Orders section */}
@@ -368,7 +373,7 @@ export default function TablesPage() {
                             order.status === 'served' ? 'bg-purple-100 text-purple-700' :
                             'bg-gray-100 text-gray-600'
                           }`}>
-                            {t(ORDER_STATUS_LABEL_KEYS[order.status] ?? order.status)}
+                            {tOrders(ORDER_STATUS_LABEL_KEYS[order.status])}
                           </span>
                         </div>
                         {order.customer?.name && (
@@ -382,7 +387,7 @@ export default function TablesPage() {
                                 <div className={`w-1.5 h-1.5 rounded-full ${sc.dot} flex-shrink-0`} />
                                 <span className="flex-1 truncate text-gray-700">{item.product_name}</span>
                                 <span className="text-gray-500">×{item.quantity}</span>
-                                <span className={`font-medium capitalize ${sc.text}`}>{t(ITEM_STATUS_LABEL_KEYS[item.status] ?? item.status)}</span>
+                                <span className={`font-medium capitalize ${sc.text}`}>{(() => { const k = itemStatusLabelKey(item.status); return k ? tOrders(k) : item.status; })()}</span>
                               </div>
                             );
                           })}
@@ -392,7 +397,7 @@ export default function TablesPage() {
                   </div>
                 ) : (
                   <div className="px-4 py-4 text-center text-xs text-gray-400">
-                    {t('tables.noActiveOrders')}
+                    {tTables('noActiveOrders')}
                   </div>
                 )}
 
@@ -401,18 +406,18 @@ export default function TablesPage() {
                   {(table.status === 'occupied' || table.status === 'reserved') && (
                     <button onClick={() => updateStatus(table.id, 'available')}
                       className="text-xs text-brand hover:text-brand-hover font-medium">
-                      {t('tables.markAvailable')}
+                      {tTables('markAvailable')}
                     </button>
                   )}
                   {table.status === 'available' && (
                     <button onClick={() => setReservingTable(table)}
                       className="text-xs text-yellow-600 hover:text-yellow-700 font-medium">
-                      {t('tables.reserve')}
+                      {tTables('reserve')}
                     </button>
                   )}
                   <button onClick={() => toggleActive(table)}
                     className={`text-xs font-medium flex items-center gap-1 ${!table.is_active ? 'text-green-600 hover:text-green-700' : 'text-red-500 hover:text-red-700'}`}>
-                    {!table.is_active ? <><RotateCcw size={12} /> {t('tables.reactivate')}</> : t('tables.deactivate')}
+                    {!table.is_active ? <><RotateCcw size={12} /> {tTables('reactivate')}</> : tTables('deactivate')}
                   </button>
                 </div>
               </div>
@@ -426,8 +431,8 @@ export default function TablesPage() {
               className={`bg-white rounded-xl p-5 border border-gray-100 text-center hover:shadow-md transition-shadow ${!table.is_active ? 'opacity-60' : ''}`}>
               <div className={`w-3 h-3 rounded-full ${statusColors[table.status]} mx-auto mb-3`} />
               <h3 className="font-bold text-lg text-gray-900">{table.name}</h3>
-              <p className="text-sm text-gray-500">{t('tables.capacitySeats', { count: table.capacity })}</p>
-              <p className="text-xs text-gray-400 mt-1">{t(TABLE_STATUS_LABEL[table.status] ?? table.status)}</p>
+              <p className="text-sm text-gray-500">{tTables('capacitySeats', { count: table.capacity })}</p>
+              <p className="text-xs text-gray-400 mt-1">{tTables(TABLE_STATUS_LABEL_KEYS[table.status])}</p>
               {table.floor && <p className="text-xs text-gray-400">{table.floor}</p>}
               {table.status === 'reserved' && table.reservation_customer_name && (
                 <p className="text-xs text-yellow-700 font-medium mt-1 truncate">{table.reservation_customer_name}</p>
@@ -439,18 +444,18 @@ export default function TablesPage() {
               {(table.status === 'occupied' || table.status === 'reserved') && (
                 <button onClick={() => updateStatus(table.id, 'available')}
                   className="mt-3 text-xs text-brand hover:text-brand-hover font-medium">
-                  {t('tables.markAvailable')}
+                  {tTables('markAvailable')}
                 </button>
               )}
               {table.status === 'available' && (
                 <button onClick={() => setReservingTable(table)}
                   className="mt-3 text-xs text-yellow-600 hover:text-yellow-700 font-medium">
-                  {t('tables.reserve')}
+                  {tTables('reserve')}
                 </button>
               )}
               <button onClick={() => toggleActive(table)}
                 className={`mt-2 block mx-auto text-xs font-medium ${!table.is_active ? 'text-green-600 hover:text-green-700' : 'text-red-500 hover:text-red-700'}`}>
-                {!table.is_active ? t('tables.reactivate') : t('tables.deactivate')}
+                {!table.is_active ? tTables('reactivate') : tTables('deactivate')}
               </button>
             </div>
           ))}
@@ -458,7 +463,7 @@ export default function TablesPage() {
       )}
 
       {tables.length === 0 && (
-        <p className="text-center text-gray-500 py-12">{t('tables.noTablesYet')}</p>
+        <p className="text-center text-gray-500 py-12">{tTables('noTablesYet')}</p>
       )}
 
       {/* Reserve Modal */}
@@ -475,28 +480,28 @@ export default function TablesPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-2xl p-6 w-full max-w-sm">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-bold">{t('tables.add')}</h2>
+              <h2 className="text-lg font-bold">{tTables('add')}</h2>
               <button onClick={() => setShowForm(false)} className="text-gray-400 hover:text-gray-600"><X size={20} /></button>
             </div>
             <form onSubmit={handleCreate} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('tables.tableName')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{tTables('tableName')}</label>
                 <input type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })}
-                  placeholder={t('tables.tableNamePlaceholder')} className="w-full px-3 py-2 border border-gray-300 rounded-lg outline-none focus:ring-2 focus:ring-brand" required />
+                  placeholder={tTables('tableNamePlaceholder')} className="w-full px-3 py-2 border border-gray-300 rounded-lg outline-none focus:ring-2 focus:ring-brand" required />
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('tables.capacity')}</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">{tTables('capacity')}</label>
                   <input type="number" min="1" value={form.capacity} onChange={(e) => setForm({ ...form, capacity: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg outline-none focus:ring-2 focus:ring-brand" required />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('tables.floor')}</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">{tTables('floor')}</label>
                   <input type="text" value={form.floor} onChange={(e) => setForm({ ...form, floor: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg outline-none focus:ring-2 focus:ring-brand" />
                 </div>
               </div>
-              <Button type="submit" className="w-full">{t('tables.createTable')}</Button>
+              <Button type="submit" className="w-full">{tTables('createTable')}</Button>
             </form>
           </div>
         </div>

--- a/frontend/src/components/orders/OrderHistoryGrid.tsx
+++ b/frontend/src/components/orders/OrderHistoryGrid.tsx
@@ -9,9 +9,8 @@ import { formatCurrency, getCountryByCode, getCurrencySymbol } from '@/lib/count
 import { useAuthStore } from '@/store/auth';
 import { useFormatDate } from '@/hooks/useFormatDate';
 import type { Order, OrderItem, Bill } from '@/lib/types';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
-import { ORDER_TYPE_LABEL_KEYS } from '@/lib/order-types';
 
 // --- Mock data ---------------------------------------------------------
 // Shaped like the real `Order` / `Bill` types (src/lib/types.ts) so this
@@ -100,18 +99,33 @@ const MOCK_HISTORY: HistoryOrder[] = [
   },
 ];
 
+type OrdersKey = keyof AppConfig['Messages']['orders'];
+
 const STATUS_BADGE: Record<string, string> = {
   completed: 'bg-green-100 text-green-700 border-green-200',
   cancelled: 'bg-red-100 text-red-700 border-red-200',
 };
 
-const STATUS_LABEL_KEY: Record<string, string> = {
-  completed: 'orders.settled',
-  cancelled: 'orders.voided',
+// History view renders settled/voided (financial settlement terms), distinct
+// from the order-lifecycle `completed`/`cancelled` labels.
+const STATUS_LABEL_KEY: Partial<Record<Order['status'], OrdersKey>> = {
+  completed: 'settled',
+  cancelled: 'voided',
 };
 
+// Typed leaf-key order-type map. The shared ORDER_TYPE_LABEL_KEYS stays dotted
+// for the not-yet-migrated KDS batch (5D), so 5C uses this local map.
+const ORDER_TYPE_KEYS = {
+  dine_in: 'dineIn',
+  takeaway: 'takeaway',
+  delivery: 'delivery',
+  online: 'online',
+} as const satisfies Record<Order['type'], OrdersKey>;
+
 function HistoryOrderCard({ order, currency, locale }: { order: HistoryOrder; currency: string; locale: string }) {
-  const { t } = useI18n();
+  const tOrders = useTranslations('orders');
+  const tCommon = useTranslations('common');
+  const tPrintTest = useTranslations('printTest');
   const { formatDate } = useFormatDate();
   const items: OrderItem[] = order.items ?? [];
   const bill = order.bill;
@@ -126,13 +140,13 @@ function HistoryOrderCard({ order, currency, locale }: { order: HistoryOrder; cu
             <CardDescription>{formatDate(order.created_at, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</CardDescription>
           </div>
           <Badge className={STATUS_BADGE[order.status] ?? ''} variant="outline">
-            {STATUS_LABEL_KEY[order.status] ? t(STATUS_LABEL_KEY[order.status]) : order.status}
+            {(() => { const key = STATUS_LABEL_KEY[order.status]; return key ? tOrders(key) : order.status; })()}
           </Badge>
         </div>
         <p className="text-sm text-muted-foreground">
-          {t(ORDER_TYPE_LABEL_KEYS[order.type])}
-          {order.table && ` · ${t('orders.tableAt', { name: order.table.name })}`}
-          {order.guest_count ? ` · ${t('orders.guestCount', { count: order.guest_count })}` : ''}
+          {tOrders(ORDER_TYPE_KEYS[order.type])}
+          {order.table && ` · ${tOrders('tableAt', { name: order.table.name })}`}
+          {order.guest_count ? ` · ${tOrders('guestCount', { count: order.guest_count })}` : ''}
         </p>
       </CardHeader>
 
@@ -140,10 +154,10 @@ function HistoryOrderCard({ order, currency, locale }: { order: HistoryOrder; cu
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="px-0">{t('printTest.item')}</TableHead>
-              <TableHead className="px-0 text-center w-10">{t('printTest.qty')}</TableHead>
-              <TableHead className="px-0 text-end">{t('printTest.rate')}</TableHead>
-              <TableHead className="px-0 text-end">{t('printTest.amt')}</TableHead>
+              <TableHead className="px-0">{tPrintTest('item')}</TableHead>
+              <TableHead className="px-0 text-center w-10">{tPrintTest('qty')}</TableHead>
+              <TableHead className="px-0 text-end">{tPrintTest('rate')}</TableHead>
+              <TableHead className="px-0 text-end">{tPrintTest('amt')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -162,46 +176,47 @@ function HistoryOrderCard({ order, currency, locale }: { order: HistoryOrder; cu
 
         <div className="space-y-1 text-sm">
           <div className="flex justify-between text-muted-foreground">
-            <span>{t('common.subtotal')}</span>
+            <span>{tCommon('subtotal')}</span>
             <span className="tabular-nums">{fmt(order.subtotal)}</span>
           </div>
           <div className="flex justify-between text-muted-foreground">
-            <span>{t('common.tax')}</span>
+            <span>{tCommon('tax')}</span>
             <span className="tabular-nums">{fmt(order.tax_amount)}</span>
           </div>
           {order.discount_amount > 0 && (
             <div className="flex justify-between text-muted-foreground">
-              <span>{t('common.discount')}{bill?.discount_reason ? ` (${bill.discount_reason})` : ''}</span>
+              <span>{tCommon('discount')}{bill?.discount_reason ? ` (${bill.discount_reason})` : ''}</span>
               <span className="tabular-nums">−{fmt(order.discount_amount)}</span>
             </div>
           )}
           {order.delivery_charge > 0 && (
             <div className="flex justify-between text-muted-foreground">
-              <span>{t('orders.delivery')}</span>
+              <span>{tOrders('delivery')}</span>
               <span className="tabular-nums">{fmt(order.delivery_charge)}</span>
             </div>
           )}
           <Separator className="my-1.5" />
           <div className="flex justify-between font-bold text-base">
-            <span>{t('common.total')}</span>
+            <span>{tCommon('total')}</span>
             <span className="tabular-nums">{fmt(order.total)}</span>
           </div>
         </div>
       </CardContent>
 
       <CardFooter className="px-4 pb-4 pt-3 border-t flex flex-wrap gap-2">
-        <Button variant="outline" size="sm">{t('orders.printReceiptTitle')}</Button>
+        <Button variant="outline" size="sm">{tOrders('printReceiptTitle')}</Button>
         {order.status === 'completed' && (
-          <Button variant="outline" size="sm">{t('orders.reopenOrder')}</Button>
+          <Button variant="outline" size="sm">{tOrders('reopenOrder')}</Button>
         )}
-        <Button variant="ghost" size="sm">{t('orders.viewLogs')}</Button>
+        <Button variant="ghost" size="sm">{tOrders('viewLogs')}</Button>
       </CardFooter>
     </Card>
   );
 }
 
 export default function OrderHistoryGrid() {
-  const { t } = useI18n();
+  const tOrders = useTranslations('orders');
+  const tDashboard = useTranslations('dashboard');
   const currentTenant = useAuthStore((s) => s.currentTenant);
   const country = getCountryByCode(currentTenant?.country ?? 'IN');
   const currency = getCurrencySymbol(currentTenant?.currency || 'INR', country?.locale);
@@ -211,8 +226,8 @@ export default function OrderHistoryGrid() {
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-bold">{t('orders.historyTitle')}</h1>
-        <Badge variant="outline">{t('dashboard.ordersCount', { count: orders.length })}</Badge>
+        <h1 className="text-2xl font-bold">{tOrders('historyTitle')}</h1>
+        <Badge variant="outline">{tDashboard('ordersCount', { count: orders.length })}</Badge>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 auto-rows-max content-start items-start">

--- a/frontend/src/lib/i18n-enums.ts
+++ b/frontend/src/lib/i18n-enums.ts
@@ -13,8 +13,13 @@
  */
 
 import { ORDER_TYPE_LABEL_KEYS } from './order-types';
+import type { Order, Table } from './types';
+import type { AppConfig } from 'use-intl';
 
 export { ORDER_TYPE_LABEL_KEYS };
+
+type OrdersKey = keyof AppConfig['Messages']['orders'];
+type TablesKey = keyof AppConfig['Messages']['tables'];
 
 /** Staff/tenant role → label. Used in login tenant picker, staff table, etc. */
 export const ROLE_LABEL_KEYS: Record<string, string> = {
@@ -25,36 +30,40 @@ export const ROLE_LABEL_KEYS: Record<string, string> = {
   server: 'staff.roleServer',
 };
 
-/** Order-level status → label. */
-export const ORDER_STATUS_LABEL_KEYS: Record<string, string> = {
-  pending: 'orders.pending',
-  preparing: 'orders.preparing',
-  ready: 'orders.ready',
-  served: 'orders.served',
-  completed: 'orders.completed',
-  cancelled: 'orders.cancelled',
-};
+/** Order-level status → label (exhaustively typed against `Order['status']`). */
+export const ORDER_STATUS_LABEL_KEYS = {
+  pending: 'pending',
+  preparing: 'preparing',
+  ready: 'ready',
+  served: 'served',
+  completed: 'completed',
+  cancelled: 'cancelled',
+} as const satisfies Record<Order['status'], OrdersKey>;
 
 /** Individual order-item status → label. Note `pending` ≠ `waiting`: the
- *  backend emits `pending` for fresh items; `waiting` is the KDS term. */
-export const ITEM_STATUS_LABEL_KEYS: Record<string, string> = {
-  pending: 'orders.itemStatusPending',
-  waiting: 'orders.itemStatusWaiting',
-  preparing: 'orders.itemStatusPreparing',
-  ready: 'orders.itemStatusReady',
-  served: 'orders.itemStatusServed',
-  cancelled: 'orders.itemStatusCancelled',
-  voided: 'orders.itemStatusVoided',
-};
+ *  backend emits `pending` for fresh items; `waiting` is the KDS term.
+ *  `void_adjustment` has no label key and falls back to the raw string. */
+export const ITEM_STATUS_LABEL_KEYS = {
+  pending: 'itemStatusPending',
+  waiting: 'itemStatusWaiting',
+  preparing: 'itemStatusPreparing',
+  ready: 'itemStatusReady',
+  served: 'itemStatusServed',
+  cancelled: 'itemStatusCancelled',
+  voided: 'itemStatusVoided',
+} as const satisfies Record<
+  'pending' | 'waiting' | 'preparing' | 'ready' | 'served' | 'cancelled' | 'voided',
+  OrdersKey
+>;
 
-/** Table status → label. */
-export const TABLE_STATUS_LABEL_KEYS: Record<string, string> = {
-  available: 'tables.statusAvailable',
-  occupied: 'tables.statusOccupied',
-  reserved: 'tables.statusReserved',
-  held: 'tables.statusHeld',
-  cleaning: 'tables.statusCleaning',
-};
+/** Table status → label (exhaustively typed against `Table['status']`). */
+export const TABLE_STATUS_LABEL_KEYS = {
+  available: 'statusAvailable',
+  occupied: 'statusOccupied',
+  reserved: 'statusReserved',
+  held: 'statusHeld',
+  cleaning: 'statusCleaning',
+} as const satisfies Record<Table['status'], TablesKey>;
 
 /** Tenant/business status → label. */
 export const TENANT_STATUS_LABEL_KEYS: Record<string, string> = {

--- a/frontend/src/lib/i18n-enums.ts
+++ b/frontend/src/lib/i18n-enums.ts
@@ -3,13 +3,17 @@
  *
  * Backend values (roles, order statuses, item statuses, table statuses, etc.)
  * are English identifiers stored in the DB. The UI must never render them
- * raw — pass them through these maps and then through `t()` so every language
- * shows a localized label.
+ * raw — pass them through these maps and then through the appropriate
+ * translator (`useTranslations()` leaf keys or legacy `t()` dotted keys) so
+ * every language shows a localized label.
  *
- * Pattern mirrors `ORDER_TYPE_LABEL_KEYS` in order-types.ts.
- * Unknown values fall back to the raw string (then to the key itself in `t()`),
- * so a new backend status never crashes the UI — it just shows in English
- * until a translation key is added.
+ * Migrated status maps (`ORDER_STATUS_LABEL_KEYS`, `ITEM_STATUS_LABEL_KEYS`,
+ * `TABLE_STATUS_LABEL_KEYS`) are exhaustively typed against use-intl leaf keys.
+ * Unmigrated maps retain dotted keys for legacy `t()` callers until their
+ * batches migrate.
+ *
+ * Unknown values fall back to the raw string, so a new backend status never
+ * crashes the UI — it just shows in English until a translation key is added.
  */
 
 import { ORDER_TYPE_LABEL_KEYS } from './order-types';


### PR DESCRIPTION
## Intent

Migrate the order management, table management, customer management, and dashboard pages (plus the OrderHistoryGrid component) from the legacy useI18n()/t() flat-key API to use-intl useTranslations(), completing Phase 3 batch 5C (issue #378) of the i18n migration epic (#372).

Scope is exactly 6 files: orders/page.tsx, tables/page.tsx, customers/page.tsx, dashboard/page.tsx, components/orders/OrderHistoryGrid.tsx, and lib/i18n-enums.ts.

Key decisions:
- Each component uses useTranslations(namespace) with typed leaf keys; multi-namespace files split into per-namespace translators (tOrders/tCommon/tNav/tWhatsappSend etc.).
- i18n-enums.ts: ORDER_STATUS_LABEL_KEYS, TABLE_STATUS_LABEL_KEYS, and ITEM_STATUS_LABEL_KEYS converted from generic Record<string,string> dotted keys to exhaustively typed leaf-key maps (satisfies Record<Order['status'], OrdersKey> / Record<Table['status'], TablesKey> / Record<ItemStatusUnion, OrdersKey>). The other maps (ROLE/TENANT_STATUS/BUSINESS_TYPE/PAYMENT_STATUS) stay dotted because settings (batch 5E) still consumes TENANT_STATUS_LABEL_KEYS via the legacy bridge.
- dashboard/page.tsx dynamic status interpolation t(`orders.${order.status}` as ...) replaced with a typed ORDER_STATUS_LABEL_KEYS lookup that keeps the raw-status fallback; the redundant localizeTemplate helper was removed in favor of direct ICU params (t('minutesValue', { minutes })).
- Payment-method labels in the dashboard use a local typed BUILT_IN_PAYMENT_KEYS map because PAYMENT_METHODS.labelKey stays dotted for other unmigrated consumers.
- orders/page.tsx and OrderHistoryGrid use local typed ORDER_TYPE_KEYS maps because the shared ORDER_TYPE_LABEL_KEYS stays dotted for the not-yet-migrated KDS batch (5D).
- sendBillViaFlo still takes a legacy dotted-key translator; orders/page.tsx bridges it with a typed whatsapp.send adapter (same pattern as PaymentModal) rather than reintroducing legacy t().

Constraints: no wording, logic, or behavior changes; no new dependencies or migrations; the legacy useI18n bridge and compatibility adapter must remain for unmigrated batches (its removal is owned by #381); the two e2e assertions pinning setup/fa behavior must not be altered.

## What Changed

- Migrated `orders`, `tables`, `customers`, `dashboard` pages, and the `OrderHistoryGrid` component from the legacy `useI18n()` flat-key hook to `use-intl` `useTranslations()` with per-namespace translators and direct ICU parameter interpolation.
- Converted `ORDER_STATUS_LABEL_KEYS`, `ITEM_STATUS_LABEL_KEYS`, and `TABLE_STATUS_LABEL_KEYS` in `frontend/src/lib/i18n-enums.ts` from dotted string maps to exhaustively typed `use-intl` leaf keys.
- Added Playwright end-to-end test suite (`frontend/e2e/i18n-batch-5c.spec.ts`) validating English LTR and Persian RTL rendering across all migrated pages.

## Risk Assessment

✅ Low: The migration from legacy useI18n to use-intl across the 6 scoped files is clean, strictly conforms to the approved scope and acceptance criteria, and introduces no regressions.

## Testing

Executed translation integrity suite, RTL and chunk-splitting suites, Next.js desktop export build, and dedicated Playwright E2E tests validating localized rendering in English and Persian across all 5 migrated surfaces; all checks passed cleanly and captured full-page visual evidence.

- Evidence: Dashboard Page (English LTR) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/dashboard-en.png</code>)
- Evidence: Dashboard Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/dashboard-fa.png</code>)
- Evidence: Orders Page (English LTR) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/orders-en.png</code>)
- Evidence: Orders Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/orders-fa.png</code>)
- Evidence: Tables Page (English LTR) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/tables-en.png</code>)
- Evidence: Tables Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/tables-fa.png</code>)
- Evidence: Customers Page (English LTR) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/customers-en.png</code>)
- Evidence: Customers Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/customers-fa.png</code>)
- Evidence: Order History Grid Component (English LTR) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/order-history-grid-en.png</code>)
- Evidence: Order History Grid Component (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0D6PY3HABMDFH71W637DKE8/order-history-grid-fa.png</code>)
- Outcome: ⚠️ 1 info across 1 run (5m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f8c59d95cb51de193d59b72ea666793013db36c2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `frontend/e2e/i18n-batch-5c.spec.ts` - new test file written by agent: frontend/e2e/i18n-batch-5c.spec.ts
- `npm run test:translations`
- `npm run test:locale-chunks`
- `npm run test:rtl-dashboard-pos-common`
- `npm run test:rtl-foundation`
- `npm run test:rtl-setup-auth-settings`
- `npm run test:rtl-kds-server-whatsapp`
- `cd frontend && npx cross-env NEXT_BUILD_MODE=desktop npm run build`
- `cd frontend && npx playwright test e2e/i18n-batch-5c.spec.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
