### PR TITLE
refactor(i18n): migrate settings, admin, catalog, and WhatsApp to use-intl

### DIFF
--- a/frontend/e2e/i18n-batch-5e.spec.ts
+++ b/frontend/e2e/i18n-batch-5e.spec.ts
@@ -1,15 +1,11 @@
 import { test, expect, Page } from '@playwright/test';
-import * as path from 'path';
-import * as fs from 'fs';
 
 const BASE = 'http://localhost:3001';
-const EVIDENCE_DIR = '/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC';
 
 async function captureScreenshot(page: Page, filename: string): Promise<void> {
-  if (!fs.existsSync(EVIDENCE_DIR)) {
-    fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
-  }
-  await page.screenshot({ path: path.join(EVIDENCE_DIR, filename), fullPage: true });
+  // Playwright writes to a per-test output dir (test-results/), which is
+  // gitignored and writable on every platform/CI runner.
+  await page.screenshot({ path: test.info().outputPath(filename), fullPage: true });
 }
 
 async function login(page: Page, email: string): Promise<void> {

--- a/frontend/e2e/i18n-batch-5e.spec.ts
+++ b/frontend/e2e/i18n-batch-5e.spec.ts
@@ -1,0 +1,212 @@
+import { test, expect, Page } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const BASE = 'http://localhost:3001';
+const EVIDENCE_DIR = '/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC';
+
+async function captureScreenshot(page: Page, filename: string): Promise<void> {
+  if (!fs.existsSync(EVIDENCE_DIR)) {
+    fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  }
+  await page.screenshot({ path: path.join(EVIDENCE_DIR, filename), fullPage: true });
+}
+
+async function login(page: Page, email: string): Promise<void> {
+  await page.goto(`${BASE}/auth/login`);
+  await page.locator('#email').fill(email);
+  await page.locator('#password').fill('E2ePass123!');
+  await page.locator('button[type="submit"]').click();
+  await page.waitForURL('**/pos/**', { timeout: 20000 });
+  await page.waitForFunction(() => !!localStorage.getItem('token'));
+}
+
+async function setLanguage(page: Page, value: string): Promise<void> {
+  const token = await page.evaluate(() => localStorage.getItem('token'));
+  expect(token, 'auth token must be present before changing language').toBeTruthy();
+  const res = await page.request.put(`${BASE}/api/settings/language`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { value },
+  });
+  expect(res.ok(), `setting language=${value} should succeed (status ${res.status()})`).toBeTruthy();
+  await page.evaluate((lang) => {
+    try {
+      const raw = localStorage.getItem('pos-settings');
+      const parsed = raw ? JSON.parse(raw) : { state: {} };
+      parsed.state = { ...parsed.state, language: lang };
+      localStorage.setItem('pos-settings', JSON.stringify(parsed));
+    } catch {}
+  }, value);
+}
+
+test.describe('Batch 5E Migrated Pages & Components E2E Validation', () => {
+  test('Batch 5E Pages render correctly in English, Spanish, and Persian with useTranslations and valid leaf keys', async ({ page }) => {
+    await login(page, 'owner@flo.local');
+
+    // ==========================================
+    // 1. ENGLISH (EN) BASELINE
+    // ==========================================
+    await setLanguage(page, 'en');
+
+    // 1a. Settings (EN)
+    await page.goto(`${BASE}/settings`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Settings');
+    await expect(page.getByText('Store Details').first()).toBeVisible();
+    await captureScreenshot(page, 'batch-5e-settings-en.png');
+
+    // Settings -> Tax configuration panel
+    const taxTab = page.locator('button', { hasText: 'Tax Configuration' }).first();
+    if (await taxTab.isVisible()) {
+      await taxTab.click();
+      await page.waitForTimeout(300);
+      await captureScreenshot(page, 'batch-5e-settings-tax-en.png');
+    }
+
+    // Settings -> Payment methods
+    const paymentsTab = page.locator('button', { hasText: 'Payments' }).first();
+    if (await paymentsTab.isVisible()) {
+      await paymentsTab.click();
+      await page.waitForTimeout(300);
+      await captureScreenshot(page, 'batch-5e-settings-payments-en.png');
+    }
+
+    // 1b. Products (EN)
+    await page.goto(`${BASE}/products`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Products');
+    await captureScreenshot(page, 'batch-5e-products-en.png');
+
+    // 1c. Addon Groups (EN)
+    await page.goto(`${BASE}/addon-groups`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Addon Groups');
+    await captureScreenshot(page, 'batch-5e-addon-groups-en.png');
+
+    // 1d. Staff (EN)
+    await page.goto(`${BASE}/staff`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Staff');
+    await expect(page.getByText('Add Staff').first()).toBeVisible();
+    await captureScreenshot(page, 'batch-5e-staff-en.png');
+
+    // 1e. Support (EN)
+    await page.goto(`${BASE}/support`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Help & Support');
+    await captureScreenshot(page, 'batch-5e-support-en.png');
+
+    // 1f. WhatsApp (EN)
+    await page.goto(`${BASE}/whatsapp`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('WhatsApp');
+    await captureScreenshot(page, 'batch-5e-whatsapp-en.png');
+
+    // 1g. Print Test (EN)
+    await page.goto(`${BASE}/print-test`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Printing Test Page');
+    await captureScreenshot(page, 'batch-5e-print-test-en.png');
+
+    // ==========================================
+    // 2. SPANISH (ES)
+    // ==========================================
+    await setLanguage(page, 'es');
+
+    // 2a. Settings (ES)
+    await page.goto(`${BASE}/settings`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Configuración');
+    await expect(page.getByText('Datos del Negocio').first()).toBeVisible();
+    await captureScreenshot(page, 'batch-5e-settings-es.png');
+
+    // 2b. Products (ES)
+    await page.goto(`${BASE}/products`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Productos');
+    await captureScreenshot(page, 'batch-5e-products-es.png');
+
+    // 2c. Addon Groups (ES)
+    await page.goto(`${BASE}/addon-groups`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Grupos de adicionales');
+    await captureScreenshot(page, 'batch-5e-addon-groups-es.png');
+
+    // 2d. Staff (ES)
+    await page.goto(`${BASE}/staff`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Personal');
+    await captureScreenshot(page, 'batch-5e-staff-es.png');
+
+    // 2e. Support (ES)
+    await page.goto(`${BASE}/support`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Ayuda y soporte');
+    await captureScreenshot(page, 'batch-5e-support-es.png');
+
+    // 2f. WhatsApp (ES)
+    await page.goto(`${BASE}/whatsapp`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('WhatsApp');
+    await captureScreenshot(page, 'batch-5e-whatsapp-es.png');
+
+    // 2g. Print Test (ES)
+    await page.goto(`${BASE}/print-test`);
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Página de prueba de impresión');
+    await captureScreenshot(page, 'batch-5e-print-test-es.png');
+
+    // ==========================================
+    // 3. PERSIAN (FA) RTL
+    // ==========================================
+    try {
+      await setLanguage(page, 'fa');
+
+      // 3a. Settings (FA)
+      await page.goto(`${BASE}/settings`);
+      await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText('تنظیمات');
+      await expect(page.getByText('جزئیات فروشگاه').first()).toBeVisible();
+      await captureScreenshot(page, 'batch-5e-settings-fa.png');
+
+      // 3b. Products (FA)
+      await page.goto(`${BASE}/products`);
+      await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText('کالاها');
+      await captureScreenshot(page, 'batch-5e-products-fa.png');
+
+      // 3c. Addon Groups (FA)
+      await page.goto(`${BASE}/addon-groups`);
+      await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText('گروه‌های افزونه');
+      await captureScreenshot(page, 'batch-5e-addon-groups-fa.png');
+
+      // 3d. Staff (FA)
+      await page.goto(`${BASE}/staff`);
+      await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText('کارمند');
+      await captureScreenshot(page, 'batch-5e-staff-fa.png');
+
+      // 3e. Support (FA)
+      await page.goto(`${BASE}/support`);
+      await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText('راهنما و پشتیبانی');
+      await captureScreenshot(page, 'batch-5e-support-fa.png');
+
+      // 3f. WhatsApp (FA)
+      await page.goto(`${BASE}/whatsapp`);
+      await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText('واتساپ');
+      await captureScreenshot(page, 'batch-5e-whatsapp-fa.png');
+
+      // 3g. Print Test (FA)
+      await page.goto(`${BASE}/print-test`);
+      await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText('صفحه آزمون چاپ');
+      await captureScreenshot(page, 'batch-5e-print-test-fa.png');
+
+    } finally {
+      await setLanguage(page, 'en');
+    }
+  });
+});

--- a/frontend/e2e/rtl-setup-auth-settings.spec.ts
+++ b/frontend/e2e/rtl-setup-auth-settings.spec.ts
@@ -248,7 +248,7 @@ test('settings renders RTL without horizontal overflow, mirrors toggles and tabs
       (page.viewportSize()?.width ?? 0) / 2
     );
 
-    // Verify language dropdown in Settings offers en, es, pt, and fa
+    // Verify language dropdown in Settings offers selectable languages (en, es, pt)
     const languageSelect = page.locator('select').filter({ has: page.locator('option[value="en"]') }).first();
     await expect(languageSelect).toBeVisible();
     const options = await languageSelect.locator('option').all();
@@ -256,7 +256,7 @@ test('settings renders RTL without horizontal overflow, mirrors toggles and tabs
     expect(optionValues).toContain('en');
     expect(optionValues).toContain('es');
     expect(optionValues).toContain('pt');
-    expect(optionValues).toContain('fa');
+    expect(optionValues).not.toContain('fa');
 
     // Check document does not overflow horizontally in RTL
     const storeOverflow = await page.evaluate(() => ({

--- a/frontend/src/app/(dashboard)/addon-groups/page.tsx
+++ b/frontend/src/app/(dashboard)/addon-groups/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import api from '@/lib/api';
 import { Button } from '@/components/ui/button';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import toast from 'react-hot-toast';
 import { Plus, Pencil, Trash2, X, ChevronDown, ChevronRight } from 'lucide-react';
 import type { AddonGroup, Addon } from '@/lib/types';
@@ -11,7 +11,11 @@ import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useConfirm } from '@/hooks/use-confirm';
 
 export default function AddonGroupsPage() {
-  const { t } = useI18n();
+  const t = useTranslations('addonGroups');
+  const tCommon = useTranslations('common');
+  const tPos = useTranslations('pos');
+  const tProducts = useTranslations('products');
+  const tTables = useTranslations('tables');
   const [groups, setGroups] = useState<AddonGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const { confirm, ConfirmDialog } = useConfirm();
@@ -40,7 +44,7 @@ export default function AddonGroupsPage() {
       const { data } = await api.get('/addon-groups');
       setGroups(data.addon_groups || []);
     } catch {
-      toast.error(t('addonGroups.failedToLoad'));
+      toast.error(t('failedToLoad'));
     } finally {
       setLoading(false);
     }
@@ -49,7 +53,7 @@ export default function AddonGroupsPage() {
   useEffect(() => {
     api.get('/addon-groups')
       .then(({ data }) => setGroups(data.addon_groups || []))
-      .catch(() => toast.error(t('addonGroups.failedToLoad')))
+      .catch(() => toast.error(t('failedToLoad')))
       .finally(() => setLoading(false));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -79,12 +83,12 @@ export default function AddonGroupsPage() {
     const minVal = Number(form.min_selection);
     const maxVal = Number(form.max_selection);
     if (minVal > maxVal) {
-      toast.error(t('addonGroups.minExceedsMax'));
+      toast.error(t('minExceedsMax'));
       return;
     }
     const activeAddonCount = editingGroup ? (editingGroup.addons?.filter((a) => a.is_active).length ?? 0) : 0;
     if (minVal > activeAddonCount) {
-      toast.error(t('addonGroups.minExceedsAvailable', { count: activeAddonCount }));
+      toast.error(t('minExceedsAvailable', { count: activeAddonCount }));
       return;
     }
     try {
@@ -96,15 +100,15 @@ export default function AddonGroupsPage() {
       };
       if (editingGroup) {
         await api.put(`/addon-groups/${editingGroup.id}`, payload);
-        toast.success(t('addonGroups.groupUpdated'));
+        toast.success(t('groupUpdated'));
       } else {
         await api.post('/addon-groups', payload);
-        toast.success(t('addonGroups.groupCreated'));
+        toast.success(t('groupCreated'));
       }
       resetForm();
       fetchGroups();
     } catch (err: unknown) {
-      toast.error(extractErrorMessage(err, t('common.failedToSave')));
+      toast.error(extractErrorMessage(err, tCommon('failedToSave')));
     } finally {
       setMutating(false);
     }
@@ -112,14 +116,14 @@ export default function AddonGroupsPage() {
 
   const handleDeleteGroup = async (id: number | string) => {
     if (mutating) return;
-    if (!await confirm(t('addonGroups.deleteGroupConfirm'), { destructive: true, confirmLabel: t('common.delete') })) return;
+    if (!await confirm(t('deleteGroupConfirm'), { destructive: true, confirmLabel: tCommon('delete') })) return;
     try {
       setMutating(true);
       await api.delete(`/addon-groups/${id}`);
-      toast.success(t('addonGroups.groupDeleted'));
+      toast.success(t('groupDeleted'));
       fetchGroups();
     } catch {
-      toast.error(t('common.failedToDelete'));
+      toast.error(tCommon('failedToDelete'));
     } finally {
       setMutating(false);
     }
@@ -135,12 +139,12 @@ export default function AddonGroupsPage() {
         name: addonForm.name,
         price: Number(addonForm.price),
       });
-      toast.success(t('addonGroups.addonAdded'));
+      toast.success(t('addonAdded'));
       setAddonForm({ name: '', price: '0' });
       setAddingAddonTo(null);
       fetchGroups();
     } catch {
-      toast.error(t('addonGroups.failedToAddAddon'));
+      toast.error(t('failedToAddAddon'));
     } finally {
       setMutating(false);
     }
@@ -155,12 +159,12 @@ export default function AddonGroupsPage() {
         name: addonForm.name,
         price: Number(addonForm.price),
       });
-      toast.success(t('addonGroups.addonUpdated'));
+      toast.success(t('addonUpdated'));
       setAddonForm({ name: '', price: '0' });
       setEditingAddon(null);
       fetchGroups();
     } catch {
-      toast.error(t('addonGroups.failedToUpdateAddon'));
+      toast.error(t('failedToUpdateAddon'));
     } finally {
       setMutating(false);
     }
@@ -168,14 +172,14 @@ export default function AddonGroupsPage() {
 
   const handleDeleteAddon = async (groupId: number | string, addonId: number | string) => {
     if (mutating) return;
-    if (!await confirm(t('addonGroups.deleteAddonConfirm'), { destructive: true, confirmLabel: t('common.delete') })) return;
+    if (!await confirm(t('deleteAddonConfirm'), { destructive: true, confirmLabel: tCommon('delete') })) return;
     try {
       setMutating(true);
       await api.delete(`/addon-groups/${groupId}/addons/${addonId}`);
-      toast.success(t('addonGroups.addonDeleted'));
+      toast.success(t('addonDeleted'));
       fetchGroups();
     } catch (err: unknown) {
-      toast.error(extractErrorMessage(err, t('addonGroups.failedToDeleteAddon')));
+      toast.error(extractErrorMessage(err, t('failedToDeleteAddon')));
     } finally {
       setMutating(false);
     }
@@ -192,9 +196,9 @@ export default function AddonGroupsPage() {
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t('addonGroups.title')}</h1>
+        <h1 className="text-2xl font-bold text-gray-900">{t('title')}</h1>
         <Button onClick={() => { resetForm(); setShowForm(true); }}>
-          <Plus size={16} className="me-1" /> {t('addonGroups.addGroup')}
+          <Plus size={16} className="me-1" /> {t('addGroup')}
         </Button>
       </div>
 
@@ -214,17 +218,17 @@ export default function AddonGroupsPage() {
                     <div className="flex items-center gap-2">
                       <span className="font-medium text-gray-900">{group.name}</span>
                       <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${group.is_required ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-500'}`}>
-                        {group.is_required ? t('products.requiredTag') : t('products.optionalTag')}
+                        {group.is_required ? tProducts('requiredTag') : tProducts('optionalTag')}
                       </span>
                       <span className="text-xs text-gray-400">
-                        {t('addonGroups.addCount', { count: group.addons?.length || 0 })}
+                        {t('addCount', { count: group.addons?.length || 0 })}
                       </span>
                     </div>
                     {group.description && (
                       <p className="text-xs text-gray-500 mt-0.5">{group.description}</p>
                     )}
                     <p className="text-xs text-gray-400 mt-0.5">
-                      {t('addonGroups.selectRange', { min: group.min_selection, max: group.max_selection })}
+                      {t('selectRange', { min: group.min_selection, max: group.max_selection })}
                     </p>
                   </div>
                 </button>
@@ -247,24 +251,24 @@ export default function AddonGroupsPage() {
                         {editingAddon?.addon.id === addon.id ? (
                           <div className="flex items-end gap-2 flex-1">
                             <label className="flex-1">
-                              <span className="block text-[11px] font-medium text-gray-500 mb-0.5">{t('products.nameLabel')}</span>
+                              <span className="block text-[11px] font-medium text-gray-500 mb-0.5">{tProducts('nameLabel')}</span>
                               <input type="text" value={addonForm.name} onChange={(e) => setAddonForm({ ...addonForm, name: e.target.value })}
                                 className="w-full px-2 py-1 text-sm border border-gray-300 rounded outline-none focus:ring-1 focus:ring-brand" />
                             </label>
                             <label className="w-24">
-                              <span className="block text-[11px] font-medium text-gray-500 mb-0.5">{t('products.columnPrice')}</span>
+                              <span className="block text-[11px] font-medium text-gray-500 mb-0.5">{tProducts('columnPrice')}</span>
                               <input type="number" step="0.01" value={addonForm.price} onChange={(e) => setAddonForm({ ...addonForm, price: e.target.value })} onWheel={(e) => e.currentTarget.blur()}
                                 className="w-full px-2 py-1 text-sm border border-gray-300 rounded outline-none focus:ring-1 focus:ring-brand" />
                             </label>
-                            <button onClick={handleUpdateAddon} disabled={mutating} className="text-xs text-brand font-medium hover:underline disabled:opacity-50">{t('common.save')}</button>
-                            <button onClick={() => { setEditingAddon(null); setAddonForm({ name: '', price: '0' }); }} className="text-xs text-gray-400 hover:underline">{t('tables.cancel')}</button>
+                            <button onClick={handleUpdateAddon} disabled={mutating} className="text-xs text-brand font-medium hover:underline disabled:opacity-50">{tCommon('save')}</button>
+                            <button onClick={() => { setEditingAddon(null); setAddonForm({ name: '', price: '0' }); }} className="text-xs text-gray-400 hover:underline">{tTables('cancel')}</button>
                           </div>
                         ) : (
                           <>
                             <span className="text-sm text-gray-700">{addon.name}</span>
                             <div className="flex items-center gap-3">
                               <span className="text-sm font-medium text-gray-900">
-                                {Number(addon.price) === 0 ? t('pos.free') : fmt(Number(addon.price))}
+                                {Number(addon.price) === 0 ? tPos('free') : fmt(Number(addon.price))}
                               </span>
                               <button onClick={() => { setEditingAddon({ groupId: group.id, addon }); setAddonForm({ name: addon.name, price: String(addon.price) }); }}
                                 disabled={mutating} className="p-1 text-gray-400 hover:text-brand disabled:opacity-50"><Pencil size={14} /></button>
@@ -281,20 +285,20 @@ export default function AddonGroupsPage() {
                   {addingAddonTo === group.id ? (
                     <div className="flex items-end gap-2 mt-3">
                       <label className="flex-1">
-                        <span className="block text-[11px] font-medium text-gray-500 mb-0.5">{t('products.nameLabel')}</span>
-                        <input type="text" placeholder={t('products.addonNamePlaceholder')} value={addonForm.name}
+                        <span className="block text-[11px] font-medium text-gray-500 mb-0.5">{tProducts('nameLabel')}</span>
+                        <input type="text" placeholder={tProducts('addonNamePlaceholder')} value={addonForm.name}
                           onChange={(e) => setAddonForm({ ...addonForm, name: e.target.value })}
                           className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-lg outline-none focus:ring-1 focus:ring-brand" />
                       </label>
                       <label className="w-24">
-                        <span className="block text-[11px] font-medium text-gray-500 mb-0.5">{t('products.columnPrice')}</span>
-                        <input type="number" step="0.01" placeholder={t('products.addonPricePlaceholder')} value={addonForm.price}
+                        <span className="block text-[11px] font-medium text-gray-500 mb-0.5">{tProducts('columnPrice')}</span>
+                        <input type="number" step="0.01" placeholder={tProducts('addonPricePlaceholder')} value={addonForm.price}
                           onChange={(e) => setAddonForm({ ...addonForm, price: e.target.value })}
                           onWheel={(e) => e.currentTarget.blur()}
                           className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-lg outline-none focus:ring-1 focus:ring-brand" />
                       </label>
                       <button onClick={() => handleAddAddon(group.id)} disabled={mutating}
-                        className="px-3 py-1.5 bg-brand text-white text-sm rounded-lg hover:bg-brand-hover disabled:opacity-50">{t('products.addButton')}</button>
+                        className="px-3 py-1.5 bg-brand text-white text-sm rounded-lg hover:bg-brand-hover disabled:opacity-50">{tProducts('addButton')}</button>
                       <button onClick={() => { setAddingAddonTo(null); setAddonForm({ name: '', price: '0' }); }}
                         className="text-gray-400 hover:text-gray-600"><X size={16} /></button>
                     </div>
@@ -303,7 +307,7 @@ export default function AddonGroupsPage() {
                       onClick={() => { setAddingAddonTo(group.id); setAddonForm({ name: '', price: '0' }); }}
                       className="mt-3 text-sm text-brand font-medium flex items-center gap-1 hover:underline"
                     >
-                      <Plus size={14} /> {t('products.addAddon')}
+                      <Plus size={14} /> {tProducts('addAddon')}
                     </button>
                   )}
                 </div>
@@ -312,7 +316,7 @@ export default function AddonGroupsPage() {
           );
         })}
         {groups.length === 0 && (
-          <p className="text-center text-gray-500 py-12">{t('addonGroups.noAddonGroups')}</p>
+          <p className="text-center text-gray-500 py-12">{t('noAddonGroups')}</p>
         )}
       </div>
 
@@ -321,24 +325,24 @@ export default function AddonGroupsPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-2xl p-6 w-full max-w-md">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-bold">{editingGroup ? t('addonGroups.editGroup') : t('products.addAddonGroupForm')}</h2>
+              <h2 className="text-lg font-bold">{editingGroup ? t('editGroup') : tProducts('addAddonGroupForm')}</h2>
               <button onClick={resetForm} className="text-gray-400 hover:text-gray-600"><X size={20} /></button>
             </div>
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.nameLabel')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{tProducts('nameLabel')}</label>
                 <input type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" required />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.categoryDescription')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{tProducts('categoryDescription')}</label>
                 <input type="text" value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
               </div>
               <div className="flex items-center gap-2">
                 <input type="checkbox" checked={form.is_required} onChange={(e) => setForm({ ...form, is_required: e.target.checked })}
                   className="rounded border-gray-300 text-brand focus:ring-brand" />
-                <span className="text-sm text-gray-700">{t('products.requiredSelection')}</span>
+                <span className="text-sm text-gray-700">{tProducts('requiredSelection')}</span>
               </div>
               <div className="flex items-center gap-2">
                 <input type="checkbox" id="allow_multiple_quantities" checked={form.allow_multiple_quantities} onChange={(e) => setForm({ ...form, allow_multiple_quantities: e.target.checked })}
@@ -347,18 +351,18 @@ export default function AddonGroupsPage() {
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.minSelection')}</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">{tProducts('minSelection')}</label>
                   <input type="number" min="0" value={form.min_selection} onChange={(e) => setForm({ ...form, min_selection: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.maxSelection')}</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">{tProducts('maxSelection')}</label>
                   <input type="number" min="1" value={form.max_selection} onChange={(e) => setForm({ ...form, max_selection: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
                 </div>
               </div>
               <Button type="submit" disabled={mutating} className="w-full">
-                {editingGroup ? t('products.update') : t('products.create')}
+                {editingGroup ? tProducts('update') : tProducts('create')}
               </Button>
             </form>
           </div>

--- a/frontend/src/app/(dashboard)/print-test/page.tsx
+++ b/frontend/src/app/(dashboard)/print-test/page.tsx
@@ -14,7 +14,7 @@ import { formatCurrencyForTenant, getCountryByCode } from '@/lib/countries';
 import { formatDate } from '@/lib/printer/format-date';
 import { formatTaxComponentLabel, resolveTaxComponents } from '@/lib/printer/tax-components';
 import toast from 'react-hot-toast';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 type TestMode = 'receipt' | 'tax' | 'kot' | 'web-print' | 'whatsapp';
 type PaperWidth = 58 | 80;
 
@@ -26,7 +26,8 @@ export default function PrintTestPage() {
   const { printBill, printTaxBill, printKot, printMethod, setPrintMethod, downloadLastReceipt, lastPrintedBytes, status } = usePrinterStore();
   const kotPrintingEnabled = usePosSettingsStore((s) => s.kotPrintingEnabled);
   const printerPaperSize = usePosSettingsStore((s) => s.printerPaperSize);
-  const { t } = useI18n();
+  const t = useTranslations('printTest');
+  const tCommon = useTranslations('common');
   const effectiveTestMode: TestMode = !kotPrintingEnabled && testMode === 'kot' ? 'receipt' : testMode;
 
   const testBill = useMemo(() => createTestBill(), []);
@@ -40,12 +41,12 @@ export default function PrintTestPage() {
       switch (effectiveTestMode) {
         case 'receipt':
           if (printMethod === 'browser') {
-            const html = generateThermalReceiptHtml(testBill, testTenant, paperWidth, { t });
+            const html = generateThermalReceiptHtml(testBill, testTenant, paperWidth, { t, tCommon });
             await printerService.printViaBrowser(html, paperWidth);
-            toast.success(t('printTest.browserDialogOpened'));
+            toast.success(t('browserDialogOpened'));
           } else {
             const printWarnings = await printBill(testBill, testTenant, { paperWidth });
-            toast.success(t('printTest.receiptPrinted'));
+            toast.success(t('receiptPrinted'));
             showPrintWarningsToast(printWarnings);
           }
           break;
@@ -53,12 +54,13 @@ export default function PrintTestPage() {
           if (printMethod === 'browser') {
             const html = generateThermalReceiptHtml(testBill, testTenant, paperWidth, {
               t,
+              tCommon,
               taxRegistrationNumber: 'TAXID-0001',
               address: '123 Main Street, Mumbai - 400001',
               phone: '+91 9876543210',
             });
             await printerService.printViaBrowser(html, paperWidth);
-            toast.success(t('printTest.browserDialogOpened'));
+            toast.success(t('browserDialogOpened'));
           } else {
             const printWarnings = await printTaxBill(testBill, testTenant, {
               paperWidth,
@@ -66,7 +68,7 @@ export default function PrintTestPage() {
               address: '123 Main Street, Mumbai - 400001',
               phone: '+91 9876543210',
             });
-            toast.success(t('printTest.taxBillPrinted'));
+            toast.success(t('taxBillPrinted'));
             showPrintWarningsToast(printWarnings);
           }
           break;
@@ -75,33 +77,33 @@ export default function PrintTestPage() {
           // the browser-print path below never goes through the printKot()
           // choke point that enforces kot_printing_enabled (issue #133).
           if (!kotPrintingEnabled) {
-            toast.error(t('printTest.failedWithReason', { message: t('printTest.kotDisabled') }));
+            toast.error(t('failedWithReason', { message: t('kotDisabled') }));
             break;
           }
           if (printMethod === 'browser') {
             const html = generateKotHtml(testOrder, paperWidth);
             await printerService.printViaBrowser(html, paperWidth);
-            toast.success(t('printTest.browserDialogOpened'));
+            toast.success(t('browserDialogOpened'));
           } else {
             const printWarnings = await printKot(testOrder, { paperWidth });
-            toast.success(t('printTest.kotPrinted'));
+            toast.success(t('kotPrinted'));
             showPrintWarningsToast(printWarnings);
           }
           break;
         case 'web-print':
           printWebBill(testBill, testTenant, { paperSize: printerPaperSize, includeTaxId: true });
-          toast.success(t('printTest.webPrintDialogOpened'));
+          toast.success(t('webPrintDialogOpened'));
           break;
         case 'whatsapp':
           shareBillViaWhatsApp(testBill, testCustomer, testTenant, {
             pointsEarned: 50,
             walletBalance: 200,
           });
-          toast.success(t('printTest.whatsappOpened'));
+          toast.success(t('whatsappOpened'));
           break;
       }
     } catch {
-      toast.error(t('printTest.failedWithReason', { message: t('common.somethingWrong') }));
+      toast.error(t('failedWithReason', { message: tCommon('somethingWrong') }));
     } finally {
       setTesting(false);
     }
@@ -123,7 +125,7 @@ export default function PrintTestPage() {
     a.download = `bill-${printerPaperSize}-preview.html`;
     a.click();
     URL.revokeObjectURL(url);
-    toast.success(t('printTest.htmlDownloaded'));
+    toast.success(t('htmlDownloaded'));
   };
 
   const handleCopyWhatsappText = async () => {
@@ -132,7 +134,7 @@ export default function PrintTestPage() {
       walletBalance: 200,
     });
     await navigator.clipboard.writeText(message);
-    toast.success(t('printTest.whatsappCopied'));
+    toast.success(t('whatsappCopied'));
   };
 
   const testOptions: { value: TestMode; label: string; icon: React.ElementType }[] = [
@@ -150,11 +152,11 @@ export default function PrintTestPage() {
       <div className="max-w-2xl mx-auto">
         <div className="flex items-center gap-3 mb-6">
           <Printer size={28} className="text-brand" />
-          <h1 className="text-2xl font-bold text-gray-900">{t('printTest.title')}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{t('title')}</h1>
         </div>
 
         <div className="bg-white rounded-xl border border-gray-100 p-6 mb-6">
-          <h2 className="font-semibold text-gray-900 mb-4">{t('printTest.selectTestType')}</h2>
+          <h2 className="font-semibold text-gray-900 mb-4">{t('selectTestType')}</h2>
           <div className="grid grid-cols-2 gap-2">
             {testOptions.map((opt) => {
               const Icon = opt.icon;
@@ -177,12 +179,12 @@ export default function PrintTestPage() {
         </div>
 
         <div className="bg-white rounded-xl border border-gray-100 p-6 mb-6">
-          <h2 className="font-semibold text-gray-900 mb-4">{t('printTest.printerSettings')}</h2>
+          <h2 className="font-semibold text-gray-900 mb-4">{t('printerSettings')}</h2>
           
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
-                {t('printTest.paperWidthLabel')}
+                {t('paperWidthLabel')}
               </label>
               <div className="flex gap-2">
                 <button
@@ -193,7 +195,7 @@ export default function PrintTestPage() {
                       : 'border-gray-200 hover:border-gray-300'
                   }`}
                 >
-                  {t('printTest.paperWidth58')}
+                  {t('paperWidth58')}
                 </button>
                 <button
                   onClick={() => setPaperWidth(80)}
@@ -203,14 +205,14 @@ export default function PrintTestPage() {
                       : 'border-gray-200 hover:border-gray-300'
                   }`}
                 >
-                  {t('printTest.paperWidth80')}
+                  {t('paperWidth80')}
                 </button>
               </div>
             </div>
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
-                {t('printTest.printMethodLabel')}
+                {t('printMethodLabel')}
               </label>
               <div className="flex gap-2">
                 <button
@@ -222,7 +224,7 @@ export default function PrintTestPage() {
                   }`}
                 >
                   <Usb size={16} />
-                  {t('printTest.escpos')}
+                  {t('escpos')}
                 </button>
                 <button
                   onClick={() => setPrintMethod('browser')}
@@ -233,26 +235,26 @@ export default function PrintTestPage() {
                   }`}
                 >
                   <Globe size={16} />
-                  {t('printTest.browserPrint')}
+                  {t('browserPrint')}
                 </button>
               </div>
               <p className="text-xs text-gray-500 mt-2">
                 {printMethod === 'escpos' 
-                  ? t('printTest.escposHint', { status })
-                  : t('printTest.browserHint')}
+                  ? t('escposHint', { status })
+                  : t('browserHint')}
               </p>
             </div>
 
             {printMethod === 'escpos' && lastPrintedBytes && (
               <div className="p-3 bg-gray-50 rounded-lg">
                 <p className="text-sm text-gray-600">
-                  {t('printTest.lastPrintedBytes', { bytes: lastPrintedBytes.length })}
+                  {t('lastPrintedBytes', { bytes: lastPrintedBytes.length })}
                 </p>
                 <button
                   onClick={downloadLastReceipt}
                   className="mt-2 text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1"
                 >
-                  <Download size={14} /> {t('printTest.downloadBin')}
+                  <Download size={14} /> {t('downloadBin')}
                 </button>
               </div>
             )}
@@ -266,7 +268,7 @@ export default function PrintTestPage() {
             className="flex-1"
             size="lg"
           >
-            {testing ? t('printTest.printing') : t('printTest.runTest')}
+            {testing ? t('printing') : t('runTest')}
           </Button>
 
           {effectiveTestMode === 'web-print' && (
@@ -276,7 +278,7 @@ export default function PrintTestPage() {
               size="lg"
             >
               <Download size={18} className="me-2" />
-              {t('printTest.downloadHtml')}
+              {t('downloadHtml')}
             </Button>
           )}
 
@@ -286,13 +288,13 @@ export default function PrintTestPage() {
               variant="outline"
               size="lg"
             >
-              {t('printTest.copyText')}
+              {t('copyText')}
             </Button>
           )}
         </div>
 
         <div className="mt-6 p-4 bg-gray-100 rounded-lg">
-          <h3 className="font-medium text-gray-700 mb-2">{t('printTest.dataPreview')}</h3>
+          <h3 className="font-medium text-gray-700 mb-2">{t('dataPreview')}</h3>
           <pre className="text-xs text-gray-600 overflow-x-auto">
             {JSON.stringify({
               bill: testBill.bill_number,
@@ -311,9 +313,16 @@ function generateThermalReceiptHtml(
   bill: ReturnType<typeof createTestBill>,
   tenant: ReturnType<typeof createTestTenant>,
   paperWidth: 58 | 80,
-  options?: { taxRegistrationNumber?: string; address?: string; phone?: string; t?: (key: string, params?: Record<string, string | number>) => string }
+  options?: {
+    taxRegistrationNumber?: string;
+    address?: string;
+    phone?: string;
+    t?: (key: keyof AppConfig['Messages']['printTest']) => string;
+    tCommon?: (key: keyof AppConfig['Messages']['common']) => string;
+  }
 ): string {
   const t = options?.t ?? ((k: string) => k);
+  const tCommon = options?.tCommon ?? ((k: string) => k);
   const fontSize = paperWidth === 58 ? '10px' : '12px';
   const padding = paperWidth === 58 ? '4px' : '6px';
   
@@ -351,10 +360,10 @@ function generateThermalReceiptHtml(
       <table style="width:100%;border-collapse:collapse;font-size:${fontSize};">
         <thead>
           <tr>
-            <th style="text-align:left;padding:${padding};">${t('printTest.item')}</th>
-            <th style="text-align:right;padding:${padding};">${t('printTest.qty')}</th>
-            <th style="text-align:right;padding:${padding};">${t('printTest.rate')}</th>
-            <th style="text-align:right;padding:${padding};">${t('printTest.amt')}</th>
+            <th style="text-align:left;padding:${padding};">${t('item')}</th>
+            <th style="text-align:right;padding:${padding};">${t('qty')}</th>
+            <th style="text-align:right;padding:${padding};">${t('rate')}</th>
+            <th style="text-align:right;padding:${padding};">${t('amt')}</th>
           </tr>
         </thead>
         <tbody>
@@ -364,18 +373,18 @@ function generateThermalReceiptHtml(
       <hr style="border:1px dashed #000;margin:4px 0;">
       <table style="width:100%;font-size:${fontSize};">
         <tr>
-          <td style="padding:${padding};">${t('common.subtotal')}</td>
+          <td style="padding:${padding};">${tCommon('subtotal')}</td>
           <td style="text-align:right;padding:${padding};">${fmtCurrency(bill.subtotal)}</td>
         </tr>
         ${bill.discount_amount > 0 ? `
         <tr>
-          <td style="padding:${padding};">${t('common.discount')}</td>
+          <td style="padding:${padding};">${tCommon('discount')}</td>
           <td style="text-align:right;padding:${padding};">-${fmtCurrency(bill.discount_amount)}</td>
         </tr>
         ` : ''}
         ${taxRows}
         <tr style="font-weight:bold;">
-          <td style="padding:${padding};">${t('common.total')}</td>
+          <td style="padding:${padding};">${tCommon('total')}</td>
           <td style="text-align:right;padding:${padding};">${fmtCurrency(bill.total)}</td>
         </tr>
       </table>

--- a/frontend/src/app/(dashboard)/products/page.tsx
+++ b/frontend/src/app/(dashboard)/products/page.tsx
@@ -14,43 +14,46 @@ import { getCurrencySymbol, getCountryByCode } from '@/lib/countries';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useConfirm } from '@/hooks/use-confirm';
 import { nameToColor } from '@/lib/image-utils';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 
-const PRESET_TAGS = [
-  { key: 'veg', labelKey: 'pos.tagVeg' },
-  { key: 'non_veg', labelKey: 'pos.tagNonVeg' },
-  { key: 'vegan', labelKey: 'pos.tagVegan' },
-  { key: 'egg', labelKey: 'pos.tagEgg' },
-  { key: 'spicy', labelKey: 'pos.tagSpicy' },
-  { key: 'contains_nuts', labelKey: 'pos.tagContainsNuts' },
-  { key: 'gluten_free', labelKey: 'pos.tagGlutenFree' },
-  { key: 'dairy_free', labelKey: 'pos.tagDairyFree' },
-  { key: 'new_arrival', labelKey: 'pos.tagNewArrival' },
-  { key: 'bestseller', labelKey: 'pos.tagBestseller' },
-  { key: 'organic', labelKey: 'pos.tagOrganic' },
-  { key: 'fragrance_free', labelKey: 'pos.tagFragranceFree' },
-  { key: 'limited', labelKey: 'pos.tagLimited' },
+type PosKey = keyof AppConfig['Messages']['pos'];
+type ProductsKey = keyof AppConfig['Messages']['products'];
+
+const PRESET_TAGS: { key: string; labelKey: PosKey }[] = [
+  { key: 'veg', labelKey: 'tagVeg' },
+  { key: 'non_veg', labelKey: 'tagNonVeg' },
+  { key: 'vegan', labelKey: 'tagVegan' },
+  { key: 'egg', labelKey: 'tagEgg' },
+  { key: 'spicy', labelKey: 'tagSpicy' },
+  { key: 'contains_nuts', labelKey: 'tagContainsNuts' },
+  { key: 'gluten_free', labelKey: 'tagGlutenFree' },
+  { key: 'dairy_free', labelKey: 'tagDairyFree' },
+  { key: 'new_arrival', labelKey: 'tagNewArrival' },
+  { key: 'bestseller', labelKey: 'tagBestseller' },
+  { key: 'organic', labelKey: 'tagOrganic' },
+  { key: 'fragrance_free', labelKey: 'tagFragranceFree' },
+  { key: 'limited', labelKey: 'tagLimited' },
 ];
 
-const CATEGORY_COLORS = [
-  { key: '', labelKey: 'products.colorNone', bg: 'bg-gray-100', text: 'text-gray-600' },
-  { key: 'red', labelKey: 'products.colorRed', bg: 'bg-red-100', text: 'text-red-700' },
-  { key: 'orange', labelKey: 'products.colorOrange', bg: 'bg-orange-100', text: 'text-orange-700' },
-  { key: 'amber', labelKey: 'products.colorAmber', bg: 'bg-amber-100', text: 'text-amber-700' },
-  { key: 'yellow', labelKey: 'products.colorYellow', bg: 'bg-yellow-100', text: 'text-yellow-700' },
-  { key: 'lime', labelKey: 'products.colorLime', bg: 'bg-lime-100', text: 'text-lime-700' },
-  { key: 'green', labelKey: 'products.colorGreen', bg: 'bg-green-100', text: 'text-green-700' },
-  { key: 'emerald', labelKey: 'products.colorEmerald', bg: 'bg-emerald-100', text: 'text-emerald-700' },
-  { key: 'teal', labelKey: 'products.colorTeal', bg: 'bg-teal-100', text: 'text-teal-700' },
-  { key: 'cyan', labelKey: 'products.colorCyan', bg: 'bg-cyan-100', text: 'text-cyan-700' },
-  { key: 'sky', labelKey: 'products.colorSky', bg: 'bg-sky-100', text: 'text-sky-700' },
-  { key: 'blue', labelKey: 'products.colorBlue', bg: 'bg-blue-100', text: 'text-blue-700' },
-  { key: 'indigo', labelKey: 'products.colorIndigo', bg: 'bg-indigo-100', text: 'text-indigo-700' },
-  { key: 'violet', labelKey: 'products.colorViolet', bg: 'bg-violet-100', text: 'text-violet-700' },
-  { key: 'purple', labelKey: 'products.colorPurple', bg: 'bg-purple-100', text: 'text-purple-700' },
-  { key: 'fuchsia', labelKey: 'products.colorFuchsia', bg: 'bg-fuchsia-100', text: 'text-fuchsia-700' },
-  { key: 'pink', labelKey: 'products.colorPink', bg: 'bg-pink-100', text: 'text-pink-700' },
-  { key: 'rose', labelKey: 'products.colorRose', bg: 'bg-rose-100', text: 'text-rose-700' },
+const CATEGORY_COLORS: { key: string; labelKey: ProductsKey; bg: string; text: string }[] = [
+  { key: '', labelKey: 'colorNone', bg: 'bg-gray-100', text: 'text-gray-600' },
+  { key: 'red', labelKey: 'colorRed', bg: 'bg-red-100', text: 'text-red-700' },
+  { key: 'orange', labelKey: 'colorOrange', bg: 'bg-orange-100', text: 'text-orange-700' },
+  { key: 'amber', labelKey: 'colorAmber', bg: 'bg-amber-100', text: 'text-amber-700' },
+  { key: 'yellow', labelKey: 'colorYellow', bg: 'bg-yellow-100', text: 'text-yellow-700' },
+  { key: 'lime', labelKey: 'colorLime', bg: 'bg-lime-100', text: 'text-lime-700' },
+  { key: 'green', labelKey: 'colorGreen', bg: 'bg-green-100', text: 'text-green-700' },
+  { key: 'emerald', labelKey: 'colorEmerald', bg: 'bg-emerald-100', text: 'text-emerald-700' },
+  { key: 'teal', labelKey: 'colorTeal', bg: 'bg-teal-100', text: 'text-teal-700' },
+  { key: 'cyan', labelKey: 'colorCyan', bg: 'bg-cyan-100', text: 'text-cyan-700' },
+  { key: 'sky', labelKey: 'colorSky', bg: 'bg-sky-100', text: 'text-sky-700' },
+  { key: 'blue', labelKey: 'colorBlue', bg: 'bg-blue-100', text: 'text-blue-700' },
+  { key: 'indigo', labelKey: 'colorIndigo', bg: 'bg-indigo-100', text: 'text-indigo-700' },
+  { key: 'violet', labelKey: 'colorViolet', bg: 'bg-violet-100', text: 'text-violet-700' },
+  { key: 'purple', labelKey: 'colorPurple', bg: 'bg-purple-100', text: 'text-purple-700' },
+  { key: 'fuchsia', labelKey: 'colorFuchsia', bg: 'bg-fuchsia-100', text: 'text-fuchsia-700' },
+  { key: 'pink', labelKey: 'colorPink', bg: 'bg-pink-100', text: 'text-pink-700' },
+  { key: 'rose', labelKey: 'colorRose', bg: 'bg-rose-100', text: 'text-rose-700' },
 ];
 
 type TabType = 'products' | 'categories' | 'addons';
@@ -60,7 +63,16 @@ function taxCategoryOptionLabel(tc: { label: string; rate_percent?: number | nul
 }
 
 export default function ProductsPage() {
-  const { t } = useI18n();
+  const t = useTranslations('products');
+  const tCommon = useTranslations('common');
+  const tPos = useTranslations('pos');
+
+  // Translate a raw tag string: known tags go through the `pos` namespace;
+  // custom tags render a formatted name (reuses DietaryBadge's tagLabel).
+  const tagLabelText = (tag: string): string => {
+    const label = tagLabel(tag);
+    return label.startsWith('pos.') ? tPos(label.slice(4) as PosKey) : label;
+  };
   const { currentTenant } = useAuthStore();
   const [activeTab, setActiveTab] = useState<TabType>('products');
   const [products, setProducts] = useState<Product[]>([]);
@@ -121,7 +133,7 @@ export default function ProductsPage() {
       setCategories((catRes.data.categories as Category[]) || []);
       if (agRes) setAddonGroups((agRes.data.addon_groups as AddonGroup[]) || []);
     } catch {
-      toast.error(t('products.failedToLoad'));
+      toast.error(t('failedToLoad'));
     } finally {
       setLoading(false);
     }
@@ -141,7 +153,7 @@ export default function ProductsPage() {
         if (agRes) setAddonGroups((agRes.data.addon_groups as AddonGroup[]) || []);
       })
       .catch((err: unknown) => {
-        if (!(err instanceof Error && (err.name === 'CanceledError' || err.name === 'AbortError'))) toast.error(t('products.failedToLoad'));
+        if (!(err instanceof Error && (err.name === 'CanceledError' || err.name === 'AbortError'))) toast.error(t('failedToLoad'));
       })
       .finally(() => { setLoading(false); });
     api.get('/tax/categories', { signal: controller.signal })
@@ -180,7 +192,7 @@ export default function ProductsPage() {
       a.click();
       URL.revokeObjectURL(url);
     } catch {
-      toast.error(t('common.downloadFailed'));
+      toast.error(tCommon('downloadFailed'));
     }
   };
 
@@ -195,9 +207,9 @@ export default function ProductsPage() {
       );
       const failedCount = results.filter((r) => r.status === 'rejected').length;
       if (failedCount > 0) {
-        toast.error(t('products.categoryAssignPartial', { assigned: results.length - failedCount, total: results.length, failed: failedCount }));
+        toast.error(t('categoryAssignPartial', { assigned: results.length - failedCount, total: results.length, failed: failedCount }));
       } else {
-        toast.success(t('products.categoryAssignSuccess', { count: results.length }));
+        toast.success(t('categoryAssignSuccess', { count: results.length }));
       }
       setShowBulkTaxModal(false);
       fetchData();
@@ -216,7 +228,7 @@ export default function ProductsPage() {
       setCsvResult(res.data);
       fetchData();
     } catch {
-      toast.error(t('common.importFailed'));
+      toast.error(tCommon('importFailed'));
     } finally {
       setCsvUploading(false);
     }
@@ -270,7 +282,7 @@ export default function ProductsPage() {
     if (loyaltyEnabled && form.cb_percent !== '') {
       const parsed = Number(form.cb_percent);
       if (isNaN(parsed) || parsed < 0 || parsed > 100) {
-        toast.error(t('products.invalidCashbackRate'));
+        toast.error(t('invalidCashbackRate'));
         return;
       }
     }
@@ -304,26 +316,26 @@ export default function ProductsPage() {
 
       if (editingProduct) {
         await api.put(`/products/${editingProduct.id}`, payload);
-        toast.success(t('products.updated'));
+        toast.success(t('updated'));
       } else {
         await api.post('/products', payload);
-        toast.success(t('products.created'));
+        toast.success(t('created'));
       }
       resetForm();
       fetchData();
     } catch {
-      toast.error(t('products.failedToSave'));
+      toast.error(t('failedToSave'));
     }
   };
 
   const handleDelete = async (id: string) => {
-    if (!await confirm(t('products.deleteConfirm'), { destructive: true, confirmLabel: t('common.delete') })) return;
+    if (!await confirm(t('deleteConfirm'), { destructive: true, confirmLabel: tCommon('delete') })) return;
     try {
       await api.delete(`/products/${id}`);
-      toast.success(t('products.deleted'));
+      toast.success(t('deleted'));
       fetchData();
     } catch {
-      toast.error(t('common.failedToDelete'));
+      toast.error(tCommon('failedToDelete'));
     }
   };
 
@@ -345,16 +357,16 @@ export default function ProductsPage() {
       const payload = { name: categoryForm.name, description: categoryForm.description || null, color: categoryForm.color || null, is_active: categoryForm.is_active };
       if (editingCategory) {
         await api.put(`/categories/${editingCategory.id}`, payload);
-        toast.success(t('products.categoryUpdated'));
+        toast.success(t('categoryUpdated'));
       } else {
         await api.post('/categories', payload);
-        toast.success(t('products.categoryCreated'));
+        toast.success(t('categoryCreated'));
       }
       resetCategoryForm();
       fetchData();
     } catch (err) {
       console.error('[Category] Save error:', err);
-      toast.error(t('products.failedToSaveCategory'));
+      toast.error(t('failedToSaveCategory'));
     }
   };
 
@@ -368,7 +380,7 @@ export default function ProductsPage() {
 
     try {
       await api.delete(`/categories/${id}`);
-      toast.success(t('products.categoryDeleted'));
+      toast.success(t('categoryDeleted'));
       fetchData();
     } catch (err: unknown) {
       const e = err as { response?: { status?: number; data?: { error?: string; productCount?: number } } };
@@ -376,7 +388,7 @@ export default function ProductsPage() {
         setCatReassignTo('');
         setCatDeleteModal({ open: true, id, name, productCount: e.response.data.productCount });
       } else {
-        toast.error(t('common.failedToDelete'));
+        toast.error(tCommon('failedToDelete'));
       }
     }
   };
@@ -385,11 +397,11 @@ export default function ProductsPage() {
     if (!catDeleteModal.id || !catReassignTo) return;
     try {
       await api.delete(`/categories/${catDeleteModal.id}?action=reassign&reassign_to=${catReassignTo}`);
-      toast.success(t('products.reassignAndDelete'));
+      toast.success(t('reassignAndDelete'));
       setCatDeleteModal({ open: false, id: null, name: '', productCount: 0 });
       fetchData();
     } catch {
-      toast.error(t('common.failedToDelete'));
+      toast.error(tCommon('failedToDelete'));
     }
   };
 
@@ -397,11 +409,11 @@ export default function ProductsPage() {
     if (!catDeleteModal.id) return;
     try {
       await api.delete(`/categories/${catDeleteModal.id}?action=delete_all`);
-      toast.success(t('products.categoryAndProductsDeleted'));
+      toast.success(t('categoryAndProductsDeleted'));
       setCatDeleteModal({ open: false, id: null, name: '', productCount: 0 });
       fetchData();
     } catch {
-      toast.error(t('common.failedToDelete'));
+      toast.error(tCommon('failedToDelete'));
     }
   };
 
@@ -425,23 +437,23 @@ export default function ProductsPage() {
       const payload = { name: addonForm.name, description: addonForm.description || null, is_required: addonForm.is_required, allow_multiple_quantities: addonForm.allow_multiple_quantities, min_selection: addonForm.min_selection, max_selection: addonForm.max_selection, addons: addonList };
       if (editingAddonGroup) {
         await api.put(`/addon-groups/${editingAddonGroup.id}`, payload);
-        toast.success(t('products.addonGroupUpdated'));
+        toast.success(t('addonGroupUpdated'));
       } else {
         await api.post('/addon-groups', payload);
-        toast.success(t('products.addonGroupCreated'));
+        toast.success(t('addonGroupCreated'));
       }
       resetAddonForm();
       fetchData();
-    } catch { toast.error(t('products.failedToSaveAddonGroup')); }
+    } catch { toast.error(t('failedToSaveAddonGroup')); }
   };
 
   const handleAddonGroupDelete = async (id: number | string) => {
-    if (!await confirm(t('products.deleteAddonGroupConfirm'), { destructive: true, confirmLabel: t('common.delete') })) return;
+    if (!await confirm(t('deleteAddonGroupConfirm'), { destructive: true, confirmLabel: tCommon('delete') })) return;
     try {
       await api.delete(`/addon-groups/${id}`);
-      toast.success(t('products.addonGroupDeleted'));
+      toast.success(t('addonGroupDeleted'));
       fetchData();
-    } catch { toast.error(t('common.failedToDelete')); }
+    } catch { toast.error(tCommon('failedToDelete')); }
   };
 
   const addAddonItem = () => setAddonList((prev) => [...prev, { name: '', price: 0 }]);
@@ -459,19 +471,19 @@ export default function ProductsPage() {
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t('products.title')}</h1>
+        <h1 className="text-2xl font-bold text-gray-900">{t('title')}</h1>
       </div>
 
       <div className="flex gap-1 mb-6 border-b">
         <button onClick={() => setActiveTab('products')} className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 -mb-px ${activeTab === 'products' ? 'border-brand text-brand' : 'border-transparent text-gray-500 hover:text-gray-700'}`}>
-          <Package size={16} /> {t('products.tabProducts')}
+          <Package size={16} /> {t('tabProducts')}
         </button>
         <button onClick={() => setActiveTab('categories')} className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 -mb-px ${activeTab === 'categories' ? 'border-brand text-brand' : 'border-transparent text-gray-500 hover:text-gray-700'}`}>
-          <Folder size={16} /> {t('products.tabCategories')}
+          <Folder size={16} /> {t('tabCategories')}
         </button>
         {isRestaurant && (
           <button onClick={() => setActiveTab('addons')} className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 -mb-px ${activeTab === 'addons' ? 'border-brand text-brand' : 'border-transparent text-gray-500 hover:text-gray-700'}`}>
-            <Puzzle size={16} /> {t('products.tabAddonGroups')}
+            <Puzzle size={16} /> {t('tabAddonGroups')}
           </button>
         )}
       </div>
@@ -481,14 +493,14 @@ export default function ProductsPage() {
           <div className="flex justify-end gap-2 mb-4">
             {isOwnerOrManager && taxCategories.length > 0 && (
               <Button variant="outline" onClick={() => { setBulkTaxCategoryId(''); setShowBulkTaxModal(true); }}>
-                {t('products.assignTaxCategory')}
+                {t('assignTaxCategory')}
               </Button>
             )}
             <Button variant="outline" onClick={() => openCsvModal('products')}>
               <FileSpreadsheet size={16} className="me-1" /> CSV
             </Button>
             <Button onClick={openCreate}>
-              <Plus size={16} className="me-1" /> {t('products.addProduct')}
+              <Plus size={16} className="me-1" /> {t('addProduct')}
             </Button>
           </div>
 
@@ -497,15 +509,15 @@ export default function ProductsPage() {
         <table className="w-full">
           <thead className="bg-gray-50">
             <tr>
-              <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnProduct')}</th>
-              <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnCategory')}</th>
-              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnAddons')}</th>
-              <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnPrice')}</th>
-              <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnTax')}</th>
-              {loyaltyEnabled && <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnCashback')}</th>}
-              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnStock')}</th>
-              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnStatus')}</th>
-              <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnActions')}</th>
+              <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('columnProduct')}</th>
+              <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('columnCategory')}</th>
+              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('columnAddons')}</th>
+              <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase">{t('columnPrice')}</th>
+              <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('columnTax')}</th>
+              {loyaltyEnabled && <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('columnCashback')}</th>}
+              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('columnStock')}</th>
+              <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('columnStatus')}</th>
+              <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase">{t('columnActions')}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
@@ -540,8 +552,8 @@ export default function ProductsPage() {
                     </div>
                     <div>
                       <p className="font-medium text-gray-900">{product.name}</p>
-                      {product.sku && <p className="text-xs text-gray-400 mt-0.5">{t('products.skuLabel', { sku: product.sku })}</p>}
-                      {product.barcode && <p className="text-xs text-gray-400 mt-0.5 font-mono">{t('products.barcodeLabel', { barcode: product.barcode })}</p>}
+                      {product.sku && <p className="text-xs text-gray-400 mt-0.5">{t('skuLabel', { sku: product.sku })}</p>}
+                      {product.barcode && <p className="text-xs text-gray-400 mt-0.5 font-mono">{t('barcodeLabel', { barcode: product.barcode })}</p>}
                       {product.tags && product.tags.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1.5">
                           {product.tags.map((tag: string) => <TagBadge key={tag} tag={tag} />)}
@@ -555,7 +567,7 @@ export default function ProductsPage() {
                     <span>{product.category?.name || '—'}</span>
                     {isCategoryInactive && (
                       <span className="inline-flex items-center gap-1 text-[11px] font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded px-1.5 py-0.5 w-fit" title="Parent category is inactive; product is hidden on POS">
-                        <AlertTriangle size={11} className="shrink-0" /> {t('products.categoryInactiveBadge')}
+                        <AlertTriangle size={11} className="shrink-0" /> {t('categoryInactiveBadge')}
                       </span>
                     )}
                   </div>
@@ -563,7 +575,7 @@ export default function ProductsPage() {
                 <td className="p-4 text-center">
                   {product.addon_groups && product.addon_groups.length > 0 ? (
                     <span className="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700 border border-indigo-200">
-                      {t('products.addonGroupCount', { count: product.addon_groups.length })}
+                      {t('addonGroupCount', { count: product.addon_groups.length })}
                     </span>
                   ) : (
                     <span className="text-gray-400 text-sm">—</span>
@@ -571,14 +583,14 @@ export default function ProductsPage() {
                 </td>
                 <td className="p-4 text-end">
                   <p className="font-medium">{fmt(Number(product.price))}</p>
-                  {product.cost_price != null && product.cost_price > 0 && <p className="text-xs text-gray-400">{t('products.costLabel', { value: fmt(Number(product.cost_price)) })}</p>}
+                  {product.cost_price != null && product.cost_price > 0 && <p className="text-xs text-gray-400">{t('costLabel', { value: fmt(Number(product.cost_price)) })}</p>}
                 </td>
                 <td className="p-4 text-sm text-gray-600">
                   <div className="flex flex-col gap-0.5">
                     <span>{taxLabel}</span>
                     {!product.tax_category_id && taxCategories.length > 0 && (
-                      <span className="inline-flex items-center gap-1 text-[11px] font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded px-1.5 py-0.5 w-fit" title={t('products.notTaxedTooltip')}>
-                        <AlertTriangle size={11} className="shrink-0" /> {t('products.notTaxedBadge')}
+                      <span className="inline-flex items-center gap-1 text-[11px] font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded px-1.5 py-0.5 w-fit" title={t('notTaxedTooltip')}>
+                        <AlertTriangle size={11} className="shrink-0" /> {t('notTaxedBadge')}
                       </span>
                     )}
                   </div>
@@ -586,7 +598,7 @@ export default function ProductsPage() {
                 {loyaltyEnabled && (
                   <td className="p-4 text-sm text-gray-600">
                     {product.cb_percent === null || product.cb_percent === undefined ? (
-                      <span>{globalCashbackPercent}% <span className="text-gray-400 text-xs">({t('products.cashbackGlobalBadge')})</span></span>
+                      <span>{globalCashbackPercent}% <span className="text-gray-400 text-xs">({t('cashbackGlobalBadge')})</span></span>
                     ) : product.cb_percent === 0 ? (
                       <span className="text-gray-400">0%</span>
                     ) : (
@@ -597,7 +609,7 @@ export default function ProductsPage() {
                 <td className="p-4 text-center">
                   {product.track_inventory ? (
                     <span className={`text-sm font-medium ${product.stock_quantity <= (product.low_stock_threshold || 0) ? 'text-red-600' : 'text-gray-900'}`}>
-                      {product.stock_quantity <= 0 ? t('pos.outOfStock') : product.stock_quantity}
+                      {product.stock_quantity <= 0 ? tPos('outOfStock') : product.stock_quantity}
                     </span>
                   ) : (
                     <span className="text-gray-400 text-sm">—</span>
@@ -607,10 +619,10 @@ export default function ProductsPage() {
                   <span className={`px-2 py-1 rounded-full text-xs font-medium ${
                     product.is_active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'
                   }`}>
-                    {product.is_active ? t('common.active') : t('common.inactive')}
+                    {product.is_active ? tCommon('active') : tCommon('inactive')}
                   </span>
                   {product.is_active && isCategoryInactive && (
-                    <span className="text-[10px] text-amber-600 font-medium block mt-1">{t('products.hiddenOnPos')}</span>
+                    <span className="text-[10px] text-amber-600 font-medium block mt-1">{t('hiddenOnPos')}</span>
                   )}
                 </td>
                 <td className="p-4 text-end">
@@ -633,7 +645,7 @@ export default function ProductsPage() {
           </tbody>
         </table>
         {products.length === 0 && (
-          <p className="text-center text-gray-500 py-12">{t('products.empty')}</p>
+          <p className="text-center text-gray-500 py-12">{t('empty')}</p>
         )}
       </div>
 
@@ -642,23 +654,23 @@ export default function ProductsPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-2xl w-full max-w-2xl max-h-[90vh] flex flex-col overflow-hidden shadow-2xl">
             <div className="flex justify-between items-center p-6 border-b border-gray-100 shrink-0">
-              <h2 className="text-lg font-bold">{editingProduct ? t('products.editProductTitle') : t('products.addProductTitle')}</h2>
+              <h2 className="text-lg font-bold">{editingProduct ? t('editProductTitle') : t('addProductTitle')}</h2>
               <button onClick={resetForm} className="text-gray-400 hover:text-gray-600"><X size={20} /></button>
             </div>
             <div className="p-6 overflow-y-auto flex-1">
               <form onSubmit={handleSubmit} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldName')}<span className="text-red-500 ms-1">*</span></label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldName')}<span className="text-red-500 ms-1">*</span></label>
                 <input type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" required />
               </div>
               <div>
-                <label htmlFor="product-description" className="block text-sm font-medium text-gray-700 mb-1">{t('products.categoryDescription')}</label>
+                <label htmlFor="product-description" className="block text-sm font-medium text-gray-700 mb-1">{t('categoryDescription')}</label>
                 <textarea id="product-description" value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" rows={2} />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldImage')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldImage')}</label>
                 <ImageUploader
                   value={form.image_url}
                   onChange={(val) => {
@@ -670,35 +682,35 @@ export default function ProductsPage() {
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldCategory')}<span className="text-red-500 ms-1">*</span></label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldCategory')}<span className="text-red-500 ms-1">*</span></label>
                   <select value={form.category_id} onChange={(e) => setForm({ ...form, category_id: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" required>
-                    <option value="">{t('products.selectPlaceholder')}</option>
+                    <option value="">{t('selectPlaceholder')}</option>
                     {categories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
                   </select>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldSku')}</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldSku')}</label>
                   <input type="text" value={form.sku} onChange={(e) => setForm({ ...form, sku: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldBarcode')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldBarcode')}</label>
                 <input type="text" value={form.barcode} onChange={(e) => setForm({ ...form, barcode: e.target.value })}
-                  placeholder={t('products.fieldBarcodePlaceholder')}
+                  placeholder={t('fieldBarcodePlaceholder')}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none font-mono" />
-                <p className="text-xs text-gray-400 mt-1">{t('products.fieldBarcodeHint')}</p>
+                <p className="text-xs text-gray-400 mt-1">{t('fieldBarcodeHint')}</p>
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.priceLabel', { currency })}<span className="text-red-500 ms-1">*</span></label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('priceLabel', { currency })}<span className="text-red-500 ms-1">*</span></label>
                   <input type="number" step="0.01" value={form.price} onChange={(e) => setForm({ ...form, price: e.target.value })}
                     onWheel={(e) => e.currentTarget.blur()}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" required />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldCostPrice')}</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldCostPrice')}</label>
                   <input type="number" step="0.01" value={form.cost_price} onChange={(e) => setForm({ ...form, cost_price: e.target.value })}
                     onWheel={(e) => e.currentTarget.blur()}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
@@ -706,7 +718,7 @@ export default function ProductsPage() {
               </div>
               {loyaltyEnabled && (
                 <div className="bg-gray-50 p-4 rounded-xl space-y-2">
-                  <label className="block text-sm font-medium text-gray-700">{t('products.cashbackLabel')}</label>
+                  <label className="block text-sm font-medium text-gray-700">{t('cashbackLabel')}</label>
                   <div className="flex items-center gap-2">
                     <input type="number" step="0.1" min="0" max="100" value={form.cb_percent}
                       onChange={(e) => setForm({ ...form, cb_percent: e.target.value })}
@@ -716,50 +728,50 @@ export default function ProductsPage() {
                   </div>
                   <p className="text-xs text-gray-500">
                     {form.cb_percent === ''
-                      ? t('products.cashbackUsingGlobal', { rate: globalCashbackPercent })
-                      : t('products.cashbackOverrideHint')}
+                      ? t('cashbackUsingGlobal', { rate: globalCashbackPercent })
+                      : t('cashbackOverrideHint')}
                   </p>
                 </div>
               )}
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.taxRateGroupLabel')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{t('taxRateGroupLabel')}</label>
                 <select value={form.tax_category_id} onChange={(e) => setForm({ ...form, tax_category_id: e.target.value })}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none">
-                  <option value="">{t('products.taxNoTax')}</option>
+                  <option value="">{t('taxNoTax')}</option>
                   {taxCategories.map((tc) => <option key={tc.id} value={tc.id}>{taxCategoryOptionLabel(tc)}</option>)}
                 </select>
                 {taxCategories.length === 0 && (
-                  <p className="text-xs text-gray-400 mt-1">{t('products.taxNoGroupsHint')}</p>
+                  <p className="text-xs text-gray-400 mt-1">{t('taxNoGroupsHint')}</p>
                 )}
                 {taxCategories.length > 0 && (
-                  <p className="text-xs text-gray-400 mt-1">{t('products.taxDefaultHint')}</p>
+                  <p className="text-xs text-gray-400 mt-1">{t('taxDefaultHint')}</p>
                 )}
               </div>
               {form.tax_category_id ? (
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.taxBehaviorLabel')}</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">{t('taxBehaviorLabel')}</label>
                   <select value={form.tax_behavior} onChange={(e) => setForm({ ...form, tax_behavior: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none">
-                    <option value="country_default">{t('products.taxCountryDefault')}</option>
-                    <option value="inclusive">{t('products.taxInclusive')}</option>
-                    <option value="exclusive">{t('products.taxExclusive')}</option>
-                    <option value="exempt">{t('products.taxExempt')}</option>
+                    <option value="country_default">{t('taxCountryDefault')}</option>
+                    <option value="inclusive">{t('taxInclusive')}</option>
+                    <option value="exclusive">{t('taxExclusive')}</option>
+                    <option value="exempt">{t('taxExempt')}</option>
                   </select>
-                  <p className="text-xs text-gray-400 mt-1">{t('products.taxRateHint')}</p>
+                  <p className="text-xs text-gray-400 mt-1">{t('taxRateHint')}</p>
                 </div>
               ) : (
                 <p className="text-xs text-gray-400 -mt-2">
-                  {t('products.taxNoCategory')}
+                  {t('taxNoCategory')}
                 </p>
               )}
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">{t('products.fieldTags')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-2">{t('fieldTags')}</label>
                 {/* Selected tags */}
                 {form.tags.length > 0 && (
                   <div className="flex flex-wrap gap-1.5 mb-2">
                     {form.tags.map((tag) => (
                       <span key={tag} className="inline-flex items-center gap-1 px-2 py-1 bg-brand/10 text-brand rounded-lg text-xs font-medium">
-                        {t(tagLabel(tag))}
+                        {tagLabelText(tag)}
                         <button type="button" onClick={() => setForm((prev) => ({ ...prev, tags: prev.tags.filter((t) => t !== tag) }))} className="hover:text-red-500">
                           <X size={11} />
                         </button>
@@ -776,7 +788,7 @@ export default function ProductsPage() {
                       onClick={() => setForm((prev) => ({ ...prev, tags: [...prev.tags, pt.key] }))}
                       className="px-2 py-1 text-xs border border-gray-200 rounded-lg text-gray-600 hover:border-brand hover:text-brand transition-colors"
                     >
-                      + {t(pt.labelKey)}
+                      + {tPos(pt.labelKey)}
                     </button>
                   ))}
                 </div>
@@ -795,7 +807,7 @@ export default function ProductsPage() {
                         }
                       }
                     }}
-                    placeholder={t('products.tagPlaceholder')}
+                    placeholder={t('tagPlaceholder')}
                     className="flex-1 px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand outline-none"
                   />
                   <button
@@ -808,13 +820,13 @@ export default function ProductsPage() {
                     }}
                     className="px-3 py-1.5 text-sm bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-600"
                   >
-                    {t('common.add')}
+                    {tCommon('add')}
                   </button>
                 </div>
               </div>
               {isRestaurant && addonGroups.length > 0 && (
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">{t('products.fieldAddonGroups')}</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">{t('fieldAddonGroups')}</label>
                   <div className="space-y-2 max-h-40 overflow-y-auto border border-gray-200 rounded-lg p-3">
                     {addonGroups.map((group) => {
                       const isChecked = form.addon_group_ids.includes(group.id);
@@ -838,7 +850,7 @@ export default function ProductsPage() {
                           <label htmlFor={`addon-group-${group.id}`} className="flex items-center gap-2 cursor-pointer select-none">
                             <span className="text-sm text-gray-700">{group.name}</span>
                             <span className={`text-[10px] px-1.5 py-0.5 rounded ${group.is_required ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-500'}`}>
-                              {group.is_required ? t('products.required') : t('products.optional')}
+                              {group.is_required ? t('required') : t('optional')}
                             </span>
                           </label>
                         </div>
@@ -851,30 +863,30 @@ export default function ProductsPage() {
                 <label className="flex items-center gap-2">
                   <input type="checkbox" checked={form.track_inventory} onChange={(e) => setForm({ ...form, track_inventory: e.target.checked })}
                     className="rounded border-gray-300 text-brand focus:ring-brand" />
-                  <span className="text-sm text-gray-700">{t('products.fieldTrackInventory')}</span>
+                  <span className="text-sm text-gray-700">{t('fieldTrackInventory')}</span>
                 </label>
                 <label className="flex items-center gap-2">
                   <input type="checkbox" checked={form.is_active} onChange={(e) => setForm({ ...form, is_active: e.target.checked })}
                     className="rounded border-gray-300 text-brand focus:ring-brand" />
-                  <span className="text-sm text-gray-700">{t('products.fieldActive')}</span>
+                  <span className="text-sm text-gray-700">{t('fieldActive')}</span>
                 </label>
               </div>
               {!!form.track_inventory && (
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldStock')}<span className="text-red-500 ms-1">*</span></label>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldStock')}<span className="text-red-500 ms-1">*</span></label>
                     <input type="number" min="0" value={form.stock_quantity} onChange={(e) => setForm({ ...form, stock_quantity: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" required />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldLowStockThreshold')}</label>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldLowStockThreshold')}</label>
                     <input type="number" min="0" value={form.low_stock_threshold} onChange={(e) => setForm({ ...form, low_stock_threshold: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" required />
                   </div>
                 </div>
               )}
               <Button type="submit" className="w-full">
-                {editingProduct ? t('products.updateProduct') : t('products.createProduct')}
+                {editingProduct ? t('updateProduct') : t('createProduct')}
               </Button>
             </form>
             </div>
@@ -891,17 +903,17 @@ export default function ProductsPage() {
               <FileSpreadsheet size={16} className="me-1" /> CSV
             </Button>
             <Button onClick={() => { resetCategoryForm(); setShowForm(true); }}>
-              <Plus size={16} className="me-1" /> {t('products.addCategory')}
+              <Plus size={16} className="me-1" /> {t('addCategory')}
             </Button>
           </div>
           <div className="bg-white rounded-xl border border-gray-100 overflow-hidden">
             <table className="w-full">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('products.categoryName')}</th>
-                  <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('products.categoryColor')}</th>
-                  <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnStatus')}</th>
-                  <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnActions')}</th>
+                  <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('categoryName')}</th>
+                  <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('categoryColor')}</th>
+                  <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('columnStatus')}</th>
+                  <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase">{t('columnActions')}</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
@@ -935,27 +947,27 @@ export default function ProductsPage() {
                 })}
               </tbody>
             </table>
-            {categories.length === 0 && <p className="text-center text-gray-500 py-12">{t('products.categoryEmpty')}</p>}
+            {categories.length === 0 && <p className="text-center text-gray-500 py-12">{t('categoryEmpty')}</p>}
           </div>
 
           {showForm && (
             <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
               <div className="bg-white rounded-2xl p-6 w-full max-w-md">
                 <div className="flex justify-between items-center mb-4">
-                  <h2 className="text-lg font-bold">{editingCategory ? t('products.editCategoryTitle') : t('products.addCategoryTitle')}</h2>
+                  <h2 className="text-lg font-bold">{editingCategory ? t('editCategoryTitle') : t('addCategoryTitle')}</h2>
                   <button onClick={resetCategoryForm} className="text-gray-400 hover:text-gray-600"><X size={20} /></button>
                 </div>
                 <form onSubmit={handleCategorySubmit} className="space-y-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldName')}<span className="text-red-500 ms-1">*</span></label>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldName')}<span className="text-red-500 ms-1">*</span></label>
                     <input type="text" value={categoryForm.name} onChange={(e) => setCategoryForm({ ...categoryForm, name: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" required />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.categoryDescription')}</label>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('categoryDescription')}</label>
                     <textarea value={categoryForm.description} onChange={(e) => setCategoryForm({ ...categoryForm, description: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" rows={2} />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">{t('products.colorLabel')}</label>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">{t('colorLabel')}</label>
                     <div className="flex flex-wrap gap-2">
                       {CATEGORY_COLORS.map((c) => (
                         <button type="button" key={c.key} onClick={() => setCategoryForm({ ...categoryForm, color: c.key })} className={`px-3 py-1.5 rounded-lg text-xs font-medium border-2 ${c.key === categoryForm.color ? 'border-brand' : 'border-transparent'} ${c.bg} ${c.text}`}>{t(c.labelKey)}</button>
@@ -964,9 +976,9 @@ export default function ProductsPage() {
                   </div>
                   <label className="flex items-center gap-2">
                     <input type="checkbox" checked={categoryForm.is_active} onChange={(e) => setCategoryForm({ ...categoryForm, is_active: e.target.checked })} className="rounded border-gray-300 text-brand focus:ring-brand" />
-                    <span className="text-sm text-gray-700">{t('products.fieldActive')}</span>
+                    <span className="text-sm text-gray-700">{t('fieldActive')}</span>
                   </label>
-                  <Button type="submit" className="w-full">{editingCategory ? t('common.update') : t('common.create')}</Button>
+                  <Button type="submit" className="w-full">{editingCategory ? tCommon('update') : tCommon('create')}</Button>
                 </form>
               </div>
             </div>
@@ -981,18 +993,18 @@ export default function ProductsPage() {
               <FileSpreadsheet size={16} className="me-1" /> CSV
             </Button>
             <Button onClick={() => { resetAddonForm(); setShowAddonModal(true); }}>
-              <Plus size={16} className="me-1" /> {t('products.addAddonGroup')}
+              <Plus size={16} className="me-1" /> {t('addAddonGroup')}
             </Button>
           </div>
           <div className="bg-white rounded-xl border border-gray-100 overflow-hidden">
             <table className="w-full">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('products.categoryName')}</th>
-                  <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnRequired')}</th>
-                  <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnSelection')}</th>
-                  <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnAddons')}</th>
-                  <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase">{t('products.columnActions')}</th>
+                  <th className="text-start p-4 text-xs font-medium text-gray-500 uppercase">{t('categoryName')}</th>
+                  <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('columnRequired')}</th>
+                  <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('columnSelection')}</th>
+                  <th className="text-center p-4 text-xs font-medium text-gray-500 uppercase">{t('columnAddons')}</th>
+                  <th className="text-end p-4 text-xs font-medium text-gray-500 uppercase">{t('columnActions')}</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
@@ -1000,9 +1012,9 @@ export default function ProductsPage() {
                   <tr key={group.id} className="hover:bg-gray-50">
                     <td className="p-4 font-medium text-gray-900">{group.name}</td>
                     <td className="p-4 text-center">
-                      <span className={`px-2 py-1 rounded-full text-xs font-medium ${group.is_required ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-600'}`}>{group.is_required ? t('common.yes') : t('common.no')}</span>
+                      <span className={`px-2 py-1 rounded-full text-xs font-medium ${group.is_required ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-600'}`}>{group.is_required ? tCommon('yes') : tCommon('no')}</span>
                     </td>
-                    <td className="p-4 text-center text-sm text-gray-600">{t('products.addonSelectionRange', { min: group.min_selection, max: group.max_selection })}</td>
+                    <td className="p-4 text-center text-sm text-gray-600">{t('addonSelectionRange', { min: group.min_selection, max: group.max_selection })}</td>
                     <td className="p-4 text-center text-sm text-gray-600">{group.addons?.length || 0}</td>
                     <td className="p-4 text-end">
                       <div className="flex gap-2 justify-end">
@@ -1018,65 +1030,65 @@ export default function ProductsPage() {
                 ))}
               </tbody>
             </table>
-            {addonGroups.length === 0 && <p className="text-center text-gray-500 py-12">{t('products.addonEmpty')}</p>}
+            {addonGroups.length === 0 && <p className="text-center text-gray-500 py-12">{t('addonEmpty')}</p>}
           </div>
 
           {showAddonModal && (
             <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
               <div className="bg-white rounded-2xl w-full max-w-2xl max-h-[90vh] flex flex-col overflow-hidden shadow-2xl">
                 <div className="flex justify-between items-center p-6 border-b border-gray-100 shrink-0">
-                  <h2 className="text-lg font-bold">{editingAddonGroup ? t('products.editAddonGroupTitle') : t('products.addAddonGroupTitle')}</h2>
+                  <h2 className="text-lg font-bold">{editingAddonGroup ? t('editAddonGroupTitle') : t('addAddonGroupTitle')}</h2>
                   <button onClick={resetAddonForm} className="text-gray-400 hover:text-gray-600"><X size={20} /></button>
                 </div>
                 <div className="p-6 overflow-y-auto flex-1">
                   <form onSubmit={handleAddonGroupSubmit} className="space-y-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.fieldName')}<span className="text-red-500 ms-1">*</span></label>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('fieldName')}<span className="text-red-500 ms-1">*</span></label>
                     <input type="text" value={addonForm.name} onChange={(e) => setAddonForm({ ...addonForm, name: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" required />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.categoryDescription')}</label>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">{t('categoryDescription')}</label>
                     <input type="text" value={addonForm.description} onChange={(e) => setAddonForm({ ...addonForm, description: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
                   </div>
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.addonMin')}</label>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">{t('addonMin')}</label>
                       <input type="number" min="0" value={addonForm.min_selection} onChange={(e) => setAddonForm({ ...addonForm, min_selection: Number(e.target.value) })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.addonMax')}</label>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">{t('addonMax')}</label>
                       <input type="number" min="0" value={addonForm.max_selection} onChange={(e) => setAddonForm({ ...addonForm, max_selection: Number(e.target.value) })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
                     </div>
                   </div>
                   <label className="flex items-center gap-2">
                     <input type="checkbox" checked={addonForm.is_required} onChange={(e) => setAddonForm({ ...addonForm, is_required: e.target.checked })} className="rounded border-gray-300 text-brand focus:ring-brand" />
-                    <span className="text-sm text-gray-700">{t('products.addonRequired')}</span>
+                    <span className="text-sm text-gray-700">{t('addonRequired')}</span>
                   </label>
                   <label className="flex items-center gap-2">
                     <input type="checkbox" checked={addonForm.allow_multiple_quantities} onChange={(e) => setAddonForm({ ...addonForm, allow_multiple_quantities: e.target.checked })} className="rounded border-gray-300 text-brand focus:ring-brand" />
-                    <span className="text-sm text-gray-700">{t('products.addonAllowMultipleQuantities')}</span>
+                    <span className="text-sm text-gray-700">{t('addonAllowMultipleQuantities')}</span>
                   </label>
                   <div>
                     <div className="flex justify-between items-center mb-2">
-                      <label className="block text-sm font-medium text-gray-700">{t('products.addonAddons')}</label>
-                      <button type="button" onClick={addAddonItem} className="text-xs text-brand hover:underline">{t('products.addAddonInline')}</button>
+                      <label className="block text-sm font-medium text-gray-700">{t('addonAddons')}</label>
+                      <button type="button" onClick={addAddonItem} className="text-xs text-brand hover:underline">{t('addAddonInline')}</button>
                     </div>
                     <div className="space-y-2">
                       <div className="grid grid-cols-[minmax(0,1fr)_6rem_1.5rem] gap-2 px-1 text-[11px] font-medium uppercase tracking-wide text-gray-500">
-                        <span>{t('products.nameLabel')}</span>
-                        <span>{t('products.columnPrice')}</span>
+                        <span>{t('nameLabel')}</span>
+                        <span>{t('columnPrice')}</span>
                         <span aria-hidden="true" />
                       </div>
                       {addonList.map((addon, idx) => (
                         <div key={idx} className="grid grid-cols-[minmax(0,1fr)_6rem_1.5rem] gap-2 items-center">
-                          <input type="text" value={addon.name} onChange={(e) => updateAddonItem(idx, 'name', e.target.value)} placeholder={t('common.namePlaceholder')} className="flex-1 px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
-                          <input type="number" step="0.01" value={addon.price} onChange={(e) => updateAddonItem(idx, 'price', Number(e.target.value))} onWheel={(e) => e.currentTarget.blur()} placeholder={t('common.pricePlaceholder')} aria-label={t('products.columnPrice')} className="w-24 px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
+                          <input type="text" value={addon.name} onChange={(e) => updateAddonItem(idx, 'name', e.target.value)} placeholder={tCommon('namePlaceholder')} className="flex-1 px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
+                          <input type="number" step="0.01" value={addon.price} onChange={(e) => updateAddonItem(idx, 'price', Number(e.target.value))} onWheel={(e) => e.currentTarget.blur()} placeholder={tCommon('pricePlaceholder')} aria-label={t('columnPrice')} className="w-24 px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none" />
                           <button type="button" onClick={() => removeAddonItem(idx)} className="text-gray-400 hover:text-red-500"><X size={16} /></button>
                         </div>
                       ))}
                     </div>
                   </div>
-                  <Button type="submit" className="w-full">{editingAddonGroup ? t('common.update') : t('common.create')}</Button>
+                  <Button type="submit" className="w-full">{editingAddonGroup ? tCommon('update') : tCommon('create')}</Button>
                 </form>
                 </div>
               </div>
@@ -1089,26 +1101,26 @@ export default function ProductsPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-2xl p-6 w-full max-w-md">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-bold">{t('products.assignTaxCategory')}</h2>
+              <h2 className="text-lg font-bold">{t('assignTaxCategory')}</h2>
               <button onClick={() => setShowBulkTaxModal(false)} className="text-gray-400 hover:text-gray-600"><X size={20} /></button>
             </div>
             {legacyProducts.length === 0 ? (
-              <p className="text-sm text-gray-500">{t('products.taxAllAssigned')}</p>
+              <p className="text-sm text-gray-500">{t('taxAllAssigned')}</p>
             ) : (
               <>
                 <p className="text-sm text-gray-600 mb-4">
-                  {t('products.taxBulkBody', { count: legacyProducts.length })}
+                  {t('taxBulkBody', { count: legacyProducts.length })}
                 </p>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.taxRateGroupLabel')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{t('taxRateGroupLabel')}</label>
                 <select value={bulkTaxCategoryId} onChange={(e) => setBulkTaxCategoryId(e.target.value)}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none mb-5">
-                  <option value="">{t('products.selectPlaceholder')}</option>
+                  <option value="">{t('selectPlaceholder')}</option>
                   {taxCategories.map((tc) => <option key={tc.id} value={tc.id}>{taxCategoryOptionLabel(tc)}</option>)}
                 </select>
                 <div className="flex justify-end gap-2">
-                  <Button variant="outline" onClick={() => setShowBulkTaxModal(false)}>{t('common.cancel')}</Button>
+                  <Button variant="outline" onClick={() => setShowBulkTaxModal(false)}>{tCommon('cancel')}</Button>
                   <Button onClick={handleBulkTaxAssign} disabled={!bulkTaxCategoryId || bulkTaxApplying}>
-                    {bulkTaxApplying ? t('products.csvImporting') : t('products.taxApplyToProducts', { count: legacyProducts.length })}
+                    {bulkTaxApplying ? t('csvImporting') : t('taxApplyToProducts', { count: legacyProducts.length })}
                   </Button>
                 </div>
               </>
@@ -1122,7 +1134,7 @@ export default function ProductsPage() {
           <div className="bg-white rounded-2xl p-6 w-full max-w-lg">
             <div className="flex justify-between items-center mb-5">
               <h2 className="text-lg font-bold">
-                {t('products.csvModalTitle', { type: csvType === 'categories' ? t('products.tabCategories') : csvType === 'products' ? t('products.tabProducts') : t('products.tabAddonGroups') })}
+                {t('csvModalTitle', { type: csvType === 'categories' ? t('tabCategories') : csvType === 'products' ? t('tabProducts') : t('tabAddonGroups') })}
               </h2>
               <button onClick={() => setShowCsvModal(false)} className="text-gray-400 hover:text-gray-600">
                 <X size={20} />
@@ -1132,39 +1144,39 @@ export default function ProductsPage() {
             <div className="space-y-5">
               {/* Download section */}
               <div className="bg-gray-50 rounded-xl p-4 space-y-3">
-                <p className="text-sm font-medium text-gray-700">{t('products.download')}</p>
+                <p className="text-sm font-medium text-gray-700">{t('download')}</p>
                 <div className="flex gap-3">
                   <button
                     onClick={() => downloadCsv(`/menu-csv/template/${csvType}`, `${csvType}-template.csv`)}
                     className="flex items-center gap-2 px-4 py-2 text-sm border border-gray-200 rounded-lg bg-white hover:bg-gray-50 font-medium"
                   >
-                    <Download size={14} /> {t('products.csvBlankTemplate')}
+                    <Download size={14} /> {t('csvBlankTemplate')}
                   </button>
                   <button
                     onClick={() => downloadCsv(`/menu-csv/export/${csvType}`, `${csvType}-export.csv`)}
                     className="flex items-center gap-2 px-4 py-2 text-sm border border-gray-200 rounded-lg bg-white hover:bg-gray-50 font-medium"
                   >
-                    <Download size={14} /> {t('products.csvCurrentData')}
+                    <Download size={14} /> {t('csvCurrentData')}
                   </button>
                 </div>
                 {csvType === 'products' && (
-                  <p className="text-xs text-gray-500">{t('products.csvProductsHelp')}</p>
+                  <p className="text-xs text-gray-500">{t('csvProductsHelp')}</p>
                 )}
                 {csvType === 'categories' && (
-                  <p className="text-xs text-gray-500">{t('products.csvCategoriesHelp')}</p>
+                  <p className="text-xs text-gray-500">{t('csvCategoriesHelp')}</p>
                 )}
                 {csvType === 'addons' && (
-                  <p className="text-xs text-gray-500">{t('products.csvAddonsHelp')}</p>
+                  <p className="text-xs text-gray-500">{t('csvAddonsHelp')}</p>
                 )}
               </div>
 
               {/* Upload section */}
               <div className="space-y-3">
-                <p className="text-sm font-medium text-gray-700">{t('products.uploadCsv')}</p>
+                <p className="text-sm font-medium text-gray-700">{t('uploadCsv')}</p>
                 <label className="flex flex-col items-center justify-center w-full h-28 border-2 border-dashed border-gray-200 rounded-xl cursor-pointer hover:bg-gray-50 transition-colors">
                   <Upload size={20} className="text-gray-400 mb-1" />
                   <span className="text-sm text-gray-500">
-                    {csvFile ? csvFile.name : t('products.csvChooseFile')}
+                    {csvFile ? csvFile.name : t('csvChooseFile')}
                   </span>
                   <input
                     type="file"
@@ -1175,7 +1187,7 @@ export default function ProductsPage() {
                 </label>
                 {csvFile && (
                   <Button onClick={handleCsvUpload} disabled={csvUploading} className="w-full">
-                    {csvUploading ? t('products.csvImporting') : t('common.import')}
+                    {csvUploading ? t('csvImporting') : tCommon('import')}
                   </Button>
                 )}
               </div>
@@ -1185,24 +1197,24 @@ export default function ProductsPage() {
                 <div className="rounded-xl border border-gray-100 overflow-hidden">
                   <div className="flex items-center gap-2 px-4 py-3 bg-green-50 border-b border-gray-100">
                     <CheckCircle size={15} className="text-green-600" />
-                    <span className="text-sm font-medium text-green-800">{t('products.importComplete')}</span>
+                    <span className="text-sm font-medium text-green-800">{t('importComplete')}</span>
                   </div>
                   <div className="px-4 py-3 text-sm text-gray-700 space-y-1">
                     {csvType === 'addons' ? (
                       <>
-                        <p>{t('products.csvGroupsCreated')} <span className="font-medium">{String(csvResult.groups_created ?? 0)}</span></p>
-                        <p>{t('products.csvAddonsCreated')} <span className="font-medium">{String(csvResult.addons_created ?? 0)}</span></p>
+                        <p>{t('csvGroupsCreated')} <span className="font-medium">{String(csvResult.groups_created ?? 0)}</span></p>
+                        <p>{t('csvAddonsCreated')} <span className="font-medium">{String(csvResult.addons_created ?? 0)}</span></p>
                       </>
                     ) : (
-                      <p>{t('common.created')} <span className="font-medium">{String(csvResult.created ?? 0)}</span></p>
+                      <p>{tCommon('created')} <span className="font-medium">{String(csvResult.created ?? 0)}</span></p>
                     )}
-                    <p>{t('common.skipped')} <span className="font-medium">{String(csvResult.skipped ?? 0)}</span></p>
+                    <p>{tCommon('skipped')} <span className="font-medium">{String(csvResult.skipped ?? 0)}</span></p>
                   </div>
                   {Array.isArray(csvResult.warnings) && (csvResult.warnings as string[]).length > 0 && (
                     <div className="px-4 py-3 border-t border-gray-100 bg-amber-50">
                       <div className="flex items-center gap-2 mb-2">
                         <AlertCircle size={14} className="text-amber-500" />
-                        <span className="text-xs font-medium text-amber-700">{t('products.csvMissingFields')}</span>
+                        <span className="text-xs font-medium text-amber-700">{t('csvMissingFields')}</span>
                       </div>
                       <ul className="space-y-1">
                         {(csvResult.warnings as string[]).map((w, i) => (
@@ -1215,7 +1227,7 @@ export default function ProductsPage() {
                     <div className="px-4 py-3 border-t border-gray-100">
                       <div className="flex items-center gap-2 mb-2">
                         <AlertCircle size={14} className="text-red-500" />
-                        <span className="text-xs font-medium text-red-700">{t('products.csvSkippedErrors')}</span>
+                        <span className="text-xs font-medium text-red-700">{t('csvSkippedErrors')}</span>
                       </div>
                       <ul className="space-y-1">
                         {(csvResult.errors as string[]).map((e, i) => (
@@ -1234,42 +1246,42 @@ export default function ProductsPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-2xl p-6 w-full max-w-md">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-bold text-gray-900">{t('products.deleteCategoryTitle')}</h2>
+              <h2 className="text-lg font-bold text-gray-900">{t('deleteCategoryTitle')}</h2>
               <button onClick={() => setCatDeleteModal({ open: false, id: null, name: '', productCount: 0 })} className="text-gray-400 hover:text-gray-600"><X size={20} /></button>
             </div>
             <p className="text-sm text-gray-700 mb-5">
-              {t('products.deleteCategoryBody', { name: catDeleteModal.name, count: catDeleteModal.productCount })}
+              {t('deleteCategoryBody', { name: catDeleteModal.name, count: catDeleteModal.productCount })}
             </p>
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t('products.moveProductsTo')}</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{t('moveProductsTo')}</label>
                 <select
                   value={catReassignTo}
                   onChange={(e) => setCatReassignTo(e.target.value)}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand outline-none"
                 >
-                  <option value="">{t('products.selectCategoryPlaceholder')}</option>
+                  <option value="">{t('selectCategoryPlaceholder')}</option>
                   {categories
                     .filter((c) => c.name.toLowerCase() === 'uncategorized' && c.id !== catDeleteModal.id)
-                    .map((c) => <option key={c.id} value={String(c.id)}>{t('products.defaultCategoryTag', { name: c.name })}</option>)}
+                    .map((c) => <option key={c.id} value={String(c.id)}>{t('defaultCategoryTag', { name: c.name })}</option>)}
                   {categories
                     .filter((c) => c.name.toLowerCase() !== 'uncategorized' && c.id !== catDeleteModal.id)
                     .map((c) => <option key={c.id} value={String(c.id)}>{c.name}</option>)}
                 </select>
               </div>
               <Button onClick={handleCategoryReassignDelete} disabled={!catReassignTo} className="w-full">
-                {t('products.moveAndDelete')}
+                {t('moveAndDelete')}
               </Button>
               <div className="relative flex items-center">
                 <div className="flex-grow border-t border-gray-200" />
-                <span className="mx-3 text-xs text-gray-400">{t('common.or')}</span>
+                <span className="mx-3 text-xs text-gray-400">{tCommon('or')}</span>
                 <div className="flex-grow border-t border-gray-200" />
               </div>
               <button
                 onClick={handleCategoryForceDelete}
                 className="w-full px-4 py-2 text-sm font-medium bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
               >
-                {t('products.deleteCategoryAndProducts')}
+                {t('deleteCategoryAndProducts')}
               </button>
             </div>
           </div>

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useAuthStore } from '@/store/auth';
 import { usePosSettingsStore, type PaperSize, type BillTemplate } from '@/store/pos-settings';
-import type { Language } from '@/lib/i18n';
+import { LANGUAGES, type Language } from '@/lib/i18n';
 import { usePrinterStore, usePrinterStatusSync } from '@/hooks/usePrinter';
 import { Settings, Building2, CreditCard, Monitor, Users, Gift, Printer, Share2, FileText, Lock, Smartphone, RefreshCw, Copy, Check, Wifi, Usb, Trash2, Plus, Star, TestTube2, ChefHat, QrCode, CheckCircle2, Database, Cloud, CloudOff, Zap, Percent, KeyRound, AlertTriangle, Wrench, HardDrive, UploadCloud, Hash, ChevronDown } from 'lucide-react';
 import { Tabs, TabsContent } from '@/components/ui/tabs';
@@ -24,11 +24,21 @@ import { TaxConfigurationPanel } from '@/components/settings/TaxConfigurationPan
 import { PaymentMethodsSettings } from '@/components/settings/PaymentMethodsSettings';
 import { LocalePreferencesPanel } from '@/components/settings/LocalePreferencesPanel';
 import type { HealthCheckReport } from '@/types/electron';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
 import { useFormatDate } from '@/hooks/useFormatDate';
 import { useUpdateStatus } from '@/hooks/useUpdateStatus';
 import { TENANT_STATUS_LABEL_KEYS } from '@/lib/i18n-enums';
+
+// Registry-derived selectable UI languages (from LANGUAGES where selectable: true).
+const SELECTABLE_LANGUAGES: Language[] = (Object.keys(LANGUAGES) as Language[]).filter(
+  (lang) => LANGUAGES[lang].selectable,
+);
+
+function tenantStatusLabel(status: string | undefined, tCommon: (key: 'active' | 'inactive') => string): string {
+  const key = (TENANT_STATUS_LABEL_KEYS as Record<string, 'active' | 'inactive' | undefined>)[status ?? ''];
+  return key ? tCommon(key) : (status ?? '');
+}
 
 const CLOUD_ACCOUNT_STATUS_CHANGED_EVENT = 'flo:cloud-account-status-changed';
 
@@ -78,9 +88,11 @@ function formatBackupSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+type SettingsKey = keyof AppConfig['Messages']['settings'];
+
 interface TemplateCard {
   id: BillTemplate;
-  nameKey?: string;
+  nameKey?: SettingsKey;
   displayName?: string;
   preview: string;
   source: 'core' | 'plugin';
@@ -88,8 +100,8 @@ interface TemplateCard {
 }
 
 const TEMPLATE_CARDS: TemplateCard[] = [
-  { id: 'classic', nameKey: 'settings.billTemplateClassicName', preview: CLASSIC_PREVIEW, source: 'core' },
-  { id: 'compact', nameKey: 'settings.billTemplateCompactName', preview: COMPACT_PREVIEW, source: 'core' },
+  { id: 'classic', nameKey: 'billTemplateClassicName', preview: CLASSIC_PREVIEW, source: 'core' },
+  { id: 'compact', nameKey: 'billTemplateCompactName', preview: COMPACT_PREVIEW, source: 'core' },
 ];
 
 function Toggle({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
@@ -150,7 +162,8 @@ function SettingsNavItem({
 }
 
 function KdsDefaultViewCard() {
-  const { t } = useI18n();
+  const t = useTranslations('settings');
+  const tCommon = useTranslations('common');
   const [view, setView] = useState<'tabs' | 'kanban'>('tabs');
   const [savedView, setSavedView] = useState<'tabs' | 'kanban'>('tabs');
   const [saving, setSaving] = useState(false);
@@ -172,9 +185,9 @@ function KdsDefaultViewCard() {
       const next = data?.kds_default_view === 'kanban' ? 'kanban' : 'tabs';
       setSavedView(next);
       setView(next);
-      toast.success(t('settings.kdsViewSaved'));
+      toast.success(t('kdsViewSaved'));
     } catch {
-      toast.error(t('settings.kdsViewSaveFailed'));
+      toast.error(t('kdsViewSaveFailed'));
     } finally {
       setSaving(false);
     }
@@ -184,9 +197,9 @@ function KdsDefaultViewCard() {
     <div className="bg-white rounded-xl border border-gray-100 p-6">
       <div className="flex items-center gap-2 mb-4">
         <Monitor size={20} className="text-gray-500" />
-        <h2 className="font-semibold text-gray-900">{t('settings.kdsDefaultView')}</h2>
+        <h2 className="font-semibold text-gray-900">{t('kdsDefaultView')}</h2>
       </div>
-      <p className="text-sm text-gray-500 mb-5">{t('settings.kdsDefaultViewHint')}</p>
+      <p className="text-sm text-gray-500 mb-5">{t('kdsDefaultViewHint')}</p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <button
@@ -200,9 +213,9 @@ function KdsDefaultViewCard() {
         >
           <div className="flex items-center gap-2 mb-1">
             <input type="radio" readOnly checked={view === 'tabs'} className="text-brand" />
-            <span className="font-medium text-gray-900">{t('settings.kdsDefaultViewTabs')}</span>
+            <span className="font-medium text-gray-900">{t('kdsDefaultViewTabs')}</span>
           </div>
-          <p className="text-xs text-gray-500 ms-6">{t('settings.kdsDefaultViewTabsHint')}</p>
+          <p className="text-xs text-gray-500 ms-6">{t('kdsDefaultViewTabsHint')}</p>
         </button>
         <button
           type="button"
@@ -215,9 +228,9 @@ function KdsDefaultViewCard() {
         >
           <div className="flex items-center gap-2 mb-1">
             <input type="radio" readOnly checked={view === 'kanban'} className="text-brand" />
-            <span className="font-medium text-gray-900">{t('settings.kdsDefaultViewKanban')}</span>
+            <span className="font-medium text-gray-900">{t('kdsDefaultViewKanban')}</span>
           </div>
-          <p className="text-xs text-gray-500 ms-6">{t('settings.kdsDefaultViewKanbanHint')}</p>
+          <p className="text-xs text-gray-500 ms-6">{t('kdsDefaultViewKanbanHint')}</p>
         </button>
       </div>
 
@@ -228,7 +241,7 @@ function KdsDefaultViewCard() {
           disabled={!dirty || saving}
           className="px-4 py-2 bg-brand text-white rounded-lg hover:opacity-90 disabled:opacity-50 font-medium text-sm"
         >
-          {saving ? t('common.saving') : t('common.save')}
+          {saving ? tCommon('saving') : tCommon('save')}
         </button>
       </div>
     </div>
@@ -242,7 +255,12 @@ export default function SettingsPage() {
   const whatsappEnabled = posSettings.whatsappEnabled;
   const { printMethod, setPrintMethod, refreshHardwarePrinter } = usePrinterStore();
   usePrinterStatusSync();
-  const { t, language, setLanguage } = useI18n();
+  const t = useTranslations('settings');
+  const tCommon = useTranslations('common');
+  const tRestore = useTranslations('restore');
+  const tWhatsappSettings = useTranslations('whatsapp.settings');
+  const language = posSettings.language;
+  const setLanguage = posSettings.setLanguage;
   const { formatDate, formatTime, formatDateTime } = useFormatDate();
   const isAdmin = currentTenant?.role === 'admin' || currentTenant?.role === 'owner';
   const canViewTaxConfiguration = currentTenant?.role === 'owner' || currentTenant?.role === 'manager';
@@ -352,7 +370,7 @@ export default function SettingsPage() {
       const { data } = await api.get('/db-tools/health-check');
       setHealthReport(data);
     } catch {
-      toast.error(t('settings.healthCheckFailed'));
+      toast.error(t('healthCheckFailed'));
       setHealthCheckOpen(false);
     }
   };
@@ -383,7 +401,7 @@ export default function SettingsPage() {
       api.get('/db-tools/health-check')
         .then(({ data }) => setHealthReport(data))
         .catch(() => {
-          toast.error(t('settings.healthCheckFailed'));
+          toast.error(t('healthCheckFailed'));
           setHealthCheckOpen(false);
         });
     }
@@ -395,13 +413,13 @@ export default function SettingsPage() {
     try {
       const { data } = await api.post('/db-tools/apply-safe-fixes', {});
       if (data.errors?.length) {
-        toast.error(t('settings.fixesAppliedPartial', { applied: data.applied.length, failed: data.errors.length }));
+        toast.error(t('fixesAppliedPartial', { applied: data.applied.length, failed: data.errors.length }));
       } else {
-        toast.success(t('settings.fixesApplied', { count: data.applied.length }));
+        toast.success(t('fixesApplied', { count: data.applied.length }));
       }
       await runHealthCheck();
     } catch {
-      toast.error(t('settings.applyingFixesFailed'));
+      toast.error(t('applyingFixesFailed'));
     } finally {
       setApplyingFixes(false);
     }
@@ -410,49 +428,49 @@ export default function SettingsPage() {
   const runImport = async (data: ImportPayload, overwrite: boolean, master_pin?: string) => {
     try {
       const response = await api.post('/db/import', { data, overwrite, master_pin });
-      if (response.data.success) toast.success(t('settings.importSuccess'));
+      if (response.data.success) toast.success(t('importSuccess'));
       return { success: true };
     } catch {
-      const message = t('settings.importFailed');
+      const message = t('importFailed');
       toast.error(message);
       return { success: false, error: message };
     }
   };
 
   const handlePinGateSubmit = async (pin: string): Promise<{ success: boolean; error?: string }> => {
-    if (!pinGate) return { success: false, error: t('settings.nothingPending') };
+    if (!pinGate) return { success: false, error: t('nothingPending') };
 
     if (pinGate.mode === 'set') {
       try {
         await api.post('/db-tools/master-pin/reset', { pin, confirm_pin: pin });
         await fetchMasterPinStatus();
-        toast.success(t('settings.masterPinSaved'));
+        toast.success(t('masterPinSaved'));
         setPinGate(null);
         return { success: true };
       } catch {
-        return { success: false, error: t('settings.savePinFailed') };
+        return { success: false, error: t('savePinFailed') };
       }
     }
 
     if (pinGate.mode === 'backup') {
       try {
         const response = await api.post('/db/backup', { master_pin: pin });
-        toast.success(`${t('settings.backupCreated')} ${response.data.path}`, { duration: 5000 });
+        toast.success(`${t('backupCreated')} ${response.data.path}`, { duration: 5000 });
         setPinGate(null);
         fetchBackups();
         return { success: true };
       } catch {
-        return { success: false, error: t('settings.backupFailedGeneric') };
+        return { success: false, error: t('backupFailedGeneric') };
       }
     }
 
     if (pinGate.mode === 'backup-custom') {
       if (!window.electronAPI?.backupDatabase) {
-        return { success: false, error: t('common.notAvailable') };
+        return { success: false, error: tCommon('notAvailable') };
       }
       const result = await window.electronAPI.backupDatabase(pin);
       if (result.success) {
-        toast.success(`${t('settings.backupCreated')} ${result.path}`, { duration: 5000 });
+        toast.success(`${t('backupCreated')} ${result.path}`, { duration: 5000 });
         setPinGate(null);
         return { success: true };
       }
@@ -460,16 +478,16 @@ export default function SettingsPage() {
         setPinGate(null);
         return { success: true };
       }
-      return { success: false, error: result.error || t('settings.backupFailedGeneric') };
+      return { success: false, error: result.error || t('backupFailedGeneric') };
     }
 
     if (pinGate.mode === 'restore') {
       if (!window.electronAPI?.restoreBackup) {
-        return { success: false, error: t('common.notAvailable') };
+        return { success: false, error: tCommon('notAvailable') };
       }
       const result = await window.electronAPI.restoreBackup(pin, pinGate.payload.backupPath);
       if (result.success) {
-        toast.success(t('restore.success'));
+        toast.success(tRestore('success'));
         setPinGate(null);
         setTimeout(() => window.location.reload(), 1500);
         return { success: true };
@@ -478,25 +496,25 @@ export default function SettingsPage() {
         setPinGate(null);
         return { success: true };
       }
-      return { success: false, error: result.error || t('settings.restoreFailedGeneric') };
+      return { success: false, error: result.error || t('restoreFailedGeneric') };
     }
 
     if (pinGate.mode === 'delete-backup') {
       try {
         await api.post(`/db-tools/backups/${encodeURIComponent(pinGate.payload.fileName)}/delete`, { master_pin: pin });
-        toast.success(t('settings.backupDeleted'));
+        toast.success(t('backupDeleted'));
         setPinGate(null);
         fetchBackups();
         return { success: true };
       } catch {
-        return { success: false, error: t('settings.backupDeleteFailed') };
+        return { success: false, error: t('backupDeleteFailed') };
       }
     }
 
     if (pinGate.mode === 'delete-cloud') {
       try {
         await api.post('/settings/cloud/delete-data', { master_pin: pin, confirmation: 'DELETE CLOUD DATA' });
-        toast.success(t('settings.cloudDeletionSubmitted'));
+        toast.success(t('cloudDeletionSubmitted'));
         await Promise.all([fetchCloudAccount(), refreshCloudStatus()]);
         notifyCloudAccountStatusChanged();
         setPinGate(null);
@@ -504,20 +522,20 @@ export default function SettingsPage() {
       } catch {
         await Promise.all([fetchCloudAccount(), refreshCloudStatus()]);
         notifyCloudAccountStatusChanged();
-        return { success: false, error: t('settings.cloudDeletionFailed') };
+        return { success: false, error: t('cloudDeletionFailed') };
       }
     }
 
     if (pinGate.mode === 'cancel-cloud-deletion') {
       try {
         await api.post('/settings/cloud/delete-data/cancel', { master_pin: pin });
-        toast.success(t('settings.cloudDeletionCancelled'));
+        toast.success(t('cloudDeletionCancelled'));
         await Promise.all([fetchCloudAccount(), refreshCloudStatus()]);
         notifyCloudAccountStatusChanged();
         setPinGate(null);
         return { success: true };
       } catch {
-        return { success: false, error: t('settings.cloudDeletionCancelFailed') };
+        return { success: false, error: t('cloudDeletionCancelFailed') };
       }
     }
 
@@ -529,15 +547,15 @@ export default function SettingsPage() {
 
   const handleCreateBackup = async () => {
     if (masterPinStatus.available && !masterPinStatus.isSet) {
-      toast.error(t('settings.masterPinRequiredForBackup'));
+      toast.error(t('masterPinRequiredForBackup'));
       return;
     }
     if (!masterPinStatus.available) {
       try {
         const response = await api.post('/db/backup', {});
-        toast.success(`${t('settings.backupCreated')} ${response.data.path}`, { duration: 5000 });
+        toast.success(`${t('backupCreated')} ${response.data.path}`, { duration: 5000 });
       } catch {
-        toast.error(t('settings.backupFailed'));
+        toast.error(t('backupFailed'));
       }
       return;
     }
@@ -551,19 +569,19 @@ export default function SettingsPage() {
   // action — since it's outside the managed backups/ directory. See #120.
   const handleChooseBackupLocation = async () => {
     if (masterPinStatus.available && !masterPinStatus.isSet) {
-      toast.error(t('settings.masterPinRequiredForBackup'));
+      toast.error(t('masterPinRequiredForBackup'));
       return;
     }
     if (!masterPinStatus.available) {
       if (!window.electronAPI?.backupDatabase) {
-        toast.error(t('common.notAvailable'));
+        toast.error(tCommon('notAvailable'));
         return;
       }
       const result = await window.electronAPI.backupDatabase('');
       if (result.success) {
-        toast.success(`${t('settings.backupCreated')} ${result.path}`, { duration: 5000 });
+        toast.success(`${t('backupCreated')} ${result.path}`, { duration: 5000 });
       } else if (result.error !== 'Cancelled') {
-        toast.error(result.error || t('settings.backupFailedGeneric'));
+        toast.error(result.error || t('backupFailedGeneric'));
       }
       return;
     }
@@ -571,28 +589,28 @@ export default function SettingsPage() {
   };
 
   const handleRestoreFromHistory = async (backup: BackupInfo) => {
-    const ok = await confirm(t('settings.restoreConfirm', { fileName: backup.fileName }), {
-      title: t('settings.confirmRestoreTitle'),
-      confirmLabel: t('settings.restoreBackup'),
+    const ok = await confirm(t('restoreConfirm', { fileName: backup.fileName }), {
+      title: t('confirmRestoreTitle'),
+      confirmLabel: t('restoreBackup'),
       destructive: true,
     });
     if (!ok) return;
 
     if (masterPinStatus.available && !masterPinStatus.isSet) {
-      toast.error(t('settings.setMasterPinFirst'));
+      toast.error(t('setMasterPinFirst'));
       return;
     }
     if (!masterPinStatus.available) {
       if (!window.electronAPI?.restoreBackup) {
-        toast.error(t('common.notAvailable'));
+        toast.error(tCommon('notAvailable'));
         return;
       }
       const result = await window.electronAPI.restoreBackup('', backup.path);
       if (result.success) {
-        toast.success(t('restore.success'));
+        toast.success(tRestore('success'));
         setTimeout(() => window.location.reload(), 1500);
       } else if (result.error !== 'Cancelled') {
-        toast.error(result.error || t('settings.restoreFailedGeneric'));
+        toast.error(result.error || t('restoreFailedGeneric'));
       }
       return;
     }
@@ -600,24 +618,24 @@ export default function SettingsPage() {
   };
 
   const handleDeleteBackup = async (backup: BackupInfo) => {
-    const ok = await confirm(t('settings.deleteBackupConfirm', { fileName: backup.fileName }), {
-      title: t('settings.confirmDeleteBackupTitle'),
-      confirmLabel: t('settings.deleteBackup'),
+    const ok = await confirm(t('deleteBackupConfirm', { fileName: backup.fileName }), {
+      title: t('confirmDeleteBackupTitle'),
+      confirmLabel: t('deleteBackup'),
       destructive: true,
     });
     if (!ok) return;
 
     if (masterPinStatus.available && !masterPinStatus.isSet) {
-      toast.error(t('settings.setMasterPinFirst'));
+      toast.error(t('setMasterPinFirst'));
       return;
     }
     if (!masterPinStatus.available) {
       try {
         await api.post(`/db-tools/backups/${encodeURIComponent(backup.fileName)}/delete`, {});
-        toast.success(t('settings.backupDeleted'));
+        toast.success(t('backupDeleted'));
         fetchBackups();
       } catch {
-        toast.error(t('settings.backupDeleteFailed'));
+        toast.error(t('backupDeleteFailed'));
       }
       return;
     }
@@ -629,7 +647,7 @@ export default function SettingsPage() {
       const { data } = await api.post('/db-tools/initialize', { master_pin: pin, confirmation_phrase: 'INITIALIZE' });
       return { success: true, backupPath: data.backupPath };
     } catch {
-      return { success: false, error: t('settings.initializeFailedGeneric') };
+      return { success: false, error: t('initializeFailedGeneric') };
     }
   };
 
@@ -651,7 +669,7 @@ export default function SettingsPage() {
     api.get('/kds-info').then((res) => {
       setKdsInfo(res.data);
     }).catch(() => {
-      toast.error(t('settings.kdsInfoFetchFailed'));
+      toast.error(t('kdsInfoFetchFailed'));
     }).finally(() => setKdsInfoLoading(false));
   };
 
@@ -670,7 +688,7 @@ export default function SettingsPage() {
     api.get('/server-app-info').then((res) => {
       setServerAppInfo(res.data);
     }).catch(() => {
-      toast.error(t('settings.serverAppInfoFetchFailed', { defaultValue: 'Could not load Server App info' }));
+      toast.error(t('serverAppInfoFetchFailed', { defaultValue: 'Could not load Server App info' }));
     }).finally(() => setServerAppInfoLoading(false));
   };
 
@@ -689,7 +707,7 @@ export default function SettingsPage() {
     api.get('/pos-info').then((res) => {
       setPosInfo(res.data);
     }).catch(() => {
-      toast.error(t('settings.posInfoFetchFailed'));
+      toast.error(t('posInfoFetchFailed'));
     }).finally(() => setPosInfoLoading(false));
   };
 
@@ -774,7 +792,7 @@ export default function SettingsPage() {
 
   const printWidthLabel = (value?: string | null): string => {
     const cols = normalizePrinterWidthValue(value).replace('cols-', '');
-    return t('settings.printColumnsShort', { cols });
+    return t('printColumnsShort', { cols });
   };
 
   const fetchPrinters = () => {
@@ -808,11 +826,11 @@ export default function SettingsPage() {
         payload.port = p.port || 9100;
       }
       await api.post('/printers', payload);
-      toast.success(t('settings.printerQuickAdded', { name: p.name }));
+      toast.success(t('printerQuickAdded', { name: p.name }));
       fetchPrinters();
       refreshHardwarePrinter();
     } catch {
-      toast.error(t('settings.printerAddFailed'));
+      toast.error(t('printerAddFailed'));
     } finally {
       setAddingDetectedName(null);
     }
@@ -835,7 +853,7 @@ export default function SettingsPage() {
   };
 
   const savePrinterHw = async () => {
-    if (!printerForm.name) { toast.error(t('settings.printerNameRequired')); return; }
+    if (!printerForm.name) { toast.error(t('printerNameRequired')); return; }
     setSavingPrinter(true);
     try {
       const payload = {
@@ -847,51 +865,51 @@ export default function SettingsPage() {
       };
       if (editingPrinterId) {
         await api.put(`/printers/${editingPrinterId}`, payload);
-        toast.success(t('settings.printerUpdated'));
+        toast.success(t('printerUpdated'));
       } else {
         await api.post('/printers', payload);
-        toast.success(t('settings.printerSaved'));
+        toast.success(t('printerSaved'));
       }
       fetchPrinters();
       refreshHardwarePrinter();
       setShowPrinterForm(false);
     } catch {
-      toast.error(t('settings.printerSaveFailed'));
+      toast.error(t('printerSaveFailed'));
     } finally {
       setSavingPrinter(false);
     }
   };
 
   const deletePrinterHw = async (id: string) => {
-    if (!await confirm(t('settings.printerDeleteConfirm'), { destructive: true, confirmLabel: t('common.delete') })) return;
+    if (!await confirm(t('printerDeleteConfirm'), { destructive: true, confirmLabel: tCommon('delete') })) return;
     try {
       await api.delete(`/printers/${id}`);
-      toast.success(t('settings.printerDeleted'));
+      toast.success(t('printerDeleted'));
       fetchPrinters();
       refreshHardwarePrinter();
-    } catch { toast.error(t('settings.printerDeleteFailed')); }
+    } catch { toast.error(t('printerDeleteFailed')); }
   };
 
   const setDefaultPrinter = async (id: string) => {
     try {
       await api.post(`/printers/${id}/set-default`);
-      toast.success(t('settings.defaultPrinterSet'));
+      toast.success(t('defaultPrinterSet'));
       fetchPrinters();
       refreshHardwarePrinter();
-    } catch { toast.error(t('settings.actionFailed')); }
+    } catch { toast.error(t('actionFailed')); }
   };
 
   const testPrinterHw = async (printer: HwPrinter) => {
     if (printer.connection_type === 'webusb') {
-      toast(t('settings.webusbTestHint'));
+      toast(t('webusbTestHint'));
       return;
     }
     setTestingPrinterId(printer.id);
     try {
       await api.post(`/printers/${printer.id}/test`);
-      toast.success(t('settings.testPrintSent'));
+      toast.success(t('testPrintSent'));
     } catch {
-      toast.error(t('settings.testPrintFailed'));
+      toast.error(t('testPrintFailed'));
     } finally {
       setTestingPrinterId(null);
     }
@@ -964,7 +982,7 @@ export default function SettingsPage() {
   };
 
   const saveStation = async () => {
-    if (!stationForm.name.trim()) { toast.error(t('settings.stationNameRequired')); return; }
+    if (!stationForm.name.trim()) { toast.error(t('stationNameRequired')); return; }
     setSavingStation(true);
     try {
       const payload = {
@@ -983,24 +1001,24 @@ export default function SettingsPage() {
         await api.put(`/kitchen-stations/${stationId}/users`, { user_ids: stationForm.user_ids });
         await fetchStationUsers(stationId);
       }
-      toast.success(editingStationId ? t('settings.stationUpdated') : t('settings.stationSaved'));
+      toast.success(editingStationId ? t('stationUpdated') : t('stationSaved'));
       setShowStationForm(false);
       fetchStations();
     } catch {
-      toast.error(t('settings.stationSaveFailed'));
+      toast.error(t('stationSaveFailed'));
     } finally {
       setSavingStation(false);
     }
   };
 
   const deleteStation = async (id: string) => {
-    if (!await confirm(t('settings.stationDeleteConfirm'), { destructive: true, confirmLabel: t('common.delete') })) return;
+    if (!await confirm(t('stationDeleteConfirm'), { destructive: true, confirmLabel: tCommon('delete') })) return;
     try {
       await api.delete(`/kitchen-stations/${id}`);
-      toast.success(t('settings.stationDeleted'));
+      toast.success(t('stationDeleted'));
       fetchStations();
     } catch {
-      toast.error(t('settings.stationDeleteFailed'));
+      toast.error(t('stationDeleteFailed'));
     }
   };
 
@@ -1092,7 +1110,7 @@ export default function SettingsPage() {
       ] as const).map(([key, value]) => api.put(`/settings/${key}`, { value: value ? 'true' : 'false' })),
     ]);
     setSavedPrinting(printingForm);
-    if (!silent) toast.success(t('settings.printingSettingsSaved'));
+    if (!silent) toast.success(t('printingSettingsSaved'));
   };
   const resetPrinting = () => setPrintingForm(savedPrinting);
 
@@ -1113,7 +1131,7 @@ export default function SettingsPage() {
       api.put('/settings/bill_footer_message', { value: billForm.billFooterMessage }),
     ]);
     setSavedBillForm(billForm);
-    if (!silent) toast.success(t('settings.billTemplateSaved'));
+    if (!silent) toast.success(t('billTemplateSaved'));
   };
   const resetBillTemplate = () => setBillForm(savedBillForm);
 
@@ -1201,9 +1219,9 @@ export default function SettingsPage() {
       await api.get('/settings/cloud/delete-data/status');
       await Promise.all([fetchCloudAccount(), refreshCloudStatus()]);
       notifyCloudAccountStatusChanged();
-      toast.success(t('settings.cloudDeletionStatusRefreshed'));
+      toast.success(t('cloudDeletionStatusRefreshed'));
     } catch {
-      toast.error(t('settings.cloudDeletionStatusRefreshFailed'));
+      toast.error(t('cloudDeletionStatusRefreshFailed'));
     } finally {
       setRefreshingDeletionStatus(false);
     }
@@ -1357,9 +1375,9 @@ export default function SettingsPage() {
       setOrderNumberForm(loadedOrderNumbering);
       setSavedOrderNumberForm(loadedOrderNumbering);
 
-      toast.success(t('settings.reloadedFromDb'));
+      toast.success(t('reloadedFromDb'));
     } catch {
-      toast.error(t('settings.reloadFailed'));
+      toast.error(t('reloadFailed'));
     }
   };
 
@@ -1407,7 +1425,7 @@ export default function SettingsPage() {
     // kdsInfoLoading already starts true for this initial fetch.
     api.get('/kds-info')
       .then((res) => setKdsInfo(res.data))
-      .catch(() => toast.error(t('settings.kdsInfoFetchFailed')))
+      .catch(() => toast.error(t('kdsInfoFetchFailed')))
       .finally(() => setKdsInfoLoading(false));
     fetchStations();
     fetchStationCategories();
@@ -1635,9 +1653,9 @@ export default function SettingsPage() {
       });
       await fetchCloudAccount();
       notifyCloudAccountStatusChanged();
-      if (!silent) toast.success(t('settings.cloudSaved'));
+      if (!silent) toast.success(t('cloudSaved'));
     } catch (err) {
-      if (!silent) toast.error(t('settings.cloudSaveFailed'));
+      if (!silent) toast.error(t('cloudSaveFailed'));
       throw err;
     } finally {
       setSavingCloud(false);
@@ -1669,10 +1687,10 @@ export default function SettingsPage() {
       await fetchCloudAccount();
       notifyCloudAccountStatusChanged();
       if (res.data.cloud_registration_status === 'registered') {
-        toast.success(t('settings.cloudRegistrationSuccess'));
+        toast.success(t('cloudRegistrationSuccess'));
       }
     } catch {
-      toast.error(t('settings.cloudRegistrationFailed'));
+      toast.error(t('cloudRegistrationFailed'));
     } finally {
       setRegisteringCloud(false);
     }
@@ -1686,7 +1704,7 @@ export default function SettingsPage() {
       await api.put('/settings/telemetry_enabled', { value: enabled ? 'true' : 'false' });
     } catch {
       setTelemetryEnabled(previous);
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     } finally {
       setSavingTelemetry(false);
     }
@@ -1700,7 +1718,7 @@ export default function SettingsPage() {
       await api.put('/settings/diagnostics_consent', { value: enabled ? 'true' : 'false' });
     } catch {
       setDiagnosticsConsent(previous);
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     } finally {
       setSavingDiagnosticsConsent(false);
     }
@@ -1711,18 +1729,18 @@ export default function SettingsPage() {
     try {
       const res = await api.post('/settings/google-drive/connect');
       setGoogleDriveStatus((prev) => ({ ...prev, ...res.data }));
-      toast.success(t('settings.googleDriveConnectedSuccess'));
+      toast.success(t('googleDriveConnectedSuccess'));
       fetchBackups();
     } catch {
-      toast.error(t('settings.googleDriveConnectFailed'));
+      toast.error(t('googleDriveConnectFailed'));
     } finally {
       setConnectingGoogleDrive(false);
     }
   };
 
   const disconnectGoogleDrive = async () => {
-    const ok = await confirm(t('settings.googleDriveDisconnectConfirm'), {
-      confirmLabel: t('settings.googleDriveDisconnect'),
+    const ok = await confirm(t('googleDriveDisconnectConfirm'), {
+      confirmLabel: t('googleDriveDisconnect'),
       destructive: true,
     });
     if (!ok) return;
@@ -1730,9 +1748,9 @@ export default function SettingsPage() {
     try {
       const res = await api.post('/settings/google-drive/disconnect');
       setGoogleDriveStatus((prev) => ({ ...prev, ...res.data }));
-      toast.success(t('settings.googleDriveDisconnectedSuccess'));
+      toast.success(t('googleDriveDisconnectedSuccess'));
     } catch {
-      toast.error(t('settings.googleDriveDisconnectFailed'));
+      toast.error(t('googleDriveDisconnectFailed'));
     } finally {
       setDisconnectingGoogleDrive(false);
     }
@@ -1743,10 +1761,10 @@ export default function SettingsPage() {
     try {
       const res = await api.post('/settings/google-drive/backup-now');
       setGoogleDriveStatus((prev) => ({ ...prev, ...res.data }));
-      toast.success(t('settings.googleDriveBackupSuccess'));
+      toast.success(t('googleDriveBackupSuccess'));
       fetchBackups();
     } catch {
-      toast.error(t('settings.googleDriveBackupFailed'));
+      toast.error(t('googleDriveBackupFailed'));
       fetchGoogleDriveStatus();
     } finally {
       setBackingUpGoogleDrive(false);
@@ -1762,7 +1780,7 @@ export default function SettingsPage() {
       setGoogleDriveStatus((prev) => ({ ...prev, ...res.data }));
     } catch {
       setGoogleDriveStatus(previous);
-      toast.error(t('settings.googleDriveSavePreferencesFailed'));
+      toast.error(t('googleDriveSavePreferencesFailed'));
     } finally {
       setSavingGoogleDrivePrefs(false);
     }
@@ -1779,11 +1797,11 @@ export default function SettingsPage() {
     setSavingKdsEnabled(true);
     try {
       await api.put('/settings/kds_enabled', { value: enabled ? 'true' : 'false' });
-      toast.success(enabled ? t('settings.kdsEnabledOn', { defaultValue: 'Kitchen Display System enabled' }) : t('settings.kdsEnabledOff', { defaultValue: 'Kitchen Display System disabled' }));
+      toast.success(enabled ? t('kdsEnabledOn', { defaultValue: 'Kitchen Display System enabled' }) : t('kdsEnabledOff', { defaultValue: 'Kitchen Display System disabled' }));
     } catch {
       setKdsEnabledSetting(previous);
       posSettings.setKdsEnabled(previous);
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     } finally {
       setSavingKdsEnabled(false);
     }
@@ -1797,11 +1815,11 @@ export default function SettingsPage() {
       await api.put('/settings/server_app_enabled', { value: enabled ? 'true' : 'false' });
       if (!enabled) setServerAppInfo(null);
       toast.success(enabled
-        ? t('settings.serverAppEnabledOn', { defaultValue: 'Server App enabled' })
-        : t('settings.serverAppEnabledOff', { defaultValue: 'Server App disabled' }));
+        ? t('serverAppEnabledOn', { defaultValue: 'Server App enabled' })
+        : t('serverAppEnabledOff', { defaultValue: 'Server App disabled' }));
     } catch {
       setServerAppEnabledSetting(previous);
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     } finally {
       setSavingServerAppEnabled(false);
     }
@@ -1814,11 +1832,11 @@ export default function SettingsPage() {
     setSavingKotPrintingEnabled(true);
     try {
       await api.put('/settings/kot_printing_enabled', { value: enabled ? 'true' : 'false' });
-      toast.success(enabled ? t('settings.kotPrintingEnabledOn', { defaultValue: 'KOT printing enabled' }) : t('settings.kotPrintingEnabledOff', { defaultValue: 'KOT printing disabled' }));
+      toast.success(enabled ? t('kotPrintingEnabledOn', { defaultValue: 'KOT printing enabled' }) : t('kotPrintingEnabledOff', { defaultValue: 'KOT printing disabled' }));
     } catch {
       setKotPrintingEnabledSetting(previous);
       posSettings.setKotPrintingEnabled(previous);
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     } finally {
       setSavingKotPrintingEnabled(false);
     }
@@ -1835,9 +1853,9 @@ export default function SettingsPage() {
       setSavedLoyaltyEnabled(loyaltyEnabled);
       setGlobalCashbackPercent(String(parsedRate));
       setSavedGlobalCashbackPercent(String(parsedRate));
-      if (!silent) toast.success(t('settings.loyaltySaved'));
+      if (!silent) toast.success(t('loyaltySaved'));
     } catch (err) {
-      if (!silent) toast.error(t('settings.saveFailed'));
+      if (!silent) toast.error(t('saveFailed'));
       throw err;
     } finally {
       setSavingLoyalty(false);
@@ -1850,9 +1868,9 @@ export default function SettingsPage() {
       const res = await api.post('/products/loyalty/apply-global-rate');
       const updated = Number(res.data.updated) || 0;
       setGlobalRateCandidates(0);
-      toast.success(t('settings.applyGlobalRateDone', { count: updated }));
+      toast.success(t('applyGlobalRateDone', { count: updated }));
     } catch {
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     } finally {
       setApplyingGlobalRate(false);
     }
@@ -1871,9 +1889,9 @@ export default function SettingsPage() {
       setSavedDiscountMaxAmount(normalizeDiscountAmount(discountMaxAmount));
       setSavedDiscountMode(discountMode);
       setSavedDiscountRequiresApproval(discountRequiresApproval);
-      if (!silent) toast.success(t('settings.discountSaved'));
+      if (!silent) toast.success(t('discountSaved'));
     } catch (err) {
-      if (!silent) toast.error(t('settings.saveFailed'));
+      if (!silent) toast.error(t('saveFailed'));
       throw err;
     } finally {
       setSavingDiscount(false);
@@ -1883,7 +1901,7 @@ export default function SettingsPage() {
   const saveBusinessInfo = async (silent = false) => {
     const norm = normalizeOptionalPhone(form.businessPhone, form.countryCode || 'IN');
     if (!norm.valid) {
-      toast.error(t('settings.invalidPhoneFormat', { defaultValue: 'Invalid phone number format' }));
+      toast.error(t('invalidPhoneFormat', { defaultValue: 'Invalid phone number format' }));
       return;
     }
     const normalizedBusinessPhone = norm.e164 ?? '';
@@ -1928,9 +1946,9 @@ export default function SettingsPage() {
                 diagnostics: { country: form.countryCode },
               }).catch(() => {});
               await api.put('/settings/taxes_enabled', { value: 'false' }).catch(() => {});
-              toast.error(t('settings.taxSupportUnavailable', { country: form.countryCode }));
+              toast.error(t('taxSupportUnavailable', { country: form.countryCode }));
             } else {
-              toast.error(t('settings.countrySavedTaxPluginFailed'));
+              toast.error(t('countrySavedTaxPluginFailed'));
             }
           }
         }
@@ -1944,10 +1962,10 @@ export default function SettingsPage() {
       posSettings.setBillingType(form.billingType);
       posSettings.setTablesRequired(form.tablesRequired);
       updateCurrentTenant({ currency: form.currency, timezone: form.timezone, country: form.countryCode, currency_display: form.currencyDisplay, number_digits: form.numberDigits, calendar: form.calendar });
-      if (!silent) toast.success(t('settings.storeSaved'));
+      if (!silent) toast.success(t('storeSaved'));
     } catch (err) {
       if (!silent) {
-        const message = t('settings.saveFailed');
+        const message = t('saveFailed');
         toast.error(message);
       }
       throw err;
@@ -1959,12 +1977,12 @@ export default function SettingsPage() {
   const saveOrderNumbering = async (silent = false) => {
     const prefix = orderNumberForm.prefix.trim();
     if (prefix && !/^[A-Za-z0-9_-]{0,12}$/.test(prefix)) {
-      toast.error(t('settings.orderNumberPrefixInvalid', { defaultValue: 'Prefix must be up to 12 characters (letters, numbers, - or _)' }));
+      toast.error(t('orderNumberPrefixInvalid', { defaultValue: 'Prefix must be up to 12 characters (letters, numbers, - or _)' }));
       return;
     }
     const invoicePrefix = orderNumberForm.invoicePrefix.trim();
     if (invoicePrefix && !/^[A-Za-z0-9_-]{0,12}$/.test(invoicePrefix)) {
-      toast.error(t('settings.invoiceNumberPrefixInvalid', { defaultValue: 'Invoice prefix must be up to 12 characters (letters, numbers, - or _)' }));
+      toast.error(t('invoiceNumberPrefixInvalid', { defaultValue: 'Invoice prefix must be up to 12 characters (letters, numbers, - or _)' }));
       return;
     }
     setSavingOrderNumbering(true);
@@ -1982,9 +2000,9 @@ export default function SettingsPage() {
       const saved = { ...orderNumberForm, prefix, invoicePrefix };
       setOrderNumberForm(saved);
       setSavedOrderNumberForm(saved);
-      if (!silent) toast.success(t('settings.orderNumberingSaved', { defaultValue: 'Numbering settings saved' }));
+      if (!silent) toast.success(t('orderNumberingSaved', { defaultValue: 'Numbering settings saved' }));
     } catch (err) {
-      if (!silent) toast.error(t('settings.saveFailed'));
+      if (!silent) toast.error(t('saveFailed'));
       throw err;
     } finally {
       setSavingOrderNumbering(false);
@@ -2003,9 +2021,9 @@ export default function SettingsPage() {
       await Promise.all([saveBusinessInfo(true), saveLoyalty(true), saveDiscount(true), saveCloud(true), saveOrderNumbering(true)]);
       await savePrinting(true);
       await saveBillTemplate(true);
-      toast.success(t('settings.allSaved'));
+      toast.success(t('allSaved'));
     } catch {
-      toast.error(t('settings.allSaveFailed'));
+      toast.error(t('allSaveFailed'));
     }
   };
 
@@ -2017,11 +2035,11 @@ export default function SettingsPage() {
       setPairingExpiresAt(res.data.expires_at);
       setPairingQrDataUrl(res.data.qr_data_url || null);
       setPairingUnavailable(false);
-      toast.success(t('settings.pairingCodeRotated'));
+      toast.success(t('pairingCodeRotated'));
       loadPairedDevices();
     } catch {
       // Show a localized failure; the specific backend reason stays in logs.
-      toast.error(t('settings.pairingCodeFailed'));
+      toast.error(t('pairingCodeFailed'));
     } finally {
       setRotatingCode(false);
     }
@@ -2036,8 +2054,8 @@ export default function SettingsPage() {
   };
 
   const paperSizeOptions: { value: PaperSize; label: string }[] = [
-    { value: 'thermal58', label: t('settings.paperSize58') },
-    { value: 'thermal80', label: t('settings.paperSize80') },
+    { value: 'thermal58', label: t('paperSize58') },
+    { value: 'thermal80', label: t('paperSize80') },
   ];
 
   const isDirty = 
@@ -2088,56 +2106,56 @@ export default function SettingsPage() {
         <div className="w-full md:w-40 md:min-w-[10rem] shrink-0 md:sticky md:top-0">
           <div className="flex items-center gap-3 mb-6">
             <Settings size={28} className="text-brand" />
-            <h1 className="text-2xl font-bold text-gray-900">{t('settings.title')}</h1>
+            <h1 className="text-2xl font-bold text-gray-900">{t('title')}</h1>
           </div>
 
            <nav className="flex md:flex-col gap-0.5 overflow-x-auto md:overflow-x-visible border-b md:border-b-0 md:border-e border-gray-200 pb-2 md:pb-0 md:pe-2">
 
             {/* General group */}
             <div className="hidden md:block px-3 pt-3 pb-2 mt-2 mb-1 border-b border-gray-100">
-              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('settings.navGroupGeneral')}</p>
+              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupGeneral')}</p>
             </div>
-            <SettingsNavItem label={t('settings.storeDetails')} value="store" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('settings.tabPrinters')} value="receipts-printers" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('settings.paymentMethods', { defaultValue: 'Payments' })} value="payments" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('storeDetails')} value="store" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabPrinters')} value="receipts-printers" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('paymentMethods', { defaultValue: 'Payments' })} value="payments" active={activeTab} onClick={setActiveTab} />
             {canViewTaxConfiguration && (
-              <SettingsNavItem label={t('settings.taxConfiguration')} value="tax" active={activeTab} onClick={setActiveTab} />
+              <SettingsNavItem label={t('taxConfiguration')} value="tax" active={activeTab} onClick={setActiveTab} />
             )}
 
             {/* Operations group */}
             <div className="hidden md:block px-3 pt-4 pb-2 mt-3 mb-1 border-b border-gray-100">
-              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('settings.navGroupOperations')}</p>
+              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupOperations')}</p>
             </div>
-            <SettingsNavItem label={t('settings.posWorkflow')} value="pos" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('settings.tabKds')} value="kds" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('settings.tablesideOrdering')} value="server-app" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('posWorkflow')} value="pos" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabKds')} value="kds" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tablesideOrdering')} value="server-app" active={activeTab} onClick={setActiveTab} />
             {/* WhatsApp opt-in lives under Operations because the receive-bill
                 workflow is what the cashier touches every time a customer pays. */}
-            <SettingsNavItem label={t('settings.tabWhatsapp')} value="whatsapp" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabWhatsapp')} value="whatsapp" active={activeTab} onClick={setActiveTab} />
 
             {/* Customers group */}
             <div className="hidden md:block px-3 pt-4 pb-2 mt-3 mb-1 border-b border-gray-100">
-              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('settings.navGroupCustomers')}</p>
+              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupCustomers')}</p>
             </div>
-            <SettingsNavItem label={t('settings.loyalty')} value="loyalty" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('settings.discounts')} value="discounts" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('loyalty')} value="loyalty" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('discounts')} value="discounts" active={activeTab} onClick={setActiveTab} />
 
             {/* Integrations group (formerly "Data") */}
             <div className="hidden md:block px-3 pt-4 pb-2 mt-3 mb-1 border-b border-gray-100">
-              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('settings.navGroupData')}</p>
+              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupData')}</p>
             </div>
-            <SettingsNavItem label={t('settings.tabMobileAccess')} value="mobile-access" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('settings.tabBackupData')} value="data" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('settings.tabOrderflow')} value="orderflow" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabMobileAccess')} value="mobile-access" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabBackupData')} value="data" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabOrderflow')} value="orderflow" active={activeTab} onClick={setActiveTab} />
 
             {/* Account group */}
             <div className="hidden md:block px-3 pt-4 pb-2 mt-3 mb-1 border-b border-gray-100">
-              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('settings.navGroupAccount')}</p>
+              <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupAccount')}</p>
             </div>
-            <SettingsNavItem label={t('settings.account')} value="account" active={activeTab} onClick={setActiveTab} attention={cloudDeletionNeedsAction || (cloudAccountAvailable && Boolean(cloudAccount?.email && !cloudAccount?.verified))} />
-            <SettingsNavItem label={t('settings.privacy')} value="privacy" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('settings.tabUpdates')} value="updates" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('settings.tabAbout')} value="about" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('account')} value="account" active={activeTab} onClick={setActiveTab} attention={cloudDeletionNeedsAction || (cloudAccountAvailable && Boolean(cloudAccount?.email && !cloudAccount?.verified))} />
+            <SettingsNavItem label={t('privacy')} value="privacy" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabUpdates')} value="updates" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabAbout')} value="about" active={activeTab} onClick={setActiveTab} />
 
           </nav>
         </div>
@@ -2150,17 +2168,17 @@ export default function SettingsPage() {
             <div className="lg:col-span-2 bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Building2 size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.storeDetails')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('storeDetails')}</h2>
                 {!isAdmin && (
                   <span className="ms-auto flex items-center gap-1 text-xs text-gray-400">
-                    <Lock size={12} /> {t('settings.adminOnly')}
+                    <Lock size={12} /> {t('adminOnly')}
                   </span>
                 )}
               </div>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm text-gray-500 mb-1">{t('settings.businessName')}</label>
+                  <label className="block text-sm text-gray-500 mb-1">{t('businessName')}</label>
                   {isAdmin ? (
                     <input type="text" value={form.businessName} onChange={(e) => setForm((p) => ({ ...p, businessName: e.target.value }))}
                       className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand" />
@@ -2172,9 +2190,9 @@ export default function SettingsPage() {
                 <div className="md:col-span-2 space-y-2">
                   {/* Headings */}
                   <div className="grid grid-cols-3 gap-2">
-                    <label className="text-sm text-gray-500">{t('settings.country')}</label>
-                    <label className="text-sm text-gray-500">{t('settings.timezone')}</label>
-                    <label className="text-sm text-gray-500">{t('settings.currency')}</label>
+                    <label className="text-sm text-gray-500">{t('country')}</label>
+                    <label className="text-sm text-gray-500">{t('timezone')}</label>
+                    <label className="text-sm text-gray-500">{t('currency')}</label>
                   </div>
                   
                   {/* Input fields */}
@@ -2191,10 +2209,10 @@ export default function SettingsPage() {
                             timezone: country?.timezone || p.timezone,
                           }));
                         }}
-                        aria-label={t('common.search')}
+                        aria-label={tCommon('search')}
                         className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
                       >
-                        <option value="">{t('settings.selectCountry')}</option>
+                        <option value="">{t('selectCountry')}</option>
                         {COUNTRIES.map((c) => (
                           <option key={c.code} value={c.code}>{countryName(c.code)}</option>
                         ))}
@@ -2203,7 +2221,7 @@ export default function SettingsPage() {
                         type="text" 
                         value={form.timezone} 
                         onChange={(e) => setForm((p) => ({ ...p, timezone: e.target.value }))}
-                        placeholder={t('settings.timezoneAutoFilled')}
+                        placeholder={t('timezoneAutoFilled')}
                         className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-gray-50" 
                         readOnly
                         dir="ltr"
@@ -2212,7 +2230,7 @@ export default function SettingsPage() {
                         type="text" 
                         value={form.currency} 
                         onChange={(e) => setForm((p) => ({ ...p, currency: e.target.value }))}
-                        placeholder={t('settings.currencyAutoFilled')}
+                        placeholder={t('currencyAutoFilled')}
                         className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-gray-50" 
                         readOnly
                         dir="ltr"
@@ -2246,54 +2264,54 @@ export default function SettingsPage() {
                   }))}
                 />
                 <div>
-                  <label className="block text-sm text-gray-500 mb-1">{t('settings.billingType')}</label>
+                  <label className="block text-sm text-gray-500 mb-1">{t('billingType')}</label>
                   {isAdmin ? (
                     <select value={form.billingType}
                       onChange={(e) => setForm((p) => ({ ...p, billingType: e.target.value as 'postpaid' | 'prepaid' }))}
                       className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white">
-                      <option value="postpaid">{t('settings.billingTypePostpaid')}</option>
-                      <option value="prepaid">{t('settings.billingTypePrepaid')}</option>
+                      <option value="postpaid">{t('billingTypePostpaid')}</option>
+                      <option value="prepaid">{t('billingTypePrepaid')}</option>
                     </select>
                   ) : (
                     <p className="font-medium text-gray-900 capitalize">{form.billingType}</p>
                   )}
                 </div>
                 <div>
-                  <label className="block text-sm text-gray-500 mb-1">{t('settings.tablesRequired')}</label>
+                  <label className="block text-sm text-gray-500 mb-1">{t('tablesRequired')}</label>
                   {isAdmin ? (
                     <select
                       value={form.tablesRequired ? 'yes' : 'no'}
                       onChange={(e) => setForm((p) => ({ ...p, tablesRequired: e.target.value === 'yes' }))}
                       className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
                     >
-                      <option value="yes">{t('settings.tablesRequiredYes')}</option>
-                      <option value="no">{t('settings.tablesRequiredNo')}</option>
+                      <option value="yes">{t('tablesRequiredYes')}</option>
+                      <option value="no">{t('tablesRequiredNo')}</option>
                     </select>
                   ) : (
-                    <p className="font-medium text-gray-900">{form.tablesRequired ? t('settings.yes') : t('settings.no')}</p>
+                    <p className="font-medium text-gray-900">{form.tablesRequired ? t('yes') : t('no')}</p>
                   )}
                 </div>
                 <div>
-                  <label className="block text-sm text-gray-500 mb-1">{t('settings.taxRegistered', { defaultValue: 'Tax Registered' })}</label>
+                  <label className="block text-sm text-gray-500 mb-1">{t('taxRegistered', { defaultValue: 'Tax Registered' })}</label>
                   {isAdmin ? (
                     <select
                       value={form.taxRegistered ? 'yes' : 'no'}
                       onChange={(e) => setForm((p) => ({ ...p, taxRegistered: e.target.value === 'yes' }))}
                       className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
                     >
-                      <option value="yes">{t('settings.yes')}</option>
-                      <option value="no">{t('settings.no')}</option>
+                      <option value="yes">{t('yes')}</option>
+                      <option value="no">{t('no')}</option>
                     </select>
                   ) : (
-                    <p className="font-medium text-gray-900">{form.taxRegistered ? t('settings.yes') : t('settings.no')}</p>
+                    <p className="font-medium text-gray-900">{form.taxRegistered ? t('yes') : t('no')}</p>
                   )}
                 </div>
                 {form.taxRegistered ? (
                   <div>
-                    <label className="block text-sm text-gray-500 mb-1">{t('settings.taxIdLabel')}</label>
+                    <label className="block text-sm text-gray-500 mb-1">{t('taxIdLabel')}</label>
                     {isAdmin ? (
                       <input type="text" value={form.taxRegistrationNumber} onChange={(e) => setForm((p) => ({ ...p, taxRegistrationNumber: e.target.value }))}
-                        placeholder={t('settings.taxIdPlaceholder')}
+                        placeholder={t('taxIdPlaceholder')}
                         className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand" dir="ltr" />
                     ) : (
                       <p className="font-medium text-gray-900"><Ltr>{form.taxRegistrationNumber || '—'}</Ltr></p>
@@ -2301,35 +2319,35 @@ export default function SettingsPage() {
                   </div>
                 ) : <div className="hidden md:block" />}
                 <div>
-                  <label className="block text-sm text-gray-500 mb-1">{t('settings.phone')}</label>
+                  <label className="block text-sm text-gray-500 mb-1">{t('phone')}</label>
                   {isAdmin ? (
                     <input type="text" value={form.businessPhone} onChange={(e) => setForm((p) => ({ ...p, businessPhone: e.target.value }))}
-                      placeholder={t('settings.phonePlaceholder', { dialCode: dialCodeFor(form.countryCode) || '+1', defaultValue: '+1 555 000 0000' })}
+                      placeholder={t('phonePlaceholder', { dialCode: dialCodeFor(form.countryCode) || '+1', defaultValue: '+1 555 000 0000' })}
                       className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand" dir="ltr" />
                   ) : (
                     <p className="font-medium text-gray-900"><Ltr>{form.businessPhone || '—'}</Ltr></p>
                   )}
                 </div>
                 <div className="md:col-span-2">
-                  <label className="block text-sm text-gray-500 mb-1">{t('settings.address')}</label>
+                  <label className="block text-sm text-gray-500 mb-1">{t('address')}</label>
                   {isAdmin ? (
                     <textarea value={form.businessAddress} onChange={(e) => setForm((p) => ({ ...p, businessAddress: e.target.value }))}
-                      rows={2} placeholder={t('settings.addressPlaceholder')}
+                      rows={2} placeholder={t('addressPlaceholder')}
                       className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand resize-none" />
                   ) : (
                     <p className="font-medium text-gray-900">{form.businessAddress || '—'}</p>
                   )}
                 </div>
                 <div>
-                  <label className="block text-sm text-gray-500 mb-1">{t('settings.instagramHandle')}</label>
+                  <label className="block text-sm text-gray-500 mb-1">{t('instagramHandle')}</label>
                   {isAdmin ? (
                     <input type="text" value={form.instagramHandle} onChange={(e) => setForm((p) => ({ ...p, instagramHandle: e.target.value }))}
-                      placeholder={t('settings.instagramPlaceholder')}
+                      placeholder={t('instagramPlaceholder')}
                       className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand" />
                   ) : (
                     <p className="font-medium text-gray-900">{form.instagramHandle || '—'}</p>
                   )}
-                  <p className="text-xs text-gray-500 mt-1">{t('settings.instagramHint')}</p>
+                  <p className="text-xs text-gray-500 mt-1">{t('instagramHint')}</p>
                 </div>
               </div>
 
@@ -2343,18 +2361,18 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Hash size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.orderNumberFormat', { defaultValue: 'Number Formats' })}</h2>
+                <h2 className="font-semibold text-gray-900">{t('orderNumberFormat', { defaultValue: 'Number Formats' })}</h2>
                 {!isAdmin && (
                   <span className="ms-auto flex items-center gap-1 text-xs text-gray-400">
-                    <Lock size={12} /> {t('settings.adminOnly')}
+                    <Lock size={12} /> {t('adminOnly')}
                   </span>
                 )}
               </div>
 
-              <h3 className="text-sm font-semibold text-gray-800 mb-3">{t('settings.orderNumbers', { defaultValue: 'Order numbers' })}</h3>
+              <h3 className="text-sm font-semibold text-gray-800 mb-3">{t('orderNumbers', { defaultValue: 'Order numbers' })}</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm text-gray-500 mb-1">{t('settings.orderNumberPrefix', { defaultValue: 'Prefix' })}</label>
+                  <label className="block text-sm text-gray-500 mb-1">{t('orderNumberPrefix', { defaultValue: 'Prefix' })}</label>
                   {isAdmin ? (
                     <input
                       type="text"
@@ -2369,7 +2387,7 @@ export default function SettingsPage() {
                   )}
                 </div>
                 <div>
-                  <label className="block text-sm text-gray-500 mb-1">{t('settings.orderNumberPreview', { defaultValue: 'Preview' })}</label>
+                  <label className="block text-sm text-gray-500 mb-1">{t('orderNumberPreview', { defaultValue: 'Preview' })}</label>
                   <p className="font-mono font-medium text-gray-900 px-3 py-2 bg-gray-50 rounded-lg border border-gray-100">
                     <Ltr>{[
                       orderNumberForm.prefix,
@@ -2383,8 +2401,8 @@ export default function SettingsPage() {
               <div className="mt-5 pt-5 border-t border-gray-100 space-y-3">
                 <div className="flex items-center justify-between py-2">
                   <div>
-                    <span className="text-sm text-gray-700">{t('settings.orderNumberIncludeDate', { defaultValue: 'Include date in order number' })}</span>
-                    <p className="text-xs text-gray-500">{t('settings.orderNumberIncludeDateHint', { defaultValue: 'Adds the current date (YYYYMMDD) after the prefix.' })}</p>
+                    <span className="text-sm text-gray-700">{t('orderNumberIncludeDate', { defaultValue: 'Include date in order number' })}</span>
+                    <p className="text-xs text-gray-500">{t('orderNumberIncludeDateHint', { defaultValue: 'Adds the current date (YYYYMMDD) after the prefix.' })}</p>
                   </div>
                   <Toggle
                     value={orderNumberForm.includeDate}
@@ -2393,8 +2411,8 @@ export default function SettingsPage() {
                 </div>
                 <div className="flex items-center justify-between py-2">
                   <div>
-                    <span className="text-sm text-gray-700">{t('settings.orderNumberResetDaily', { defaultValue: 'Reset series every 24 hours' })}</span>
-                    <p className="text-xs text-gray-500">{t('settings.orderNumberResetDailyHint', { defaultValue: 'Numbering restarts from 1 at midnight in the store’s timezone.' })}</p>
+                    <span className="text-sm text-gray-700">{t('orderNumberResetDaily', { defaultValue: 'Reset series every 24 hours' })}</span>
+                    <p className="text-xs text-gray-500">{t('orderNumberResetDailyHint', { defaultValue: 'Numbering restarts from 1 at midnight in the store’s timezone.' })}</p>
                   </div>
                   <Toggle
                     value={orderNumberForm.resetDaily}
@@ -2404,10 +2422,10 @@ export default function SettingsPage() {
               </div>
 
               <div className="mt-6 pt-5 border-t border-gray-100">
-                <h3 className="text-sm font-semibold text-gray-800 mb-3">{t('settings.invoiceNumbers', { defaultValue: 'Invoice numbers' })}</h3>
+                <h3 className="text-sm font-semibold text-gray-800 mb-3">{t('invoiceNumbers', { defaultValue: 'Invoice numbers' })}</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <label className="block text-sm text-gray-500 mb-1">{t('settings.invoiceNumberPrefix', { defaultValue: 'Prefix' })}</label>
+                    <label className="block text-sm text-gray-500 mb-1">{t('invoiceNumberPrefix', { defaultValue: 'Prefix' })}</label>
                     {isAdmin ? (
                       <input
                         type="text"
@@ -2422,7 +2440,7 @@ export default function SettingsPage() {
                     )}
                   </div>
                   <div>
-                    <label className="block text-sm text-gray-500 mb-1">{t('settings.invoiceNumberPreview', { defaultValue: 'Preview' })}</label>
+                    <label className="block text-sm text-gray-500 mb-1">{t('invoiceNumberPreview', { defaultValue: 'Preview' })}</label>
                     <p className="font-mono font-medium text-gray-900 px-3 py-2 bg-gray-50 rounded-lg border border-gray-100">
                       <Ltr>{[
                         orderNumberForm.invoicePrefix,
@@ -2436,17 +2454,17 @@ export default function SettingsPage() {
                     </p>
                   </div>
                   <div>
-                    <label className="block text-sm text-gray-500 mb-1">{t('settings.invoiceResetPeriod', { defaultValue: 'Reset series' })}</label>
+                    <label className="block text-sm text-gray-500 mb-1">{t('invoiceResetPeriod', { defaultValue: 'Reset series' })}</label>
                     {isAdmin ? (
                       <select
                         value={orderNumberForm.invoiceResetPeriod}
                         onChange={(e) => setOrderNumberForm((p) => ({ ...p, invoiceResetPeriod: e.target.value as InvoiceResetPeriod }))}
                         className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand bg-white"
                       >
-                        <option value="daily">{t('settings.invoiceResetDaily', { defaultValue: 'Daily' })}</option>
-                        <option value="monthly">{t('settings.invoiceResetMonthly', { defaultValue: 'Monthly' })}</option>
-                        <option value="financial_year">{t('settings.invoiceResetFinancialYear', { defaultValue: 'Financial year' })}</option>
-                        <option value="never">{t('settings.invoiceResetNever', { defaultValue: 'Never' })}</option>
+                        <option value="daily">{t('invoiceResetDaily', { defaultValue: 'Daily' })}</option>
+                        <option value="monthly">{t('invoiceResetMonthly', { defaultValue: 'Monthly' })}</option>
+                        <option value="financial_year">{t('invoiceResetFinancialYear', { defaultValue: 'Financial year' })}</option>
+                        <option value="never">{t('invoiceResetNever', { defaultValue: 'Never' })}</option>
                       </select>
                     ) : (
                       <p className="font-medium text-gray-900">{orderNumberForm.invoiceResetPeriod.replace('_', ' ')}</p>
@@ -2455,7 +2473,7 @@ export default function SettingsPage() {
                   {orderNumberForm.invoiceResetPeriod === 'financial_year' && (
                     <div className="grid grid-cols-2 gap-3">
                       <div>
-                        <label className="block text-sm text-gray-500 mb-1">{t('settings.financialYearStartMonth', { defaultValue: 'FY start month' })}</label>
+                        <label className="block text-sm text-gray-500 mb-1">{t('financialYearStartMonth', { defaultValue: 'FY start month' })}</label>
                         <input
                           type="number"
                           min={1}
@@ -2467,7 +2485,7 @@ export default function SettingsPage() {
                         />
                       </div>
                       <div>
-                        <label className="block text-sm text-gray-500 mb-1">{t('settings.financialYearStartDay', { defaultValue: 'FY start day' })}</label>
+                        <label className="block text-sm text-gray-500 mb-1">{t('financialYearStartDay', { defaultValue: 'FY start day' })}</label>
                         <input
                           type="number"
                           min={1}
@@ -2485,8 +2503,8 @@ export default function SettingsPage() {
                 <div className="mt-5 pt-5 border-t border-gray-100">
                   <div className="flex items-center justify-between py-2">
                     <div>
-                      <span className="text-sm text-gray-700">{t('settings.invoiceNumberIncludePeriod', { defaultValue: 'Include period in invoice number' })}</span>
-                      <p className="text-xs text-gray-500">{t('settings.invoiceNumberIncludePeriodHint', { defaultValue: 'Adds the date, month, or financial year after the prefix.' })}</p>
+                      <span className="text-sm text-gray-700">{t('invoiceNumberIncludePeriod', { defaultValue: 'Include period in invoice number' })}</span>
+                      <p className="text-xs text-gray-500">{t('invoiceNumberIncludePeriodHint', { defaultValue: 'Adds the date, month, or financial year after the prefix.' })}</p>
                     </div>
                     <Toggle
                       value={orderNumberForm.invoiceIncludePeriod}
@@ -2502,36 +2520,35 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <CreditCard size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.subscription')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('subscription')}</h2>
               </div>
               <div className="space-y-3">
                 <div>
-                  <p className="text-sm text-gray-500">{t('settings.plan')}</p>
+                  <p className="text-sm text-gray-500">{t('plan')}</p>
                   <p className="font-medium text-gray-900 capitalize">{currentTenant?.plan}</p>
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500">{t('settings.status')}</p>
+                  <p className="text-sm text-gray-500">{t('status')}</p>
                   <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${
                     currentTenant?.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
                   }`}>
-                    {t(TENANT_STATUS_LABEL_KEYS[currentTenant?.status ?? ''] ?? currentTenant?.status ?? '')}
+                    {tenantStatusLabel(currentTenant?.status, tCommon)}
                   </span>
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500 mb-1">{t('settings.languages')}</p>
+                  <p className="text-sm text-gray-500 mb-1">{t('languages')}</p>
                   <select
                     value={language}
                     onChange={(e) => {
                       const lang = e.target.value as Language;
                       setLanguage(lang);
-                      api.put('/settings/business', { language: lang }).catch(() => toast.error(t('settings.saveFailed')));
+                      api.put('/settings/business', { language: lang }).catch(() => toast.error(t('saveFailed')));
                     }}
                     className="block w-full rounded-md border-gray-200 shadow-sm focus:border-brand focus:ring-brand sm:text-sm px-3 py-2 border"
                   >
-                    <option value="en">{t('settings.languageEn')}</option>
-                    <option value="es">{t('settings.languageEs')}</option>
-                    <option value="pt">{t('settings.languagePt')}</option>
-                    <option value="fa">{t('settings.languageFa')}</option>
+                    {SELECTABLE_LANGUAGES.map((lang) => (
+                      <option key={lang} value={lang}>{LANGUAGES[lang].nativeName}</option>
+                    ))}
                   </select>
                 </div>
               </div>
@@ -2557,16 +2574,16 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Monitor size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.posDisplay')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('posDisplay')}</h2>
               </div>
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1 min-w-0">
-                  <p className="font-medium text-gray-900">{t('settings.showProductImages')}</p>
-                  <p className="text-sm text-gray-500">{t('settings.showProductImagesHint')}</p>
+                  <p className="font-medium text-gray-900">{t('showProductImages')}</p>
+                  <p className="text-sm text-gray-500">{t('showProductImagesHint')}</p>
                 </div>
                 <Toggle value={posSettings.showProductImages} onChange={(v) => {
                   posSettings.setShowProductImages(v);
-                  toast.success(v ? t('settings.productImagesEnabled', { defaultValue: 'Product images enabled' }) : t('settings.productImagesDisabled', { defaultValue: 'Product images disabled' }), { id: 'pos-local' });
+                  toast.success(v ? t('productImagesEnabled', { defaultValue: 'Product images enabled' }) : t('productImagesDisabled', { defaultValue: 'Product images disabled' }), { id: 'pos-local' });
                 }} />
               </div>
             </div>
@@ -2575,28 +2592,28 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Users size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.posWorkflow')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('posWorkflow')}</h2>
               </div>
               <div className="space-y-4">
                 <div className="flex items-center justify-between gap-4">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900">{t('settings.customerMandatory')}</p>
-                    <p className="text-sm text-gray-500">{t('settings.customerMandatoryHint')}</p>
+                    <p className="font-medium text-gray-900">{t('customerMandatory')}</p>
+                    <p className="text-sm text-gray-500">{t('customerMandatoryHint')}</p>
                   </div>
                   <Toggle value={posSettings.customerMandatory} onChange={(v) => {
                     posSettings.setCustomerMandatory(v);
-                    toast.success(v ? t('settings.customerMandatoryEnabled', { defaultValue: 'Mandatory customer enabled' }) : t('settings.customerMandatoryDisabled', { defaultValue: 'Mandatory customer disabled' }), { id: 'pos-local' });
+                    toast.success(v ? t('customerMandatoryEnabled', { defaultValue: 'Mandatory customer enabled' }) : t('customerMandatoryDisabled', { defaultValue: 'Mandatory customer disabled' }), { id: 'pos-local' });
                   }} />
                 </div>
-                <p className="text-sm text-gray-500">{t('settings.phoneDigitsDerived')}</p>
+                <p className="text-sm text-gray-500">{t('phoneDigitsDerived')}</p>
                 <div className="flex items-center justify-between gap-4 pt-2 border-t border-gray-100">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900">{t('settings.enforcePhoneLength', { defaultValue: 'Enforce Phone Number Length' })}</p>
-                    <p className="text-sm text-gray-500">{t('settings.enforcePhoneLengthHint', { defaultValue: 'Automatically jump to the Name field once a valid phone number for your country has been typed — e.g. 10 digits for India.' })}</p>
+                    <p className="font-medium text-gray-900">{t('enforcePhoneLength', { defaultValue: 'Enforce Phone Number Length' })}</p>
+                    <p className="text-sm text-gray-500">{t('enforcePhoneLengthHint', { defaultValue: 'Automatically jump to the Name field once a valid phone number for your country has been typed — e.g. 10 digits for India.' })}</p>
                   </div>
                   <Toggle value={posSettings.enforcePhoneLength} onChange={(v) => {
                     posSettings.setEnforcePhoneLength(v);
-                    toast.success(v ? t('settings.enforcePhoneLengthEnabled', { defaultValue: 'Phone length enforcement enabled' }) : t('settings.enforcePhoneLengthDisabled', { defaultValue: 'Phone length enforcement disabled' }), { id: 'pos-local' });
+                    toast.success(v ? t('enforcePhoneLengthEnabled', { defaultValue: 'Phone length enforcement enabled' }) : t('enforcePhoneLengthDisabled', { defaultValue: 'Phone length enforcement disabled' }), { id: 'pos-local' });
                   }} />
                 </div>
               </div>
@@ -2606,10 +2623,10 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Smartphone size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.posPairing')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('posPairing')}</h2>
               </div>
               <p className="text-sm text-gray-500 mb-5">
-                {t('settings.posPairingHint')}
+                {t('posPairingHint')}
               </p>
 
               {posInfoLoading && (
@@ -2626,7 +2643,7 @@ export default function SettingsPage() {
                         {posInfo.ips_data.map((ipInfo: { ip: string; url: string; qr_data: string | null }, idx: number) => (
                           <div key={idx} className="flex flex-col items-center p-4 bg-gray-50 border border-gray-200 rounded-lg">
                             <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
-                              {ipInfo.ip.startsWith('100.') ? t('settings.vpnMeshNetwork') : t('settings.localNetwork')}
+                              {ipInfo.ip.startsWith('100.') ? t('vpnMeshNetwork') : t('localNetwork')}
                             </p>
                             {ipInfo.qr_data ? (
                               <img src={ipInfo.qr_data} alt={`QR Code for ${ipInfo.ip}`} className="w-40 h-40 rounded-lg mb-3 bg-white p-2 border border-gray-100" />
@@ -2644,12 +2661,12 @@ export default function SettingsPage() {
                       <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
                         <div className="flex items-start gap-3">
                           <div className="flex-1">
-                            <p className="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-1">{t('settings.appleDevices')}</p>
+                            <p className="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-1">{t('appleDevices')}</p>
                             <Ltr as="a" href={posInfo.mdns_url} target="_blank" rel="noopener noreferrer" className="block font-mono text-sm text-blue-600 break-all hover:underline">
                               {posInfo.mdns_url}
                             </Ltr>
                             <p className="text-xs text-blue-600 mt-2">
-                              {t('settings.appleDevicesHint')}
+                              {t('appleDevicesHint')}
                             </p>
                           </div>
                         </div>
@@ -2659,7 +2676,7 @@ export default function SettingsPage() {
                     <div className="flex flex-col sm:flex-row gap-6 items-start">
                       <div className="shrink-0">
                         {posInfo.qr_data_url ? (
-                          <img src={posInfo.qr_data_url} alt={t('settings.posQrAlt')} className="w-48 h-48 rounded-xl border border-gray-200" />
+                          <img src={posInfo.qr_data_url} alt={t('posQrAlt')} className="w-48 h-48 rounded-xl border border-gray-200" />
                         ) : (
                           <div className="w-48 h-48 rounded-xl border border-gray-200 flex items-center justify-center text-gray-400">
                             <QrCode size={48} />
@@ -2668,13 +2685,13 @@ export default function SettingsPage() {
                       </div>
                       <div className="flex-1 space-y-4">
                         <div>
-                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('settings.directIp')}</p>
+                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('directIp')}</p>
                           <Ltr as="a" href={posInfo.ip_url} target="_blank" rel="noopener noreferrer" className="block font-mono text-sm text-brand break-all hover:underline">
                             {posInfo.ip_url}
                           </Ltr>
                         </div>
                         <div>
-                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('settings.mdnsAlwaysStable')}</p>
+                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('mdnsAlwaysStable')}</p>
                           <Ltr as="a" href={posInfo.mdns_url} target="_blank" rel="noopener noreferrer" className="block font-mono text-sm text-gray-700 break-all hover:underline">
                             {posInfo.mdns_url}
                           </Ltr>
@@ -2687,7 +2704,7 @@ export default function SettingsPage() {
                     <button onClick={fetchPosInfo} disabled={posInfoLoading}
                       className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-800">
                       <RefreshCw size={14} className={posInfoLoading ? 'animate-spin' : ''} />
-                      {t('settings.refreshUrls')}
+                      {t('refreshUrls')}
                     </button>
                   </div>
                 </div>
@@ -2696,11 +2713,11 @@ export default function SettingsPage() {
               {!posInfo && !posInfoLoading && (
                 <>
                   <p className="text-sm text-gray-500 mb-3">
-                    {t('settings.posLoadHint')}
+                    {t('posLoadHint')}
                   </p>
                   <button onClick={fetchPosInfo}
                     className="px-4 py-2 text-sm bg-brand text-white rounded-lg hover:opacity-90 font-medium">
-                    {t('settings.loadPosInfo')}
+                    {t('loadPosInfo')}
                   </button>
                 </>
               )}
@@ -2715,8 +2732,8 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1 min-w-0">
-                  <p className="font-medium text-gray-900">{t('settings.kdsEnabledToggle', { defaultValue: 'Kitchen Display System' })}</p>
-                  <p className="text-sm text-gray-500">{t('settings.kdsEnabledToggleHint', { defaultValue: 'Show the Kitchen Display and allow devices to pair over your network. Turn this off if this business doesn’t use a KDS.' })}</p>
+                  <p className="font-medium text-gray-900">{t('kdsEnabledToggle', { defaultValue: 'Kitchen Display System' })}</p>
+                  <p className="text-sm text-gray-500">{t('kdsEnabledToggleHint', { defaultValue: 'Show the Kitchen Display and allow devices to pair over your network. Turn this off if this business doesn’t use a KDS.' })}</p>
                 </div>
                 <Toggle value={kdsEnabledSetting} onChange={(v) => { if (!savingKdsEnabled) saveKdsEnabled(v); }} />
               </div>
@@ -2724,7 +2741,7 @@ export default function SettingsPage() {
                 <div className="mt-4 flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg">
                   <AlertTriangle size={16} className="text-amber-600 shrink-0 mt-0.5" />
                   <p className="text-xs text-amber-800">
-                    {t('settings.kitchenWorkflowBothOffNote', { defaultValue: 'Both the Kitchen Display and KOT printing are off. Kitchen items won’t display or print anywhere — orders will need to be marked served directly at the counter.' })}
+                    {t('kitchenWorkflowBothOffNote', { defaultValue: 'Both the Kitchen Display and KOT printing are off. Kitchen items won’t display or print anywhere — orders will need to be marked served directly at the counter.' })}
                   </p>
                 </div>
               )}
@@ -2732,7 +2749,7 @@ export default function SettingsPage() {
 
             {!kdsEnabledSetting && (
               <p className="text-sm text-gray-400 italic">
-                {t('settings.kdsPairingHiddenHint', { defaultValue: 'Pairing is hidden while the Kitchen Display System is disabled.' })}
+                {t('kdsPairingHiddenHint', { defaultValue: 'Pairing is hidden while the Kitchen Display System is disabled.' })}
               </p>
             )}
 
@@ -2740,10 +2757,10 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <ChefHat size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.kds')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('kds')}</h2>
               </div>
               <p className="text-sm text-gray-500 mb-5">
-                {t('settings.kdsPairingHint')}
+                {t('kdsPairingHint')}
               </p>
 
               {kdsInfoLoading && (
@@ -2760,7 +2777,7 @@ export default function SettingsPage() {
                         {kdsInfo.ips_data.map((ipInfo: { ip: string; url: string; qr_data: string | null }, idx: number) => (
                           <div key={idx} className="flex flex-col items-center p-4 bg-gray-50 border border-gray-200 rounded-lg">
                             <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
-                              {ipInfo.ip.startsWith('100.') ? t('settings.vpnMeshNetwork') : t('settings.localNetwork')}
+                              {ipInfo.ip.startsWith('100.') ? t('vpnMeshNetwork') : t('localNetwork')}
                             </p>
                             {ipInfo.qr_data ? (
                               <img src={ipInfo.qr_data} alt={`QR Code for ${ipInfo.ip}`} className="w-40 h-40 rounded-lg mb-3 bg-white p-2 border border-gray-100" />
@@ -2778,12 +2795,12 @@ export default function SettingsPage() {
                       <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
                         <div className="flex items-start gap-3">
                           <div className="flex-1">
-                            <p className="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-1">{t('settings.appleDevices')}</p>
+                            <p className="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-1">{t('appleDevices')}</p>
                             <Ltr as="a" href={kdsInfo.mdns_url} target="_blank" rel="noopener noreferrer" className="block font-mono text-sm text-blue-600 break-all hover:underline">
                               {kdsInfo.mdns_url}
                             </Ltr>
                             <p className="text-xs text-blue-600 mt-2">
-                              {t('settings.appleDevicesHint')}
+                              {t('appleDevicesHint')}
                             </p>
                           </div>
                         </div>
@@ -2793,7 +2810,7 @@ export default function SettingsPage() {
                     <div className="flex flex-col sm:flex-row gap-6 items-start">
                       <div className="shrink-0">
                         {kdsInfo.qr_data_url ? (
-                          <img src={kdsInfo.qr_data_url} alt={t('settings.kdsQrAlt')} className="w-48 h-48 rounded-xl border border-gray-200" />
+                          <img src={kdsInfo.qr_data_url} alt={t('kdsQrAlt')} className="w-48 h-48 rounded-xl border border-gray-200" />
                         ) : (
                           <div className="w-48 h-48 rounded-xl border border-gray-200 flex items-center justify-center text-gray-400">
                             <QrCode size={48} />
@@ -2802,13 +2819,13 @@ export default function SettingsPage() {
                       </div>
                       <div className="flex-1 space-y-4">
                         <div>
-                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('settings.directIp')}</p>
+                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('directIp')}</p>
                           <Ltr as="a" href={kdsInfo.ip_url} target="_blank" rel="noopener noreferrer" className="block font-mono text-sm text-brand break-all hover:underline">
                             {kdsInfo.ip_url}
                           </Ltr>
                         </div>
                         <div>
-                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('settings.mdnsAlwaysStable')}</p>
+                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('mdnsAlwaysStable')}</p>
                           <Ltr as="a" href={kdsInfo.mdns_url} target="_blank" rel="noopener noreferrer" className="block font-mono text-sm text-gray-700 break-all hover:underline">
                             {kdsInfo.mdns_url}
                           </Ltr>
@@ -2821,7 +2838,7 @@ export default function SettingsPage() {
                     <button onClick={fetchKdsInfo} disabled={kdsInfoLoading}
                       className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-800">
                       <RefreshCw size={14} className={kdsInfoLoading ? 'animate-spin' : ''} />
-                      {t('settings.refreshUrls')}
+                      {t('refreshUrls')}
                     </button>
                   </div>
                 </div>
@@ -2830,11 +2847,11 @@ export default function SettingsPage() {
               {!kdsInfo && !kdsInfoLoading && (
                 <>
                   <p className="text-sm text-gray-500 mb-3">
-                    {t('settings.kdsLoadHint', { defaultValue: 'Load connection details to pair kitchen display devices on your local network.' })}
+                    {t('kdsLoadHint', { defaultValue: 'Load connection details to pair kitchen display devices on your local network.' })}
                   </p>
                   <button onClick={fetchKdsInfo}
                     className="px-4 py-2 text-sm bg-brand text-white rounded-lg hover:opacity-90 font-medium">
-                    {t('settings.loadKdsInfo')}
+                    {t('loadKdsInfo')}
                   </button>
                 </>
               )}
@@ -2845,18 +2862,18 @@ export default function SettingsPage() {
               <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center gap-2">
                   <ChefHat size={20} className="text-gray-500" />
-                  <h2 className="font-semibold text-gray-900">{t('settings.kitchenStations')}</h2>
+                  <h2 className="font-semibold text-gray-900">{t('kitchenStations')}</h2>
                 </div>
                 <button onClick={openAddStation}
                   className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-brand text-white rounded-lg hover:opacity-90 font-medium">
                   <Plus size={14} />
-                  {t('settings.addStation')}
+                  {t('addStation')}
                 </button>
               </div>
-              <p className="text-sm text-gray-500 mb-5">{t('settings.kitchenStationsHint')}</p>
+              <p className="text-sm text-gray-500 mb-5">{t('kitchenStationsHint')}</p>
 
               {stations.length === 0 ? (
-                <p className="text-sm text-gray-400 py-4 text-center">{t('settings.noStationsYet')}</p>
+                <p className="text-sm text-gray-400 py-4 text-center">{t('noStationsYet')}</p>
               ) : (
                 <div className="space-y-2">
                   {stations.map((station) => {
@@ -2872,16 +2889,16 @@ export default function SettingsPage() {
                         <div className="min-w-0">
                           <p className="font-medium text-gray-900">{station.name}</p>
                           <p className="text-xs text-gray-500 mt-0.5">
-                            {categoryNames.length > 0 ? categoryNames.join(', ') : t('settings.stationNoCategories')}
+                            {categoryNames.length > 0 ? categoryNames.join(', ') : t('stationNoCategories')}
                             {' · '}
-                            {printer ? printer.name : t('settings.stationNoPrinter')}
+                            {printer ? printer.name : t('stationNoPrinter')}
                             {users.length > 0 && ` · ${users.map((u) => u.name).join(', ')}`}
                           </p>
                         </div>
                         <div className="flex items-center gap-1 shrink-0">
                           <button onClick={() => openEditStation(station)}
                             className="px-2 py-1 text-xs text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded">
-                            {t('common.edit')}
+                            {tCommon('edit')}
                           </button>
                           <button onClick={() => deleteStation(station.id)}
                             className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded">
@@ -2898,22 +2915,22 @@ export default function SettingsPage() {
                 <Dialog open={showStationForm} onOpenChange={setShowStationForm}>
                   <DialogContent>
                     <DialogHeader>
-                      <DialogTitle>{editingStationId ? t('settings.editStation') : t('settings.addStation')}</DialogTitle>
-                      <DialogDescription>{t('settings.stationFormHint')}</DialogDescription>
+                      <DialogTitle>{editingStationId ? t('editStation') : t('addStation')}</DialogTitle>
+                      <DialogDescription>{t('stationFormHint')}</DialogDescription>
                     </DialogHeader>
                     <div className="space-y-4 py-2">
                       <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">{t('settings.stationName')}</label>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">{t('stationName')}</label>
                         <input type="text" value={stationForm.name}
                           onChange={(e) => setStationForm((f) => ({ ...f, name: e.target.value }))}
-                          placeholder={t('settings.stationNamePlaceholder')}
+                          placeholder={t('stationNamePlaceholder')}
                           className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm" />
                       </div>
 
                       <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">{t('settings.stationCategories')}</label>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">{t('stationCategories')}</label>
                         {stationCategories.length === 0 ? (
-                          <p className="text-xs text-gray-400">{t('settings.noCategoriesYet')}</p>
+                          <p className="text-xs text-gray-400">{t('noCategoriesYet')}</p>
                         ) : (
                           <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto">
                             {stationCategories.map((cat) => (
@@ -2929,11 +2946,11 @@ export default function SettingsPage() {
                       </div>
 
                       <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">{t('settings.stationPrinter')}</label>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">{t('stationPrinter')}</label>
                         <select value={stationForm.printer_id}
                           onChange={(e) => setStationForm((f) => ({ ...f, printer_id: e.target.value }))}
                           className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white">
-                          <option value="">{t('settings.stationUseDefaultPrinter')}</option>
+                          <option value="">{t('stationUseDefaultPrinter')}</option>
                           {hwPrinters.map((p) => (
                             <option key={p.id} value={p.id}>{p.name}</option>
                           ))}
@@ -2941,9 +2958,9 @@ export default function SettingsPage() {
                       </div>
 
                       <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">{t('settings.stationStaff')}</label>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">{t('stationStaff')}</label>
                         {stationStaff.length === 0 ? (
-                          <p className="text-xs text-gray-400">{t('settings.noStaffYet')}</p>
+                          <p className="text-xs text-gray-400">{t('noStaffYet')}</p>
                         ) : (
                           <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto">
                             {stationStaff.map((u) => (
@@ -2959,9 +2976,9 @@ export default function SettingsPage() {
                       </div>
                     </div>
                     <DialogFooter>
-                      <Button variant="outline" onClick={() => setShowStationForm(false)}>{t('common.cancel')}</Button>
+                      <Button variant="outline" onClick={() => setShowStationForm(false)}>{tCommon('cancel')}</Button>
                       <Button onClick={saveStation} disabled={savingStation}>
-                        {savingStation ? t('common.saving') : t('common.save')}
+                        {savingStation ? tCommon('saving') : tCommon('save')}
                       </Button>
                     </DialogFooter>
                   </DialogContent>
@@ -2972,7 +2989,7 @@ export default function SettingsPage() {
             <KdsDefaultViewCard />
 
             <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 text-sm text-blue-800">
-              <strong>{t('settings.howItWorks')}</strong> {t('settings.howItWorksBody')}
+              <strong>{t('howItWorks')}</strong> {t('howItWorksBody')}
             </div>
           </div>
         </TabsContent>
@@ -2982,9 +2999,9 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1 min-w-0">
-                  <p className="font-medium text-gray-900">{t('settings.serverApp', { defaultValue: 'Server App' })}</p>
+                  <p className="font-medium text-gray-900">{t('serverApp', { defaultValue: 'Server App' })}</p>
                   <p className="text-sm text-gray-500">
-                    {t('settings.serverAppEnabledHint', { defaultValue: 'Let service staff open a mobile/tablet-friendly order pad for tableside ordering.' })}
+                    {t('serverAppEnabledHint', { defaultValue: 'Let service staff open a mobile/tablet-friendly order pad for tableside ordering.' })}
                   </p>
                 </div>
                 <Toggle value={serverAppEnabledSetting} onChange={(v) => { if (!savingServerAppEnabled) saveServerAppEnabled(v); }} />
@@ -2993,7 +3010,7 @@ export default function SettingsPage() {
 
             {!serverAppEnabledSetting && (
               <p className="text-sm text-gray-400 italic">
-                {t('settings.serverAppPairingHiddenHint', { defaultValue: 'Pairing is hidden while the Server App is disabled.' })}
+                {t('serverAppPairingHiddenHint', { defaultValue: 'Pairing is hidden while the Server App is disabled.' })}
               </p>
             )}
 
@@ -3001,10 +3018,10 @@ export default function SettingsPage() {
               <div className="bg-white rounded-xl border border-gray-100 p-6">
                 <div className="flex items-center gap-2 mb-4">
                   <Smartphone size={20} className="text-gray-500" />
-                  <h2 className="font-semibold text-gray-900">{t('settings.tablesideOrdering', { defaultValue: 'Tableside Ordering' })}</h2>
+                  <h2 className="font-semibold text-gray-900">{t('tablesideOrdering', { defaultValue: 'Tableside Ordering' })}</h2>
                 </div>
                 <p className="text-sm text-gray-500 mb-5">
-                  {t('settings.serverAppPairingHint', { defaultValue: 'Pair servers’ phones or tablets on your local network. They can punch table orders and see compact kitchen status icons.' })}
+                  {t('serverAppPairingHint', { defaultValue: 'Pair servers’ phones or tablets on your local network. They can punch table orders and see compact kitchen status icons.' })}
                 </p>
 
                 {serverAppInfoLoading && (
@@ -3021,7 +3038,7 @@ export default function SettingsPage() {
                           {serverAppInfo.ips_data.map((ipInfo: { ip: string; url: string; qr_data: string | null }, idx: number) => (
                             <div key={idx} className="flex flex-col items-center p-4 bg-gray-50 border border-gray-200 rounded-lg">
                               <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
-                                {ipInfo.ip.startsWith('100.') ? t('settings.vpnMeshNetwork') : t('settings.localNetwork')}
+                                {ipInfo.ip.startsWith('100.') ? t('vpnMeshNetwork') : t('localNetwork')}
                               </p>
                               {ipInfo.qr_data ? (
                                 <img src={ipInfo.qr_data} alt={`QR Code for ${ipInfo.ip}`} className="w-40 h-40 rounded-lg mb-3 bg-white p-2 border border-gray-100" />
@@ -3037,18 +3054,18 @@ export default function SettingsPage() {
                           ))}
                         </div>
                         <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                          <p className="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-1">{t('settings.appleDevices')}</p>
+                          <p className="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-1">{t('appleDevices')}</p>
                           <Ltr as="a" href={serverAppInfo.mdns_url} target="_blank" rel="noopener noreferrer" className="block font-mono text-sm text-blue-600 break-all hover:underline">
                             {serverAppInfo.mdns_url}
                           </Ltr>
-                          <p className="text-xs text-blue-600 mt-2">{t('settings.appleDevicesHint')}</p>
+                          <p className="text-xs text-blue-600 mt-2">{t('appleDevicesHint')}</p>
                         </div>
                       </>
                     ) : (
                       <div className="flex flex-col sm:flex-row gap-6 items-start">
                         <div className="shrink-0">
                           {serverAppInfo.qr_data_url ? (
-                            <img src={serverAppInfo.qr_data_url} alt={t('settings.serverAppQrAlt', { defaultValue: 'Server App QR code' })} className="w-48 h-48 rounded-xl border border-gray-200" />
+                            <img src={serverAppInfo.qr_data_url} alt={t('serverAppQrAlt', { defaultValue: 'Server App QR code' })} className="w-48 h-48 rounded-xl border border-gray-200" />
                           ) : (
                             <div className="w-48 h-48 rounded-xl border border-gray-200 flex items-center justify-center text-gray-400">
                               <QrCode size={48} />
@@ -3057,13 +3074,13 @@ export default function SettingsPage() {
                         </div>
                         <div className="flex-1 space-y-4">
                           <div>
-                            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('settings.directIp')}</p>
+                            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('directIp')}</p>
                             <Ltr as="a" href={serverAppInfo.ip_url} target="_blank" rel="noopener noreferrer" className="block font-mono text-sm text-brand break-all hover:underline">
                               {serverAppInfo.ip_url}
                             </Ltr>
                           </div>
                           <div>
-                            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('settings.mdnsAlwaysStable')}</p>
+                            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{t('mdnsAlwaysStable')}</p>
                             <Ltr as="a" href={serverAppInfo.mdns_url} target="_blank" rel="noopener noreferrer" className="block font-mono text-sm text-gray-700 break-all hover:underline">
                               {serverAppInfo.mdns_url}
                             </Ltr>
@@ -3076,7 +3093,7 @@ export default function SettingsPage() {
                       <button onClick={fetchServerAppInfo} disabled={serverAppInfoLoading}
                         className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-800">
                         <RefreshCw size={14} className={serverAppInfoLoading ? 'animate-spin' : ''} />
-                        {t('settings.refreshUrls')}
+                        {t('refreshUrls')}
                       </button>
                     </div>
                   </div>
@@ -3085,11 +3102,11 @@ export default function SettingsPage() {
                 {!serverAppInfo && !serverAppInfoLoading && (
                   <>
                     <p className="text-sm text-gray-500 mb-3">
-                      {t('settings.serverAppLoadHint', { defaultValue: 'Load connection details to pair tableside ordering devices on your local network.' })}
+                      {t('serverAppLoadHint', { defaultValue: 'Load connection details to pair tableside ordering devices on your local network.' })}
                     </p>
                     <button onClick={fetchServerAppInfo}
                       className="px-4 py-2 text-sm bg-brand text-white rounded-lg hover:opacity-90 font-medium">
-                      {t('settings.loadServerAppInfo', { defaultValue: 'Load Server App Info' })}
+                      {t('loadServerAppInfo', { defaultValue: 'Load Server App Info' })}
                     </button>
                   </>
                 )}
@@ -3104,14 +3121,14 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Gift size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.loyaltyProgram')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('loyaltyProgram')}</h2>
               </div>
               <div className="space-y-5">
                 {/* Enable toggle */}
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium text-gray-900">{t('settings.enableLoyalty')}</p>
-                    <p className="text-sm text-gray-500">{t('settings.loyaltyHint')}</p>
+                    <p className="font-medium text-gray-900">{t('enableLoyalty')}</p>
+                    <p className="text-sm text-gray-500">{t('loyaltyHint')}</p>
                   </div>
                   <button
                     onClick={() => setLoyaltyEnabled(!loyaltyEnabled)}
@@ -3128,8 +3145,8 @@ export default function SettingsPage() {
                 {loyaltyEnabled && (
                   <div className="pt-4 border-t border-gray-100 flex items-center justify-between">
                     <div>
-                      <p className="font-medium text-gray-900">{t('settings.globalLoyaltyRate')}</p>
-                      <p className="text-sm text-gray-500">{t('settings.globalLoyaltyRateHint')}</p>
+                      <p className="font-medium text-gray-900">{t('globalLoyaltyRate')}</p>
+                      <p className="text-sm text-gray-500">{t('globalLoyaltyRateHint')}</p>
                     </div>
                     <div className="flex items-center gap-2">
                       <input
@@ -3151,9 +3168,9 @@ export default function SettingsPage() {
                     until the owner explicitly opts them in. */}
                 {loyaltyEnabled && globalRateCandidates > 0 && (
                   <div className="pt-4 border-t border-gray-100">
-                    <p className="font-medium text-gray-900">{t('settings.applyGlobalRateTitle')}</p>
+                    <p className="font-medium text-gray-900">{t('applyGlobalRateTitle')}</p>
                     <p className="text-sm text-gray-500 mt-1">
-                      {t('settings.applyGlobalRateHint', { count: globalRateCandidates })}
+                      {t('applyGlobalRateHint', { count: globalRateCandidates })}
                     </p>
                     <button
                       type="button"
@@ -3162,8 +3179,8 @@ export default function SettingsPage() {
                       className="mt-3 px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 hover:bg-gray-50 disabled:opacity-50"
                     >
                       {applyingGlobalRate
-                        ? t('settings.applyGlobalRateWorking')
-                        : t('settings.applyGlobalRateAction', { count: globalRateCandidates })}
+                        ? t('applyGlobalRateWorking')
+                        : t('applyGlobalRateAction', { count: globalRateCandidates })}
                     </button>
                   </div>
                 )}
@@ -3178,52 +3195,52 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Percent size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.discountLimits')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('discountLimits')}</h2>
               </div>
               <div className="space-y-5">
                 {/* Discount mode */}
                 <div>
-                  <p className="font-medium text-gray-900">{t('settings.discountMode')}</p>
-                  <p className="text-sm text-gray-500 mb-2">{t('settings.discountModeHint')}</p>
+                  <p className="font-medium text-gray-900">{t('discountMode')}</p>
+                  <p className="text-sm text-gray-500 mb-2">{t('discountModeHint')}</p>
                   <select value={discountMode}
                     onChange={(e) => setDiscountMode(e.target.value)}
                     className="w-48 px-3 py-1.5 text-sm border border-gray-200 rounded-lg outline-none focus:ring-1 focus:ring-brand bg-white">
-                    <option value="both">{t('settings.discountBoth')}</option>
-                    <option value="percentage">{t('settings.discountPercentageOnly')}</option>
-                    <option value="flat">{t('settings.discountFlatOnly')}</option>
+                    <option value="both">{t('discountBoth')}</option>
+                    <option value="percentage">{t('discountPercentageOnly')}</option>
+                    <option value="flat">{t('discountFlatOnly')}</option>
                   </select>
                 </div>
 
                 {(discountMode === 'percentage' || discountMode === 'both') && (
                   <div>
-                    <p className="font-medium text-gray-900">{t('settings.maxDiscountPercentage')}</p>
-                    <p className="text-sm text-gray-500 mb-2">{t('settings.maxDiscountPercentageHint')}</p>
+                    <p className="font-medium text-gray-900">{t('maxDiscountPercentage')}</p>
+                    <p className="text-sm text-gray-500 mb-2">{t('maxDiscountPercentageHint')}</p>
                     <div className="flex items-center gap-3">
                       <input type="number" min={1} max={100} value={discountMaxPct}
                         onChange={(e) => setDiscountMaxPct(normalizeDiscountPercentage(e.target.value))}
                         className="w-24 px-3 py-1.5 text-sm border border-gray-200 rounded-lg outline-none focus:ring-1 focus:ring-brand" />
-                      <span className="text-sm text-gray-500">{t('settings.percentMaximum')}</span>
+                      <span className="text-sm text-gray-500">{t('percentMaximum')}</span>
                     </div>
                   </div>
                 )}
 
                 {(discountMode === 'flat' || discountMode === 'both') && (
                   <div>
-                    <p className="font-medium text-gray-900">{t('settings.maxDiscountAmount')}</p>
-                    <p className="text-sm text-gray-500 mb-2">{t('settings.maxDiscountAmountHint')}</p>
+                    <p className="font-medium text-gray-900">{t('maxDiscountAmount')}</p>
+                    <p className="text-sm text-gray-500 mb-2">{t('maxDiscountAmountHint')}</p>
                     <div className="flex items-center gap-3">
                       <input type="number" min={0} max={999999} value={discountMaxAmount}
                         onChange={(e) => setDiscountMaxAmount(normalizeDiscountAmount(e.target.value))}
                         className="w-24 px-3 py-1.5 text-sm border border-gray-200 rounded-lg outline-none focus:ring-1 focus:ring-brand" />
-                      <span className="text-sm text-gray-500">{t('settings.zeroNoLimit')}</span>
+                      <span className="text-sm text-gray-500">{t('zeroNoLimit')}</span>
                     </div>
                   </div>
                 )}
 
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium text-gray-900">{t('settings.requireApproval')}</p>
-                    <p className="text-sm text-gray-500">{t('settings.requireApprovalHint')}</p>
+                    <p className="font-medium text-gray-900">{t('requireApproval')}</p>
+                    <p className="text-sm text-gray-500">{t('requireApprovalHint')}</p>
                   </div>
                   <button
                     onClick={() => setDiscountRequiresApproval(!discountRequiresApproval)}
@@ -3246,18 +3263,18 @@ export default function SettingsPage() {
           <div className="pb-6 max-w-3xl space-y-6">
             {/* Account */}
             <div className="bg-white rounded-xl border border-gray-100 p-6">
-              <h2 className="font-semibold text-gray-900 mb-4">{t('settings.account')}</h2>
+              <h2 className="font-semibold text-gray-900 mb-4">{t('account')}</h2>
               <div className="space-y-3">
                 <div>
-                  <p className="text-sm text-gray-500">{t('settings.name')}</p>
+                  <p className="text-sm text-gray-500">{t('name')}</p>
                   <p className="font-medium text-gray-900">{user?.name}</p>
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500">{t('settings.email')}</p>
+                  <p className="text-sm text-gray-500">{t('email')}</p>
                   <p className="font-medium text-gray-900"><Ltr>{user?.email}</Ltr></p>
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500">{t('settings.role')}</p>
+                  <p className="text-sm text-gray-500">{t('role')}</p>
                   <p className="font-medium text-gray-900 capitalize">{currentTenant?.role || '—'}</p>
                 </div>
               </div>
@@ -3266,32 +3283,32 @@ export default function SettingsPage() {
               <div className={`rounded-xl border p-6 ${cloudAccountAvailable && cloudAccount?.email && !cloudAccount.verified ? 'border-red-200 bg-red-50/40' : 'border-gray-100 bg-white'}`}>
                 <div className="flex items-start justify-between gap-4">
                   <div>
-                    <h2 className="font-semibold text-gray-900">{t('settings.contactEmailTitle')}</h2>
-                    <p className="mt-1 text-sm text-gray-600">{cloudAccountLoadFailed ? t('settings.cloudAccountLoadFailed') : cloudAccountAvailable ? <Ltr>{cloudAccount?.email || user?.email || t('settings.noCloudContactEmail')}</Ltr> : t('settings.cloudAccountUnavailable')}</p>
+                    <h2 className="font-semibold text-gray-900">{t('contactEmailTitle')}</h2>
+                    <p className="mt-1 text-sm text-gray-600">{cloudAccountLoadFailed ? t('cloudAccountLoadFailed') : cloudAccountAvailable ? <Ltr>{cloudAccount?.email || user?.email || t('noCloudContactEmail')}</Ltr> : t('cloudAccountUnavailable')}</p>
                   </div>
                   <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${!cloudAccountAvailable ? 'bg-gray-100 text-gray-600' : cloudAccount?.verified ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
-                    {cloudAccountLoadFailed ? t('settings.cloudStatusUnavailable') : !cloudAccountAvailable ? t('settings.cloudUnavailableBadge') : cloudAccount?.verified ? t('settings.cloudVerified') : t('settings.cloudPendingVerification')}
+                    {cloudAccountLoadFailed ? t('cloudStatusUnavailable') : !cloudAccountAvailable ? t('cloudUnavailableBadge') : cloudAccount?.verified ? t('cloudVerified') : t('cloudPendingVerification')}
                   </span>
                 </div>
-                <p className="mt-3 text-sm text-gray-600">{cloudAccountLoadFailed ? t('settings.cloudAccountLoadError') : cloudAccountAvailable ? t('settings.cloudVerificationHint') : cloudDeletionPending ? t('settings.cloudDeletionPendingHint') : cloudDeletionStatus === 'processing' ? t('settings.cloudDeletionProcessingHint') : cloudDeletionStatus === 'failed' || cloudStatus.cloud_deletion_status === 'failed' ? t('settings.cloudDeletionFailedHint') : t('settings.cloudEnableHintAccount')}</p>
+                <p className="mt-3 text-sm text-gray-600">{cloudAccountLoadFailed ? t('cloudAccountLoadError') : cloudAccountAvailable ? t('cloudVerificationHint') : cloudDeletionPending ? t('cloudDeletionPendingHint') : cloudDeletionStatus === 'processing' ? t('cloudDeletionProcessingHint') : cloudDeletionStatus === 'failed' || cloudStatus.cloud_deletion_status === 'failed' ? t('cloudDeletionFailedHint') : t('cloudEnableHintAccount')}</p>
                 {cloudAccountLoadFailed && (
-                  <Button variant="outline" className="mt-4" onClick={() => void fetchCloudAccount()}>{t('settings.retry')}</Button>
+                  <Button variant="outline" className="mt-4" onClick={() => void fetchCloudAccount()}>{t('retry')}</Button>
                 )}
                 {cloudAccountAvailable && !cloudAccount?.verified && (
                   <Button className="mt-4" disabled={cloudAccountBusy} onClick={async () => {
                     setCloudAccountBusy(true);
-                    try { await api.post('/settings/cloud/account/verification'); toast.success(t('settings.verificationEmailQueued')); await fetchCloudAccount(); }
+                    try { await api.post('/settings/cloud/account/verification'); toast.success(t('verificationEmailQueued')); await fetchCloudAccount(); }
                     catch {
-                      toast.error(t('settings.verificationEmailFailed'));
+                      toast.error(t('verificationEmailFailed'));
                     }
                     finally { setCloudAccountBusy(false); }
-                  }}>{cloudAccountBusy ? t('settings.cloudSendingVerification') : t('settings.cloudSendVerificationEmail')}</Button>
+                  }}>{cloudAccountBusy ? t('cloudSendingVerification') : t('cloudSendVerificationEmail')}</Button>
                 )}
                 {cloudAccountAvailable && (
                   <div className="mt-5 space-y-3 border-t border-gray-200 pt-4">
-                    <label className="flex items-center justify-between gap-4 text-sm"><span>{t('settings.cloudPrefProductUpdates')}</span><Toggle value={Boolean(cloudAccount?.product_updates)} onChange={async (value) => { setCloudAccountBusy(true); try { const { data } = await api.put('/settings/cloud/account/preferences', { product_updates: value }); setCloudAccount(data); } catch { toast.error(t('settings.couldNotSavePreference')); } finally { setCloudAccountBusy(false); } }} /></label>
-                    <label className="flex items-center justify-between gap-4 text-sm"><span>{t('settings.cloudPrefMarketing')}</span><Toggle value={Boolean(cloudAccount?.marketing)} onChange={async (value) => { setCloudAccountBusy(true); try { const { data } = await api.put('/settings/cloud/account/preferences', { marketing: value }); setCloudAccount(data); } catch { toast.error(t('settings.couldNotSavePreference')); } finally { setCloudAccountBusy(false); } }} /></label>
-                    <p className="text-xs text-gray-500">{t('settings.cloudPrefNote')}</p>
+                    <label className="flex items-center justify-between gap-4 text-sm"><span>{t('cloudPrefProductUpdates')}</span><Toggle value={Boolean(cloudAccount?.product_updates)} onChange={async (value) => { setCloudAccountBusy(true); try { const { data } = await api.put('/settings/cloud/account/preferences', { product_updates: value }); setCloudAccount(data); } catch { toast.error(t('couldNotSavePreference')); } finally { setCloudAccountBusy(false); } }} /></label>
+                    <label className="flex items-center justify-between gap-4 text-sm"><span>{t('cloudPrefMarketing')}</span><Toggle value={Boolean(cloudAccount?.marketing)} onChange={async (value) => { setCloudAccountBusy(true); try { const { data } = await api.put('/settings/cloud/account/preferences', { marketing: value }); setCloudAccount(data); } catch { toast.error(t('couldNotSavePreference')); } finally { setCloudAccountBusy(false); } }} /></label>
+                    <p className="text-xs text-gray-500">{t('cloudPrefNote')}</p>
                   </div>
                 )}
               </div>
@@ -3306,7 +3323,7 @@ export default function SettingsPage() {
               <div className="flex items-center gap-2">
                 <Lock size={20} className="text-gray-500" />
                 <div>
-                  <h2 className="font-semibold text-gray-900">{t('settings.privacy')}</h2>
+                  <h2 className="font-semibold text-gray-900">{t('privacy')}</h2>
                 </div>
               </div>
 
@@ -3318,9 +3335,9 @@ export default function SettingsPage() {
                   onChange={(e) => saveTelemetry(e.target.checked)}
                   className="rounded border-gray-300 text-brand focus:ring-brand"
                 />
-                <span className="text-sm text-gray-700">{t('settings.anonymousTelemetry')}</span>
+                <span className="text-sm text-gray-700">{t('anonymousTelemetry')}</span>
               </label>
-              <p className="text-xs text-gray-500">{t('settings.anonymousTelemetryHint')}</p>
+              <p className="text-xs text-gray-500">{t('anonymousTelemetryHint')}</p>
 
               <div className="border-t border-gray-100 pt-4">
                 <label className="flex items-center gap-3 cursor-pointer">
@@ -3331,26 +3348,26 @@ export default function SettingsPage() {
                     onChange={(e) => saveDiagnosticsConsent(e.target.checked)}
                     className="rounded border-gray-300 text-brand focus:ring-brand"
                   />
-                  <span className="text-sm text-gray-700">{t('settings.storeDiagnostics')}</span>
+                  <span className="text-sm text-gray-700">{t('storeDiagnostics')}</span>
                 </label>
-                <p className="text-xs text-gray-500 mt-1">{t('settings.storeDiagnosticsHint')}</p>
+                <p className="text-xs text-gray-500 mt-1">{t('storeDiagnosticsHint')}</p>
               </div>
             </div>
 
             {currentTenant?.role === 'owner' && (
               <div className="rounded-xl border border-gray-100 bg-white p-6">
-                <h2 className="font-semibold text-gray-900">{t('settings.cloudPrivacyControls')}</h2>
-                <p className="mt-2 text-sm text-gray-600">{t('settings.cloudStopReversible')}</p>
+                <h2 className="font-semibold text-gray-900">{t('cloudPrivacyControls')}</h2>
+                <p className="mt-2 text-sm text-gray-600">{t('cloudStopReversible')}</p>
                 {cloudAccount?.deletion_request && (
                   <div className={`mt-4 rounded-lg border p-3 text-sm ${cloudAccount.deletion_request.status === 'pending' || cloudAccount.deletion_request.status === 'processing' ? 'border-amber-200 bg-amber-50 text-amber-900' : cloudAccount.deletion_request.status === 'approved' || cloudAccount.deletion_request.status === 'completed' || cloudAccount.deletion_request.status === 'deleted' ? 'border-green-200 bg-green-50 text-green-800' : cloudAccount.deletion_request.status === 'failed' ? 'border-red-200 bg-red-50 text-red-800' : 'border-gray-200 bg-gray-50 text-gray-700'}`}>
-                    <p className="font-semibold">{t('settings.cloudDeletionRequest', { status: cloudAccount.deletion_request.status || '' })}</p>
+                    <p className="font-semibold">{t('cloudDeletionRequest', { status: cloudAccount.deletion_request.status || '' })}</p>
                     {cloudAccount.deletion_request.id && <p className="mt-1 font-mono text-xs"><Ltr>{cloudAccount.deletion_request.id}</Ltr></p>}
                     {cloudAccount.deletion_request.decision_note && <p className="mt-2">{cloudAccount.deletion_request.decision_note}</p>}
                   </div>
                 )}
                 <div className="mt-4 flex flex-wrap gap-3">
                   <Button variant="outline" onClick={async () => {
-                    if (!await confirm(t('settings.cloudStopAllConfirm'))) return;
+                    if (!await confirm(t('cloudStopAllConfirm'))) return;
                     try {
                       const { data } = await api.post('/settings/cloud/stop-all');
                       setCloudStatus({
@@ -3368,25 +3385,25 @@ export default function SettingsPage() {
                       setDiagnosticsConsent(false);
                       await fetchCloudAccount();
                       notifyCloudAccountStatusChanged();
-                      toast.success(t('settings.cloudAllStopped'));
+                      toast.success(t('cloudAllStopped'));
                     }
-                    catch { toast.error(t('settings.cloudStopFailed')); }
-                  }}><CloudOff size={16} className="me-2" />{t('settings.cloudStopAllButton')}</Button>
+                    catch { toast.error(t('cloudStopFailed')); }
+                  }}><CloudOff size={16} className="me-2" />{t('cloudStopAllButton')}</Button>
                   {!cloudDeletionFinal && <Button variant="destructive" disabled={cloudAccount?.deletion_request?.status === 'pending' || cloudAccount?.deletion_request?.status === 'processing' || cloudAccount?.deletion_request?.status === 'approved' || cloudStatus.cloud_deletion_status === 'processing'} onClick={() => {
-                    const phrase = window.prompt(t('settings.cloudDeletePrompt'));
+                    const phrase = window.prompt(t('cloudDeletePrompt'));
                     if (phrase === 'DELETE CLOUD DATA') setPinGate({ mode: 'delete-cloud' });
-                    else if (phrase !== null) toast.error(t('settings.confirmationPhraseMismatch'));
-                  }}><Trash2 size={16} className="me-2" />{t('settings.cloudDeleteDataButton')}</Button>}
+                    else if (phrase !== null) toast.error(t('confirmationPhraseMismatch'));
+                  }}><Trash2 size={16} className="me-2" />{t('cloudDeleteDataButton')}</Button>}
                   {cloudDeletionNeedsAction && (
                     <>
                       <Button variant="outline" onClick={() => void refreshDeletionStatus()} disabled={refreshingDeletionStatus}>
-                        {refreshingDeletionStatus ? t('settings.cloudRefreshingDeletion') : t('settings.cloudRefreshDeletion')}
+                        {refreshingDeletionStatus ? t('cloudRefreshingDeletion') : t('cloudRefreshDeletion')}
                       </Button>
-                      {cloudDeletionCanCancel && <Button variant="outline" onClick={() => setPinGate({ mode: 'cancel-cloud-deletion' })}>{t('settings.cloudCancelDeletion')}</Button>}
+                      {cloudDeletionCanCancel && <Button variant="outline" onClick={() => setPinGate({ mode: 'cancel-cloud-deletion' })}>{t('cloudCancelDeletion')}</Button>}
                     </>
                   )}
                 </div>
-                <p className="mt-3 text-xs text-gray-500">{t('settings.cloudTelemetryNote')}</p>
+                <p className="mt-3 text-xs text-gray-500">{t('cloudTelemetryNote')}</p>
               </div>
             )}
           </div>
@@ -3400,18 +3417,18 @@ export default function SettingsPage() {
               <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center gap-2">
                   <Printer size={20} className="text-gray-500" />
-                  <h2 className="font-semibold text-gray-900">{t('settings.printers')}</h2>
+                  <h2 className="font-semibold text-gray-900">{t('printers')}</h2>
                 </div>
                 {!showPrinterForm && (
                   <div className="flex items-center gap-2">
                     <button onClick={fetchDetectedPrinters} disabled={detectingPrinters}
-                      title={t('settings.refreshList')}
+                      title={t('refreshList')}
                       className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-200 text-gray-600 rounded-lg hover:bg-gray-50 font-medium disabled:opacity-50">
-                      <RefreshCw size={14} className={detectingPrinters ? 'animate-spin' : ''} /> {t('settings.refresh')}
+                      <RefreshCw size={14} className={detectingPrinters ? 'animate-spin' : ''} /> {t('refresh')}
                     </button>
                     <button onClick={openAddPrinter}
                       className="flex items-center gap-2 px-4 py-2 text-sm border border-gray-200 text-gray-600 rounded-lg hover:bg-gray-50 font-medium">
-                      <Plus size={14} /> {t('settings.addPrinterManually')}
+                      <Plus size={14} /> {t('addPrinterManually')}
                     </button>
                   </div>
                 )}
@@ -3427,15 +3444,15 @@ export default function SettingsPage() {
                     aria-expanded={installedPrintersOpen}
                   >
                     <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-                      {t('settings.installedOnThisComputer')} ({detectedPrinters.length})
+                      {t('installedOnThisComputer')} ({detectedPrinters.length})
                     </span>
                     <ChevronDown size={16} className={`text-gray-400 transition-transform ${installedPrintersOpen ? 'rotate-180' : ''}`} />
                   </button>
                   {installedPrintersOpen && (detectingPrinters && detectedPrinters.length === 0 ? (
-                    <div className="py-6 text-center text-gray-400 text-sm">{t('settings.scanningForPrinters')}</div>
+                    <div className="py-6 text-center text-gray-400 text-sm">{t('scanningForPrinters')}</div>
                   ) : detectedPrinters.length === 0 ? (
                     <div className="mt-2 py-6 text-center text-gray-400 text-sm border border-dashed border-gray-200 rounded-lg">
-                      {t('settings.noInstalledPrinters')}
+                      {t('noInstalledPrinters')}
                     </div>
                   ) : (
                     <div className="mt-2 space-y-2">
@@ -3443,7 +3460,7 @@ export default function SettingsPage() {
                         const alreadyAdded = hwPrinters.some((h) => h.name.toLowerCase() === p.name.toLowerCase());
                         const isAdding = addingDetectedName === p.name;
                         const dotColor = p.status === 'idle' ? 'bg-green-500' : p.status === 'printing' ? 'bg-yellow-500' : 'bg-gray-300';
-                        const statusLabel = p.status === 'idle' ? t('settings.printerOnline') : p.status === 'printing' ? t('settings.printerPrinting') : t('settings.printerOffline');
+                        const statusLabel = p.status === 'idle' ? t('printerOnline') : p.status === 'printing' ? t('printerPrinting') : t('printerOffline');
                         return (
                           <div key={p.name} className="flex items-center gap-3 rounded-xl border border-gray-200 p-3">
                             <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-gray-100 shrink-0">
@@ -3461,17 +3478,17 @@ export default function SettingsPage() {
                                 {p.make !== 'Unknown' ? `${p.make} ${p.model}` : p.model}
                                 {p.connectionType === 'network' && p.ipAddress ? <> · <Ltr>{p.ipAddress}{p.port ? ':' + p.port : ''}</Ltr></> : ''}
                                 {p.paperWidth ? ` · ${printWidthLabel(p.paperWidth)}` : ''}
-                                {p.profileId ? ` · ${t('settings.printerSupportedProfile')}` : ''}
+                                {p.profileId ? ` · ${t('printerSupportedProfile')}` : ''}
                               </p>
                             </div>
                             {alreadyAdded ? (
                               <span className="text-xs text-gray-400 px-3 py-1.5 flex items-center gap-1">
-                                <CheckCircle2 size={14} className="text-green-500" /> {t('settings.printerAdded')}
+                                <CheckCircle2 size={14} className="text-green-500" /> {t('printerAdded')}
                               </span>
                             ) : (
                               <button onClick={() => quickAddDetected(p)} disabled={isAdding}
                                 className="px-3 py-1.5 text-xs bg-brand text-white rounded-lg hover:opacity-90 disabled:opacity-50 font-medium flex items-center gap-1">
-                                <Plus size={13} /> {isAdding ? t('settings.printerAdding') : t('common.add')}
+                                <Plus size={13} /> {isAdding ? t('printerAdding') : tCommon('add')}
                               </button>
                             )}
                           </div>
@@ -3485,13 +3502,13 @@ export default function SettingsPage() {
               {/* Configured printer list */}
               {hwPrinters.length === 0 && !showPrinterForm && (
                 <div className="py-6 text-center text-gray-400">
-                  <p className="text-sm">{t('settings.noPrintersConfigured')}</p>
-                  <p className="text-xs mt-1">{t('settings.printerHint')}</p>
+                  <p className="text-sm">{t('noPrintersConfigured')}</p>
+                  <p className="text-xs mt-1">{t('printerHint')}</p>
                 </div>
               )}
 
               {hwPrinters.length > 0 && !showPrinterForm && (
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">{t('settings.configuredPrinters')}</h3>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">{t('configuredPrinters')}</h3>
               )}
               <div className="space-y-3">
                 {hwPrinters.map((p) => (
@@ -3505,34 +3522,34 @@ export default function SettingsPage() {
                       <div className="flex items-center gap-2">
                         <span className="font-semibold text-gray-900 text-sm">{p.name}</span>
                         {p.is_default === 1 && (
-                          <span className="text-[10px] bg-brand/10 text-brand px-2 py-0.5 rounded-full font-medium">{t('settings.defaultPrinter')}</span>
+                          <span className="text-[10px] bg-brand/10 text-brand px-2 py-0.5 rounded-full font-medium">{t('defaultPrinter')}</span>
                         )}
                       </div>
                       <p className="text-xs text-gray-500 mt-0.5">
                         {p.connection_type === 'network' ? <Ltr>{p.ip_address}:{p.port}</Ltr> :
-                         p.connection_type === 'usb' ? t('settings.connectionUsb') :
-                         t('settings.browserWebusb')}
+                         p.connection_type === 'usb' ? t('connectionUsb') :
+                         t('browserWebusb')}
                         {' · '}{printWidthLabel(p.paper_width)}
                         {p.profile_name ? ` · ${p.profile_name}` : ''}
                       </p>
                     </div>
                     <div className="flex items-center gap-1 shrink-0">
                       <button onClick={() => testPrinterHw(p)} disabled={testingPrinterId === p.id}
-                        title={t('settings.testPrint')}
+                        title={t('testPrint')}
                         className="p-2 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-700 disabled:opacity-40">
                         <TestTube2 size={15} />
                       </button>
                       {p.is_default !== 1 && (
-                        <button onClick={() => setDefaultPrinter(p.id)} title={t('settings.setAsDefault')}
+                        <button onClick={() => setDefaultPrinter(p.id)} title={t('setAsDefault')}
                           className="p-2 rounded-lg hover:bg-yellow-50 text-gray-400 hover:text-yellow-600">
                           <Star size={15} />
                         </button>
                       )}
-                      <button onClick={() => openEditPrinter(p)} title={t('settings.edit')}
+                      <button onClick={() => openEditPrinter(p)} title={t('edit')}
                         className="p-2 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-700">
                         <Settings size={15} />
                       </button>
-                      <button onClick={() => deletePrinterHw(p.id)} title={t('settings.delete')}
+                      <button onClick={() => deletePrinterHw(p.id)} title={t('delete')}
                         className="p-2 rounded-lg hover:bg-red-50 text-gray-400 hover:text-red-600">
                         <Trash2 size={15} />
                       </button>
@@ -3545,61 +3562,61 @@ export default function SettingsPage() {
               {showPrinterForm && (
                 <div className="mt-5 pt-5 border-t border-gray-100">
                   <h3 className="font-semibold text-gray-900 text-sm mb-4">
-                    {editingPrinterId ? t('settings.editPrinter') : t('settings.addPrinter')}
+                    {editingPrinterId ? t('editPrinter') : t('addPrinter')}
                   </h3>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
-                      <label className="block text-xs text-gray-500 mb-1">{t('settings.printerName')}</label>
+                      <label className="block text-xs text-gray-500 mb-1">{t('printerName')}</label>
                       <input type="text" value={printerForm.name}
                         onChange={(e) => setPrinterForm((p) => ({ ...p, name: e.target.value }))}
-                        placeholder={t('settings.printerNamePlaceholder')}
+                        placeholder={t('printerNamePlaceholder')}
                         className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand" />
                     </div>
                     <div>
-                      <label className="block text-xs text-gray-500 mb-1">{t('settings.connectionType')}</label>
+                      <label className="block text-xs text-gray-500 mb-1">{t('connectionType')}</label>
                       <select value={printerForm.connection_type}
                         onChange={(e) => setPrinterForm((p) => ({ ...p, connection_type: e.target.value as HwPrinter['connection_type'] }))}
                         className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand">
-                        <option value="network">{t('settings.connectionNetwork')}</option>
-                        <option value="usb">{t('settings.connectionUsb')}</option>
-                        <option value="webusb">{t('settings.connectionWebusb')}</option>
+                        <option value="network">{t('connectionNetwork')}</option>
+                        <option value="usb">{t('connectionUsb')}</option>
+                        <option value="webusb">{t('connectionWebusb')}</option>
                       </select>
                     </div>
 
                     {printerForm.connection_type === 'network' && (<>
                       <div>
-                        <label className="block text-xs text-gray-500 mb-1">{t('settings.ipAddress')}</label>
+                        <label className="block text-xs text-gray-500 mb-1">{t('ipAddress')}</label>
                         <input type="text" value={printerForm.ip_address}
                           onChange={(e) => setPrinterForm((p) => ({ ...p, ip_address: e.target.value }))}
-                          placeholder={t('settings.ipAddressPlaceholder')}
+                          placeholder={t('ipAddressPlaceholder')}
                           className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand" dir="ltr" />
                       </div>
                       <div>
-                        <label className="block text-xs text-gray-500 mb-1">{t('settings.port')}</label>
+                        <label className="block text-xs text-gray-500 mb-1">{t('port')}</label>
                         <input type="number" value={printerForm.port}
                           onChange={(e) => setPrinterForm((p) => ({ ...p, port: e.target.value }))}
-                          placeholder={t('settings.portPlaceholder')}
+                          placeholder={t('portPlaceholder')}
                           className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand" />
                       </div>
                     </>)}
 
                     {printerForm.connection_type === 'webusb' && (
                       <div className="md:col-span-2 bg-blue-50 rounded-lg p-3 text-sm text-blue-700">
-                        {t('settings.webusbHint')}
+                        {t('webusbHint')}
                       </div>
                     )}
 
                     <div>
-                      <label className="block text-xs text-gray-500 mb-1">{t('settings.paperWidth')}</label>
+                      <label className="block text-xs text-gray-500 mb-1">{t('paperWidth')}</label>
                       <select value={printerForm.paper_width}
                         onChange={(e) => setPrinterForm((p) => ({ ...p, paper_width: e.target.value }))}
                         className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand">
-                        <option value="cols-32">{t('settings.printColumns32')}</option>
-                        <option value="cols-36">{t('settings.printColumns36')}</option>
-                        <option value="cols-40">{t('settings.printColumns40')}</option>
-                        <option value="cols-42">{t('settings.printColumns42')}</option>
-                        <option value="cols-44">{t('settings.printColumns44')}</option>
-                        <option value="cols-48">{t('settings.printColumns48')}</option>
+                        <option value="cols-32">{t('printColumns32')}</option>
+                        <option value="cols-36">{t('printColumns36')}</option>
+                        <option value="cols-40">{t('printColumns40')}</option>
+                        <option value="cols-42">{t('printColumns42')}</option>
+                        <option value="cols-44">{t('printColumns44')}</option>
+                        <option value="cols-48">{t('printColumns48')}</option>
                       </select>
                     </div>
                   </div>
@@ -3607,11 +3624,11 @@ export default function SettingsPage() {
                   <div className="mt-4 flex gap-2">
                     <button onClick={savePrinterHw} disabled={savingPrinter}
                       className="px-5 py-2 text-sm bg-brand text-white rounded-lg hover:opacity-90 disabled:opacity-50 font-medium">
-                      {savingPrinter ? t('settings.saving') : editingPrinterId ? t('common.update') : t('settings.addPrinter')}
+                      {savingPrinter ? t('saving') : editingPrinterId ? tCommon('update') : t('addPrinter')}
                     </button>
                     <button onClick={() => setShowPrinterForm(false)}
                       className="px-5 py-2 text-sm border border-gray-200 text-gray-600 rounded-lg hover:bg-gray-50 font-medium">
-                      {t('settings.cancel')}
+                      {t('cancel')}
                     </button>
                   </div>
                 </div>
@@ -3619,29 +3636,29 @@ export default function SettingsPage() {
             </div>
 
             <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-800">
-              <strong>{t('settings.defaultPrinterTipTitle')}</strong> {t('settings.defaultPrinterTipBody')}
+              <strong>{t('defaultPrinterTipTitle')}</strong> {t('defaultPrinterTipBody')}
             </div>
 
             {/* Print Options — merged into the same Printers page rather than a separate tab */}
             <div className="pt-4 border-t border-gray-100">
-              <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-400">{t('settings.tabPrinting')}</h2>
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-400">{t('tabPrinting')}</h2>
             </div>
 
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Printer size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.printing')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('printing')}</h2>
               </div>
               <div className="space-y-4">
                 <div className="flex items-center justify-between gap-4">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900">{t('settings.enablePrinter')}</p>
-                    <p className="text-sm text-gray-500">{t('settings.enablePrinterHint')}</p>
+                    <p className="font-medium text-gray-900">{t('enablePrinter')}</p>
+                    <p className="text-sm text-gray-500">{t('enablePrinterHint')}</p>
                   </div>
                   <Toggle value={printingForm.printerEnabled} onChange={(v) => setPrintingForm((p) => ({ ...p, printerEnabled: v }))} />
                 </div>
                 <div>
-                  <p className="font-medium text-gray-900 mb-2">{t('settings.paperSize')}</p>
+                  <p className="font-medium text-gray-900 mb-2">{t('paperSize')}</p>
                   <select value={printingForm.printerPaperSize}
                     onChange={(e) => setPrintingForm((p) => ({ ...p, printerPaperSize: e.target.value as PaperSize }))}
                     className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand">
@@ -3651,33 +3668,33 @@ export default function SettingsPage() {
                   </select>
                 </div>
                 <div>
-                  <p className="font-medium text-gray-900 mb-2">{t('settings.printMethod')}</p>
+                  <p className="font-medium text-gray-900 mb-2">{t('printMethod')}</p>
                   <select value={printingForm.printMethod}
                     onChange={(e) => setPrintingForm((p) => ({ ...p, printMethod: e.target.value as 'escpos' | 'browser' }))}
                     className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand">
-                    <option value="escpos">{t('settings.printMethodEscpos')}</option>
-                    <option value="browser">{t('settings.printMethodBrowser')}</option>
+                    <option value="escpos">{t('printMethodEscpos')}</option>
+                    <option value="browser">{t('printMethodBrowser')}</option>
                   </select>
                   <p className="text-xs text-gray-500 mt-1">
                     {printingForm.printMethod === 'escpos'
-                      ? t('settings.printMethodEscposHint')
-                      : t('settings.printMethodBrowserHint')}
+                      ? t('printMethodEscposHint')
+                      : t('printMethodBrowserHint')}
                   </p>
                 </div>
                 <div className="flex items-center justify-between gap-4 border-t border-gray-100 pt-4">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900">{t('settings.kotPrintingEnabledToggle', { defaultValue: 'KOT Ticket Printing' })}</p>
-                    <p className="text-sm text-gray-500">{t('settings.kotPrintingEnabledToggleHint', { defaultValue: 'Allow KOT tickets to print at all, automatically or manually. Turn this off if this business doesn’t use a KOT printer.' })}</p>
+                    <p className="font-medium text-gray-900">{t('kotPrintingEnabledToggle', { defaultValue: 'KOT Ticket Printing' })}</p>
+                    <p className="text-sm text-gray-500">{t('kotPrintingEnabledToggleHint', { defaultValue: 'Allow KOT tickets to print at all, automatically or manually. Turn this off if this business doesn’t use a KOT printer.' })}</p>
                   </div>
                   <Toggle value={kotPrintingEnabledSetting} onChange={(v) => { if (!savingKotPrintingEnabled) saveKotPrintingEnabled(v); }} />
                 </div>
                 <div className={`flex items-center justify-between gap-4 ${!kotPrintingEnabledSetting ? 'opacity-50' : ''}`}>
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900">{t('settings.autoPrintKot')}</p>
+                    <p className="font-medium text-gray-900">{t('autoPrintKot')}</p>
                     <p className="text-sm text-gray-500">
                       {kotPrintingEnabledSetting
-                        ? t('settings.autoPrintKotHint')
-                        : t('settings.autoPrintKotDisabledHint', { defaultValue: 'KOT printing is turned off above, so this has no effect.' })}
+                        ? t('autoPrintKotHint')
+                        : t('autoPrintKotDisabledHint', { defaultValue: 'KOT printing is turned off above, so this has no effect.' })}
                     </p>
                   </div>
                   <Toggle
@@ -3689,46 +3706,46 @@ export default function SettingsPage() {
                   <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg">
                     <AlertTriangle size={16} className="text-amber-600 shrink-0 mt-0.5" />
                     <p className="text-xs text-amber-800">
-                      {t('settings.kitchenWorkflowBothOffNote', { defaultValue: 'Both the Kitchen Display and KOT printing are off. Kitchen items won’t display or print anywhere — orders will need to be marked served directly at the counter.' })}
+                      {t('kitchenWorkflowBothOffNote', { defaultValue: 'Both the Kitchen Display and KOT printing are off. Kitchen items won’t display or print anywhere — orders will need to be marked served directly at the counter.' })}
                     </p>
                   </div>
                 )}
                 <div className="flex items-center justify-between gap-4">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900">{t('settings.autoPrintBill')}</p>
-                    <p className="text-sm text-gray-500">{t('settings.autoPrintBillHint')}</p>
+                    <p className="font-medium text-gray-900">{t('autoPrintBill')}</p>
+                    <p className="text-sm text-gray-500">{t('autoPrintBillHint')}</p>
                   </div>
                   <Toggle value={printingForm.autoPrintBill} onChange={(v) => setPrintingForm((p) => ({ ...p, autoPrintBill: v }))} />
                 </div>
                 <div className="flex items-center justify-between gap-4">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900">{t('settings.printerUnicode')}</p>
+                    <p className="font-medium text-gray-900">{t('printerUnicode')}</p>
                     <p className="text-sm text-gray-500">
-                      {t('settings.printerUnicodeHint')}
+                      {t('printerUnicodeHint')}
                     </p>
                   </div>
                   <Toggle value={printingForm.printerUseUnicode} onChange={(v) => setPrintingForm((p) => ({ ...p, printerUseUnicode: v }))} />
                 </div>
                 <div className="flex items-center justify-between gap-4">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900">{t('settings.trimDecimals')}</p>
-                    <p className="text-sm text-gray-500">{t('settings.trimDecimalsHint')}</p>
+                    <p className="font-medium text-gray-900">{t('trimDecimals')}</p>
+                    <p className="text-sm text-gray-500">{t('trimDecimalsHint')}</p>
                   </div>
                   <Toggle value={printingForm.printerTrimDecimals} onChange={(v) => setPrintingForm((p) => ({ ...p, printerTrimDecimals: v }))} />
                 </div>
                 <div className="pt-4 border-t border-gray-100">
-                  <p className="font-medium text-gray-900 mb-1">{t('settings.billContent')}</p>
-                  <p className="text-sm text-gray-500 mb-3">{t('settings.billContentHint')}</p>
+                  <p className="font-medium text-gray-900 mb-1">{t('billContent')}</p>
+                  <p className="text-sm text-gray-500 mb-3">{t('billContentHint')}</p>
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1">
                     {([
-                      { label: t('settings.showRestaurantName'), key: 'billShowName' as const },
-                      { label: t('settings.showRestaurantAddress'), key: 'billShowAddress' as const },
-                      { label: t('settings.showRestaurantPhone'), key: 'billShowPhone' as const },
-                      { label: t('settings.showTaxId'), key: 'billShowTaxId' as const },
-                      { label: t('settings.showTaxBreakdown'), key: 'billShowTaxBreakdown' as const },
-                      { label: t('settings.showCustomerName'), key: 'billShowCustomerName' as const },
-                      { label: t('settings.showCustomerPhone'), key: 'billShowCustomerPhone' as const },
-                      { label: t('settings.showTableNumber'), key: 'billShowTableNumber' as const },
+                      { label: t('showRestaurantName'), key: 'billShowName' as const },
+                      { label: t('showRestaurantAddress'), key: 'billShowAddress' as const },
+                      { label: t('showRestaurantPhone'), key: 'billShowPhone' as const },
+                      { label: t('showTaxId'), key: 'billShowTaxId' as const },
+                      { label: t('showTaxBreakdown'), key: 'billShowTaxBreakdown' as const },
+                      { label: t('showCustomerName'), key: 'billShowCustomerName' as const },
+                      { label: t('showCustomerPhone'), key: 'billShowCustomerPhone' as const },
+                      { label: t('showTableNumber'), key: 'billShowTableNumber' as const },
                     ] as const).map((item) => (
                       <div key={item.key} className="flex min-h-11 items-center justify-between gap-3 py-1">
                         <span className="text-sm text-gray-700">{item.label}</span>
@@ -3740,13 +3757,13 @@ export default function SettingsPage() {
                     ))}
                   </div>
                   <div className="mt-4 border-t border-gray-100 pt-4">
-                    <label htmlFor="footer-message" className="block text-sm font-medium text-gray-700 mb-1">{t('settings.footerMessage')}</label>
+                    <label htmlFor="footer-message" className="block text-sm font-medium text-gray-700 mb-1">{t('footerMessage')}</label>
                     <textarea id="footer-message" rows={2}
-                      placeholder={t('settings.footerMessagePlaceholder')}
+                      placeholder={t('footerMessagePlaceholder')}
                       value={billForm.billFooterMessage}
                       onChange={(e) => setBillForm((p) => ({ ...p, billFooterMessage: e.target.value }))}
                       className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-brand resize-none" />
-                    <p className="text-xs text-gray-400 mt-1">{t('settings.footerMessageHint')}</p>
+                    <p className="text-xs text-gray-400 mt-1">{t('footerMessageHint')}</p>
                   </div>
                 </div>
               </div>
@@ -3755,12 +3772,12 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Share2 size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.whatsappSharing')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('whatsappSharing')}</h2>
               </div>
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="font-medium text-gray-900">{t('settings.enableWhatsappShare')}</p>
-                  <p className="text-sm text-gray-500">{t('settings.enableWhatsappShareHint')}</p>
+                  <p className="font-medium text-gray-900">{t('enableWhatsappShare')}</p>
+                  <p className="text-sm text-gray-500">{t('enableWhatsappShareHint')}</p>
                 </div>
                 <Toggle value={printingForm.whatsappShareEnabled} onChange={(v) => setPrintingForm((p) => ({ ...p, whatsappShareEnabled: v }))} />
               </div>
@@ -3771,7 +3788,7 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <FileText size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.billTemplate')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('billTemplate')}</h2>
               </div>
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
                 {billTemplateCards.map((card) => {
@@ -3791,8 +3808,8 @@ export default function SettingsPage() {
                         {card.source === 'plugin'
                           ? card.description
                           : card.id === 'classic'
-                            ? t('settings.billTemplateClassicDesc')
-                            : t('settings.billTemplateCompactDesc')}
+                            ? t('billTemplateClassicDesc')
+                            : t('billTemplateCompactDesc')}
                       </p>
                     </button>
                   );
@@ -3809,15 +3826,15 @@ export default function SettingsPage() {
         <TabsContent value="data">
           <div className="pb-6 max-w-3xl space-y-6">
             <div className="space-y-6">
-            <h2 className="text-lg font-semibold text-gray-900">{t('settings.tabBackupData')}</h2>
+            <h2 className="text-lg font-semibold text-gray-900">{t('tabBackupData')}</h2>
             {/* Database Export */}
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <FileText size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.exportDatabase')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('exportDatabase')}</h2>
               </div>
               <p className="text-sm text-gray-500 mb-4">
-                {t('settings.exportDatabaseHint')}
+                {t('exportDatabaseHint')}
               </p>
               <button
                 onClick={async () => {
@@ -3832,14 +3849,14 @@ export default function SettingsPage() {
                     a.click();
                     document.body.removeChild(a);
                     window.URL.revokeObjectURL(url);
-                    toast.success(t('settings.databaseExported'));
+                    toast.success(t('databaseExported'));
                   } catch {
-                    toast.error(t('settings.exportFailed'));
+                    toast.error(t('exportFailed'));
                   }
                 }}
                 className="px-5 py-2 text-sm bg-brand text-white rounded-lg hover:opacity-90 font-medium"
               >
-                {t('settings.exportToJson')}
+                {t('exportToJson')}
               </button>
             </div>
 
@@ -3847,23 +3864,23 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-blue-100 bg-blue-50/30 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Database size={20} className="text-blue-600" />
-                <h2 className="font-semibold text-gray-900">{t('settings.createBackup')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('createBackup')}</h2>
               </div>
               <p className="text-sm text-gray-500 mb-4">
-                {t('settings.createBackupHint')}
+                {t('createBackupHint')}
               </p>
               <div className="flex flex-wrap gap-2">
                 <button
                   onClick={handleCreateBackup}
                   className="px-5 py-2 text-sm bg-gray-600 text-white rounded-lg hover:opacity-90 font-medium"
                 >
-                  {t('settings.createBackup')}
+                  {t('createBackup')}
                 </button>
                 <button
                   onClick={handleChooseBackupLocation}
                   className="px-5 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 font-medium"
                 >
-                  {t('settings.chooseBackupLocation')}
+                  {t('chooseBackupLocation')}
                 </button>
               </div>
             </div>
@@ -3873,23 +3890,23 @@ export default function SettingsPage() {
               <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center gap-2">
                   <Database size={20} className="text-gray-500" />
-                  <h2 className="font-semibold text-gray-900">{t('settings.backupHistory')}</h2>
+                  <h2 className="font-semibold text-gray-900">{t('backupHistory')}</h2>
                 </div>
                 <button
                   onClick={fetchBackups}
                   disabled={backupsLoading}
                   className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-50 disabled:opacity-50"
-                  title={t('settings.refresh')}
+                  title={t('refresh')}
                 >
                   <RefreshCw size={16} className={backupsLoading ? 'animate-spin' : ''} />
                 </button>
               </div>
               <p className="text-sm text-gray-500 mb-4">
-                {t('settings.backupHistoryHint')}
+                {t('backupHistoryHint')}
               </p>
               {backups.length === 0 ? (
                 <p className="text-sm text-gray-400 py-4 text-center">
-                  {backupsLoading ? t('common.loading') : t('settings.backupHistoryEmpty')}
+                  {backupsLoading ? tCommon('loading') : t('backupHistoryEmpty')}
                 </p>
               ) : (
                 <div className="divide-y divide-gray-100">
@@ -3900,19 +3917,19 @@ export default function SettingsPage() {
                           <span className="text-sm font-medium text-gray-900">{formatDateTime(backup.createdAt)}</span>
                           {backup.kind === 'auto' && (
                             <span className="text-xs px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-100">
-                              {t('settings.backupKindAuto')}
+                              {t('backupKindAuto')}
                             </span>
                           )}
                           {googleDriveStatus.last_backup_filename === backup.fileName && (
                             <span className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-50 text-blue-700 border border-blue-100">
                               <HardDrive size={11} />
-                              {t('settings.googleDriveUploadedBadge')}
+                              {t('googleDriveUploadedBadge')}
                             </span>
                           )}
                         </div>
                         <p className="text-xs text-gray-400 truncate">
                           {formatBackupSize(backup.sizeBytes)}
-                          {backup.schemaVersion != null && ` · ${t('settings.backupSchemaVersion', { version: backup.schemaVersion })}`}
+                          {backup.schemaVersion != null && ` · ${t('backupSchemaVersion', { version: backup.schemaVersion })}`}
                         </p>
                       </div>
                       <div className="shrink-0 flex items-center gap-2">
@@ -3920,12 +3937,12 @@ export default function SettingsPage() {
                           onClick={() => handleRestoreFromHistory(backup)}
                           className="px-3 py-1.5 text-xs bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 font-medium"
                         >
-                          {t('settings.restoreBackup')}
+                          {t('restoreBackup')}
                         </button>
                         <button
                           onClick={() => handleDeleteBackup(backup)}
                           className="p-1.5 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50"
-                          title={t('settings.deleteBackup')}
+                          title={t('deleteBackup')}
                         >
                           <Trash2 size={14} />
                         </button>
@@ -3941,8 +3958,8 @@ export default function SettingsPage() {
               <div className="flex items-center gap-2">
                 <HardDrive size={20} className="text-gray-500" />
                 <div>
-                  <h2 className="font-semibold text-gray-900">{t('settings.googleDrive')}</h2>
-                  <p className="text-xs text-gray-500 mt-0.5">{t('settings.googleDriveHint')}</p>
+                  <h2 className="font-semibold text-gray-900">{t('googleDrive')}</h2>
+                  <p className="text-xs text-gray-500 mt-0.5">{t('googleDriveHint')}</p>
                 </div>
               </div>
 
@@ -3951,13 +3968,13 @@ export default function SettingsPage() {
                   <div className="p-3 bg-white rounded-full shadow-sm">
                     <HardDrive className="w-6 h-6 text-gray-400" />
                   </div>
-                  <p className="text-sm font-medium text-gray-900">{t('settings.googleDriveNotConfigured')}</p>
-                  <p className="text-xs text-gray-500 max-w-sm">{t('settings.googleDriveNotConfiguredHint')}</p>
+                  <p className="text-sm font-medium text-gray-900">{t('googleDriveNotConfigured')}</p>
+                  <p className="text-xs text-gray-500 max-w-sm">{t('googleDriveNotConfiguredHint')}</p>
                 </div>
               ) : !googleDriveStatus.secure_storage_available ? (
                 <div className="flex items-center gap-2 bg-amber-50 border border-amber-100 rounded-lg px-4 py-3">
                   <AlertTriangle size={16} className="text-amber-600 shrink-0" />
-                  <p className="text-sm text-amber-800">{t('settings.googleDriveSecureStorageUnavailable')}</p>
+                  <p className="text-sm text-amber-800">{t('googleDriveSecureStorageUnavailable')}</p>
                 </div>
               ) : (
                 <>
@@ -3970,10 +3987,10 @@ export default function SettingsPage() {
                       )}
                       <div>
                         <p className="text-sm font-medium text-gray-900">
-                          {googleDriveStatus.connected ? t('settings.googleDriveConnected') : t('settings.googleDriveNotConnected')}
+                          {googleDriveStatus.connected ? t('googleDriveConnected') : t('googleDriveNotConnected')}
                         </p>
                         {googleDriveStatus.connected && googleDriveStatus.account_email && (
-                          <p className="text-xs text-gray-500">{t('settings.googleDriveAccount')}: <Ltr>{googleDriveStatus.account_email}</Ltr></p>
+                          <p className="text-xs text-gray-500">{t('googleDriveAccount')}: <Ltr>{googleDriveStatus.account_email}</Ltr></p>
                         )}
                       </div>
                     </div>
@@ -3984,7 +4001,7 @@ export default function SettingsPage() {
                           disabled={disconnectingGoogleDrive}
                           className="px-4 py-2 text-sm border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50 font-medium shrink-0"
                         >
-                          {disconnectingGoogleDrive ? t('settings.googleDriveDisconnecting') : t('settings.googleDriveDisconnect')}
+                          {disconnectingGoogleDrive ? t('googleDriveDisconnecting') : t('googleDriveDisconnect')}
                         </button>
                       ) : (
                         <button
@@ -3992,7 +4009,7 @@ export default function SettingsPage() {
                           disabled={connectingGoogleDrive}
                           className="px-4 py-2 text-sm bg-brand text-white rounded-lg hover:opacity-90 disabled:opacity-50 font-medium shrink-0"
                         >
-                          {connectingGoogleDrive ? t('settings.googleDriveConnecting') : t('settings.googleDriveConnect')}
+                          {connectingGoogleDrive ? t('googleDriveConnecting') : t('googleDriveConnect')}
                         </button>
                       )
                     )}
@@ -4002,19 +4019,19 @@ export default function SettingsPage() {
                     <>
                       <div className="grid sm:grid-cols-2 gap-4">
                         <div>
-                          <label className="block text-sm font-medium text-gray-700 mb-1">{t('settings.googleDriveFrequency')}</label>
+                          <label className="block text-sm font-medium text-gray-700 mb-1">{t('googleDriveFrequency')}</label>
                           <select
                             value={googleDriveStatus.frequency}
                             disabled={savingGoogleDrivePrefs}
                             onChange={(e) => updateGoogleDrivePrefs({ frequency: e.target.value as 'daily' | 'weekly' })}
                             className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand outline-none disabled:opacity-50"
                           >
-                            <option value="daily">{t('settings.googleDriveFrequencyDaily')}</option>
-                            <option value="weekly">{t('settings.googleDriveFrequencyWeekly')}</option>
+                            <option value="daily">{t('googleDriveFrequencyDaily')}</option>
+                            <option value="weekly">{t('googleDriveFrequencyWeekly')}</option>
                           </select>
                         </div>
                         <div>
-                          <label className="block text-sm font-medium text-gray-700 mb-1">{t('settings.googleDriveRetention')}</label>
+                          <label className="block text-sm font-medium text-gray-700 mb-1">{t('googleDriveRetention')}</label>
                           <input
                             type="number"
                             min={1}
@@ -4030,7 +4047,7 @@ export default function SettingsPage() {
                           />
                         </div>
                       </div>
-                      <p className="text-xs text-gray-500">{t('settings.googleDriveRetentionHint')}</p>
+                      <p className="text-xs text-gray-500">{t('googleDriveRetentionHint')}</p>
 
                       <div className="flex items-center justify-between gap-3 flex-wrap pt-1">
                         <div className="text-xs text-gray-500">
@@ -4038,16 +4055,16 @@ export default function SettingsPage() {
                             googleDriveStatus.last_backup_status === 'error' ? (
                               <span className="flex items-center gap-1 text-red-600">
                                 <AlertTriangle size={13} />
-                                {t('settings.googleDriveLastBackupErrorAt', { time: formatDateTime(googleDriveStatus.last_backup_at) })}
+                                {t('googleDriveLastBackupErrorAt', { time: formatDateTime(googleDriveStatus.last_backup_at) })}
                               </span>
                             ) : (
                               <span className="flex items-center gap-1 text-gray-500">
                                 <CheckCircle2 size={13} className="text-green-600" />
-                                {t('settings.googleDriveLastBackupSuccessAt', { time: formatDateTime(googleDriveStatus.last_backup_at) })}
+                                {t('googleDriveLastBackupSuccessAt', { time: formatDateTime(googleDriveStatus.last_backup_at) })}
                               </span>
                             )
                           ) : (
-                            <span>{t('settings.googleDriveLastBackup')}: {t('settings.googleDriveLastBackupNever')}</span>
+                            <span>{t('googleDriveLastBackup')}: {t('googleDriveLastBackupNever')}</span>
                           )}
                         </div>
                         {(currentTenant?.role === 'owner') && (
@@ -4057,7 +4074,7 @@ export default function SettingsPage() {
                             className="flex items-center gap-1.5 px-4 py-2 text-sm bg-gray-600 text-white rounded-lg hover:opacity-90 disabled:opacity-50 font-medium shrink-0"
                           >
                             <UploadCloud size={15} />
-                            {backingUpGoogleDrive ? t('settings.googleDriveBackingUp') : t('settings.googleDriveBackupNow')}
+                            {backingUpGoogleDrive ? t('googleDriveBackingUp') : t('googleDriveBackupNow')}
                           </button>
                         )}
                       </div>
@@ -4071,10 +4088,10 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <FileText size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.importDatabase')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('importDatabase')}</h2>
               </div>
               <p className="text-sm text-gray-500 mb-4">
-                {t('settings.importDatabaseHint')}
+                {t('importDatabaseHint')}
               </p>
               <input
                 type="file"
@@ -4090,11 +4107,11 @@ export default function SettingsPage() {
                     try {
                       const data = JSON.parse(event.target?.result as string);
                       if (!data.app || data.app !== 'FloDesktop') {
-                        toast.error(t('settings.invalidExportFile'));
+                        toast.error(t('invalidExportFile'));
                         return;
                       }
 
-                      const overwrite = await confirm(t('settings.importOverwriteConfirm'), { confirmLabel: t('settings.replaceAll') });
+                      const overwrite = await confirm(t('importOverwriteConfirm'), { confirmLabel: t('replaceAll') });
 
                       // A schema-mismatch import takes the same destructive
                       // delete-and-replace path as an overwrite, so it needs the
@@ -4107,7 +4124,7 @@ export default function SettingsPage() {
 
                       if (destructive && masterPinStatus.available) {
                         if (!masterPinStatus.isSet) {
-                          toast.error(t('settings.masterPinRequiredForReplace'));
+                          toast.error(t('masterPinRequiredForReplace'));
                           return;
                         }
                         setPinGate({ mode: 'import', payload: { data, overwrite } });
@@ -4116,7 +4133,7 @@ export default function SettingsPage() {
 
                       await runImport(data, overwrite);
                     } catch {
-                      toast.error(t('settings.importFailed'));
+                      toast.error(t('importFailed'));
                     }
                   };
                   reader.readAsText(file);
@@ -4128,7 +4145,7 @@ export default function SettingsPage() {
                   htmlFor="import-file"
                   className="px-5 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 cursor-pointer font-medium"
                 >
-                  {t('settings.selectFileAndImport')}
+                  {t('selectFileAndImport')}
                 </label>
               </div>
             </div>
@@ -4137,7 +4154,7 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Database size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.databaseInformation')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('databaseInformation')}</h2>
               </div>
               <button
                 onClick={async () => {
@@ -4147,12 +4164,12 @@ export default function SettingsPage() {
                     setTableInfo(tables);
                     setTableInfoOpen(true);
                   } catch {
-                    toast.error(t('settings.tableInfoFailed'));
+                    toast.error(t('tableInfoFailed'));
                   }
                 }}
                 className="px-5 py-2 text-sm border border-gray-200 text-gray-600 rounded-lg hover:bg-gray-50 font-medium"
               >
-                {t('settings.viewTableInfo')}
+                {t('viewTableInfo')}
               </button>
             </div>
 
@@ -4160,16 +4177,16 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Wrench size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.databaseHealthCheck')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('databaseHealthCheck')}</h2>
               </div>
               <p className="text-sm text-gray-500 mb-4">
-                {t('settings.databaseHealthCheckDescription')}
+                {t('databaseHealthCheckDescription')}
               </p>
               <button
                 onClick={runHealthCheck}
                 className="px-5 py-2 text-sm border border-gray-200 text-gray-600 rounded-lg hover:bg-gray-50 font-medium"
               >
-                {t('settings.databaseHealthCheck')}
+                {t('databaseHealthCheck')}
               </button>
             </div>
 
@@ -4177,23 +4194,23 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <KeyRound size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.masterPin')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('masterPin')}</h2>
               </div>
               <p className="text-sm text-gray-500 mb-4">
-                {t('settings.masterPinDataDescription')}
+                {t('masterPinDataDescription')}
               </p>
               {!masterPinStatus.available ? (
-                <p className="text-sm text-amber-600">{t('settings.notAvailableOnDevice')}</p>
+                <p className="text-sm text-amber-600">{t('notAvailableOnDevice')}</p>
               ) : (
                 <div className="flex items-center gap-3">
                   <span className={`text-sm font-medium ${masterPinStatus.isSet ? 'text-green-600' : 'text-amber-600'}`}>
-                    {masterPinStatus.isSet ? t('settings.masterPinStatusSet') : t('settings.masterPinStatusNotSet')}
+                    {masterPinStatus.isSet ? t('masterPinStatusSet') : t('masterPinStatusNotSet')}
                   </span>
                   <button
                     onClick={() => setPinGate({ mode: 'set' })}
                     className="px-5 py-2 text-sm border border-gray-200 text-gray-600 rounded-lg hover:bg-gray-50 font-medium"
                   >
-                    {masterPinStatus.isSet ? t('settings.masterPinChangeButton') : t('settings.masterPinSetButton')}
+                    {masterPinStatus.isSet ? t('masterPinChangeButton') : t('masterPinSetButton')}
                   </button>
                 </div>
               )}
@@ -4203,16 +4220,16 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-red-200 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <AlertTriangle size={20} className="text-red-600" />
-                <h2 className="font-semibold text-red-600">{t('settings.initializeDatabase')}</h2>
+                <h2 className="font-semibold text-red-600">{t('initializeDatabase')}</h2>
               </div>
               <p className="text-sm text-gray-500 mb-4">
-                {t('settings.initializeDatabaseDescription')}
+                {t('initializeDatabaseDescription')}
               </p>
               <button
                 onClick={() => setInitializeDbOpen(true)}
                 className="px-5 py-2 text-sm bg-red-600 text-white rounded-lg hover:opacity-90 font-medium"
               >
-                {t('settings.initializeDatabaseButton')}
+                {t('initializeDatabaseButton')}
               </button>
             </div>
           </div>
@@ -4227,11 +4244,11 @@ export default function SettingsPage() {
             ) : (
               <div className="bg-white rounded-xl border border-gray-100 p-6 flex items-center justify-between gap-4">
                 <div>
-                  <p className="font-semibold text-gray-900">{t('whatsapp.settings.enabled')}</p>
-                  <p className="text-xs text-gray-500 mt-0.5">{t('whatsapp.settings.enabledHint')}</p>
+                  <p className="font-semibold text-gray-900">{tWhatsappSettings('enabled')}</p>
+                  <p className="text-xs text-gray-500 mt-0.5">{tWhatsappSettings('enabledHint')}</p>
                 </div>
                 <Button asChild variant="outline" size="sm">
-                  <Link href="/whatsapp">{t('whatsapp.settings.openConnection')}</Link>
+                  <Link href="/whatsapp">{tWhatsappSettings('openConnection')}</Link>
                 </Button>
               </div>
             )}
@@ -4241,15 +4258,15 @@ export default function SettingsPage() {
         <TabsContent value="mobile-access">
           <div className="pb-6 max-w-3xl space-y-6">
             <div className="space-y-6">
-            <h2 className="text-lg font-semibold text-gray-900">{t('settings.tabMobileAccess')}</h2>
+            <h2 className="text-lg font-semibold text-gray-900">{t('tabMobileAccess')}</h2>
 
             {/* FloAdmin — reporting sync */}
             <div className="bg-white rounded-xl border border-gray-100 p-6 space-y-5">
               <div className="flex items-center gap-2">
                 <Cloud size={20} className="text-brand" />
                 <div>
-                  <h2 className="font-semibold text-gray-900">{t('settings.floadminSalesReporting')}</h2>
-                  <p className="text-xs text-gray-500 mt-0.5">{t('settings.floadminSalesReportingHint')}</p>
+                  <h2 className="font-semibold text-gray-900">{t('floadminSalesReporting')}</h2>
+                  <p className="text-xs text-gray-500 mt-0.5">{t('floadminSalesReportingHint')}</p>
                 </div>
               </div>
 
@@ -4259,14 +4276,14 @@ export default function SettingsPage() {
                     <Cloud className="w-6 h-6 text-brand" />
                   </div>
                   <div>
-                    <h3 className="font-medium text-gray-900">{t('settings.cloudServicesDisabled')}</h3>
-                    <p className="text-sm text-gray-500 mt-1 max-w-sm">{t('settings.cloudServicesDisabledHint')}</p>
+                    <h3 className="font-medium text-gray-900">{t('cloudServicesDisabled')}</h3>
+                    <p className="text-sm text-gray-500 mt-1 max-w-sm">{t('cloudServicesDisabledHint')}</p>
                   </div>
                   <button
                     onClick={() => setShowInitializeCloudConfirm(true)}
                     className="px-4 py-2 bg-brand text-white text-sm font-medium rounded-lg hover:opacity-90"
                   >
-                    {t('settings.cloudInitializeButton')}
+                    {t('cloudInitializeButton')}
                   </button>
                 </div>
               ) : (
@@ -4280,25 +4297,25 @@ export default function SettingsPage() {
                   )}
                   <div>
                     <p className="text-sm font-medium text-gray-900">
-                      {cloudStatus.cloud_registration_status === 'registered' && cloudServicesStopped && t('settings.cloudServicesStopped')}
-                      {cloudStatus.cloud_registration_status === 'registered' && !cloudServicesStopped && (cloudStatus.cloud_connected ? t('settings.connectedToFloadmin') : t('settings.registeredReconnecting'))}
-                      {cloudStatus.cloud_registration_status === 'rejected' && t('settings.registrationRejected')}
-                      {cloudStatus.cloud_registration_status === 'deletion_pending' && (cloudStatus.cloud_last_error || cloudStatus.cloud_deletion_status === 'failed') && t('settings.cloudDeletionFailed')}
-                      {cloudStatus.cloud_registration_status === 'deletion_pending' && cloudStatus.cloud_deletion_status === 'processing' && t('settings.cloudDeletionProcessing')}
-                      {cloudStatus.cloud_registration_status === 'deletion_pending' && !cloudStatus.cloud_last_error && cloudStatus.cloud_deletion_status !== 'failed' && cloudStatus.cloud_deletion_status !== 'processing' && t('settings.cloudDeletionPending')}
-                      {cloudStatus.cloud_registration_status === 'deleted' && t('settings.cloudDataDeleted')}
-                      {(cloudStatus.cloud_registration_status === 'unregistered' || cloudStatus.cloud_registration_status === 'registration_failed') && t('settings.notRegistered')}
+                      {cloudStatus.cloud_registration_status === 'registered' && cloudServicesStopped && t('cloudServicesStopped')}
+                      {cloudStatus.cloud_registration_status === 'registered' && !cloudServicesStopped && (cloudStatus.cloud_connected ? t('connectedToFloadmin') : t('registeredReconnecting'))}
+                      {cloudStatus.cloud_registration_status === 'rejected' && t('registrationRejected')}
+                      {cloudStatus.cloud_registration_status === 'deletion_pending' && (cloudStatus.cloud_last_error || cloudStatus.cloud_deletion_status === 'failed') && t('cloudDeletionFailed')}
+                      {cloudStatus.cloud_registration_status === 'deletion_pending' && cloudStatus.cloud_deletion_status === 'processing' && t('cloudDeletionProcessing')}
+                      {cloudStatus.cloud_registration_status === 'deletion_pending' && !cloudStatus.cloud_last_error && cloudStatus.cloud_deletion_status !== 'failed' && cloudStatus.cloud_deletion_status !== 'processing' && t('cloudDeletionPending')}
+                      {cloudStatus.cloud_registration_status === 'deleted' && t('cloudDataDeleted')}
+                      {(cloudStatus.cloud_registration_status === 'unregistered' || cloudStatus.cloud_registration_status === 'registration_failed') && t('notRegistered')}
                     </p>
                     <p className="text-xs text-gray-500">
-                      {cloudStatus.cloud_registration_status === 'registered' && cloudServicesStopped && t('settings.cloudResumeHint')}
-                      {cloudStatus.cloud_registration_status === 'registered' && !cloudServicesStopped && (cloudStatus.cloud_last_heartbeat ? t('settings.liveChannelHeartbeat', { mode: cloudStatus.cloud_relay_mode.replace('_', ' '), time: formatTime(cloudStatus.cloud_last_heartbeat) }) : t('settings.liveChannel', { mode: cloudStatus.cloud_relay_mode.replace('_', ' ') }))}
-                      {cloudStatus.cloud_registration_status === 'rejected' && t('settings.registrationContactSupport')}
-                      {cloudStatus.cloud_registration_status === 'registration_failed' && (cloudStatus.cloud_last_error ? t('settings.registrationLastError', { error: cloudStatus.cloud_last_error }) : t('settings.registrationLastFailed'))}
-                      {cloudStatus.cloud_registration_status === 'deletion_pending' && (cloudStatus.cloud_last_error || cloudStatus.cloud_deletion_status === 'failed') && t('settings.cloudDeletionFailedHint2')}
-                      {cloudStatus.cloud_registration_status === 'deletion_pending' && cloudStatus.cloud_deletion_status === 'processing' && t('settings.cloudDeletionProcessingHint2')}
-                      {cloudStatus.cloud_registration_status === 'deletion_pending' && !cloudStatus.cloud_last_error && cloudStatus.cloud_deletion_status !== 'failed' && cloudStatus.cloud_deletion_status !== 'processing' && t('settings.cloudServicesStoppedHint')}
-                      {cloudStatus.cloud_registration_status === 'deleted' && t('settings.cloudDataDeletedHint')}
-                      {cloudStatus.cloud_registration_status === 'unregistered' && t('settings.registrationRegisterHelp')}
+                      {cloudStatus.cloud_registration_status === 'registered' && cloudServicesStopped && t('cloudResumeHint')}
+                      {cloudStatus.cloud_registration_status === 'registered' && !cloudServicesStopped && (cloudStatus.cloud_last_heartbeat ? t('liveChannelHeartbeat', { mode: cloudStatus.cloud_relay_mode.replace('_', ' '), time: formatTime(cloudStatus.cloud_last_heartbeat) }) : t('liveChannel', { mode: cloudStatus.cloud_relay_mode.replace('_', ' ') }))}
+                      {cloudStatus.cloud_registration_status === 'rejected' && t('registrationContactSupport')}
+                      {cloudStatus.cloud_registration_status === 'registration_failed' && (cloudStatus.cloud_last_error ? t('registrationLastError', { error: cloudStatus.cloud_last_error }) : t('registrationLastFailed'))}
+                      {cloudStatus.cloud_registration_status === 'deletion_pending' && (cloudStatus.cloud_last_error || cloudStatus.cloud_deletion_status === 'failed') && t('cloudDeletionFailedHint2')}
+                      {cloudStatus.cloud_registration_status === 'deletion_pending' && cloudStatus.cloud_deletion_status === 'processing' && t('cloudDeletionProcessingHint2')}
+                      {cloudStatus.cloud_registration_status === 'deletion_pending' && !cloudStatus.cloud_last_error && cloudStatus.cloud_deletion_status !== 'failed' && cloudStatus.cloud_deletion_status !== 'processing' && t('cloudServicesStoppedHint')}
+                      {cloudStatus.cloud_registration_status === 'deleted' && t('cloudDataDeletedHint')}
+                      {cloudStatus.cloud_registration_status === 'unregistered' && t('registrationRegisterHelp')}
                     </p>
                   </div>
                 </div>
@@ -4308,14 +4325,14 @@ export default function SettingsPage() {
                     disabled={registeringCloud}
                     className="px-4 py-2 text-sm bg-brand text-white rounded-lg hover:opacity-90 disabled:opacity-50 font-medium shrink-0"
                   >
-                    {registeringCloud ? t('settings.registering') : t('settings.registerWithFloadmin')}
+                    {registeringCloud ? t('registering') : t('registerWithFloadmin')}
                   </button>
                 )}
               </div>
 
               {cloudStatus.cloud_registration_status !== 'deleted' && (
               <div className="space-y-3">
-                <p className="text-sm text-gray-600">{t('settings.cloudManagedAutomatically')}</p>
+                <p className="text-sm text-gray-600">{t('cloudManagedAutomatically')}</p>
 
                 <label className="flex items-start gap-3 cursor-pointer">
                   <input
@@ -4325,13 +4342,13 @@ export default function SettingsPage() {
                     className="mt-0.5 rounded border-gray-300 text-brand focus:ring-brand"
                   />
                   <div>
-                    <span className="text-sm font-medium text-gray-900 block">{cloudServicesStopped ? t('settings.cloudEnableButton') : t('settings.enableBillSync')}</span>
-                    <p className="text-xs text-gray-500 mt-1">{cloudServicesStopped ? t('settings.cloudResumeHintStopped') : t('settings.enableBillSyncHint')}</p>
+                    <span className="text-sm font-medium text-gray-900 block">{cloudServicesStopped ? t('cloudEnableButton') : t('enableBillSync')}</span>
+                    <p className="text-xs text-gray-500 mt-1">{cloudServicesStopped ? t('cloudResumeHintStopped') : t('enableBillSyncHint')}</p>
                   </div>
                 </label>
 
                     {cloudSettings.cloud_last_sync && (
-                      <p className="text-xs text-gray-400">{t('settings.lastSync', { time: formatDateTime(cloudSettings.cloud_last_sync) })}</p>
+                      <p className="text-xs text-gray-400">{t('lastSync', { time: formatDateTime(cloudSettings.cloud_last_sync) })}</p>
                     )}
                   </div>
               )}
@@ -4344,8 +4361,8 @@ export default function SettingsPage() {
               <div className="flex items-center gap-2">
                 <Smartphone size={20} className="text-gray-500" />
                 <div>
-                  <h2 className="font-semibold text-gray-900">{revflo?.name || t('settings.revflo')}</h2>
-                  <p className="text-xs text-gray-500 mt-0.5">{revflo?.tagline || t('settings.revfloHint')}</p>
+                  <h2 className="font-semibold text-gray-900">{revflo?.name || t('revflo')}</h2>
+                  <p className="text-xs text-gray-500 mt-0.5">{revflo?.tagline || t('revfloHint')}</p>
                 </div>
               </div>
 
@@ -4353,7 +4370,7 @@ export default function SettingsPage() {
                 <div className="flex flex-col sm:flex-row gap-5 items-start border border-gray-100 rounded-xl p-5">
                   <div className="shrink-0">
                     {revflo.qr_data_url ? (
-                      <img src={revflo.qr_data_url} alt={t('settings.appQrAlt', { name: revflo.name })}
+                      <img src={revflo.qr_data_url} alt={t('appQrAlt', { name: revflo.name })}
                         className="w-28 h-28 rounded-lg border border-gray-200" />
                     ) : (
                       <div className="w-28 h-28 rounded-lg border border-gray-200 flex items-center justify-center text-gray-400">
@@ -4364,12 +4381,12 @@ export default function SettingsPage() {
                   <div className="flex gap-3 text-sm">
                     {revflo.ios_url && (
                       <a href={revflo.ios_url} target="_blank" rel="noopener noreferrer" className="text-brand hover:underline">
-                        {t('settings.downloadForIos')}
+                        {t('downloadForIos')}
                       </a>
                     )}
                     {revflo.android_url && (
                       <a href={revflo.android_url} target="_blank" rel="noopener noreferrer" className="text-brand hover:underline">
-                        {t('settings.downloadForAndroid')}
+                        {t('downloadForAndroid')}
                       </a>
                     )}
                   </div>
@@ -4377,15 +4394,15 @@ export default function SettingsPage() {
               )}
 
               <div>
-                <p className="text-sm font-medium text-gray-900 mb-1">{t('settings.mobileApp')}</p>
-                <p className="text-xs text-gray-500 mb-4">{t('settings.mobileAppHint')}</p>
+                <p className="text-sm font-medium text-gray-900 mb-1">{t('mobileApp')}</p>
+                <p className="text-xs text-gray-500 mb-4">{t('mobileAppHint')}</p>
                 {pairingUnavailable ? (
-                  <p className="text-sm text-gray-500">{t('settings.mobilePairingNeedsCloud')}</p>
+                  <p className="text-sm text-gray-500">{t('mobilePairingNeedsCloud')}</p>
                 ) : pairingCode ? (
                   <div className="space-y-3">
                     <div className="flex items-center gap-4">
                       {pairingQrDataUrl && (
-                        <img src={pairingQrDataUrl} alt={t('settings.pairingQrAlt')} className="w-28 h-28 rounded-lg border border-gray-200" />
+                        <img src={pairingQrDataUrl} alt={t('pairingQrAlt')} className="w-28 h-28 rounded-lg border border-gray-200" />
                       )}
                       <div className="flex items-center gap-3 flex-1">
                       <div className="flex-1 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 text-center">
@@ -4396,7 +4413,7 @@ export default function SettingsPage() {
                       <button
                         onClick={copyPairingCode}
                         className="p-2.5 border border-gray-200 rounded-lg hover:bg-gray-50 text-gray-500"
-                        title={t('settings.copyCode')}
+                        title={t('copyCode')}
                       >
                         {copiedCode ? <Check size={18} className="text-green-600" /> : <Copy size={18} />}
                       </button>
@@ -4404,11 +4421,11 @@ export default function SettingsPage() {
                     </div>
                     {pairingExpiresAt && (
                       <p className="text-xs text-gray-400">
-                        {t('settings.codeExpires', { date: formatDate(pairingExpiresAt) })}
+                        {t('codeExpires', { date: formatDate(pairingExpiresAt) })}
                       </p>
                     )}
                     <p className="text-xs text-gray-500">
-                      {t('settings.pairingCodeSingleUse')}
+                      {t('pairingCodeSingleUse')}
                     </p>
                     <button
                       onClick={rotatePairingCode}
@@ -4416,10 +4433,10 @@ export default function SettingsPage() {
                       className="flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 disabled:opacity-50"
                     >
                       <RefreshCw size={14} className={rotatingCode ? 'animate-spin' : ''} />
-                      {rotatingCode ? t('settings.generating') : t('settings.generateNewCode')}
+                      {rotatingCode ? t('generating') : t('generateNewCode')}
                     </button>
                     <p className="text-xs text-amber-600">
-                      {t('settings.disconnectDevicesWarning')}
+                      {t('disconnectDevicesWarning')}
                     </p>
                   </div>
                 ) : (
@@ -4428,33 +4445,33 @@ export default function SettingsPage() {
                     disabled={rotatingCode}
                     className="px-5 py-2 text-sm bg-brand text-white rounded-lg hover:opacity-90 disabled:opacity-50 font-medium"
                   >
-                    {rotatingCode ? t('settings.generating') : t('settings.generatePairingCode')}
+                    {rotatingCode ? t('generating') : t('generatePairingCode')}
                   </button>
                 )}
               </div>
 
               {!pairingUnavailable && (
                 <div className="pt-5 border-t border-gray-100">
-                  <p className="text-sm font-medium text-gray-900 mb-3">{t('settings.pairedDevices')}</p>
+                  <p className="text-sm font-medium text-gray-900 mb-3">{t('pairedDevices')}</p>
                   {devicesLoading ? (
-                    <p className="text-sm text-gray-400">{t('settings.loading')}</p>
+                    <p className="text-sm text-gray-400">{t('loading')}</p>
                   ) : pairedDevices.length === 0 ? (
-                    <p className="text-sm text-gray-500">{t('settings.noPairedDevices')}</p>
+                    <p className="text-sm text-gray-500">{t('noPairedDevices')}</p>
                   ) : (
                     <div className="space-y-2">
                       {pairedDevices.map((d) => (
                         <div key={d.id} className="bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 text-sm">
                           <div className="flex items-center justify-between">
                             <span className="font-medium text-gray-900 capitalize">
-                              {d.platform || t('settings.unknownPlatform')}
+                              {d.platform || t('unknownPlatform')}
                               {d.country ? ` · ${d.country}` : ''}
                             </span>
                             <span className="text-xs text-gray-400">
-                              {t('settings.lastActive', { date: formatDate(d.last_seen_at) })}
+                              {t('lastActive', { date: formatDate(d.last_seen_at) })}
                             </span>
                           </div>
                           <p className="text-xs text-gray-500 mt-1">
-                            {t('settings.firstPaired', { date: formatDate(d.first_seen_at) })}
+                            {t('firstPaired', { date: formatDate(d.first_seen_at) })}
                             {d.app_version ? ` · v${d.app_version}` : ''}
                           </p>
                           {d.user_agent && (
@@ -4474,15 +4491,15 @@ export default function SettingsPage() {
         <TabsContent value="orderflow">
           <div className="pb-6 max-w-3xl space-y-6">
             <div className="space-y-6">
-            <h2 className="text-lg font-semibold text-gray-900">{t('settings.tabOrderflow')}</h2>
+            <h2 className="text-lg font-semibold text-gray-900">{t('tabOrderflow')}</h2>
 
             {/* OrderFlow — online orders */}
             <div className="bg-white rounded-xl border border-gray-100 p-6 space-y-4">
               <div className="flex items-center gap-2">
                 <Zap size={20} className="text-amber-500" />
                 <div>
-                  <h2 className="font-semibold text-gray-900">{t('settings.orderflowOnlineOrders')}</h2>
-                  <p className="text-xs text-gray-500 mt-0.5">{t('settings.orderflowOnlineOrdersHint')}</p>
+                  <h2 className="font-semibold text-gray-900">{t('orderflowOnlineOrders')}</h2>
+                  <p className="text-xs text-gray-500 mt-0.5">{t('orderflowOnlineOrdersHint')}</p>
                 </div>
               </div>
 
@@ -4493,7 +4510,7 @@ export default function SettingsPage() {
                   onChange={(e) => setCloudSettings({ ...cloudSettings, cloud_orders_enabled: e.target.checked })}
                   className="rounded border-gray-300 text-brand focus:ring-brand"
                 />
-                <span className="text-sm text-gray-700">{t('settings.enableOnlineOrderPolling')}</span>
+                <span className="text-sm text-gray-700">{t('enableOnlineOrderPolling')}</span>
               </label>
 
             </div>
@@ -4505,18 +4522,18 @@ export default function SettingsPage() {
         <TabsContent value="about">
           <div className="pb-6 max-w-3xl space-y-6">
             <div className="bg-white rounded-xl border border-gray-100 p-6">
-              <h2 className="font-semibold text-gray-900 mb-4">{t('settings.aboutFloCafe')}</h2>
+              <h2 className="font-semibold text-gray-900 mb-4">{t('aboutFloCafe')}</h2>
               <p className="text-sm text-gray-600 mb-6">
-                {t('settings.aboutDescription')}
+                {t('aboutDescription')}
               </p>
               <div className="space-y-3">
                 <a href="https://github.com/FreeOpenSourcePOS/FloCafe" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-brand hover:underline">
                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
-                  {t('settings.aboutGithub')}
+                  {t('aboutGithub')}
                 </a>
                 <a href="https://flopos.com/" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-brand hover:underline">
                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>
-                  {t('settings.aboutWebsite')}
+                  {t('aboutWebsite')}
                 </a>
               </div>
             </div>
@@ -4525,10 +4542,10 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Smartphone size={20} className="text-gray-500" />
-                <h2 className="font-semibold text-gray-900">{t('settings.moreApps')}</h2>
+                <h2 className="font-semibold text-gray-900">{t('moreApps')}</h2>
               </div>
               <p className="text-sm text-gray-500 mb-5">
-                {t('settings.moreAppsHint')}
+                {t('moreAppsHint')}
               </p>
 
               {moreAppsLoading && (
@@ -4543,7 +4560,7 @@ export default function SettingsPage() {
                     <div key={app.id} className="flex flex-col sm:flex-row gap-5 items-start border border-gray-100 rounded-xl p-5">
                       <div className="shrink-0">
                         {app.qr_data_url ? (
-                          <img src={app.qr_data_url} alt={t('settings.appQrAlt', { name: app.name })}
+                          <img src={app.qr_data_url} alt={t('appQrAlt', { name: app.name })}
                             className="w-32 h-32 rounded-lg border border-gray-200" />
                         ) : (
                           <div className="w-32 h-32 rounded-lg border border-gray-200 flex items-center justify-center text-gray-400">
@@ -4555,19 +4572,19 @@ export default function SettingsPage() {
                         <div className="flex items-center gap-2 mb-1">
                           <h3 className="font-semibold text-gray-900">{app.name}</h3>
                           {!app.available && (
-                            <span className="text-xs font-medium text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">{t('settings.comingSoon')}</span>
+                            <span className="text-xs font-medium text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">{t('comingSoon')}</span>
                           )}
                         </div>
                         <p className="text-sm text-gray-500 mb-3">{app.tagline}</p>
                         <div className="flex gap-3 text-sm">
                           {app.ios_url && (
                             <a href={app.ios_url} target="_blank" rel="noopener noreferrer" className="text-brand hover:underline">
-                              {t('settings.downloadForIos')}
+                              {t('downloadForIos')}
                             </a>
                           )}
                           {app.android_url && (
                             <a href={app.android_url} target="_blank" rel="noopener noreferrer" className="text-brand hover:underline">
-                              {t('settings.downloadForAndroid')}
+                              {t('downloadForAndroid')}
                             </a>
                           )}
                         </div>
@@ -4575,7 +4592,7 @@ export default function SettingsPage() {
                     </div>
                   ))}
                   {moreApps.length === 0 && (
-                    <p className="text-sm text-gray-400 text-center py-10">{t('settings.noAppsToShow')}</p>
+                    <p className="text-sm text-gray-400 text-center py-10">{t('noAppsToShow')}</p>
                   )}
                 </div>
               )}
@@ -4589,14 +4606,14 @@ export default function SettingsPage() {
             <div className="bg-white rounded-xl border border-gray-100 p-6">
             <div className="flex items-center gap-2 mb-4">
               <RefreshCw size={20} className="text-gray-500" />
-              <h2 className="font-semibold text-gray-900">{t('settings.updates')}</h2>
+              <h2 className="font-semibold text-gray-900">{t('updates')}</h2>
             </div>
             <p className="text-sm text-gray-500 mb-6">
               {updateStatus?.status === 'store'
-                ? t('settings.softwareUpdatesHintStore')
+                ? t('softwareUpdatesHintStore')
                 : updateStatus?.status === 'linux-managed'
-                ? t('settings.softwareUpdatesHintLinuxManaged')
-                : t('settings.softwareUpdatesHintDefault')}
+                ? t('softwareUpdatesHintLinuxManaged')
+                : t('softwareUpdatesHintDefault')}
             </p>
 
             {updateStatus && updateStatus.status !== 'store' && updateStatus.status !== 'linux-managed' && (
@@ -4618,17 +4635,17 @@ export default function SettingsPage() {
                   {updateStatus.status === 'error' && <span className="text-red-600">✕</span>}
                   {updateStatus.status === 'dev-mode' && <span className="text-yellow-600">⚠</span>}
                   <span className="font-medium capitalize">
-                    {updateStatus.status === 'available' ? t('settings.updateStatusAvailable')
-                     : updateStatus.status === 'up-to-date' ? t('settings.updateStatusUpToDate')
-                     : updateStatus.status === 'ready-to-install' ? t('settings.updateStatusReadyToInstall')
+                    {updateStatus.status === 'available' ? t('updateStatusAvailable')
+                     : updateStatus.status === 'up-to-date' ? t('updateStatusUpToDate')
+                     : updateStatus.status === 'ready-to-install' ? t('updateStatusReadyToInstall')
                      : updateStatus.status.replace(/-/g, ' ')}
                   </span>
                 </div>
                 {appVersion && (
-                  <p className="text-sm font-medium text-gray-900">{t('settings.version')}: <Ltr>{appVersion}</Ltr></p>
+                  <p className="text-sm font-medium text-gray-900">{t('version')}: <Ltr>{appVersion}</Ltr></p>
                 )}
                 {updateStatus.version && updateStatus.version !== appVersion && (
-                  <p className="text-sm text-gray-600 mt-1">{t('settings.updateLatestAvailable')} <Ltr>{updateStatus.version}</Ltr></p>
+                  <p className="text-sm text-gray-600 mt-1">{t('updateLatestAvailable')} <Ltr>{updateStatus.version}</Ltr></p>
                 )}
                 {updateStatus.percent !== undefined && (
                   <div className="mt-2">
@@ -4638,17 +4655,17 @@ export default function SettingsPage() {
                         style={{ width: `${updateStatus.percent}%` }}
                       />
                     </div>
-                    <p className="text-xs text-gray-500 mt-1">{t('settings.percentDownloaded', { percent: updateStatus.percent.toFixed(1) })}</p>
+                    <p className="text-xs text-gray-500 mt-1">{t('percentDownloaded', { percent: updateStatus.percent.toFixed(1) })}</p>
                   </div>
                 )}
                 {updateStatus.error && (
                   <p className="text-sm text-red-600 mt-1">{updateStatus.error}</p>
                 )}
                 {updateStatus.status === 'up-to-date' && (
-                  <p className="text-sm text-gray-600">{t('settings.upToDate')}</p>
+                  <p className="text-sm text-gray-600">{t('upToDate')}</p>
                 )}
                 {updateStatus.status === 'dev-mode' && (
-                  <p className="text-sm text-yellow-600">{t('settings.devModeDisabled')}</p>
+                  <p className="text-sm text-yellow-600">{t('devModeDisabled')}</p>
                 )}
               </div>
             )}
@@ -4661,7 +4678,7 @@ export default function SettingsPage() {
                   className="px-4 py-2 rounded-lg text-sm font-medium flex items-center gap-2 disabled:opacity-50 bg-brand text-white hover:opacity-90"
                 >
                   <RefreshCw size={16} className={updateStatus?.status === 'checking' ? 'animate-spin' : ''} />
-                  {updateStatus?.status === 'checking' ? t('settings.checking') : t('settings.checkForUpdates')}
+                  {updateStatus?.status === 'checking' ? t('checking') : t('checkForUpdates')}
                 </button>
               </div>
             )}
@@ -4677,19 +4694,19 @@ export default function SettingsPage() {
       <Dialog open={tableInfoOpen} onOpenChange={setTableInfoOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>{t('settings.databaseTables')}</DialogTitle>
-            <DialogDescription>{t('settings.rowCountsForAll')}</DialogDescription>
+            <DialogTitle>{t('databaseTables')}</DialogTitle>
+            <DialogDescription>{t('rowCountsForAll')}</DialogDescription>
           </DialogHeader>
           <div className="max-h-60 overflow-y-auto space-y-1.5">
             {tableInfo.map((row) => (
               <div key={row.name} className="flex justify-between text-sm">
                 <span className="text-gray-700 font-mono">{row.name}</span>
-                <span className="text-gray-500">{row.rows.toLocaleString()} {t('settings.rows')}</span>
+                <span className="text-gray-500">{row.rows.toLocaleString()} {t('rows')}</span>
               </div>
             ))}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setTableInfoOpen(false)}>{t('settings.close')}</Button>
+            <Button variant="outline" onClick={() => setTableInfoOpen(false)}>{t('close')}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -4698,20 +4715,20 @@ export default function SettingsPage() {
       <Dialog open={showInitializeCloudConfirm} onOpenChange={setShowInitializeCloudConfirm}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>{t('settings.cloudInitializeDialogTitle')}</DialogTitle>
+            <DialogTitle>{t('cloudInitializeDialogTitle')}</DialogTitle>
             <DialogDescription>
-              {t('settings.cloudInitializeDialogBody')}
+              {t('cloudInitializeDialogBody')}
               <br /><br />
-              {t('settings.cloudInitializeDialogBody2')}
+              {t('cloudInitializeDialogBody2')}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowInitializeCloudConfirm(false)}>{t('settings.cancel')}</Button>
+            <Button variant="outline" onClick={() => setShowInitializeCloudConfirm(false)}>{t('cancel')}</Button>
             <Button
               disabled={registeringCloud}
               onClick={() => { setShowInitializeCloudConfirm(false); registerCloud(''); }}
             >
-              {registeringCloud ? t('settings.registering') : t('settings.cloudInitializeAccept')}
+              {registeringCloud ? t('registering') : t('cloudInitializeAccept')}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -4721,11 +4738,11 @@ export default function SettingsPage() {
         open={pinGate !== null}
         mode={pinGate?.mode === 'set' ? 'set' : 'verify'}
         title={
-          pinGate?.mode === 'backup' || pinGate?.mode === 'backup-custom' ? t('settings.confirmBackupTitle')
-          : pinGate?.mode === 'import' ? t('settings.confirmImportTitle')
-          : pinGate?.mode === 'restore' ? t('settings.confirmRestoreTitle')
-          : pinGate?.mode === 'delete-cloud' ? t('settings.cloudConfirmDeletion')
-          : pinGate?.mode === 'cancel-cloud-deletion' ? t('settings.cloudCancelDeletionTitle')
+          pinGate?.mode === 'backup' || pinGate?.mode === 'backup-custom' ? t('confirmBackupTitle')
+          : pinGate?.mode === 'import' ? t('confirmImportTitle')
+          : pinGate?.mode === 'restore' ? t('confirmRestoreTitle')
+          : pinGate?.mode === 'delete-cloud' ? t('cloudConfirmDeletion')
+          : pinGate?.mode === 'cancel-cloud-deletion' ? t('cloudCancelDeletionTitle')
           : undefined
         }
         onCancel={() => setPinGate(null)}
@@ -4745,17 +4762,17 @@ export default function SettingsPage() {
         onOpenChange={setInitializeDbOpen}
         onConfirm={handleInitializeDatabase}
         onSuccess={() => {
-          toast.success(t('settings.dbInitializedRedirecting'));
+          toast.success(t('dbInitializedRedirecting'));
           setTimeout(() => window.location.replace('/setup'), 1200);
         }}
       />
       {isAdmin && isDirty && (
         <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 pointer-events-none animate-in slide-in-from-bottom-5 duration-300">
           <div className={`bg-gray-900 text-white px-6 py-4 rounded-full shadow-2xl flex items-center gap-6 pointer-events-auto ${shakeSaveBar ? 'animate-shake' : ''}`}>
-            <span className="text-sm font-medium">{t('settings.unsavedChanges', { defaultValue: 'You have unsaved changes' })}</span>
+            <span className="text-sm font-medium">{t('unsavedChanges', { defaultValue: 'You have unsaved changes' })}</span>
             <div className="flex items-center gap-2">
-              <button onClick={resetAllSettings} disabled={savingBusiness || savingLoyalty || savingDiscount || savingCloud || savingOrderNumbering} className="px-4 py-1.5 text-sm bg-gray-800 hover:bg-gray-700 rounded-full transition-colors disabled:opacity-50 text-white">{t('settings.discard', { defaultValue: 'Discard' })}</button>
-              <button onClick={saveAllSettings} disabled={savingBusiness || savingLoyalty || savingDiscount || savingCloud || savingOrderNumbering} className="px-4 py-1.5 text-sm bg-brand hover:opacity-90 rounded-full font-medium transition-colors disabled:opacity-50 text-white">{(savingBusiness || savingLoyalty || savingDiscount || savingCloud || savingOrderNumbering) ? t('settings.saving') : t('settings.saveChanges', { defaultValue: 'Save Changes' })}</button>
+              <button onClick={resetAllSettings} disabled={savingBusiness || savingLoyalty || savingDiscount || savingCloud || savingOrderNumbering} className="px-4 py-1.5 text-sm bg-gray-800 hover:bg-gray-700 rounded-full transition-colors disabled:opacity-50 text-white">{t('discard', { defaultValue: 'Discard' })}</button>
+              <button onClick={saveAllSettings} disabled={savingBusiness || savingLoyalty || savingDiscount || savingCloud || savingOrderNumbering} className="px-4 py-1.5 text-sm bg-brand hover:opacity-90 rounded-full font-medium transition-colors disabled:opacity-50 text-white">{(savingBusiness || savingLoyalty || savingDiscount || savingCloud || savingOrderNumbering) ? t('saving') : t('saveChanges', { defaultValue: 'Save Changes' })}</button>
             </div>
           </div>
         </div>

--- a/frontend/src/app/(dashboard)/staff/page.tsx
+++ b/frontend/src/app/(dashboard)/staff/page.tsx
@@ -6,17 +6,19 @@ import { Button } from '@/components/ui/button';
 import toast from 'react-hot-toast';
 import { Plus, X, Edit, RotateCcw, Eye, EyeOff } from 'lucide-react';
 import type { Staff } from '@/lib/types';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 
 const VALID_ROLES = ['owner', 'manager', 'cashier', 'server', 'chef'];
 
-const roleColorKey: Record<string, string> = {
-  owner: 'staff.roleOwner',
-  manager: 'staff.roleManager',
-  cashier: 'staff.roleCashier',
-  server: 'staff.roleServer',
-  chef: 'staff.roleChef',
-};
+type StaffKey = keyof AppConfig['Messages']['staff'];
+
+const roleColorKey = {
+  owner: 'roleOwner',
+  manager: 'roleManager',
+  cashier: 'roleCashier',
+  server: 'roleServer',
+  chef: 'roleChef',
+} as const satisfies Record<'owner' | 'manager' | 'cashier' | 'server' | 'chef', StaffKey>;
 
 const roleColors: Record<string, string> = {
   owner: 'bg-red-100 text-red-800',
@@ -26,8 +28,16 @@ const roleColors: Record<string, string> = {
   chef: 'bg-orange-100 text-orange-800',
 };
 
+function roleLabel(role: string, t: (key: StaffKey) => string): string {
+  const key = (roleColorKey as Record<string, StaffKey | undefined>)[role];
+  return key ? t(key) : role;
+}
+
 export default function StaffPage() {
-  const { t } = useI18n();
+  const t = useTranslations('staff');
+  const tCommon = useTranslations('common');
+  const tAuth = useTranslations('auth');
+  const tSetup = useTranslations('setup');
   const [staff, setStaff] = useState<Staff[]>([]);
   const [, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -53,7 +63,7 @@ export default function StaffPage() {
       const { data } = await api.get('/staff');
       setStaff(data.staff || []);
     } catch {
-      toast.error(t('staff.failedToLoad'));
+      toast.error(t('failedToLoad'));
     } finally {
       setLoading(false);
     }
@@ -62,7 +72,7 @@ export default function StaffPage() {
   useEffect(() => {
     api.get('/staff')
       .then(({ data }) => setStaff(data.staff || []))
-      .catch(() => toast.error(t('staff.failedToLoad')))
+      .catch(() => toast.error(t('failedToLoad')))
       .finally(() => setLoading(false));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -94,7 +104,7 @@ export default function StaffPage() {
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
     if (form.password && form.password !== form.confirmPassword) {
-      toast.error(t('setup.passwordsMismatch'));
+      toast.error(tSetup('passwordsMismatch'));
       return;
     }
     try {
@@ -106,7 +116,7 @@ export default function StaffPage() {
           ...(form.password ? { password: form.password } : {}),
           ...(form.pin ? { pin: form.pin } : {}),
         });
-        toast.success(t('staff.updatedToast'));
+        toast.success(t('updatedToast'));
       } else {
         await api.post('/staff', {
           name: form.name,
@@ -115,27 +125,27 @@ export default function StaffPage() {
           role: form.role,
           ...(form.pin ? { pin: form.pin } : {}),
         });
-        toast.success(t('staff.addedToast'));
+        toast.success(t('addedToast'));
       }
       closeForm();
       fetchStaff();
     } catch {
-      toast.error(t('staff.failedToSave'));
+      toast.error(t('failedToSave'));
     }
   };
 
   const handleResetPassword = async () => {
     if (!resetPwStaff || !newPassword) return;
     if (newPassword !== confirmNewPassword) {
-      toast.error(t('setup.passwordsMismatch'));
+      toast.error(tSetup('passwordsMismatch'));
       return;
     }
     try {
       await api.put(`/staff/${resetPwStaff.id}`, { password: newPassword });
-      toast.success(t('staff.resetPasswordToast'));
+      toast.success(t('resetPasswordToast'));
       closeResetPassword();
     } catch {
-      toast.error(t('staff.failedToReset'));
+      toast.error(t('failedToReset'));
     }
   };
 
@@ -155,7 +165,7 @@ export default function StaffPage() {
       await api.post(`/staff/${s.id}/${s.is_active ? 'deactivate' : 'reactivate'}`);
       fetchStaff();
     } catch {
-      toast.error(t('staff.failedToUpdate'));
+      toast.error(t('failedToUpdate'));
     }
   };
 
@@ -166,8 +176,8 @@ export default function StaffPage() {
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t('staff.title')}</h1>
-        <Button onClick={openAdd}><Plus size={16} className="me-1" /> {t('staff.addButton')}</Button>
+        <h1 className="text-2xl font-bold text-gray-900">{t('title')}</h1>
+        <Button onClick={openAdd}><Plus size={16} className="me-1" /> {t('addButton')}</Button>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -178,19 +188,19 @@ export default function StaffPage() {
                 <p className="font-bold text-gray-900">{s.name}</p>
                 <p className="text-xs text-gray-500">{s.email || '—'}</p>
                 {Boolean(s.has_pin) && (
-                  <p className="text-xs text-green-600 mt-1">{t('staff.pinSet')}</p>
+                  <p className="text-xs text-green-600 mt-1">{t('pinSet')}</p>
                 )}
               </div>
               <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${roleColors[s.role] || 'bg-gray-100 text-gray-800'}`}>
-                {roleColorKey[s.role] ? t(roleColorKey[s.role]) : s.role}
+                {roleLabel(s.role, t)}
               </span>
             </div>
             <div className="flex flex-wrap gap-2 mt-3">
               <Button variant="outline" size="sm" onClick={() => openEdit(s)}>
-                <Edit size={14} className="me-1" /> {t('common.edit')}
+                <Edit size={14} className="me-1" /> {tCommon('edit')}
               </Button>
               <Button variant="outline" size="sm" onClick={() => openResetPw(s)}>
-                <RotateCcw size={14} className="me-1" /> {t('staff.resetPwButton')}
+                <RotateCcw size={14} className="me-1" /> {t('resetPwButton')}
               </Button>
               <Button
                 variant="ghost"
@@ -198,36 +208,36 @@ export default function StaffPage() {
                 onClick={() => toggleActive(s)}
                 className={s.is_active ? 'text-red-500 hover:text-red-700 hover:bg-red-50' : 'text-green-500 hover:text-green-700 hover:bg-green-50'}
               >
-                {s.is_active ? t('staff.deactivate') : t('staff.reactivate')}
+                {s.is_active ? t('deactivate') : t('reactivate')}
               </Button>
             </div>
           </div>
         ))}
       </div>
 
-      {staff.length === 0 && <p className="text-center text-gray-500 py-12">{t('staff.empty')}</p>}
+      {staff.length === 0 && <p className="text-center text-gray-500 py-12">{t('empty')}</p>}
 
       {showForm && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-2xl p-6 w-full max-w-sm">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-bold">{editingStaff ? t('staff.modalTitleEdit') : t('staff.modalTitleAdd')}</h2>
+              <h2 className="text-lg font-bold">{editingStaff ? t('modalTitleEdit') : t('modalTitleAdd')}</h2>
               <button type="button" onClick={closeForm}><X size={20} className="text-gray-400" /></button>
             </div>
             <form onSubmit={handleSave} className="space-y-4">
               <input
-                type="text" placeholder={t('staff.namePlaceholder')} value={form.name}
+                type="text" placeholder={t('namePlaceholder')} value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
                 className="w-full px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand" required
               />
               <input
-                type="email" placeholder={`${t('auth.email')} (${t('common.optional')})`} value={form.email}
+                type="email" placeholder={`${tAuth('email')} (${tCommon('optional')})`} value={form.email}
                 onChange={(e) => setForm({ ...form, email: e.target.value })}
                 className="w-full px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
               />
               <div className="relative">
                 <input
-                  type={showPassword ? 'text' : 'password'} placeholder={editingStaff ? t('staff.newPasswordPlaceholder') : t('staff.passwordPlaceholder')}
+                  type={showPassword ? 'text' : 'password'} placeholder={editingStaff ? t('newPasswordPlaceholder') : t('passwordPlaceholder')}
                   value={form.password}
                   onChange={(e) => setForm({ ...form, password: e.target.value })}
                   className="w-full px-3 py-2 pe-10 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
@@ -238,7 +248,7 @@ export default function StaffPage() {
                 </button>
               </div>
               <input
-                type={showPassword ? 'text' : 'password'} placeholder={t('auth.confirmPassword')}
+                type={showPassword ? 'text' : 'password'} placeholder={tAuth('confirmPassword')}
                 value={form.confirmPassword}
                 onChange={(e) => setForm({ ...form, confirmPassword: e.target.value })}
                 className="w-full px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
@@ -252,14 +262,14 @@ export default function StaffPage() {
                 className="w-full px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
               >
                 {VALID_ROLES.map((r) => (
-                  <option key={r} value={r} disabled={editingLastActiveOwner && r !== 'owner'}>{roleColorKey[r] ? t(roleColorKey[r]) : r}</option>
+                  <option key={r} value={r} disabled={editingLastActiveOwner && r !== 'owner'}>{roleLabel(r, t)}</option>
                 ))}
               </select>
               {['owner', 'manager'].includes(form.role) && (
                 <div>
                   <div className="relative">
                     <input
-                      type={showPin ? 'text' : 'password'} placeholder={editingStaff ? t('staff.pinPlaceholderEdit') : t('staff.pinPlaceholderAdd')}
+                      type={showPin ? 'text' : 'password'} placeholder={editingStaff ? t('pinPlaceholderEdit') : t('pinPlaceholderAdd')}
                       value={form.pin}
                       onChange={(e) => setForm({ ...form, pin: e.target.value.replace(/\D/g, '').slice(0, 6) })}
                       className="w-full px-3 py-2 pe-10 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
@@ -271,10 +281,10 @@ export default function StaffPage() {
                       {showPin ? <EyeOff size={16} /> : <Eye size={16} />}
                     </button>
                   </div>
-                  <p className="text-xs text-gray-500 mt-1">{t('staff.pinHint')}</p>
+                  <p className="text-xs text-gray-500 mt-1">{t('pinHint')}</p>
                 </div>
               )}
-              <Button type="submit" className="w-full">{editingStaff ? t('staff.updateButton') : t('staff.addButton')}</Button>
+              <Button type="submit" className="w-full">{editingStaff ? t('updateButton') : t('addButton')}</Button>
             </form>
           </div>
         </div>
@@ -284,14 +294,14 @@ export default function StaffPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-2xl p-6 w-full max-w-sm">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-bold">{t('staff.resetPasswordTitle')}</h2>
+              <h2 className="text-lg font-bold">{t('resetPasswordTitle')}</h2>
               <button type="button" onClick={closeResetPassword}><X size={20} className="text-gray-400" /></button>
             </div>
-            <p className="text-sm text-gray-600 mb-4">{t('staff.resetPasswordBody', { name: resetPwStaff.name })}</p>
+            <p className="text-sm text-gray-600 mb-4">{t('resetPasswordBody', { name: resetPwStaff.name })}</p>
             <div className="space-y-4">
               <div className="relative">
                 <input
-                  type={showResetPassword ? 'text' : 'password'} placeholder={t('staff.newPasswordPlaceholder')} value={newPassword}
+                  type={showResetPassword ? 'text' : 'password'} placeholder={t('newPasswordPlaceholder')} value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
                   className="w-full px-3 py-2 pe-10 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
                 />
@@ -300,11 +310,11 @@ export default function StaffPage() {
                 </button>
               </div>
               <input
-                type={showResetPassword ? 'text' : 'password'} placeholder={t('auth.confirmPassword')} value={confirmNewPassword}
+                type={showResetPassword ? 'text' : 'password'} placeholder={tAuth('confirmPassword')} value={confirmNewPassword}
                 onChange={(e) => setConfirmNewPassword(e.target.value)}
                 className="w-full px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
               />
-              <Button onClick={handleResetPassword} className="w-full">{t('staff.resetPasswordTitle')}</Button>
+              <Button onClick={handleResetPassword} className="w-full">{t('resetPasswordTitle')}</Button>
             </div>
           </div>
         </div>

--- a/frontend/src/app/(dashboard)/support/page.tsx
+++ b/frontend/src/app/(dashboard)/support/page.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { useFormatNumber } from '@/hooks/useFormatNumber';
 import { useSupportTicketStatus } from '@/hooks/useSupportTicketStatus';
 import { useSupportDiagnosticsPreview } from '@/hooks/useSupportDiagnosticsPreview';
@@ -30,7 +30,7 @@ const EMPTY_PROFILE: SupportProfile = {
 };
 
 export default function SupportPage() {
-  const { t } = useI18n();
+  const t = useTranslations('support');
   const fmtNum = useFormatNumber();
   const [profile, setProfile] = useState<SupportProfile>(EMPTY_PROFILE);
   const [category, setCategory] = useState('general');
@@ -46,7 +46,7 @@ export default function SupportPage() {
   useEffect(() => {
     api.get('/support-ticket/profile')
       .then(({ data }) => setProfile({ ...EMPTY_PROFILE, ...data }))
-      .catch(() => toast.error(t('support.profileLoadFailed')))
+      .catch(() => toast.error(t('profileLoadFailed')))
       .finally(() => setLoading(false));
   }, [t]);
 
@@ -69,9 +69,9 @@ export default function SupportPage() {
       setSubmittedId(data.client_ticket_id || '');
       setSubject('');
       setMessage('');
-      toast.success(t('support.queued'));
+      toast.success(t('queued'));
     } catch {
-      toast.error(t('support.submitFailed'));
+      toast.error(t('submitFailed'));
     } finally {
       setSubmitting(false);
     }
@@ -82,8 +82,8 @@ export default function SupportPage() {
       <div className="flex items-start gap-3">
         <div className="rounded-xl bg-brand/10 p-3 text-brand"><LifeBuoy className="size-6" /></div>
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">{t('support.title')}</h1>
-          <p className="mt-1 text-sm text-muted-foreground">{t('support.subtitle')}</p>
+          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">{t('subtitle')}</p>
         </div>
       </div>
 
@@ -91,17 +91,17 @@ export default function SupportPage() {
         <div className="flex gap-3 rounded-xl border border-green-200 bg-green-50 p-4 text-green-900">
           <CheckCircle2 className="mt-0.5 size-5 shrink-0" />
           <div>
-            <p className="font-medium">{t('support.requestQueued')}</p>
+            <p className="font-medium">{t('requestQueued')}</p>
             {delivery.status === 'delivered' && delivery.supportCode ? (
               <>
-                <p className="mt-1 text-sm font-semibold">{t('support.supportCode')}: <span className="font-mono">{delivery.supportCode}</span></p>
-                <p className="mt-0.5 text-xs opacity-80">{t('support.supportCodeHint')}</p>
+                <p className="mt-1 text-sm font-semibold">{t('supportCode')}: <span className="font-mono">{delivery.supportCode}</span></p>
+                <p className="mt-0.5 text-xs opacity-80">{t('supportCodeHint')}</p>
               </>
             ) : (
               <>
-                <p className="mt-1 text-xs opacity-80">{t('support.requestId')}: {submittedId}</p>
+                <p className="mt-1 text-xs opacity-80">{t('requestId')}: {submittedId}</p>
                 <p className="mt-0.5 text-xs opacity-80">
-                  {delivery.status === 'failed' ? t('support.stillQueuedLocally') : t('support.confirmingDelivery')}
+                  {delivery.status === 'failed' ? t('stillQueuedLocally') : t('confirmingDelivery')}
                 </p>
               </>
             )}
@@ -112,71 +112,71 @@ export default function SupportPage() {
       <form onSubmit={submit} className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
         <Card>
           <CardHeader>
-            <CardTitle className="flex items-center gap-2"><MessageSquareText className="size-5" />{t('support.describeIssue')}</CardTitle>
-            <CardDescription>{t('support.descriptionHint')}</CardDescription>
+            <CardTitle className="flex items-center gap-2"><MessageSquareText className="size-5" />{t('describeIssue')}</CardTitle>
+            <CardDescription>{t('descriptionHint')}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-5">
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="support-category">{t('support.category')}</Label>
+                <Label htmlFor="support-category">{t('category')}</Label>
                 <select id="support-category" value={category} onChange={(e) => setCategory(e.target.value)} className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-xs">
-                  <option value="general">{t('support.categoryGeneral')}</option>
-                  <option value="bug">{t('support.categoryBug')}</option>
-                  <option value="printer">{t('support.categoryPrinter')}</option>
-                  <option value="account">{t('support.categoryAccount')}</option>
-                  <option value="tax">{t('support.categoryTax')}</option>
-                  <option value="feature">{t('support.categoryFeature')}</option>
+                  <option value="general">{t('categoryGeneral')}</option>
+                  <option value="bug">{t('categoryBug')}</option>
+                  <option value="printer">{t('categoryPrinter')}</option>
+                  <option value="account">{t('categoryAccount')}</option>
+                  <option value="tax">{t('categoryTax')}</option>
+                  <option value="feature">{t('categoryFeature')}</option>
                 </select>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="support-severity">{t('support.urgency')}</Label>
+                <Label htmlFor="support-severity">{t('urgency')}</Label>
                 <select id="support-severity" value={severity} onChange={(e) => setSeverity(e.target.value)} className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-xs">
-                  <option value="low">{t('support.urgencyLow')}</option>
-                  <option value="normal">{t('support.urgencyNormal')}</option>
-                  <option value="high">{t('support.urgencyHigh')}</option>
-                  <option value="urgent">{t('support.urgencyUrgent')}</option>
+                  <option value="low">{t('urgencyLow')}</option>
+                  <option value="normal">{t('urgencyNormal')}</option>
+                  <option value="high">{t('urgencyHigh')}</option>
+                  <option value="urgent">{t('urgencyUrgent')}</option>
                 </select>
               </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="support-subject">{t('support.subject')}</Label>
-              <Input id="support-subject" value={subject} onChange={(e) => setSubject(e.target.value)} maxLength={255} placeholder={t('support.subjectPlaceholder')} required />
+              <Label htmlFor="support-subject">{t('subject')}</Label>
+              <Input id="support-subject" value={subject} onChange={(e) => setSubject(e.target.value)} maxLength={255} placeholder={t('subjectPlaceholder')} required />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="support-message">{t('support.description')}</Label>
-              <textarea id="support-message" value={message} onChange={(e) => setMessage(e.target.value)} maxLength={20000} rows={10} className="w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50" placeholder={t('support.descriptionPlaceholder')} required />
+              <Label htmlFor="support-message">{t('description')}</Label>
+              <textarea id="support-message" value={message} onChange={(e) => setMessage(e.target.value)} maxLength={20000} rows={10} className="w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50" placeholder={t('descriptionPlaceholder')} required />
               <p className="text-end text-xs text-muted-foreground">{fmtNum(message.length)} / 20,000</p>
             </div>
             <Button type="submit" disabled={loading || submitting || !subject.trim() || !message.trim()} className="w-full sm:w-auto">
-              {submitting ? <Loader2 className="animate-spin" /> : <LifeBuoy />}{submitting ? t('support.submitting') : t('support.submit')}
+              {submitting ? <Loader2 className="animate-spin" /> : <LifeBuoy />}{submitting ? t('submitting') : t('submit')}
             </Button>
           </CardContent>
         </Card>
 
         <div className="space-y-6">
           <Card>
-            <CardHeader><CardTitle className="text-base">{t('support.contactDetails')}</CardTitle><CardDescription>{t('support.contactHint')}</CardDescription></CardHeader>
+            <CardHeader><CardTitle className="text-base">{t('contactDetails')}</CardTitle><CardDescription>{t('contactHint')}</CardDescription></CardHeader>
             <CardContent className="space-y-4">
-              <div className="rounded-lg bg-muted/60 p-3 text-sm"><span className="text-muted-foreground">{t('support.restaurant')}</span><p className="font-medium">{profile.restaurant_name || '—'}</p></div>
-              <div className="space-y-2"><Label htmlFor="support-name">{t('support.contactName')}</Label><Input id="support-name" value={profile.contact_name} onChange={(e) => setProfile({ ...profile, contact_name: e.target.value })} maxLength={255} /></div>
-              <div className="space-y-2"><Label htmlFor="support-email">{t('support.email')}</Label><Input id="support-email" type="email" value={profile.contact_email} onChange={(e) => setProfile({ ...profile, contact_email: e.target.value })} maxLength={255} /></div>
-              <div className="space-y-2"><Label htmlFor="support-phone">{t('support.phone')}</Label><Input id="support-phone" type="tel" value={profile.contact_phone} onChange={(e) => setProfile({ ...profile, contact_phone: e.target.value })} maxLength={50} /></div>
+              <div className="rounded-lg bg-muted/60 p-3 text-sm"><span className="text-muted-foreground">{t('restaurant')}</span><p className="font-medium">{profile.restaurant_name || '—'}</p></div>
+              <div className="space-y-2"><Label htmlFor="support-name">{t('contactName')}</Label><Input id="support-name" value={profile.contact_name} onChange={(e) => setProfile({ ...profile, contact_name: e.target.value })} maxLength={255} /></div>
+              <div className="space-y-2"><Label htmlFor="support-email">{t('email')}</Label><Input id="support-email" type="email" value={profile.contact_email} onChange={(e) => setProfile({ ...profile, contact_email: e.target.value })} maxLength={255} /></div>
+              <div className="space-y-2"><Label htmlFor="support-phone">{t('phone')}</Label><Input id="support-phone" type="tel" value={profile.contact_phone} onChange={(e) => setProfile({ ...profile, contact_phone: e.target.value })} maxLength={50} /></div>
             </CardContent>
           </Card>
 
           <Card>
-            <CardHeader><CardTitle className="flex items-center gap-2 text-base"><Bug className="size-4" />{t('support.technicalDetails')}</CardTitle></CardHeader>
+            <CardHeader><CardTitle className="flex items-center gap-2 text-base"><Bug className="size-4" />{t('technicalDetails')}</CardTitle></CardHeader>
             <CardContent className="space-y-3 text-sm">
-              <p className="text-muted-foreground">{t('support.technicalHint')}</p>
+              <p className="text-muted-foreground">{t('technicalHint')}</p>
               <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 rounded-lg bg-muted/60 p-3 text-xs">
-                <dt className="text-muted-foreground">{t('support.version')}</dt><dd>{profile.app_version || '—'}</dd>
-                <dt className="text-muted-foreground">{t('support.platform')}</dt><dd>{profile.platform || '—'}</dd>
-                <dt className="text-muted-foreground">{t('support.location')}</dt><dd>{[profile.country, profile.timezone].filter(Boolean).join(' · ') || '—'}</dd>
+                <dt className="text-muted-foreground">{t('version')}</dt><dd>{profile.app_version || '—'}</dd>
+                <dt className="text-muted-foreground">{t('platform')}</dt><dd>{profile.platform || '—'}</dd>
+                <dt className="text-muted-foreground">{t('location')}</dt><dd>{[profile.country, profile.timezone].filter(Boolean).join(' · ') || '—'}</dd>
               </dl>
-              <div className="flex gap-2 text-xs text-muted-foreground"><ShieldCheck className="mt-0.5 size-4 shrink-0 text-green-600" /><span>{t('support.privacyHint')}</span></div>
+              <div className="flex gap-2 text-xs text-muted-foreground"><ShieldCheck className="mt-0.5 size-4 shrink-0 text-green-600" /><span>{t('privacyHint')}</span></div>
               {diagnosticsPreview && (
                 <details className="text-xs text-muted-foreground">
-                  <summary className="cursor-pointer">{t('support.showPayload')}</summary>
+                  <summary className="cursor-pointer">{t('showPayload')}</summary>
                   <pre className="mt-2 max-h-40 overflow-auto rounded bg-muted/60 p-2">{JSON.stringify(diagnosticsPreview, null, 2)}</pre>
                 </details>
               )}

--- a/frontend/src/app/(dashboard)/whatsapp/page.tsx
+++ b/frontend/src/app/(dashboard)/whatsapp/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import api from '@/lib/api';
-import { apiErrorText } from '@/lib/api-error';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -15,7 +14,7 @@ import {
 import toast from 'react-hot-toast';
 import Link from 'next/link';
 import { useAuthStore } from '@/store/auth';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import { useConfirm } from '@/hooks/use-confirm';
 import { usePosSettingsStore } from '@/store/pos-settings';
 import { formatDate, formatTime } from '@/lib/printer/format-date';
@@ -31,9 +30,29 @@ interface WhatsAppStatus {
   cooldownUntil: string | null;
 }
 
+type WhatsAppApiErrorKey = keyof AppConfig['Messages']['whatsapp']['apiError'];
+
+// Exhaustively typed backend error codes for the `whatsapp.apiError` namespace.
+const WHATSAPP_API_ERROR_KEYS: readonly WhatsAppApiErrorKey[] = [
+  'bad_connect_method',
+  'body_required',
+  'inbound_not_found',
+  'no_pairing_code',
+  'no_qr',
+  'phone_not_in_blocklist',
+  'phone_required',
+  'phone_required_pairing',
+];
+
+function isWhatsAppApiErrorKey(code: string): code is WhatsAppApiErrorKey {
+  return (WHATSAPP_API_ERROR_KEYS as readonly string[]).includes(code);
+}
+
 /** Show a backend error as a localized toast, mapping `whatsapp.apiError.<reason>` and never surfacing raw English. */
-function toastApiError(err: unknown, fallback: string, t: (k: string, p?: Record<string, string | number>) => string): void {
-  toast.error(apiErrorText(err, fallback, t, 'whatsapp.apiError'));
+function toastApiError(err: unknown, fallback: string, tApiError: (key: WhatsAppApiErrorKey) => string): void {
+  const data = (err as { response?: { data?: { reason?: string; code?: string } } })?.response?.data;
+  const code = data?.reason || data?.code;
+  toast.error(code && isWhatsAppApiErrorKey(code) ? tApiError(code) : fallback);
 }
 
 interface SentMessage {
@@ -71,14 +90,48 @@ interface BlocklistRow {
   blocked_by_user_id: string | null;
 }
 
-const STATE_KEYS: Record<string, string> = {
-  disconnected: 'whatsapp.state.disconnected',
-  connecting: 'whatsapp.state.connecting',
-  waiting_qr: 'whatsapp.state.waiting_qr',
-  waiting_pairing: 'whatsapp.state.waiting_pairing',
-  connected: 'whatsapp.state.connected',
-  cooldown: 'whatsapp.state.cooldown',
-};
+type WhatsAppMessageStatus = 'queued' | 'typing' | 'sent' | 'delivered' | 'read' | 'failed';
+type WhatsAppStatusKey = keyof AppConfig['Messages']['whatsapp']['status'];
+
+const WHATSAPP_STATUS_KEYS = {
+  queued: 'queued',
+  typing: 'typing',
+  sent: 'sent',
+  delivered: 'delivered',
+  read: 'read',
+  failed: 'failed',
+} as const satisfies Record<WhatsAppMessageStatus, WhatsAppStatusKey>;
+
+type WhatsAppMessageKind = 'bill_receipt' | 'manual_reply' | 'auto_followup';
+type WhatsAppKindKey = keyof AppConfig['Messages']['whatsapp']['kind'];
+
+const WHATSAPP_KIND_KEYS = {
+  bill_receipt: 'bill_receipt',
+  manual_reply: 'manual_reply',
+  auto_followup: 'auto_followup',
+} as const satisfies Record<WhatsAppMessageKind, WhatsAppKindKey>;
+
+type WhatsAppState = 'disconnected' | 'connecting' | 'waiting_qr' | 'waiting_pairing' | 'connected' | 'cooldown';
+type WhatsAppStateKey = keyof AppConfig['Messages']['whatsapp']['state'];
+
+const STATE_KEYS = {
+  disconnected: 'disconnected',
+  connecting: 'connecting',
+  waiting_qr: 'waiting_qr',
+  waiting_pairing: 'waiting_pairing',
+  connected: 'connected',
+  cooldown: 'cooldown',
+} as const satisfies Record<WhatsAppState, WhatsAppStateKey>;
+
+type WhatsAppLastErrorReason = 'reconnecting' | 'rate_limited' | 'logged_out' | 'cooldown';
+type WhatsAppLastErrorKey = keyof AppConfig['Messages']['whatsapp']['lastError'];
+
+const WHATSAPP_LAST_ERROR_KEYS = {
+  reconnecting: 'reconnecting',
+  rate_limited: 'rate_limited',
+  logged_out: 'logged_out',
+  cooldown: 'cooldown',
+} as const satisfies Record<WhatsAppLastErrorReason, WhatsAppLastErrorKey>;
 
 const STATUS_STEPS = ['queued', 'typing', 'sent', 'delivered', 'read'] as const;
 type StatusStep = typeof STATUS_STEPS[number];
@@ -87,11 +140,14 @@ function stepIndex(status: string): number {
   return STATUS_STEPS.indexOf(status as StatusStep);
 }
 
-function StatusStepper({ status, t }: { status: string; t: (k: string) => string }) {
+function StatusStepper({ status }: { status: string }) {
+  const tStatus = useTranslations('whatsapp.status');
   const failed = status === 'failed';
   const current = failed ? -1 : stepIndex(status);
+  const statusKey = (WHATSAPP_STATUS_KEYS as Record<string, WhatsAppStatusKey | undefined>)[status];
+  const title = failed ? tStatus('failed') : statusKey ? tStatus(statusKey) : status;
   return (
-    <div className="flex items-center gap-1" title={failed ? t('whatsapp.status.failed') : t(`whatsapp.status.${status}` as 'whatsapp.status.queued' | 'whatsapp.status.typing' | 'whatsapp.status.sent' | 'whatsapp.status.delivered' | 'whatsapp.status.read')}>
+    <div className="flex items-center gap-1" title={title}>
       {STATUS_STEPS.map((step, i) => {
         const reached = !failed && i <= current;
         return (
@@ -101,7 +157,7 @@ function StatusStepper({ status, t }: { status: string; t: (k: string) => string
           />
         );
       })}
-      {failed && <span className="ms-1 text-xs text-destructive">{t('whatsapp.status.failed')}</span>}
+      {failed && <span className="ms-1 text-xs text-destructive">{tStatus('failed')}</span>}
     </div>
   );
 }
@@ -114,30 +170,40 @@ function StatusStepper({ status, t }: { status: string; t: (k: string) => string
 function translateLastError(
   reason: string | null | undefined,
   raw: string | null | undefined,
-  t: (k: string, p?: Record<string, string | number>) => string,
+  tLastError: (k: WhatsAppLastErrorKey, p?: Record<string, string | number>) => string,
 ): string {
-  if (reason) {
-    if (reason === 'reconnecting') {
-      // Extract the status code from the raw message if present.
-      const m = raw?.match(/\((\d+|unknown)\)/);
-      const code = m?.[1] ?? 'unknown';
-      const seconds = 5;
-      return t('whatsapp.lastError.reconnecting', { code, seconds });
-    }
-    if (reason === 'rate_limited') {
-      const m = raw?.match(/\((\d+)\)/);
-      const code = m?.[1] ?? '429';
-      return t('whatsapp.lastError.rate_limited', { code });
-    }
-    const key = `whatsapp.lastError.${reason}`;
-    const translated = t(key);
-    if (translated !== key) return translated;
+  if (reason === 'reconnecting') {
+    // Extract the status code from the raw message if present.
+    const m = raw?.match(/\((\d+|unknown)\)/);
+    const code = m?.[1] ?? 'unknown';
+    const seconds = 5;
+    return tLastError('reconnecting', { code, seconds });
   }
-  return raw ?? t('whatsapp.lastError.cooldown');
+  if (reason === 'rate_limited') {
+    const m = raw?.match(/\((\d+)\)/);
+    const code = m?.[1] ?? '429';
+    return tLastError('rate_limited', { code });
+  }
+  const key = (WHATSAPP_LAST_ERROR_KEYS as Record<string, WhatsAppLastErrorKey | undefined>)[reason ?? ''];
+  if (key) return tLastError(key);
+  return raw ?? tLastError('cooldown');
 }
 
 export default function WhatsAppPage() {
-  const { t, language } = useI18n();
+  const tNav = useTranslations('nav');
+  const tTabs = useTranslations('whatsapp.tabs');
+  const tConnection = useTranslations('whatsapp.connection');
+  const tConnect = useTranslations('whatsapp.connect');
+  const tActive = useTranslations('whatsapp.active');
+  const tBlocklist = useTranslations('whatsapp.blocklist');
+  const tInbox = useTranslations('whatsapp.inbox');
+  const tSent = useTranslations('whatsapp.sent');
+  const tCommon = useTranslations('common');
+  const tState = useTranslations('whatsapp.state');
+  const tKind = useTranslations('whatsapp.kind');
+  const tLastError = useTranslations('whatsapp.lastError');
+  const tApiError = useTranslations('whatsapp.apiError');
+  const language = usePosSettingsStore((s) => s.language);
   const { confirm, ConfirmDialog } = useConfirm();
   const setWhatsappEnabled = usePosSettingsStore((s) => s.setWhatsappEnabled);
   const { currentTenant } = useAuthStore();
@@ -154,9 +220,9 @@ export default function WhatsAppPage() {
   const copyToClipboard = async (value: string, label: string) => {
     try {
       await navigator.clipboard.writeText(value);
-      toast.success(t('whatsapp.inbox.phoneCopied', { phone: label }));
+      toast.success(tInbox('phoneCopied', { phone: label }));
     } catch {
-      toast.error(t('whatsapp.inbox.copyFailed'));
+      toast.error(tInbox('copyFailed'));
     }
   };
 
@@ -289,17 +355,17 @@ export default function WhatsAppPage() {
   }, [refreshBlocklist]);
 
   const disableFeature = async () => {
-    if (!await confirm(t('whatsapp.active.disableConfirm'), {
-      title: t('whatsapp.active.disableTitle'),
-      confirmLabel: t('whatsapp.active.disableCta'),
+    if (!await confirm(tActive('disableConfirm'), {
+      title: tActive('disableTitle'),
+      confirmLabel: tActive('disableCta'),
       destructive: true,
     })) return;
     try {
       await api.post('/whatsapp/disable');
       setWhatsappEnabled(false);
-      toast.success(t('whatsapp.active.disabledSuccess'));
+      toast.success(tActive('disabledSuccess'));
       void refreshStatus();
-} catch (err) { toastApiError(err, t('whatsapp.active.disableFailed'), t);
+} catch (err) { toastApiError(err, tActive('disableFailed'), tApiError);
     }
   };
 
@@ -307,34 +373,34 @@ export default function WhatsAppPage() {
     try {
       await api.post('/whatsapp/connect', { method: 'qr' });
       void refreshStatus();
-} catch (err) { toastApiError(err, t('whatsapp.connect.qrFailed'), t);
+} catch (err) { toastApiError(err, tConnect('qrFailed'), tApiError);
     }
   };
 
   const connectPairing = async () => {
     if (!pairingPhone.trim()) {
-      toast.error(t('whatsapp.connect.pairingPhoneRequired'));
+      toast.error(tConnect('pairingPhoneRequired'));
       return;
     }
     try {
       const { data } = await api.post('/whatsapp/connect', { method: 'pairing_code', phone: pairingPhone.trim() });
       if (data?.code) setPairingCode(data.code);
       void refreshStatus();
-} catch (err) { toastApiError(err, t('whatsapp.connect.pairingFailed'), t);
+} catch (err) { toastApiError(err, tConnect('pairingFailed'), tApiError);
     }
   };
 
   const disconnect = async () => {
-    if (!await confirm(t('whatsapp.connect.disconnectConfirm'), {
-      title: t('whatsapp.connect.disconnectTitle'),
-      confirmLabel: t('whatsapp.connect.disconnectCta'),
+    if (!await confirm(tConnect('disconnectConfirm'), {
+      title: tConnect('disconnectTitle'),
+      confirmLabel: tConnect('disconnectCta'),
       destructive: true,
     })) return;
     try {
       await api.post('/whatsapp/disconnect');
-      toast.success(t('whatsapp.connect.disconnectedSuccess'));
+      toast.success(tConnect('disconnectedSuccess'));
       void refreshStatus();
-} catch (err) { toastApiError(err, t('whatsapp.connect.disconnectFailed'), t);
+} catch (err) { toastApiError(err, tConnect('disconnectFailed'), tApiError);
     }
   };
 
@@ -342,7 +408,7 @@ export default function WhatsAppPage() {
     const tenantCountry = currentTenant?.country ?? 'IN';
     const parsed = parsePhone(blockPhone.trim(), tenantCountry);
     if (!parsed) {
-      toast.error(t('whatsapp.blocklist.phoneRequired'));
+      toast.error(tBlocklist('phoneRequired'));
       return;
     }
     try {
@@ -350,41 +416,41 @@ export default function WhatsAppPage() {
       setBlockPhone('');
       setBlockReason('');
       void refreshBlocklist();
-      toast.success(t('whatsapp.blocklist.addedSuccess'));
-    } catch (err) { toastApiError(err, t('whatsapp.blocklist.failed'), t);
+      toast.success(tBlocklist('addedSuccess'));
+    } catch (err) { toastApiError(err, tBlocklist('failed'), tApiError);
     }
   };
 
   const removeBlock = async (phone: string) => {
-    if (!await confirm(t('whatsapp.blocklist.removeConfirm', { phone }), {
-      confirmLabel: t('whatsapp.blocklist.removeCta'),
+    if (!await confirm(tBlocklist('removeConfirm', { phone }), {
+      confirmLabel: tBlocklist('removeCta'),
       destructive: true,
     })) return;
     try {
       await api.delete(`/whatsapp/blocklist/${encodeURIComponent(phone)}`);
       void refreshBlocklist();
-} catch (err) { toastApiError(err, t('whatsapp.blocklist.failed'), t);
+} catch (err) { toastApiError(err, tBlocklist('failed'), tApiError);
     }
   };
 
   const blockFromInbox = async (phone: string) => {
     if (blocklist.some((b) => b.phone_e164 === phone)) {
-      toast.error(t('whatsapp.blocklist.alreadyBlocked'));
+      toast.error(tBlocklist('alreadyBlocked'));
       return;
     }
     try {
-      await api.post('/whatsapp/blocklist', { phone_e164: phone, reason: t('whatsapp.blocklist.defaultReason') });
+      await api.post('/whatsapp/blocklist', { phone_e164: phone, reason: tBlocklist('defaultReason') });
       void refreshBlocklist();
       void refreshInbox();
-      toast.success(t('whatsapp.blocklist.fromInboxSuccess', { phone }));
+      toast.success(tBlocklist('fromInboxSuccess', { phone }));
     } catch (err) {
-      toastApiError(err, t('whatsapp.blocklist.failed'), t);
+      toastApiError(err, tBlocklist('failed'), tApiError);
     }
   };
 
   const stateLabel = (state: string) => {
-    const key = STATE_KEYS[state];
-    return key ? t(key) : state;
+    const key = (STATE_KEYS as Record<string, WhatsAppStateKey | undefined>)[state];
+    return key ? tState(key) : state;
   };
 
   return (
@@ -392,7 +458,7 @@ export default function WhatsAppPage() {
       {ConfirmDialog}
       <div className="space-y-4 p-2">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">{t('nav.whatsapp')}</h1>
+        <h1 className="text-2xl font-semibold">{tNav('whatsapp')}</h1>
         {status && (
           <Badge variant={status.state === 'connected' ? 'default' : status.state === 'cooldown' ? 'destructive' : 'secondary'}>
             {stateLabel(status.state)}
@@ -403,9 +469,9 @@ export default function WhatsAppPage() {
 
       <Tabs value={effectiveTab} onValueChange={onTabChange}>
         <TabsList>
-          <TabsTrigger value="sent"><Send className="size-4" /> {t('whatsapp.tabs.sent')}</TabsTrigger>
-          <TabsTrigger value="inbox"><Inbox className="size-4" /> {t('whatsapp.tabs.inbox')}</TabsTrigger>
-          <TabsTrigger value="connection"><QrCode className="size-4" /> {t('whatsapp.tabs.connection')}</TabsTrigger>
+          <TabsTrigger value="sent"><Send className="size-4" /> {tTabs('sent')}</TabsTrigger>
+          <TabsTrigger value="inbox"><Inbox className="size-4" /> {tTabs('inbox')}</TabsTrigger>
+          <TabsTrigger value="connection"><QrCode className="size-4" /> {tTabs('connection')}</TabsTrigger>
         </TabsList>
 
         <TabsContent value="connection" className="space-y-4">
@@ -413,13 +479,13 @@ export default function WhatsAppPage() {
             <Card>
               <CardContent className="text-sm text-muted-foreground flex items-center justify-between gap-4 py-4">
                 <span>
-                  {t('whatsapp.connection.notEnabled', {
+                  {tConnection('notEnabled', {
                     defaultValue: 'WhatsApp is not enabled on this tenant.',
                   })}
                 </span>
                 <Button asChild variant="outline" size="sm">
                   <Link href="/settings?tab=whatsapp">
-                    {t('whatsapp.connection.enableInSettings', {
+                    {tConnection('enableInSettings', {
                       defaultValue: 'Enable in Settings',
                     })}
                   </Link>
@@ -433,8 +499,8 @@ export default function WhatsAppPage() {
               {isAdmin && (
                 <Card>
                   <CardHeader>
-                    <CardTitle>{t('whatsapp.connect.title')}</CardTitle>
-                    <CardDescription>{t('whatsapp.connect.description')}</CardDescription>
+                    <CardTitle>{tConnect('title')}</CardTitle>
+                    <CardDescription>{tConnect('description')}</CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     {status.state === 'disconnected' && (
@@ -444,17 +510,17 @@ export default function WhatsAppPage() {
                             <div className="flex items-center justify-center size-9 rounded-md bg-brand-light text-brand">
                               <QrCode className="size-5" />
                             </div>
-                            <h3 className="font-semibold text-sm">{t('whatsapp.connect.qrMethodTitle')}</h3>
+                            <h3 className="font-semibold text-sm">{tConnect('qrMethodTitle')}</h3>
                           </div>
-                          <p className="text-sm text-muted-foreground">{t('whatsapp.connect.qrMethodDescription')}</p>
+                          <p className="text-sm text-muted-foreground">{tConnect('qrMethodDescription')}</p>
                           <div className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                             <div className="flex items-start gap-1.5">
                               <Info className="size-3.5 mt-0.5 shrink-0" />
-                              <span>{t('whatsapp.connect.qrMethodWhere')}</span>
+                              <span>{tConnect('qrMethodWhere')}</span>
                             </div>
                           </div>
                           <Button onClick={connectQr} className="mt-auto w-full">
-                            <QrCode className="size-4" /> {t('whatsapp.connect.startQr')}
+                            <QrCode className="size-4" /> {tConnect('startQr')}
                           </Button>
                         </div>
 
@@ -463,27 +529,27 @@ export default function WhatsAppPage() {
                             <div className="flex items-center justify-center size-9 rounded-md bg-brand-light text-brand">
                               <KeyRound className="size-5" />
                             </div>
-                            <h3 className="font-semibold text-sm">{t('whatsapp.connect.pairingMethodTitle')}</h3>
+                            <h3 className="font-semibold text-sm">{tConnect('pairingMethodTitle')}</h3>
                           </div>
-                          <p className="text-sm text-muted-foreground">{t('whatsapp.connect.pairingMethodDescription')}</p>
+                          <p className="text-sm text-muted-foreground">{tConnect('pairingMethodDescription')}</p>
                           <div className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                             <div className="flex items-start gap-1.5">
                               <Info className="size-3.5 mt-0.5 shrink-0" />
-                              <span>{t('whatsapp.connect.pairingMethodWhere')}</span>
+                              <span>{tConnect('pairingMethodWhere')}</span>
                             </div>
                           </div>
                           <div className="space-y-1.5">
-                            <label className="text-xs text-muted-foreground">{t('whatsapp.connect.pairingPhoneLabel')}</label>
+                            <label className="text-xs text-muted-foreground">{tConnect('pairingPhoneLabel')}</label>
                             <Input
                               value={pairingPhone}
                               onChange={(e) => setPairingPhone(e.target.value)}
-                              placeholder={t('whatsapp.connect.pairingPhonePlaceholder', { dialCode: dialCode || '+CC' })}
+                              placeholder={tConnect('pairingPhonePlaceholder', { dialCode: dialCode || '+CC' })}
                               inputMode="tel"
                               dir="ltr"
                             />
                           </div>
                           <Button onClick={connectPairing} variant="outline" className="w-full">
-                            <KeyRound className="size-4" /> {t('whatsapp.connect.usePairing')}
+                            <KeyRound className="size-4" /> {tConnect('usePairing')}
                           </Button>
                         </div>
                       </div>
@@ -491,25 +557,25 @@ export default function WhatsAppPage() {
 
                     {status.state === 'waiting_qr' && (
                       <div className="space-y-2">
-                        <p className="text-sm text-muted-foreground">{t('whatsapp.connect.qrInstruction')}</p>
+                        <p className="text-sm text-muted-foreground">{tConnect('qrInstruction')}</p>
                         {qrDataUrl ? (
                           <div className="rounded-md border p-3 inline-block bg-white">
-                            <img src={qrDataUrl} alt={t('whatsapp.tabs.connection')} className="w-64 h-64" />
+                            <img src={qrDataUrl} alt={tTabs('connection')} className="w-64 h-64" />
                           </div>
                         ) : (
-                          <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="size-4 animate-spin" /> {t('whatsapp.connect.qrGenerating')}</div>
+                          <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="size-4 animate-spin" /> {tConnect('qrGenerating')}</div>
                         )}
-                        <p className="text-xs text-muted-foreground">{t('whatsapp.connect.qrRefreshHint')}</p>
+                        <p className="text-xs text-muted-foreground">{tConnect('qrRefreshHint')}</p>
                       </div>
                     )}
 
                     {status.state === 'waiting_pairing' && (
                       <div className="space-y-2">
-                        <p className="text-sm text-muted-foreground">{t('whatsapp.connect.pairingInstruction')}</p>
+                        <p className="text-sm text-muted-foreground">{tConnect('pairingInstruction')}</p>
                         {pairingCode ? (
                           <Ltr as="div" className="text-3xl font-mono tracking-widest p-4 rounded-md bg-muted inline-block">{pairingCode}</Ltr>
                         ) : (
-                          <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="size-4 animate-spin" /> {t('whatsapp.connect.pairingWaiting')}</div>
+                          <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="size-4 animate-spin" /> {tConnect('pairingWaiting')}</div>
                         )}
                       </div>
                     )}
@@ -518,18 +584,18 @@ export default function WhatsAppPage() {
                       <div className="space-y-3">
                         <div className="flex items-center gap-2 text-green-700">
                           <CheckCircle2 className="size-5" />
-                          <span>{t('whatsapp.connect.connectedAs')}</span>
+                          <span>{tConnect('connectedAs')}</span>
                           <button
                             type="button"
                             onClick={() => status.connectedPhone && copyToClipboard(status.connectedPhone, status.connectedPhone)}
                             className="inline-flex items-center gap-1 font-mono font-semibold hover:underline cursor-pointer"
-                            title={t('whatsapp.inbox.copyPhone')}
+                            title={tInbox('copyPhone')}
                           >
                             <Ltr>{status.connectedPhone}</Ltr>
                           </button>
                         </div>
                         <div className="flex flex-wrap gap-2">
-                          <Button variant="outline" onClick={disconnect}>{t('whatsapp.connect.disconnectCta')}</Button>
+                          <Button variant="outline" onClick={disconnect}>{tConnect('disconnectCta')}</Button>
                         </div>
                         <label className="flex items-start gap-3 text-sm cursor-pointer pt-2 border-t">
                           <input
@@ -540,11 +606,11 @@ export default function WhatsAppPage() {
                               const next = e.target.checked;
                               setFilterGroupsState(next);
                               void api.post('/whatsapp/settings', { filterGroups: next })
-                                .catch(() => { setFilterGroupsState(!next); toast.error(t('common.saveFailed')); });
+                                .catch(() => { setFilterGroupsState(!next); toast.error(tCommon('saveFailed')); });
                             }}
                           />
                           <span className="text-muted-foreground">
-                            {t('whatsapp.connect.filterGroupsLabel')}
+                            {tConnect('filterGroupsLabel')}
                           </span>
                         </label>
                       </div>
@@ -552,20 +618,20 @@ export default function WhatsAppPage() {
 
                     {status.state === 'cooldown' && (
                       <div className="space-y-2">
-                        <div className="flex items-center gap-2 text-amber-700"><AlertTriangle className="size-5" /> {translateLastError(status.lastErrorReason, status.lastError, t)}</div>
-                        {status.cooldownUntil && <p className="text-xs text-muted-foreground">{t('whatsapp.connect.cooldownResumesAt', { time: fmtClock(status.cooldownUntil) })}</p>}
+                        <div className="flex items-center gap-2 text-amber-700"><AlertTriangle className="size-5" /> {translateLastError(status.lastErrorReason, status.lastError, tLastError)}</div>
+                        {status.cooldownUntil && <p className="text-xs text-muted-foreground">{tConnect('cooldownResumesAt', { time: fmtClock(status.cooldownUntil) })}</p>}
                         <div className="flex flex-wrap gap-2">
-                          <Button variant="outline" onClick={disconnect}>{t('whatsapp.connect.disconnectCta')}</Button>
+                          <Button variant="outline" onClick={disconnect}>{tConnect('disconnectCta')}</Button>
                         </div>
                       </div>
                     )}
 
                     {status.state === 'connecting' && (
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="size-4 animate-spin" /> {t('whatsapp.connect.connecting')}</div>
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="size-4 animate-spin" /> {tConnect('connecting')}</div>
                     )}
 
                     <div className="pt-2 border-t flex justify-end">
-                      <Button variant="destructive" size="sm" onClick={disableFeature}>{t('whatsapp.active.disableCta')}</Button>
+                      <Button variant="destructive" size="sm" onClick={disableFeature}>{tActive('disableCta')}</Button>
                     </div>
                   </CardContent>
                 </Card>
@@ -574,12 +640,12 @@ export default function WhatsAppPage() {
               {!isAdmin && status.state === 'connected' && status.connectedPhone && (
                 <Card>
                   <CardHeader>
-                    <CardTitle>{t('whatsapp.connect.title')}</CardTitle>
+                    <CardTitle>{tConnect('title')}</CardTitle>
                   </CardHeader>
                   <CardContent>
                     <div className="flex items-center gap-2 text-green-700">
                       <CheckCircle2 className="size-5" />
-                      <span>{t('whatsapp.connect.connectedAs')}</span>
+                      <span>{tConnect('connectedAs')}</span>
                       <Ltr as="strong" className="font-mono">{status.connectedPhone}</Ltr>
                     </div>
                   </CardContent>
@@ -589,36 +655,36 @@ export default function WhatsAppPage() {
               {isAdmin && (
                 <Card>
                   <CardHeader>
-                    <CardTitle className="flex items-center gap-2"><Ban className="size-5" /> {t('whatsapp.blocklist.title')}</CardTitle>
-                    <CardDescription>{t('whatsapp.blocklist.description')}</CardDescription>
+                    <CardTitle className="flex items-center gap-2"><Ban className="size-5" /> {tBlocklist('title')}</CardTitle>
+                    <CardDescription>{tBlocklist('description')}</CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-3">
                     <div className="flex flex-wrap gap-2 items-end">
                       <div className="flex-1 min-w-[180px]">
-                        <label className="text-xs text-gray-500">{t('whatsapp.blocklist.phoneLabel')}</label>
+                        <label className="text-xs text-gray-500">{tBlocklist('phoneLabel')}</label>
                         <Input
                           value={blockPhone}
                           onChange={(e) => setBlockPhone(e.target.value)}
-                          placeholder={t('whatsapp.blocklist.phonePlaceholder', { dialCode: dialCode || '+CC' })}
+                          placeholder={tBlocklist('phonePlaceholder', { dialCode: dialCode || '+CC' })}
                           inputMode="tel"
                           dir="ltr"
                         />
                       </div>
                       <div className="flex-1 min-w-[180px]">
-                        <label className="text-xs text-gray-500">{t('whatsapp.blocklist.reasonLabel')}</label>
-                        <Input value={blockReason} onChange={(e) => setBlockReason(e.target.value)} placeholder={t('whatsapp.blocklist.reasonPlaceholder')} />
+                        <label className="text-xs text-gray-500">{tBlocklist('reasonLabel')}</label>
+                        <Input value={blockReason} onChange={(e) => setBlockReason(e.target.value)} placeholder={tBlocklist('reasonPlaceholder')} />
                       </div>
-                      <Button onClick={addBlock}>{t('whatsapp.blocklist.addCta')}</Button>
+                      <Button onClick={addBlock}>{tBlocklist('addCta')}</Button>
                     </div>
                     {blocklist.length === 0 ? (
-                      <p className="text-sm text-gray-500">{t('whatsapp.blocklist.empty')}</p>
+                      <p className="text-sm text-gray-500">{tBlocklist('empty')}</p>
                     ) : (
                       <Table>
                         <TableHeader>
                           <TableRow>
-                            <TableHead>{t('whatsapp.blocklist.colPhone')}</TableHead>
-                            <TableHead>{t('whatsapp.blocklist.colReason')}</TableHead>
-                            <TableHead>{t('whatsapp.blocklist.colWhen')}</TableHead>
+                            <TableHead>{tBlocklist('colPhone')}</TableHead>
+                            <TableHead>{tBlocklist('colReason')}</TableHead>
+                            <TableHead>{tBlocklist('colWhen')}</TableHead>
                             <TableHead></TableHead>
                           </TableRow>
                         </TableHeader>
@@ -628,7 +694,7 @@ export default function WhatsAppPage() {
                               <TableCell className="font-mono text-sm"><Ltr>{b.phone_e164}</Ltr></TableCell>
                               <TableCell className="text-sm text-gray-600">{b.reason ?? '—'}</TableCell>
                               <TableCell className="text-sm text-gray-600">{fmt(b.blocked_at)}</TableCell>
-                              <TableCell><Button size="sm" variant="ghost" onClick={() => removeBlock(b.phone_e164)}>{t('whatsapp.blocklist.removeCta')}</Button></TableCell>
+                              <TableCell><Button size="sm" variant="ghost" onClick={() => removeBlock(b.phone_e164)}>{tBlocklist('removeCta')}</Button></TableCell>
                             </TableRow>
                           ))}
                         </TableBody>
@@ -644,25 +710,25 @@ export default function WhatsAppPage() {
         <TabsContent value="sent" className="space-y-2">
           <Card>
             <CardHeader>
-              <CardTitle>{t('whatsapp.sent.title')}</CardTitle>
-              <CardDescription>{t('whatsapp.sent.description')}</CardDescription>
+              <CardTitle>{tSent('title')}</CardTitle>
+              <CardDescription>{tSent('description')}</CardDescription>
             </CardHeader>
             <CardContent>
               {sentMessages.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-10 text-center text-sm text-muted-foreground">
                   <Send className="size-8 mb-2 opacity-40" />
-                  <p className="font-medium text-foreground">{t('whatsapp.sent.empty')}</p>
-                  <p className="mt-1 max-w-sm">{t('whatsapp.sent.emptyHint')}</p>
+                  <p className="font-medium text-foreground">{tSent('empty')}</p>
+                  <p className="mt-1 max-w-sm">{tSent('emptyHint')}</p>
                 </div>
               ) : (
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      <TableHead>{t('whatsapp.sent.colWhen')}</TableHead>
-                      <TableHead>{t('whatsapp.sent.colPhone')}</TableHead>
-                      <TableHead>{t('whatsapp.sent.colKind')}</TableHead>
-                      <TableHead>{t('whatsapp.sent.colStatus')}</TableHead>
-                      <TableHead>{t('whatsapp.sent.colBody')}</TableHead>
+                      <TableHead>{tSent('colWhen')}</TableHead>
+                      <TableHead>{tSent('colPhone')}</TableHead>
+                      <TableHead>{tSent('colKind')}</TableHead>
+                      <TableHead>{tSent('colStatus')}</TableHead>
+                      <TableHead>{tSent('colBody')}</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -674,28 +740,28 @@ export default function WhatsAppPage() {
                             type="button"
                             onClick={() => copyToClipboard(m.phone_e164, m.phone_e164)}
                             className="hover:text-foreground transition-colors cursor-pointer"
-                            title={t('whatsapp.inbox.copyPhone')}
+                            title={tInbox('copyPhone')}
                           >
                             <Ltr>{m.phone_e164}</Ltr>
                           </button>
                         </TableCell>
-                        <TableCell className="text-xs">{t(`whatsapp.kind.${m.kind}` as 'whatsapp.kind.bill_receipt' | 'whatsapp.kind.manual_reply' | 'whatsapp.kind.auto_followup')}</TableCell>
+                        <TableCell className="text-xs">{tKind(WHATSAPP_KIND_KEYS[m.kind])}</TableCell>
                         <TableCell>
                           <div className="flex flex-col gap-1">
-                            <StatusStepper status={m.status} t={t} />
+                            <StatusStepper status={m.status} />
                             {m.error && <div className="text-xs text-destructive">{m.error}</div>}
                           </div>
                         </TableCell>
                         <TableCell className="text-sm max-w-md">
                           <div className="line-clamp-3 whitespace-pre-line break-words">{m.body}</div>
                           <details className="text-xs text-muted-foreground mt-1">
-                            <summary>{t('whatsapp.sent.timeline')}</summary>
-                            <div>{t('whatsapp.sent.timelineQueued', { time: fmt(m.queued_at) })}</div>
-                            {m.typing_at && <div>{t('whatsapp.sent.timelineTyping', { time: fmt(m.typing_at) })}</div>}
-                            {m.sent_at && <div>{t('whatsapp.sent.timelineSent', { time: fmt(m.sent_at) })}</div>}
-                            {m.delivered_at && <div>{t('whatsapp.sent.timelineDelivered', { time: fmt(m.delivered_at) })}</div>}
-                            {m.read_at && <div>{t('whatsapp.sent.timelineRead', { time: fmt(m.read_at) })}</div>}
-                            {m.failed_at && <div>{t('whatsapp.sent.timelineFailed', { time: fmt(m.failed_at) })}</div>}
+                            <summary>{tSent('timeline')}</summary>
+                            <div>{tSent('timelineQueued', { time: fmt(m.queued_at) })}</div>
+                            {m.typing_at && <div>{tSent('timelineTyping', { time: fmt(m.typing_at) })}</div>}
+                            {m.sent_at && <div>{tSent('timelineSent', { time: fmt(m.sent_at) })}</div>}
+                            {m.delivered_at && <div>{tSent('timelineDelivered', { time: fmt(m.delivered_at) })}</div>}
+                            {m.read_at && <div>{tSent('timelineRead', { time: fmt(m.read_at) })}</div>}
+                            {m.failed_at && <div>{tSent('timelineFailed', { time: fmt(m.failed_at) })}</div>}
                           </details>
                         </TableCell>
                       </TableRow>
@@ -710,23 +776,23 @@ export default function WhatsAppPage() {
         <TabsContent value="inbox" className="space-y-2">
           <Card>
             <CardHeader>
-              <CardTitle>{t('whatsapp.inbox.title')}</CardTitle>
-              <CardDescription>{t('whatsapp.inbox.description')}</CardDescription>
+              <CardTitle>{tInbox('title')}</CardTitle>
+              <CardDescription>{tInbox('description')}</CardDescription>
             </CardHeader>
             <CardContent>
               {inbox.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-10 text-center text-sm text-muted-foreground">
                   <Inbox className="size-8 mb-2 opacity-40" />
-                  <p className="font-medium text-foreground">{t('whatsapp.inbox.empty')}</p>
-                  <p className="mt-1 max-w-sm">{t('whatsapp.inbox.emptyHint')}</p>
+                  <p className="font-medium text-foreground">{tInbox('empty')}</p>
+                  <p className="mt-1 max-w-sm">{tInbox('emptyHint')}</p>
                 </div>
               ) : (
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      <TableHead>{t('whatsapp.sent.colWhen')}</TableHead>
-                      <TableHead>{t('whatsapp.sent.colPhone')}</TableHead>
-                      <TableHead>{t('whatsapp.sent.colBody')}</TableHead>
+                      <TableHead>{tSent('colWhen')}</TableHead>
+                      <TableHead>{tSent('colPhone')}</TableHead>
+                      <TableHead>{tSent('colBody')}</TableHead>
                       <TableHead></TableHead>
                     </TableRow>
                   </TableHeader>
@@ -741,7 +807,7 @@ export default function WhatsAppPage() {
                               type="button"
                               onClick={() => copyToClipboard(m.phone_e164, m.phone_e164)}
                               className="inline-flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
-                              title={t('whatsapp.inbox.copyPhone')}
+                              title={tInbox('copyPhone')}
                             >
                               <Copy className="size-3 opacity-0 group-hover:opacity-100" />
                               <Ltr>{m.phone_e164}</Ltr>
@@ -750,10 +816,10 @@ export default function WhatsAppPage() {
                           <TableCell className="text-sm whitespace-pre-line break-words max-w-md">{m.body}</TableCell>
                           <TableCell>
                             {isBlocked ? (
-                              <Badge variant="secondary">{t('whatsapp.inbox.blocked')}</Badge>
+                              <Badge variant="secondary">{tInbox('blocked')}</Badge>
                             ) : (
                               <Button size="sm" variant="outline" onClick={() => blockFromInbox(m.phone_e164)}>
-                                <Ban className="size-3" /> {t('whatsapp.inbox.blockCta')}
+                                <Ban className="size-3" /> {tInbox('blockCta')}
                               </Button>
                             )}
                           </TableCell>
@@ -770,7 +836,7 @@ export default function WhatsAppPage() {
 
       {status?.lastError && status.state !== 'cooldown' && (
         <div className="text-sm text-red-600 flex items-center gap-1">
-          <XCircle className="size-4" /> {translateLastError(status.lastErrorReason, status.lastError, t)}
+          <XCircle className="size-4" /> {translateLastError(status.lastErrorReason, status.lastError, tLastError)}
         </div>
       )}
       </div>

--- a/frontend/src/components/products/ImageUploader.tsx
+++ b/frontend/src/components/products/ImageUploader.tsx
@@ -7,7 +7,7 @@ import { Camera, Link, Upload, X, Check } from 'lucide-react';
 import { compressCroppedImage, MAX_RAW_FILE_SIZE } from '@/lib/image-utils';
 import api from '@/lib/api';
 import toast from 'react-hot-toast';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 interface ImageUploaderProps {
   /** Current Base64 data URI (or null if no image) */
   value: string | null;
@@ -20,7 +20,8 @@ interface ImageUploaderProps {
 type Mode = 'idle' | 'cropping' | 'url-input';
 
 export default function ImageUploader({ value, onChange, productId }: ImageUploaderProps) {
-  const { t } = useI18n();
+  const t = useTranslations('products');
+  const tCommon = useTranslations('common');
   const [mode, setMode] = useState<Mode>('idle');
   const [cropSrc, setCropSrc] = useState<string | null>(null);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
@@ -38,11 +39,11 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
 
   const processFile = useCallback(async (file: File) => {
     if (file.size > MAX_RAW_FILE_SIZE) {
-      toast.error(t('products.imageTooLarge', { size: MAX_RAW_FILE_SIZE / 1024 / 1024 }));
+      toast.error(t('imageTooLarge', { size: MAX_RAW_FILE_SIZE / 1024 / 1024 }));
       return;
     }
     if (!file.type.startsWith('image/')) {
-      toast.error(t('products.imageSelectFile'));
+      toast.error(t('imageSelectFile'));
       return;
     }
 
@@ -55,7 +56,7 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
       setZoom(1);
     };
     reader.onerror = () => {
-      toast.error(t('products.imageReadFailed'));
+      toast.error(t('imageReadFailed'));
     };
     reader.readAsDataURL(file);
   }, [t]);
@@ -88,16 +89,16 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
 
       const dataUri = compressCroppedImage(img, { x, y, width, height });
       if (!dataUri) {
-        toast.error(t('products.imageCompressFailed'));
+        toast.error(t('imageCompressFailed'));
         return;
       }
 
       onChange(dataUri);
       setMode('idle');
       setCropSrc(null);
-      toast.success(t('products.imageReady'));
+      toast.success(t('imageReady'));
     } catch {
-      toast.error(t('products.imageCropFailed'));
+      toast.error(t('imageCropFailed'));
       setMode('idle');
       setCropSrc(null);
     }
@@ -107,7 +108,7 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
     const trimmed = urlInput.trim();
     if (!trimmed) return;
     if (!trimmed.toLowerCase().startsWith('https://')) {
-      toast.error(t('products.imageHttpsOnly'));
+      toast.error(t('imageHttpsOnly'));
       return;
     }
     setFetching(true);
@@ -117,7 +118,7 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
       const dataUri = res.data.data;
 
       if (!dataUri) {
-        toast.error(t('products.imageFetchFailed'));
+        toast.error(t('imageFetchFailed'));
         return;
       }
 
@@ -128,7 +129,7 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
       setZoom(1);
       setUrlInput('');
     } catch {
-      toast.error(t('products.imageFetchFailed'));
+      toast.error(t('imageFetchFailed'));
     } finally {
       setFetching(false);
     }
@@ -160,7 +161,7 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
       <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4">
         <div className="bg-white rounded-2xl max-w-lg w-full overflow-hidden">
           <div className="flex items-center justify-between px-4 py-3 border-b">
-            <h3 className="font-semibold text-gray-900">{t('products.cropImage')}</h3>
+            <h3 className="font-semibold text-gray-900">{t('cropImage')}</h3>
             <button type="button" onClick={() => { setMode('idle'); setCropSrc(null); }} className="text-gray-400 hover:text-gray-600">
               <X size={20} />
             </button>
@@ -191,7 +192,7 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
               className="flex items-center gap-2 px-4 py-2 bg-brand text-white rounded-lg hover:bg-brand/90 transition-colors"
             >
               <Check size={16} />
-              {t('products.imageCropApply')}
+              {t('imageCropApply')}
             </button>
           </div>
         </div>
@@ -218,16 +219,16 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
             disabled={fetching || !urlInput.trim()}
             className="px-3 py-2 bg-brand text-white rounded-lg text-sm hover:bg-brand/90 disabled:opacity-50"
           >
-            {fetching ? t('products.imageFetching') : t('products.imageFetch')}
+            {fetching ? t('imageFetching') : t('imageFetch')}
           </button>
           <button type="button"
             onClick={() => { setMode('idle'); setUrlInput(''); }}
             className="px-3 py-2 text-gray-500 hover:text-gray-700 text-sm"
           >
-            {t('common.cancel')}
+            {tCommon('cancel')}
           </button>
         </div>
-        <p className="text-xs text-gray-400">{t('products.imageUrlHint')}</p>
+        <p className="text-xs text-gray-400">{t('imageUrlHint')}</p>
       </div>
     );
   }
@@ -264,13 +265,13 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
           <input {...getInputProps()} />
           <Upload size={24} className="mb-2 text-gray-400" />
           <p className="text-sm font-medium text-center">
-            {isDragActive ? t('products.imageDropActive') : t('products.imageDropIdle')}
+            {isDragActive ? t('imageDropActive') : t('imageDropIdle')}
           </p>
         </div>
 
         <div className="flex items-center gap-2 justify-center">
           <div className="flex-1 h-px bg-gray-200"></div>
-          <span className="text-xs text-gray-400 font-medium uppercase px-2">{t('products.imageOrUse')}</span>
+          <span className="text-xs text-gray-400 font-medium uppercase px-2">{t('imageOrUse')}</span>
           <div className="flex-1 h-px bg-gray-200"></div>
         </div>
 
@@ -281,7 +282,7 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
             className="flex items-center gap-2 px-4 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 hover:bg-gray-50 hover:border-gray-300 transition-colors"
           >
             <Camera size={16} />
-            {t('products.imageCamera')}
+            {t('imageCamera')}
           </button>
           <input
             ref={cameraInputRef}
@@ -302,13 +303,13 @@ export default function ImageUploader({ value, onChange, productId }: ImageUploa
             className="flex items-center gap-2 px-4 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 hover:bg-gray-50 hover:border-gray-300 transition-colors"
           >
             <Link size={16} />
-            {t('products.imagePasteUrl')}
+            {t('imagePasteUrl')}
           </button>
         </div>
       </div>
 
       <p className="text-xs text-gray-400 text-center mt-4">
-        {t('products.imageMaxSize', { size: MAX_RAW_FILE_SIZE / 1024 / 1024 })}
+        {t('imageMaxSize', { size: MAX_RAW_FILE_SIZE / 1024 / 1024 })}
       </p>
     </div>
   );

--- a/frontend/src/components/settings/HealthCheckDialog.tsx
+++ b/frontend/src/components/settings/HealthCheckDialog.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from '@/components/ui/button';
 import type { HealthCheckReport, HealthFinding } from '@/types/electron';
 import { AlertTriangle, CheckCircle2, Wrench } from 'lucide-react';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 
 interface HealthCheckDialogProps {
   open: boolean;
@@ -48,7 +48,8 @@ function FindingRow({ finding }: { finding: HealthFinding }) {
 }
 
 export function HealthCheckDialog({ open, onOpenChange, report, applying, onApplySafeFixes }: HealthCheckDialogProps) {
-  const { t } = useI18n();
+  const t = useTranslations('settings');
+  const tCommon = useTranslations('common');
   const safeFindings = (report?.findings ?? []).filter((f) => f.risk === 'safe');
   const reviewFindings = (report?.findings ?? []).filter((f) => f.risk === 'manual_review');
   const isClean = report && report.findings.length === 0;
@@ -57,21 +58,21 @@ export function HealthCheckDialog({ open, onOpenChange, report, applying, onAppl
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-2xl max-h-[85vh] flex flex-col">
         <DialogHeader>
-          <DialogTitle>{t('settings.databaseHealthCheck')}</DialogTitle>
+          <DialogTitle>{t('databaseHealthCheck')}</DialogTitle>
           <DialogDescription>
-            {t('settings.healthCheckDescription')}
+            {t('healthCheckDescription')}
           </DialogDescription>
         </DialogHeader>
 
         <div className="flex-1 overflow-y-auto space-y-6 py-2">
           {!report && (
-            <p className="text-sm text-gray-500 text-center py-10">{t('common.loading')}</p>
+            <p className="text-sm text-gray-500 text-center py-10">{tCommon('loading')}</p>
           )}
 
           {isClean && (
             <div className="flex items-center gap-2 text-green-700 bg-green-50 border border-green-200 rounded-lg p-4">
               <CheckCircle2 size={18} />
-              <span className="text-sm font-medium">{t('settings.healthCheckClean')}</span>
+              <span className="text-sm font-medium">{t('healthCheckClean')}</span>
             </div>
           )}
 
@@ -79,7 +80,7 @@ export function HealthCheckDialog({ open, onOpenChange, report, applying, onAppl
             <div>
               <div className="flex items-center gap-2 mb-2">
                 <Wrench size={16} className="text-brand" />
-                <h3 className="font-medium text-gray-900">{t('settings.healthCheckSafeHeader', { count: safeFindings.length })}</h3>
+                <h3 className="font-medium text-gray-900">{t('healthCheckSafeHeader', { count: safeFindings.length })}</h3>
               </div>
               <div className="space-y-2">
                 {safeFindings.map((f) => <FindingRow key={f.id} finding={f} />)}
@@ -91,10 +92,10 @@ export function HealthCheckDialog({ open, onOpenChange, report, applying, onAppl
             <div>
               <div className="flex items-center gap-2 mb-2">
                 <AlertTriangle size={16} className="text-amber-600" />
-                <h3 className="font-medium text-gray-900">{t('settings.healthCheckReviewHeader', { count: reviewFindings.length })}</h3>
+                <h3 className="font-medium text-gray-900">{t('healthCheckReviewHeader', { count: reviewFindings.length })}</h3>
               </div>
               <p className="text-xs text-gray-500 mb-2">
-                {t('settings.healthCheckReviewHint')}
+                {t('healthCheckReviewHint')}
               </p>
               <div className="space-y-2">
                 {reviewFindings.map((f) => <FindingRow key={f.id} finding={f} />)}
@@ -104,10 +105,10 @@ export function HealthCheckDialog({ open, onOpenChange, report, applying, onAppl
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>{t('settings.close')}</Button>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>{t('close')}</Button>
           {safeFindings.length > 0 && (
             <Button onClick={onApplySafeFixes} disabled={applying}>
-              {applying ? t('settings.applyingFixes') : t('settings.applySafeFixes', { count: safeFindings.length })}
+              {applying ? t('applyingFixes') : t('applySafeFixes', { count: safeFindings.length })}
             </Button>
           )}
         </DialogFooter>

--- a/frontend/src/components/settings/InitializeDatabaseDialog.tsx
+++ b/frontend/src/components/settings/InitializeDatabaseDialog.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { MasterPinPrompt } from './MasterPinPrompt';
 import { AlertTriangle } from 'lucide-react';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 
 const CONFIRM_PHRASE = 'INITIALIZE';
 
@@ -26,7 +26,8 @@ interface InitializeDatabaseDialogProps {
 }
 
 export function InitializeDatabaseDialog({ open, onOpenChange, onConfirm, onSuccess }: InitializeDatabaseDialogProps) {
-  const { t } = useI18n();
+  const t = useTranslations('settings');
+  const tCommon = useTranslations('common');
   const [phrase, setPhrase] = useState('');
   const [showPinPrompt, setShowPinPrompt] = useState(false);
 
@@ -62,21 +63,21 @@ export function InitializeDatabaseDialog({ open, onOpenChange, onConfirm, onSucc
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 text-red-600">
               <AlertTriangle size={18} />
-              {t('settings.initializeDatabase')}
+              {t('initializeDatabase')}
             </DialogTitle>
             <DialogDescription className="space-y-2 pt-2 text-start">
               <span className="block">
-                {t('settings.initializeDialogBody')}
+                {t('initializeDialogBody')}
               </span>
               <span className="block font-medium text-gray-700">
-                {t('settings.initializeDialogBackup')}
+                {t('initializeDialogBackup')}
               </span>
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-2">
             <Label htmlFor="initialize-confirm">
-              {t('settings.initializeTypeConfirm', { phrase: CONFIRM_PHRASE })}
+              {t('initializeTypeConfirm', { phrase: CONFIRM_PHRASE })}
             </Label>
             <Input
               id="initialize-confirm"
@@ -88,13 +89,13 @@ export function InitializeDatabaseDialog({ open, onOpenChange, onConfirm, onSucc
           </div>
 
           <DialogFooter>
-            <Button variant="outline" onClick={close}>{t('common.cancel')}</Button>
+            <Button variant="outline" onClick={close}>{tCommon('cancel')}</Button>
             <Button
               variant="destructive"
               disabled={phrase !== CONFIRM_PHRASE}
               onClick={() => setShowPinPrompt(true)}
             >
-              {t('common.continue')}
+              {tCommon('continue')}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -103,8 +104,8 @@ export function InitializeDatabaseDialog({ open, onOpenChange, onConfirm, onSucc
       <MasterPinPrompt
         open={open && showPinPrompt}
         mode="verify"
-        title={t('settings.masterPin')}
-        description={t('settings.initializeMasterPinPrompt')}
+        title={t('masterPin')}
+        description={t('initializeMasterPinPrompt')}
         onCancel={() => setShowPinPrompt(false)}
         onSubmit={handlePinSubmit}
       />

--- a/frontend/src/components/settings/LocalePreferencesPanel.tsx
+++ b/frontend/src/components/settings/LocalePreferencesPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import type { CountryLocaleOptions, CurrencyDisplay, DigitMode, CalendarMode } from '@/lib/countries';
 
 interface Props {
@@ -12,29 +12,31 @@ interface Props {
   onChange: (patch: { currencyDisplay?: CurrencyDisplay; digits?: DigitMode; calendar?: CalendarMode }) => void;
 }
 
+type SettingsKey = keyof AppConfig['Messages']['settings'];
+
 // Option labels keyed by value. The panel itself is region-agnostic: which
 // controls (and which options within them) are rendered is driven entirely by
 // the country profile's `localeOptions`, so a region without locale options
 // never sees this panel.
-const CURRENCY_DISPLAY_LABELS: Record<CurrencyDisplay, string> = {
-  rial: 'settings.iranCurrencyDisplayRial',
-  toman: 'settings.iranCurrencyDisplayToman',
-  toman_short: 'settings.iranCurrencyDisplayTomanShort',
-};
+const CURRENCY_DISPLAY_LABELS = {
+  rial: 'iranCurrencyDisplayRial',
+  toman: 'iranCurrencyDisplayToman',
+  toman_short: 'iranCurrencyDisplayTomanShort',
+} as const satisfies Record<CurrencyDisplay, SettingsKey>;
 
-const DIGIT_LABELS: Record<DigitMode, string> = {
-  locale: 'settings.iranNumberDigitsLocale',
-  latin: 'settings.iranNumberDigitsLatin',
-};
+const DIGIT_LABELS = {
+  locale: 'iranNumberDigitsLocale',
+  latin: 'iranNumberDigitsLatin',
+} as const satisfies Record<DigitMode, SettingsKey>;
 
-const CALENDAR_LABELS: Record<CalendarMode, string> = {
-  locale: 'settings.iranCalendarLocale',
-  persian: 'settings.iranCalendarPersian',
-  gregorian: 'settings.iranCalendarGregorian',
-};
+const CALENDAR_LABELS = {
+  locale: 'iranCalendarLocale',
+  persian: 'iranCalendarPersian',
+  gregorian: 'iranCalendarGregorian',
+} as const satisfies Record<CalendarMode, SettingsKey>;
 
 export function LocalePreferencesPanel({ options, currencyDisplay, digits, calendar, isAdmin, onChange }: Props) {
-  const { t } = useI18n();
+  const t = useTranslations('settings');
 
   const hasAny = Boolean(
     options?.currencyDisplay?.length || options?.digits?.length || options?.calendar?.length,
@@ -43,11 +45,11 @@ export function LocalePreferencesPanel({ options, currencyDisplay, digits, calen
 
   return (
     <div className="md:col-span-2 space-y-4 rounded-lg border border-gray-100 bg-gray-50/60 p-4">
-      <p className="text-sm font-medium text-gray-700">{t('settings.iranLocaleTitle')}</p>
+      <p className="text-sm font-medium text-gray-700">{t('iranLocaleTitle')}</p>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {options?.currencyDisplay?.length ? (
           <div>
-            <label className="block text-sm text-gray-500 mb-1">{t('settings.iranCurrencyDisplay')}</label>
+            <label className="block text-sm text-gray-500 mb-1">{t('iranCurrencyDisplay')}</label>
             {isAdmin ? (
               <select
                 value={currencyDisplay}
@@ -66,7 +68,7 @@ export function LocalePreferencesPanel({ options, currencyDisplay, digits, calen
 
         {options?.digits?.length ? (
           <div>
-            <label className="block text-sm text-gray-500 mb-1">{t('settings.iranNumberDigits')}</label>
+            <label className="block text-sm text-gray-500 mb-1">{t('iranNumberDigits')}</label>
             {isAdmin ? (
               <select
                 value={digits}
@@ -85,7 +87,7 @@ export function LocalePreferencesPanel({ options, currencyDisplay, digits, calen
 
         {options?.calendar?.length ? (
           <div>
-            <label className="block text-sm text-gray-500 mb-1">{t('settings.iranCalendar')}</label>
+            <label className="block text-sm text-gray-500 mb-1">{t('iranCalendar')}</label>
             {isAdmin ? (
               <select
                 value={calendar}
@@ -102,7 +104,7 @@ export function LocalePreferencesPanel({ options, currencyDisplay, digits, calen
           </div>
         ) : null}
       </div>
-      <p className="text-xs text-gray-400">{t('settings.iranLocaleHint')}</p>
+      <p className="text-xs text-gray-400">{t('iranLocaleHint')}</p>
     </div>
   );
 }

--- a/frontend/src/components/settings/MasterPinPrompt.tsx
+++ b/frontend/src/components/settings/MasterPinPrompt.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 
 interface MasterPinPromptProps {
   open: boolean;
@@ -26,7 +26,8 @@ interface MasterPinPromptProps {
 const PIN_REGEX = /^\d{4}$/;
 
 export function MasterPinPrompt({ open, mode, title, description, onCancel, onSubmit }: MasterPinPromptProps) {
-  const { t } = useI18n();
+  const t = useTranslations('settings');
+  const tCommon = useTranslations('common');
   const [pin, setPin] = useState('');
   const [confirmPin, setConfirmPin] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -48,11 +49,11 @@ export function MasterPinPrompt({ open, mode, title, description, onCancel, onSu
     setError(null);
 
     if (!PIN_REGEX.test(pin)) {
-      setError(t('settings.pinFourDigits'));
+      setError(t('pinFourDigits'));
       return;
     }
     if (mode === 'set' && pin !== confirmPin) {
-      setError(t('settings.pinMismatch'));
+      setError(t('pinMismatch'));
       setConfirmPin('');
       return;
     }
@@ -64,7 +65,7 @@ export function MasterPinPrompt({ open, mode, title, description, onCancel, onSu
     if (result.success) {
       reset();
     } else {
-      setError(result.error || t('common.somethingWrong'));
+      setError(result.error || tCommon('somethingWrong'));
       setPin('');
       setConfirmPin('');
     }
@@ -74,17 +75,17 @@ export function MasterPinPrompt({ open, mode, title, description, onCancel, onSu
     <Dialog open={open} onOpenChange={(next) => !next && handleCancel()}>
       <DialogContent className="sm:max-w-sm" showCloseButton={false}>
         <DialogHeader>
-          <DialogTitle>{title || t('settings.masterPin')}</DialogTitle>
+          <DialogTitle>{title || t('masterPin')}</DialogTitle>
           <DialogDescription>
             {description || (mode === 'set'
-              ? t('settings.setPinDescription')
-              : t('settings.verifyPinDescription'))}
+              ? t('setPinDescription')
+              : t('verifyPinDescription'))}
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="master-pin">{mode === 'set' ? t('settings.newPin') : t('settings.masterPin')}</Label>
+            <Label htmlFor="master-pin">{mode === 'set' ? t('newPin') : t('masterPin')}</Label>
             <Input
               id="master-pin"
               type="password"
@@ -102,7 +103,7 @@ export function MasterPinPrompt({ open, mode, title, description, onCancel, onSu
 
           {mode === 'set' && (
             <div className="space-y-2">
-              <Label htmlFor="master-pin-confirm">{t('settings.confirmPin')}</Label>
+              <Label htmlFor="master-pin-confirm">{t('confirmPin')}</Label>
               <Input
                 id="master-pin-confirm"
                 type="password"
@@ -123,10 +124,10 @@ export function MasterPinPrompt({ open, mode, title, description, onCancel, onSu
 
         <DialogFooter>
           <Button variant="outline" onClick={handleCancel} disabled={submitting}>
-            {t('common.cancel')}
+            {tCommon('cancel')}
           </Button>
           <Button onClick={handleSubmit} disabled={submitting || pin.length !== 4}>
-            {submitting ? t('common.loading') : mode === 'set' ? t('settings.setPinButton') : t('settings.confirmButton')}
+            {submitting ? tCommon('loading') : mode === 'set' ? t('setPinButton') : t('confirmButton')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/settings/PaymentMethodsSettings.tsx
+++ b/frontend/src/components/settings/PaymentMethodsSettings.tsx
@@ -5,7 +5,7 @@ import { CreditCard, Plus, Save, Trash2, Merge } from 'lucide-react';
 import api from '@/lib/api';
 import toast from 'react-hot-toast';
 import { Button } from '@/components/ui/button';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { useFormatDate } from '@/hooks/useFormatDate';
 import type { CustomPaymentMethod } from '@/lib/payment-methods';
 
@@ -18,7 +18,8 @@ interface MergeRecord {
 }
 
 export function PaymentMethodsSettings({ isAdmin }: { isAdmin: boolean }) {
-  const { t } = useI18n();
+  const t = useTranslations('settings');
+  const tCommon = useTranslations('common');
   const { formatDate } = useFormatDate();
   const [methods, setMethods] = useState<CustomPaymentMethod[]>([]);
   const [names, setNames] = useState<Record<number, string>>({});
@@ -42,7 +43,7 @@ export function PaymentMethodsSettings({ isAdmin }: { isAdmin: boolean }) {
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    void load().catch(() => toast.error(t('settings.loadFailed')));
+    void load().catch(() => toast.error(t('loadFailed')));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const add = async () => {
@@ -52,7 +53,7 @@ export function PaymentMethodsSettings({ isAdmin }: { isAdmin: boolean }) {
       setNewName('');
       await load();
     } catch {
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     }
   };
 
@@ -61,42 +62,42 @@ export function PaymentMethodsSettings({ isAdmin }: { isAdmin: boolean }) {
       await api.put(`/payment-methods/${method.id}`, changes);
       await load();
     } catch {
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     }
   };
 
   const remove = async (method: CustomPaymentMethod) => {
-    if (!window.confirm(t('settings.deletePaymentMethodConfirm', { defaultValue: `Delete ${method.name}?` }))) return;
+    if (!window.confirm(t('deletePaymentMethodConfirm', { defaultValue: `Delete ${method.name}?` }))) return;
     try {
       await api.delete(`/payment-methods/${method.id}`);
       await load();
     } catch {
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     }
   };
 
   const merge = async (method: CustomPaymentMethod) => {
     const target = mergeTargets[method.id];
     if (!target) return;
-    if (!window.confirm(t('settings.mergePaymentMethodConfirm', { defaultValue: `Replace all ${method.name} payments with the selected method?` }))) return;
+    if (!window.confirm(t('mergePaymentMethodConfirm', { defaultValue: `Replace all ${method.name} payments with the selected method?` }))) return;
     try {
       await api.post(`/payment-methods/${method.id}/merge`, target === 'card'
         ? { target_type: 'card' }
         : { target_type: 'custom', target_id: Number(target) });
       await load();
-      toast.success(t('settings.paymentMethodMerged', { defaultValue: 'Payment methods merged' }));
+      toast.success(t('paymentMethodMerged', { defaultValue: 'Payment methods merged' }));
     } catch {
-      toast.error(t('settings.saveFailed'));
+      toast.error(t('saveFailed'));
     }
   };
 
   return (
     <div className="pb-6 max-w-3xl space-y-6">
       <div className="bg-white rounded-xl border border-gray-100 p-6">
-        <div className="flex items-center gap-2 mb-2"><CreditCard size={20} className="text-gray-500" /><h2 className="font-semibold text-gray-900">{t('settings.paymentMethods', { defaultValue: 'Payment methods' })}</h2></div>
-        <p className="text-sm text-gray-500 mb-5">{t('settings.paymentMethodsHint', { defaultValue: 'Cash, Card, and Loyalty Wallet are built in. Add any other manual methods used by your store.' })}</p>
+        <div className="flex items-center gap-2 mb-2"><CreditCard size={20} className="text-gray-500" /><h2 className="font-semibold text-gray-900">{t('paymentMethods', { defaultValue: 'Payment methods' })}</h2></div>
+        <p className="text-sm text-gray-500 mb-5">{t('paymentMethodsHint', { defaultValue: 'Cash, Card, and Loyalty Wallet are built in. Add any other manual methods used by your store.' })}</p>
         <div className="rounded-lg border border-gray-100 divide-y">
-          {['Cash', 'Card', 'Loyalty Wallet'].map((name) => <div key={name} className="px-3 py-2 flex justify-between text-sm"><span>{name}</span><span className="text-xs text-gray-400">{t('settings.builtIn', { defaultValue: 'Built in' })}</span></div>)}
+          {['Cash', 'Card', 'Loyalty Wallet'].map((name) => <div key={name} className="px-3 py-2 flex justify-between text-sm"><span>{name}</span><span className="text-xs text-gray-400">{t('builtIn', { defaultValue: 'Built in' })}</span></div>)}
         </div>
         <div className="mt-5 space-y-3">
           {methods.map((method) => (
@@ -104,28 +105,28 @@ export function PaymentMethodsSettings({ isAdmin }: { isAdmin: boolean }) {
               <div className="flex gap-2 items-center">
                 <input disabled={!isAdmin} value={names[method.id] ?? method.name} onChange={(e) => setNames((old) => ({ ...old, [method.id]: e.target.value }))} className="flex-1 px-3 py-2 text-sm border rounded-lg" />
                 <Button variant="outline" size="sm" disabled={!isAdmin || names[method.id] === method.name} onClick={() => update(method, { name: names[method.id] })}><Save size={14} /></Button>
-                <label className="flex items-center gap-1.5 text-xs text-gray-500"><input type="checkbox" disabled={!isAdmin} checked={method.is_active} onChange={(e) => update(method, { is_active: e.target.checked })} /> {t('settings.active', { defaultValue: 'Active' })}</label>
+                <label className="flex items-center gap-1.5 text-xs text-gray-500"><input type="checkbox" disabled={!isAdmin} checked={method.is_active} onChange={(e) => update(method, { is_active: e.target.checked })} /> {t('active', { defaultValue: 'Active' })}</label>
                 <Button variant="outline" size="sm" disabled={!isAdmin || Boolean(method.usage_count)} onClick={() => remove(method)}><Trash2 size={14} /></Button>
               </div>
               {Boolean(method.usage_count) && isAdmin && <div className="flex gap-2 items-center">
                 <select value={mergeTargets[method.id] || ''} onChange={(e) => setMergeTargets((old) => ({ ...old, [method.id]: e.target.value }))} className="flex-1 px-2 py-1.5 text-xs border rounded-md bg-white">
-                  <option value="">{t('settings.mergeInto', { defaultValue: 'Merge into…' })}</option><option value="card">Card</option>
+                  <option value="">{t('mergeInto', { defaultValue: 'Merge into…' })}</option><option value="card">Card</option>
                   {methods.filter((target) => target.id !== method.id).map((target) => <option key={target.id} value={target.id}>{target.name}</option>)}
                 </select>
-                <Button variant="outline" size="sm" disabled={!mergeTargets[method.id]} onClick={() => merge(method)}><Merge size={14} className="me-1" />{t('settings.merge', { defaultValue: 'Merge' })}</Button>
+                <Button variant="outline" size="sm" disabled={!mergeTargets[method.id]} onClick={() => merge(method)}><Merge size={14} className="me-1" />{t('merge', { defaultValue: 'Merge' })}</Button>
               </div>}
             </div>
           ))}
-          {isAdmin && <div className="flex gap-2"><input value={newName} onChange={(e) => setNewName(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') void add(); }} placeholder={t('settings.paymentMethodName', { defaultValue: 'e.g. Paytm, cheque, bank transfer' })} className="flex-1 px-3 py-2 text-sm border rounded-lg" /><Button onClick={add} disabled={!newName.trim()}><Plus size={14} className="me-1" />{t('common.add')}</Button></div>}
+          {isAdmin && <div className="flex gap-2"><input value={newName} onChange={(e) => setNewName(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') void add(); }} placeholder={t('paymentMethodName', { defaultValue: 'e.g. Paytm, cheque, bank transfer' })} className="flex-1 px-3 py-2 text-sm border rounded-lg" /><Button onClick={add} disabled={!newName.trim()}><Plus size={14} className="me-1" />{tCommon('add')}</Button></div>}
         </div>
       </div>
 
       <div className="bg-white rounded-xl border border-gray-100 p-6 flex items-center justify-between gap-4">
-        <div><h2 className="font-semibold text-gray-900">{t('settings.splitChecks', { defaultValue: 'Split checks' })}</h2><p className="text-sm text-gray-500 mt-1">{t('settings.splitChecksHint', { defaultValue: 'Allow dine-in orders to be divided into separate guest checks by item quantity. Disabled by default.' })}</p></div>
-        <input type="checkbox" className="size-5" disabled={!isAdmin} checked={splitChecksEnabled} onChange={async (e) => { const value = e.target.checked; setSplitChecksEnabled(value); try { await api.put('/settings/split_checks_enabled', { value: String(value) }); } catch { setSplitChecksEnabled(!value); toast.error(t('settings.saveFailed')); } }} />
+        <div><h2 className="font-semibold text-gray-900">{t('splitChecks', { defaultValue: 'Split checks' })}</h2><p className="text-sm text-gray-500 mt-1">{t('splitChecksHint', { defaultValue: 'Allow dine-in orders to be divided into separate guest checks by item quantity. Disabled by default.' })}</p></div>
+        <input type="checkbox" className="size-5" disabled={!isAdmin} checked={splitChecksEnabled} onChange={async (e) => { const value = e.target.checked; setSplitChecksEnabled(value); try { await api.put('/settings/split_checks_enabled', { value: String(value) }); } catch { setSplitChecksEnabled(!value); toast.error(t('saveFailed')); } }} />
       </div>
 
-      {merges.length > 0 && <div className="bg-white rounded-xl border border-gray-100 p-6"><h2 className="font-semibold text-gray-900 mb-3">{t('settings.mergeHistory', { defaultValue: 'Recent merges' })}</h2><div className="space-y-2 text-sm text-gray-600">{merges.map((entry) => <p key={entry.id}>{entry.source_name} → {entry.target_name} · {entry.affected_payments} · {formatDate(entry.merged_at)}</p>)}</div></div>}
+      {merges.length > 0 && <div className="bg-white rounded-xl border border-gray-100 p-6"><h2 className="font-semibold text-gray-900 mb-3">{t('mergeHistory', { defaultValue: 'Recent merges' })}</h2><div className="space-y-2 text-sm text-gray-600">{merges.map((entry) => <p key={entry.id}>{entry.source_name} → {entry.target_name} · {entry.affected_payments} · {formatDate(entry.merged_at)}</p>)}</div></div>}
     </div>
   );
 }

--- a/frontend/src/components/settings/TaxConfigurationPanel.tsx
+++ b/frontend/src/components/settings/TaxConfigurationPanel.tsx
@@ -22,7 +22,7 @@ import toast from 'react-hot-toast';
 import api from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { useFormatDate } from '@/hooks/useFormatDate';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations, type AppConfig } from 'use-intl';
 import { apiErrorText } from '@/lib/api-error';
 
 type PackSummary = {
@@ -162,13 +162,16 @@ function newManualCategory(label: string): ManualCategory {
   return { tempId: manualId('category'), label, components: [newManualComponent()] };
 }
 
-const ENTITY_LABELS: Record<OverrideEntityType, string> = {
-  product: 'tax.entityProduct',
-  addon: 'tax.entityAddon',
-  packaging: 'tax.entityPackaging',
-  delivery: 'tax.entityDelivery',
-  service_charge: 'tax.entityServiceCharge',
-};
+type TaxKey = keyof AppConfig['Messages']['tax'];
+type Translate = (key: TaxKey, params?: Record<string, string | number>) => string;
+
+const ENTITY_LABELS = {
+  product: 'entityProduct',
+  addon: 'entityAddon',
+  packaging: 'entityPackaging',
+  delivery: 'entityDelivery',
+  service_charge: 'entityServiceCharge',
+} as const satisfies Record<OverrideEntityType, TaxKey>;
 
 const pluginRequestSettingKey = (country: string) => `tax_plugin_request:${country}`;
 
@@ -185,18 +188,27 @@ async function loadPluginRequestId(country: string): Promise<string | null> {
 }
 const CHARGE_TYPES: OverrideEntityType[] = ['packaging', 'delivery', 'service_charge'];
 
-const ACTION_LABELS: Record<string, string> = {
-  install_bundled_pack: 'tax.actionInstallBundled',
-  install_downloaded_pack: 'tax.actionInstallDownloaded',
-  activate_pack: 'tax.actionActivate',
-  rollback_pack: 'tax.actionRollback',
-  create_override: 'tax.actionCreateOverride',
-  update_override: 'tax.actionUpdateOverride',
-  reset_override: 'tax.actionResetOverride',
-};
+const ACTION_LABELS = {
+  install_bundled_pack: 'actionInstallBundled',
+  install_downloaded_pack: 'actionInstallDownloaded',
+  activate_pack: 'actionActivate',
+  rollback_pack: 'actionRollback',
+  create_override: 'actionCreateOverride',
+  update_override: 'actionUpdateOverride',
+  reset_override: 'actionResetOverride',
+} as const satisfies Record<string, TaxKey>;
 
-function apiMessage(error: unknown, fallback: string, t: Translate): string {
-  return apiErrorText(error, fallback, t);
+function actionLabel(t: Translate, action: string): string {
+  const key = (ACTION_LABELS as Record<string, TaxKey | undefined>)[action];
+  return key ? t(key) : action;
+}
+
+// The `tax` namespace has no `apiError` sub-namespace, so the shared legacy
+// helper always falls back to the localized fallback message.
+const apiErrorT = (key: string): string => key;
+
+function apiMessage(error: unknown, fallback: string): string {
+  return apiErrorText(error, fallback, apiErrorT);
 }
 
 function taxModeSegmentClass(active: boolean): string {
@@ -209,50 +221,48 @@ function categoryIdOf(override: TaxOverride): string {
   return override.value?.categoryId || '';
 }
 
-type Translate = (key: string, params?: Record<string, string | number>) => string;
-
 function entityTypeLabel(t: Translate, entityType: unknown): string {
   if (typeof entityType === 'string' && entityType in ENTITY_LABELS) {
     return t(ENTITY_LABELS[entityType as OverrideEntityType]);
   }
-  return t('tax.target');
+  return t('target');
 }
 
 function auditDescription(row: AuditRow, t: Translate): string {
   const details = row.details || {};
-  if (row.action === 'install_bundled_pack') return t('tax.auditInstallBundled', { version: String(details.version || '') });
-  if (row.action === 'install_downloaded_pack') return t('tax.auditInstallDownloaded', { version: String(details.version || '') });
+  if (row.action === 'install_bundled_pack') return t('auditInstallBundled', { version: String(details.version || '') });
+  if (row.action === 'install_downloaded_pack') return t('auditInstallDownloaded', { version: String(details.version || '') });
   if (row.action === 'create_override') {
-    return t('tax.auditCreateOverride', {
+    return t('auditCreateOverride', {
       entityType: entityTypeLabel(t, details.entityType),
-      entityId: String(details.entityId || t('tax.storeWide')),
+      entityId: String(details.entityId || t('storeWide')),
       categoryId: String(details.categoryId || ''),
     });
   }
   if (row.action === 'update_override') {
     const before = (details.before || {}) as Record<string, unknown>;
     const after = (details.after || {}) as Record<string, unknown>;
-    return t('tax.auditUpdateOverride', {
+    return t('auditUpdateOverride', {
       entityType: entityTypeLabel(t, after.entityType || before.entityType),
-      entityId: String(after.entityId || before.entityId || t('tax.storeWide')),
+      entityId: String(after.entityId || before.entityId || t('storeWide')),
       before: String(before.categoryId || ''),
       after: String(after.categoryId || ''),
     });
   }
   if (row.action === 'reset_override') {
-    return t('tax.auditResetOverride', {
+    return t('auditResetOverride', {
       entityType: entityTypeLabel(t, details.entityType),
-      entityId: String(details.entityId || t('tax.storeWide')),
+      entityId: String(details.entityId || t('storeWide')),
     });
   }
-  if (row.action === 'activate_pack') return t('tax.auditActivatePack', { previousVersionId: String(details.previousVersionId || 'none') });
-  if (row.action === 'rollback_pack') return t('tax.auditRollbackPack', { previousVersionId: String(details.previousVersionId || 'unknown') });
+  if (row.action === 'activate_pack') return t('auditActivatePack', { previousVersionId: String(details.previousVersionId || 'none') });
+  if (row.action === 'rollback_pack') return t('auditRollbackPack', { previousVersionId: String(details.previousVersionId || 'unknown') });
   return '';
 }
 
 export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
   const { formatDateTime } = useFormatDate();
-  const { t } = useI18n();
+  const t = useTranslations('tax');
   const [packs, setPacks] = useState<PackSummary[]>([]);
   const [storeCountry, setStoreCountry] = useState('');
   const [selectedPackId, setSelectedPackId] = useState('');
@@ -383,7 +393,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         ...(selectedPackId ? [loadDetail(selectedPackId)] : []),
       ]);
     } catch (error) {
-      toast.error(apiMessage(error, t('tax.loadFailed'), t));
+      toast.error(apiMessage(error, t('loadFailed')));
     } finally {
       setLoading(false);
     }
@@ -411,7 +421,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         if (packResponse.data.store_country) void loadManualDetail(packResponse.data.store_country, nextPacks);
       })
       .catch((error) => {
-        if (!cancelled) toast.error(apiMessage(error, t('tax.loadFailed'), t));
+        if (!cancelled) toast.error(apiMessage(error, t('loadFailed')));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -455,7 +465,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         setCalculation(null);
       })
       .catch((error) => {
-        if (!cancelled) toast.error(apiMessage(error, t('tax.loadPackDetailsFailed'), t));
+        if (!cancelled) toast.error(apiMessage(error, t('loadPackDetailsFailed')));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -494,7 +504,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
   async function checkForPluginUpdates(announce: boolean) {
     const packId = detail?.pack.id;
     if (!pluginUpdateApplicable || !packId) {
-      if (announce) toast.error(t('tax.noPluginToCheck'));
+      if (announce) toast.error(t('noPluginToCheck'));
       return;
     }
     setCheckingUpdate(true);
@@ -503,9 +513,9 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       const updates = (response.data?.updates || []) as TaxPackUpdate[];
       const match = updates.find((update) => update.installedPackId === packId) || null;
       setPackUpdate(match);
-      if (announce) toast.success(match ? t('tax.updateAvailable', { version: match.latestVersion }) : t('tax.upToDate'));
+      if (announce) toast.success(match ? t('updateAvailable', { version: match.latestVersion }) : t('upToDate'));
     } catch (error) {
-      if (announce) toast.error(apiMessage(error, t('tax.checkUpdatesFailed'), t));
+      if (announce) toast.error(apiMessage(error, t('checkUpdatesFailed')));
     } finally {
       setCheckingUpdate(false);
     }
@@ -541,7 +551,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       await api.post(
         `/tax-packs/${encodeURIComponent(installed.packId)}/versions/${encodeURIComponent(installed.versionId)}/activate`,
       );
-      toast.success(t('tax.updatedTo', { version: update.latestVersion }));
+      toast.success(t('updatedTo', { version: update.latestVersion }));
       setPackUpdate(null);
       // installed.packId can differ from the pack that was active before
       // (e.g. a catalog rename, official-in -> official-india) — switch the
@@ -551,7 +561,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       setSelectedPackId(installed.packId);
       await Promise.all([loadList(), loadAudit(), loadDetail(installed.packId)]);
     } catch (error) {
-      toast.error(apiMessage(error, t('tax.installUpdateFailed'), t));
+      toast.error(apiMessage(error, t('installUpdateFailed')));
     } finally {
       setInstallingUpdate(false);
     }
@@ -567,7 +577,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
     const packId = detail?.pack.id;
     const versionId = detail?.active_version?.id;
     if (!isOwner || !pluginUpdateApplicable || !packId || !versionId) return;
-    if (!window.confirm(t('tax.reinstallConfirm'))) {
+    if (!window.confirm(t('reinstallConfirm'))) {
       return;
     }
     setReinstallingPlugin(true);
@@ -575,10 +585,10 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       await api.post(
         `/tax-packs/${encodeURIComponent(packId)}/versions/${encodeURIComponent(versionId)}/reinstall`,
       );
-      toast.success(t('tax.reinstalled'));
+      toast.success(t('reinstalled'));
       await Promise.all([loadList(), loadAudit(), loadDetail(packId)]);
     } catch (error) {
-      toast.error(apiMessage(error, t('tax.reinstallFailed'), t));
+      toast.error(apiMessage(error, t('reinstallFailed')));
     } finally {
       setReinstallingPlugin(false);
     }
@@ -601,7 +611,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
   async function saveOverride() {
     if (!isOwner) return;
     if (!categoryId || (needsEntity && !entityId)) {
-      toast.error(t('tax.chooseTargetAndCategory'));
+      toast.error(t('chooseTargetAndCategory'));
       return;
     }
     setSaving(true);
@@ -613,30 +623,30 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       };
       if (editingOverrideId) {
         await api.put(`/tax-packs/overrides/${editingOverrideId}`, payload);
-        toast.success(t('tax.overrideUpdated'));
+        toast.success(t('overrideUpdated'));
       } else {
         await api.post('/tax-packs/overrides', payload);
-        toast.success(t('tax.overrideAdded'));
+        toast.success(t('overrideAdded'));
       }
       resetOverrideForm();
       await Promise.all([loadDetail(selectedPackId), loadList(), loadAudit()]);
     } catch (error) {
-      toast.error(apiMessage(error, t('tax.overrideSaveFailed'), t));
+      toast.error(apiMessage(error, t('overrideSaveFailed')));
     } finally {
       setSaving(false);
     }
   }
 
   async function removeOverride(override: TaxOverride) {
-    if (!isOwner || !window.confirm(t('tax.removeOverrideConfirm', { target: override.entity_name || t(ENTITY_LABELS[override.entity_type]) }))) return;
+    if (!isOwner || !window.confirm(t('removeOverrideConfirm', { target: override.entity_name || t(ENTITY_LABELS[override.entity_type]) }))) return;
     setSaving(true);
     try {
       await api.delete(`/tax-packs/overrides/${override.id}`);
-      toast.success(t('tax.overrideRemoved'));
+      toast.success(t('overrideRemoved'));
       if (editingOverrideId === override.id) resetOverrideForm();
       await Promise.all([loadDetail(selectedPackId), loadList(), loadAudit()]);
     } catch (error) {
-      toast.error(apiMessage(error, t('tax.overrideRemoveFailed'), t));
+      toast.error(apiMessage(error, t('overrideRemoveFailed')));
     } finally {
       setSaving(false);
     }
@@ -651,7 +661,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
     try {
       if (!nextCategoryId) {
         if (current) await api.delete(`/tax-packs/overrides/${current.id}`);
-        toast.success(t('tax.chargeRestored', { entity: t(ENTITY_LABELS[entityType]) }));
+        toast.success(t('chargeRestored', { entity: t(ENTITY_LABELS[entityType]) }));
       } else {
         const payload = {
           entity_type: entityType,
@@ -663,11 +673,11 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         } else {
           await api.post('/tax-packs/overrides', payload);
         }
-        toast.success(t('tax.chargeSaved', { entity: t(ENTITY_LABELS[entityType]) }));
+        toast.success(t('chargeSaved', { entity: t(ENTITY_LABELS[entityType]) }));
       }
       await Promise.all([loadDetail(selectedPackId), loadList(), loadAudit()]);
     } catch (error) {
-      toast.error(apiMessage(error, t('tax.chargeSaveFailed'), t));
+      toast.error(apiMessage(error, t('chargeSaveFailed')));
     } finally {
       setSaving(false);
     }
@@ -680,9 +690,9 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       await api.put('/settings/taxes_enabled', { value: 'false' });
       setTaxesEnabled(false);
       setManualBuilderOpen(false);
-      toast.success(t('tax.turnedOff'));
+      toast.success(t('turnedOff'));
     } catch (error) {
-      toast.error(apiMessage(error, t('tax.turnOffFailed'), t));
+      toast.error(apiMessage(error, t('turnOffFailed')));
     } finally {
       setSaving(false);
     }
@@ -699,7 +709,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       setPluginRequested(false);
       setManualBuilderOpen(false);
       await Promise.all([loadList(), loadAudit()]);
-      toast.success(t('tax.enabledFor', { country: storeCountry }));
+      toast.success(t('enabledFor', { country: storeCountry }));
     } catch (error) {
       const status = (error as { response?: { status?: number } }).response?.status;
       if (status === 404) {
@@ -723,7 +733,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         }
         return;
       }
-      toast.error(apiMessage(error, t('tax.enableFailed'), t));
+      toast.error(apiMessage(error, t('enableFailed')));
     } finally {
       setEnablingTaxes(false);
     }
@@ -731,12 +741,12 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
 
   async function calculate() {
     if (!selectedPack?.active_for_store) {
-      toast.error(t('tax.selectActivePack'));
+      toast.error(t('selectActivePack'));
       return;
     }
     const amountNum = Number(testAmount);
     if (!testCategoryId || !testAmount || isNaN(amountNum) || amountNum <= 0) {
-      toast.error(t('tax.invalidTestAmount'));
+      toast.error(t('invalidTestAmount'));
       return;
     }
     try {
@@ -748,7 +758,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       setCalculation(response.data.calculation);
     } catch (error) {
       setCalculation(null);
-      toast.error(apiMessage(error, t('tax.calculateFailed'), t));
+      toast.error(apiMessage(error, t('calculateFailed')));
     }
   }
 
@@ -793,17 +803,17 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
     if (!isOwner) return;
     for (const category of manualCategories) {
       if (!category.label.trim()) {
-        toast.error(t('tax.categoryNameRequired'));
+        toast.error(t('categoryNameRequired'));
         return;
       }
       if (category.components.length === 0) {
-        toast.error(t('tax.categoryNeedsComponent', { label: category.label }));
+        toast.error(t('categoryNeedsComponent', { label: category.label }));
         return;
       }
       for (const component of category.components) {
         const value = Number(component.value);
         if (!Number.isFinite(value) || value < 0 || (component.type === 'percent' && value > 100)) {
-          toast.error(t('tax.componentNeedsValidRate', { label: component.label || category.label }));
+          toast.error(t('componentNeedsValidRate', { label: component.label || category.label }));
           return;
         }
       }
@@ -831,9 +841,9 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       const remapped = (response.data?.remapped || []) as Array<{ entity: string; count: number }>;
       if (remapped.length > 0) {
         const summary = remapped.map((row) => `${row.count} ${row.entity}${row.count === 1 ? '' : 's'}`).join(' and ');
-        toast(t('tax.reassignedSummary', { summary }), { icon: '⚠️' });
+        toast(t('reassignedSummary', { summary }), { icon: '⚠️' });
       }
-      toast.success(t('tax.manualSaved'));
+      toast.success(t('manualSaved'));
       setManualOverrideConfirm(null);
       setTaxesEnabled(true);
       await Promise.all([loadList(), loadAudit(), applyManualDefinition(storeCountry)]);
@@ -845,22 +855,22 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         return;
       }
       const failedChecks = response?.data?.validation?.checks?.filter((check) => !check.passed).map((check) => check.message);
-      toast.error(failedChecks?.length ? failedChecks.join('; ') : apiMessage(error, t('tax.manualSaveFailed'), t));
+      toast.error(failedChecks?.length ? failedChecks.join('; ') : apiMessage(error, t('manualSaveFailed')));
     } finally {
       setManualSaving(false);
     }
   }
 
   if (loading && !detail) {
-    return <div className="py-16 text-center text-sm text-gray-500">{t('tax.loading')}</div>;
+    return <div className="py-16 text-center text-sm text-gray-500">{t('loading')}</div>;
   }
 
   return (
     <div className="pb-6 max-w-5xl space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">{t('tax.title')}</h2>
-          <p className="mt-1 text-sm text-gray-500">{t('tax.subtitle')}</p>
+          <h2 className="text-xl font-semibold text-gray-900">{t('title')}</h2>
+          <p className="mt-1 text-sm text-gray-500">{t('subtitle')}</p>
         </div>
         <div className="flex gap-2">
           <Button
@@ -871,7 +881,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
             }}
             disabled={loading}
           >
-            <RefreshCw size={15} className={loading ? 'animate-spin' : ''} /> {t('tax.refresh')}
+            <RefreshCw size={15} className={loading ? 'animate-spin' : ''} /> {t('refresh')}
           </Button>
         </div>
       </div>
@@ -879,12 +889,12 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       {!isOwner && (
         <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
           <Lock size={16} className="mt-0.5 shrink-0" />
-          {t('tax.managerNotice')}
+          {t('managerNotice')}
         </div>
       )}
 
       <section className="rounded-xl border border-gray-200 bg-white p-5">
-        <h3 className="font-semibold text-gray-900">{t('tax.mode')}</h3>
+        <h3 className="font-semibold text-gray-900">{t('mode')}</h3>
         <div className="mt-3 inline-flex flex-wrap rounded-lg border border-gray-200 bg-gray-50 p-1">
           <button
             type="button"
@@ -895,19 +905,19 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
             }}
             className={taxModeSegmentClass(activeSegment === 'off')}
           >
-            {t('tax.modeOff')}
+            {t('modeOff')}
           </button>
           <button
             type="button"
             disabled={!isOwner || enablingTaxes || officialPackAvailableResolved === false}
-            title={officialPackAvailableResolved === false ? t('tax.noOfficialPack', { country: storeCountry }) : undefined}
+            title={officialPackAvailableResolved === false ? t('noOfficialPack', { country: storeCountry }) : undefined}
             onClick={() => {
               setManualBuilderOpen(false);
               if (taxMode !== 'official') void enableCountryTaxes();
             }}
             className={taxModeSegmentClass(activeSegment === 'official')}
           >
-            {enablingTaxes ? t('tax.enabling') : t('tax.modeOfficial')}
+            {enablingTaxes ? t('enabling') : t('modeOfficial')}
           </button>
           <button
             type="button"
@@ -915,25 +925,25 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
             onClick={() => setManualBuilderOpen(true)}
             className={taxModeSegmentClass(activeSegment === 'manual')}
           >
-            {t('tax.modeManual')}
+            {t('modeManual')}
           </button>
         </div>
         <p className="mt-3 text-sm text-gray-600">
-          {taxMode === 'off' && t('tax.modeOffHint')}
-          {taxMode === 'official' && t('tax.modeOfficialHint', { country: storeCountry })}
-          {taxMode === 'manual' && t('tax.modeManualHint', { country: storeCountry })}
-          {manualBuilderOpen && taxMode !== 'manual' && t('tax.modeManualUnsavedHint')}
+          {taxMode === 'off' && t('modeOffHint')}
+          {taxMode === 'official' && t('modeOfficialHint', { country: storeCountry })}
+          {taxMode === 'manual' && t('modeManualHint', { country: storeCountry })}
+          {manualBuilderOpen && taxMode !== 'manual' && t('modeManualUnsavedHint')}
         </p>
         {countryPackUnavailable && (
           <p role="status" className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-            {t('tax.supportUnavailable', { country: storeCountry })}
-            {pluginRequested && t('tax.requestQueued')}
+            {t('supportUnavailable', { country: storeCountry })}
+            {pluginRequested && t('requestQueued')}
           </p>
         )}
         {taxMode === 'official' && detail?.active_version && detail.pack.publisher !== 'local' && (
           <div className="mt-3 flex flex-wrap items-center gap-3 rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-700">
             <span>
-              {t('tax.pluginVersion')} <span className="font-mono font-medium">v{detail.active_version.version}</span>
+              {t('pluginVersion')} <span className="font-mono font-medium">v{detail.active_version.version}</span>
               <span className="ms-1 text-gray-400">({detail.pack.trust_status})</span>
             </span>
             <span className="ms-auto flex items-center gap-3">
@@ -942,11 +952,11 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                   type="button"
                   onClick={() => void reinstallPlugin()}
                   disabled={reinstallingPlugin}
-                  title={t('tax.reinstallHint')}
+                  title={t('reinstallHint')}
                   className="flex items-center gap-1 font-medium text-gray-600 hover:text-gray-800 disabled:opacity-50"
                 >
                   <Wrench size={13} className={reinstallingPlugin ? 'animate-spin' : ''} />
-                  {reinstallingPlugin ? t('tax.reinstalling') : t('tax.reinstallPlugin')}
+                  {reinstallingPlugin ? t('reinstalling') : t('reinstallPlugin')}
                 </button>
               )}
               <button
@@ -956,7 +966,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                 className="flex items-center gap-1 font-medium text-brand disabled:opacity-50"
               >
                 <RefreshCw size={13} className={checkingUpdate ? 'animate-spin' : ''} />
-                {checkingUpdate ? t('tax.checking') : t('tax.checkUpdates')}
+                {checkingUpdate ? t('checking') : t('checkUpdates')}
               </button>
             </span>
           </div>
@@ -965,15 +975,15 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
           <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-brand/30 bg-brand/5 px-3 py-2 text-sm">
             <span className="flex items-center gap-1.5">
               <Download size={14} className="text-brand" />
-              {t('tax.updateAvailableLabel')} <span className="font-mono font-medium">v{activePluginUpdate.latestVersion}</span>
-              <span className="text-gray-500">{t('tax.currentVersion', { current: activePluginUpdate.currentVersion })}</span>
+              {t('updateAvailableLabel')} <span className="font-mono font-medium">v{activePluginUpdate.latestVersion}</span>
+              <span className="text-gray-500">{t('currentVersion', { current: activePluginUpdate.currentVersion })}</span>
             </span>
             {isOwner ? (
               <Button size="sm" disabled={installingUpdate} onClick={() => void installPluginUpdate()}>
-                {installingUpdate ? t('tax.installing') : t('tax.installAndActivate')}
+                {installingUpdate ? t('installing') : t('installAndActivate')}
               </Button>
             ) : (
-              <span className="text-xs text-gray-500">{t('tax.askOwnerToInstall')}</span>
+              <span className="text-xs text-gray-500">{t('askOwnerToInstall')}</span>
             )}
           </div>
         )}
@@ -984,14 +994,14 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">
             <Wrench size={20} className="text-brand" />
-            <h3 className="font-semibold text-gray-900">{t('tax.manualBuilder')}</h3>
+            <h3 className="font-semibold text-gray-900">{t('manualBuilder')}</h3>
           </div>
           {!taxesEnabled && (
-            <button type="button" onClick={() => setManualBuilderOpen(false)} className="text-sm text-gray-400 hover:text-gray-600">{t('tax.hide')}</button>
+            <button type="button" onClick={() => setManualBuilderOpen(false)} className="text-sm text-gray-400 hover:text-gray-600">{t('hide')}</button>
           )}
         </div>
         <p className="mt-1 text-sm text-gray-500">
-          {t('tax.manualBuilderHint', { country: storeCountry || t('tax.yourStore') })}
+          {t('manualBuilderHint', { country: storeCountry || t('yourStore') })}
         </p>
 
         <div className="mt-4 space-y-3">
@@ -1002,11 +1012,11 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                   value={category.label}
                   onChange={(event) => updateManualCategoryLabel(category.tempId, event.target.value)}
                   disabled={!isOwner}
-                  placeholder={t('tax.categoryNamePlaceholder')}
+                  placeholder={t('categoryNamePlaceholder')}
                   className="flex-1 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm font-medium disabled:bg-gray-100"
                 />
                 {isOwner && manualCategories.length > 1 && (
-                  <button type="button" onClick={() => removeManualCategory(category.tempId)} className="p-2 text-gray-400 hover:text-red-600" title={t('tax.removeCategory')}>
+                  <button type="button" onClick={() => removeManualCategory(category.tempId)} className="p-2 text-gray-400 hover:text-red-600" title={t('removeCategory')}>
                     <Trash2 size={16} />
                   </button>
                 )}
@@ -1018,7 +1028,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                       value={component.label}
                       onChange={(event) => updateManualComponent(category.tempId, component.key, { label: event.target.value })}
                       disabled={!isOwner}
-                      placeholder={t('tax.componentPlaceholder')}
+                      placeholder={t('componentPlaceholder')}
                       className="flex-1 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm disabled:bg-gray-100"
                     />
                     <select
@@ -1028,7 +1038,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                       className="rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm disabled:bg-gray-100"
                     >
                       <option value="percent">%</option>
-                      <option value="fixed">{t('tax.fixed')}</option>
+                      <option value="fixed">{t('fixed')}</option>
                     </select>
                     <input
                       type="number"
@@ -1040,7 +1050,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                       className="w-24 rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-end disabled:bg-gray-100"
                     />
                     {isOwner && category.components.length > 1 && (
-                      <button type="button" onClick={() => removeManualComponent(category.tempId, component.key)} className="p-1.5 text-gray-400 hover:text-red-600" title={t('tax.removeComponent')}>
+                      <button type="button" onClick={() => removeManualComponent(category.tempId, component.key)} className="p-1.5 text-gray-400 hover:text-red-600" title={t('removeComponent')}>
                         <Trash2 size={14} />
                       </button>
                     )}
@@ -1048,7 +1058,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                 ))}
                 {isOwner && (
                   <button type="button" onClick={() => addManualComponent(category.tempId)} className="ms-4 flex items-center gap-1 text-xs font-medium text-brand">
-                    <Plus size={12} /> {t('tax.addComponent')}
+                    <Plus size={12} /> {t('addComponent')}
                   </button>
                 )}
               </div>
@@ -1056,34 +1066,34 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
           ))}
           {isOwner && (
             <button type="button" onClick={addManualCategory} className="flex items-center gap-1 text-sm font-medium text-brand">
-              <Plus size={14} /> {t('tax.addCategory')}
+              <Plus size={14} /> {t('addCategory')}
             </button>
           )}
         </div>
 
         <div className="mt-5 border-t border-gray-100 pt-4">
-          <p className="text-sm font-medium text-gray-800">{t('tax.menuPrices')}</p>
+          <p className="text-sm font-medium text-gray-800">{t('menuPrices')}</p>
           <div className="mt-2 flex gap-4 text-sm">
             <label className="flex items-center gap-2">
               <input type="radio" checked={!manualInclusive} onChange={() => setManualInclusive(false)} disabled={!isOwner} />
-              {t('tax.exclusiveLabel')}
+              {t('exclusiveLabel')}
             </label>
             <label className="flex items-center gap-2">
               <input type="radio" checked={manualInclusive} onChange={() => setManualInclusive(true)} disabled={!isOwner} />
-              {t('tax.inclusiveLabel')}
+              {t('inclusiveLabel')}
             </label>
           </div>
         </div>
 
         <div className="mt-5 border-t border-gray-100 pt-4">
-          <p className="text-sm font-medium text-gray-800">{t('tax.defaultCategory')}</p>
-          <p className="text-xs text-gray-500 mb-2">{t('tax.defaultCategoryHint')}</p>
+          <p className="text-sm font-medium text-gray-800">{t('defaultCategory')}</p>
+          <p className="text-xs text-gray-500 mb-2">{t('defaultCategoryHint')}</p>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {([
-              ['product', t('tax.defaultNewProducts')],
-              ['packaging', t('tax.defaultPackaging')],
-              ['delivery', t('tax.defaultDelivery')],
-              ['service_charge', t('tax.defaultServiceCharge')],
+              ['product', t('defaultNewProducts')],
+              ['packaging', t('defaultPackaging')],
+              ['delivery', t('defaultDelivery')],
+              ['service_charge', t('defaultServiceCharge')],
             ] as Array<[keyof ManualDefaults, string]>).map(([key, label]) => (
               <label key={key} className="block">
                 <span className="text-xs text-gray-500">{label}</span>
@@ -1094,7 +1104,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                   className="mt-1 w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm disabled:bg-gray-100"
                 >
                   {manualCategories.map((category) => (
-                    <option key={category.tempId} value={category.tempId}>{category.label || t('tax.untitledCategory')}</option>
+                    <option key={category.tempId} value={category.tempId}>{category.label || t('untitledCategory')}</option>
                   ))}
                 </select>
               </label>
@@ -1104,17 +1114,17 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
 
         {manualOverrideConfirm && (
           <div className="mt-4 flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-            <span>{t('tax.manualOverrideConfirm', { country: storeCountry })}</span>
+            <span>{t('manualOverrideConfirm', { country: storeCountry })}</span>
             <div className="flex gap-2 shrink-0">
-              <Button variant="outline" onClick={() => setManualOverrideConfirm(null)}>{t('tax.cancel')}</Button>
-              <Button disabled={manualSaving} onClick={() => void saveManualConfig(true)}>{t('tax.replace')}</Button>
+              <Button variant="outline" onClick={() => setManualOverrideConfirm(null)}>{t('cancel')}</Button>
+              <Button disabled={manualSaving} onClick={() => void saveManualConfig(true)}>{t('replace')}</Button>
             </div>
           </div>
         )}
 
         <div className="mt-5 flex justify-end">
           <Button disabled={!isOwner || manualSaving} onClick={() => void saveManualConfig(false)}>
-            {manualSaving ? t('tax.saving') : manualLoaded ? t('tax.saveManual') : t('tax.createManual')}
+            {manualSaving ? t('saving') : manualLoaded ? t('saveManual') : t('createManual')}
           </Button>
         </div>
       </section>
@@ -1126,8 +1136,8 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         className="flex w-full items-center justify-between rounded-xl border border-gray-200 bg-white p-5 text-start"
       >
         <div>
-          <h3 className="font-semibold text-gray-900">{t('tax.advancedTools')}</h3>
-          <p className="mt-1 text-sm text-gray-500">{t('tax.advancedToolsHint')}</p>
+          <h3 className="font-semibold text-gray-900">{t('advancedTools')}</h3>
+          <p className="mt-1 text-sm text-gray-500">{t('advancedToolsHint')}</p>
         </div>
         <ChevronDown size={18} className={`shrink-0 text-gray-500 ${showAdvancedTools ? 'rotate-180' : ''}`} />
       </button>
@@ -1138,9 +1148,9 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-2">
             <ShieldCheck size={20} className="text-brand" />
-            <h3 className="font-semibold text-gray-900">{t('tax.installedPacks')}</h3>
+            <h3 className="font-semibold text-gray-900">{t('installedPacks')}</h3>
           </div>
-          <span className="text-xs text-gray-500">{t('tax.installedPacksHint', { country: storeCountry })}</span>
+          <span className="text-xs text-gray-500">{t('installedPacksHint', { country: storeCountry })}</span>
         </div>
 
         {selectedPack && detail ? (
@@ -1148,14 +1158,14 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
             {detail.active_version ? (
               <>
                 <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                  <Info label={t('tax.storeCountry')} value={storeCountry} />
-                  <Info label={t('tax.jurisdiction')} value={selectedPack.jurisdiction} />
-                  <Info label={t('tax.activeVersion')} value={detail.active_version.version} />
-                  <Info label={t('tax.trustStatus')} value={detail.pack.trust_status} />
+                  <Info label={t('storeCountry')} value={storeCountry} />
+                  <Info label={t('jurisdiction')} value={selectedPack.jurisdiction} />
+                  <Info label={t('activeVersion')} value={detail.active_version.version} />
+                  <Info label={t('trustStatus')} value={detail.pack.trust_status} />
                 </div>
                 <div className="mt-4 flex flex-wrap items-center gap-3 rounded-lg bg-gray-50 p-3 text-xs text-gray-600">
-                  <span>{t('tax.effectiveFrom', { date: detail.active_version.effective_from })}</span>
-                  <span>{t('tax.publishedAt', { date: detail.active_version.published_at })}</span>
+                  <span>{t('effectiveFrom', { date: detail.active_version.effective_from })}</span>
+                  <span>{t('publishedAt', { date: detail.active_version.published_at })}</span>
                   <span><Ltr>{detail.active_version.definition.currency}</Ltr></span>
                   <button
                     type="button"
@@ -1164,8 +1174,8 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                   >
                     {detail.active_version.validation.valid ? <CheckCircle2 size={14} /> : <AlertTriangle size={14} />}
                     {detail.active_version.validation.valid
-                      ? t('tax.checksPassed', { passed: detail.active_version.validation.checks.filter((c) => c.passed).length, total: detail.active_version.validation.checks.length })
-                      : t('tax.checksFailed')}
+                      ? t('checksPassed', { passed: detail.active_version.validation.checks.filter((c) => c.passed).length, total: detail.active_version.validation.checks.length })
+                      : t('checksFailed')}
                     <ChevronDown size={14} className={expandedChecklist ? 'rotate-180' : ''} />
                   </button>
                 </div>
@@ -1181,12 +1191,12 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
               </>
             ) : (
               <p className="mt-4 text-sm text-gray-500">
-                {t('tax.noActiveVersion')}
+                {t('noActiveVersion')}
               </p>
             )}
             <div className="mt-5 border-t border-gray-100 pt-4">
               <div className="mb-2 flex items-center justify-between">
-                <p className="text-sm font-medium text-gray-800">{t('tax.installedVersions')}</p>
+                <p className="text-sm font-medium text-gray-800">{t('installedVersions')}</p>
               </div>
               <div className="space-y-2">
                 {detail.versions.map((version) => {
@@ -1197,7 +1207,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                         v{version.version}
                         <span className="ms-2 text-xs text-gray-400">{version.status}</span>
                       </span>
-                      {active && <span className="text-xs font-medium text-emerald-700">{t('tax.active')}</span>}
+                      {active && <span className="text-xs font-medium text-emerald-700">{t('active')}</span>}
                     </div>
                   );
                 })}
@@ -1205,18 +1215,18 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
             </div>
           </>
         ) : (
-          <p className="mt-4 text-sm text-gray-500">{t('tax.noActivePack')}</p>
+          <p className="mt-4 text-sm text-gray-500">{t('noActivePack')}</p>
         )}
       </section>
 
       <section className="rounded-xl border border-gray-200 bg-white p-5">
         <div className="flex items-center gap-2">
           <Calculator size={20} className="text-brand" />
-          <h3 className="font-semibold text-gray-900">{t('tax.testCalculation')}</h3>
+          <h3 className="font-semibold text-gray-900">{t('testCalculation')}</h3>
         </div>
-        <p className="mt-1 text-sm text-gray-500">{t('tax.testCalculationHint')}</p>
+        <p className="mt-1 text-sm text-gray-500">{t('testCalculationHint')}</p>
         {!selectedPack?.active_for_store && (
-          <p className="mt-2 text-xs text-amber-700">{t('tax.packNotActive')}</p>
+          <p className="mt-2 text-xs text-amber-700">{t('packNotActive')}</p>
         )}
         <div className="mt-4 grid gap-3 sm:grid-cols-4">
           <select disabled={!selectedPack?.active_for_store} value={testCategoryId} onChange={(event) => setTestCategoryId(event.target.value)} className="rounded-md border border-gray-200 px-3 py-2 text-sm disabled:bg-gray-100">
@@ -1226,24 +1236,24 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
             value={testAmount}
             onChange={(event) => setTestAmount(event.target.value)}
             inputMode="decimal"
-            placeholder={t('tax.amount')}
+            placeholder={t('amount')}
             disabled={!selectedPack?.active_for_store}
             className="rounded-md border border-gray-200 px-3 py-2 text-sm disabled:bg-gray-100"
           />
           <select disabled={!selectedPack?.active_for_store} value={testBehavior} onChange={(event) => setTestBehavior(event.target.value)} className="rounded-md border border-gray-200 px-3 py-2 text-sm disabled:bg-gray-100">
-            <option value="country_default">{t('tax.behaviorCountryDefault')}</option>
-            <option value="exclusive">{t('tax.behaviorExclusive')}</option>
-            <option value="inclusive">{t('tax.behaviorInclusive')}</option>
-            <option value="exempt">{t('tax.behaviorExempt')}</option>
+            <option value="country_default">{t('behaviorCountryDefault')}</option>
+            <option value="exclusive">{t('behaviorExclusive')}</option>
+            <option value="inclusive">{t('behaviorInclusive')}</option>
+            <option value="exempt">{t('behaviorExempt')}</option>
           </select>
-          <Button disabled={!selectedPack?.active_for_store} onClick={() => void calculate()}>{t('tax.calculate')}</Button>
+          <Button disabled={!selectedPack?.active_for_store} onClick={() => void calculate()}>{t('calculate')}</Button>
         </div>
         {calculation && (
           <div className="mt-4 rounded-lg bg-gray-50 p-4">
             <div className="grid gap-3 sm:grid-cols-3">
-              <Info label={t('tax.taxableBase')} value={calculation.taxableBase} />
-              <Info label={t('tax.tax')} value={calculation.taxAmount} />
-              <Info label={t('tax.payableTotal')} value={calculation.payableTotal} />
+              <Info label={t('taxableBase')} value={calculation.taxableBase} />
+              <Info label={t('tax')} value={calculation.taxAmount} />
+              <Info label={t('payableTotal')} value={calculation.payableTotal} />
             </div>
             {calculation.lines[0]?.components.length > 0 && (
               <div className="mt-3 border-t border-gray-200 pt-3 text-xs text-gray-600">
@@ -1262,13 +1272,13 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       <section className="rounded-xl border border-gray-200 bg-white p-5">
         <div className="flex items-center gap-2">
           <SlidersHorizontal size={20} className="text-brand" />
-          <h3 className="font-semibold text-gray-900">{t('tax.chargeCategories')}</h3>
+          <h3 className="font-semibold text-gray-900">{t('chargeCategories')}</h3>
         </div>
         <p className="mt-1 text-sm text-gray-500">
-          {t('tax.chargeCategoriesHint')}
+          {t('chargeCategoriesHint')}
         </p>
         {!selectedPack?.active_for_store && (
-          <p className="mt-2 text-xs text-amber-700">{t('tax.chargeCategoriesNotActive')}</p>
+          <p className="mt-2 text-xs text-amber-700">{t('chargeCategoriesNotActive')}</p>
         )}
         <div className="mt-4 grid gap-4 sm:grid-cols-3">
           {CHARGE_TYPES.map((chargeType) => {
@@ -1284,7 +1294,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                   disabled={!isOwner || saving || !selectedPack?.active_for_store}
                   className="mt-2 w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm disabled:bg-gray-100"
                 >
-                  <option value="">{t('tax.chargeNotConfigured')}</option>
+                  <option value="">{t('chargeNotConfigured')}</option>
                   {detail?.categories.map((category) => (
                     <option key={category.category_id} value={category.category_id}>{category.label}</option>
                   ))}
@@ -1298,10 +1308,10 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       <section className="rounded-xl border border-gray-200 bg-white p-5">
         <div className="flex items-center gap-2">
           <SlidersHorizontal size={20} className="text-brand" />
-          <h3 className="font-semibold text-gray-900">{t('tax.merchantOverrides')}</h3>
+          <h3 className="font-semibold text-gray-900">{t('merchantOverrides')}</h3>
         </div>
         <p className="mt-1 text-sm text-gray-500">
-          {t('tax.merchantOverridesHint')}
+          {t('merchantOverridesHint')}
         </p>
 
         {isOwner && (
@@ -1320,19 +1330,19 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
             </select>
             {needsEntity ? (
               <select value={entityId} onChange={(event) => setEntityId(event.target.value)} className="rounded-md border border-gray-200 bg-white px-3 py-2 text-sm">
-                <option value="">{t('tax.chooseEntity', { entity: t(ENTITY_LABELS[entityType]) })}</option>
+                <option value="">{t('chooseEntity', { entity: t(ENTITY_LABELS[entityType]) })}</option>
                 {targetOptions.map((target) => <option key={target.id} value={target.id}>{target.name}</option>)}
               </select>
             ) : (
-              <div className="rounded-md border border-gray-200 bg-gray-100 px-3 py-2 text-sm text-gray-500">{t('tax.storeWideCharge')}</div>
+              <div className="rounded-md border border-gray-200 bg-gray-100 px-3 py-2 text-sm text-gray-500">{t('storeWideCharge')}</div>
             )}
             <select value={categoryId} onChange={(event) => setCategoryId(event.target.value)} className="rounded-md border border-gray-200 bg-white px-3 py-2 text-sm">
               {detail?.categories.map((category) => <option key={category.category_id} value={category.category_id}>{category.label}</option>)}
             </select>
             <div className="flex gap-2 sm:col-span-3 sm:justify-end">
-              {editingOverrideId && <Button variant="outline" onClick={resetOverrideForm}>{t('tax.cancel')}</Button>}
+              {editingOverrideId && <Button variant="outline" onClick={resetOverrideForm}>{t('cancel')}</Button>}
               <Button disabled={saving} onClick={() => void saveOverride()}>
-                <Plus size={14} /> {editingOverrideId ? t('tax.saveOverride') : t('tax.addOverride')}
+                <Plus size={14} /> {editingOverrideId ? t('saveOverride') : t('addOverride')}
               </Button>
             </div>
           </div>
@@ -1341,46 +1351,46 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         <div className="mt-4 overflow-x-auto">
           <table className="w-full min-w-[620px] text-start text-sm">
             <thead className="border-b border-gray-100 text-xs uppercase text-gray-400">
-              <tr><th className="py-2 pe-3">{t('tax.target')}</th><th className="py-2 pe-3">{t('tax.category')}</th><th className="py-2 pe-3">{t('tax.updated')}</th><th className="py-2 text-end">{t('tax.actions')}</th></tr>
+              <tr><th className="py-2 pe-3">{t('target')}</th><th className="py-2 pe-3">{t('category')}</th><th className="py-2 pe-3">{t('updated')}</th><th className="py-2 text-end">{t('actions')}</th></tr>
             </thead>
             <tbody>
               {detail?.overrides.map((override) => (
                 <tr key={override.id} className="border-b border-gray-50">
-                  <td className="py-3 pe-3"><span className="text-xs text-gray-400">{t(ENTITY_LABELS[override.entity_type])}</span><br />{override.entity_name || t('tax.storeWide')}</td>
+                  <td className="py-3 pe-3"><span className="text-xs text-gray-400">{t(ENTITY_LABELS[override.entity_type])}</span><br />{override.entity_name || t('storeWide')}</td>
                   <td className="py-3 pe-3">{categoriesById.get(categoryIdOf(override)) || categoryIdOf(override)}</td>
                   <td className="py-3 pe-3 text-xs text-gray-500">{formatDateTime(override.updated_at)}{override.created_by_name ? ` · ${override.created_by_name}` : ''}</td>
                   <td className="py-3 text-end">
                     {isOwner ? (
                       <div className="flex justify-end gap-2">
                         {!CHARGE_TYPES.includes(override.entity_type) && (
-                          <button className="text-brand hover:underline" onClick={() => editOverride(override)}>{t('tax.edit')}</button>
+                          <button className="text-brand hover:underline" onClick={() => editOverride(override)}>{t('edit')}</button>
                         )}
-                        <button className="text-red-600 hover:underline" onClick={() => void removeOverride(override)}>{t('tax.remove')}</button>
+                        <button className="text-red-600 hover:underline" onClick={() => void removeOverride(override)}>{t('remove')}</button>
                       </div>
-                    ) : <span className="text-xs text-gray-400">{t('tax.readOnly')}</span>}
+                    ) : <span className="text-xs text-gray-400">{t('readOnly')}</span>}
                   </td>
                 </tr>
               ))}
-              {!detail?.overrides.length && <tr><td colSpan={4} className="py-8 text-center text-gray-400">{t('tax.noOverrides')}</td></tr>}
+              {!detail?.overrides.length && <tr><td colSpan={4} className="py-8 text-center text-gray-400">{t('noOverrides')}</td></tr>}
             </tbody>
           </table>
         </div>
       </section>
 
       <section className="rounded-xl border border-gray-200 bg-white p-5">
-        <h3 className="font-semibold text-gray-900">{t('tax.packReference')}</h3>
-        <p className="mt-1 text-sm text-gray-500">{t('tax.packReferenceHint')}</p>
+        <h3 className="font-semibold text-gray-900">{t('packReference')}</h3>
+        <p className="mt-1 text-sm text-gray-500">{t('packReferenceHint')}</p>
         <div className="mt-4 overflow-x-auto">
           <table className="w-full min-w-[680px] text-start text-sm">
             <thead className="border-b border-gray-100 text-xs uppercase text-gray-400">
-              <tr><th className="py-2 pe-3">{t('tax.category')}</th><th className="py-2 pe-3">{t('tax.defaultBehavior')}</th><th className="py-2">{t('tax.rules')}</th></tr>
+              <tr><th className="py-2 pe-3">{t('category')}</th><th className="py-2 pe-3">{t('defaultBehavior')}</th><th className="py-2">{t('rules')}</th></tr>
             </thead>
             <tbody>
               {detail?.categories.map((category) => (
                 <tr key={category.category_id} className="border-b border-gray-50">
                   <td className="py-3 pe-3"><span className="font-medium">{category.label}</span><br /><Ltr as="code" className="text-xs text-gray-400">{category.category_id}</Ltr></td>
-                  <td className="py-3 pe-3">{category.default_behavior || t('tax.packDefault')}</td>
-                  <td className="py-3 text-xs text-gray-600">{category.definition.ruleIds?.join(', ') || t('tax.none')}</td>
+                  <td className="py-3 pe-3">{category.default_behavior || t('packDefault')}</td>
+                  <td className="py-3 text-xs text-gray-600">{category.definition.ruleIds?.join(', ') || t('none')}</td>
                 </tr>
               ))}
             </tbody>
@@ -1389,7 +1399,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
         <div className="mt-5 overflow-x-auto">
           <table className="w-full min-w-[760px] text-start text-sm">
             <thead className="border-b border-gray-100 text-xs uppercase text-gray-400">
-              <tr><th className="py-2 pe-3">{t('tax.rule')}</th><th className="py-2 pe-3">{t('tax.type')}</th><th className="py-2 pe-3">{t('tax.value')}</th><th className="py-2 pe-3">{t('tax.scope')}</th><th className="py-2">{t('tax.dependsOn')}</th></tr>
+              <tr><th className="py-2 pe-3">{t('rule')}</th><th className="py-2 pe-3">{t('type')}</th><th className="py-2 pe-3">{t('value')}</th><th className="py-2 pe-3">{t('scope')}</th><th className="py-2">{t('dependsOn')}</th></tr>
             </thead>
             <tbody>
               {detail?.rules.map((rule) => (
@@ -1398,7 +1408,7 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
                   <td className="py-3 pe-3">{rule.calculation_type}</td>
                   <td className="py-3 pe-3">{rule.rate !== null ? `${rule.rate}%` : rule.amount}</td>
                   <td className="py-3 pe-3">{rule.applies_per}</td>
-                  <td className="py-3 text-xs text-gray-600">{rule.base_rule_ids.join(', ') || t('tax.none')}</td>
+                  <td className="py-3 text-xs text-gray-600">{rule.base_rule_ids.join(', ') || t('none')}</td>
                 </tr>
               ))}
             </tbody>
@@ -1409,20 +1419,20 @@ export function TaxConfigurationPanel({ isOwner }: { isOwner: boolean }) {
       <section className="rounded-xl border border-gray-200 bg-white p-5">
         <div className="flex items-center gap-2">
           <History size={20} className="text-brand" />
-          <h3 className="font-semibold text-gray-900">{t('tax.auditHistory')}</h3>
+          <h3 className="font-semibold text-gray-900">{t('auditHistory')}</h3>
         </div>
         <div className="mt-4 space-y-2">
           {audit.map((row) => (
             <div key={row.id} className="flex items-start gap-3 rounded-lg border border-gray-100 px-3 py-3">
               <Clock3 size={15} className="mt-0.5 shrink-0 text-gray-400" />
               <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-gray-800">{t(ACTION_LABELS[row.action] || row.action)}</p>
+                <p className="text-sm font-medium text-gray-800">{actionLabel(t, row.action)}</p>
                 {auditDescription(row, t) && <p className="truncate text-xs text-gray-600">{auditDescription(row, t)}</p>}
-                <p className="text-xs text-gray-500">{row.actor_name || (row.actor_user_id ? t('tax.auditUnknownUser') : t('tax.auditSystem'))} · {formatDateTime(row.created_at)}</p>
+                <p className="text-xs text-gray-500">{row.actor_name || (row.actor_user_id ? t('auditUnknownUser') : t('auditSystem'))} · {formatDateTime(row.created_at)}</p>
               </div>
             </div>
           ))}
-          {!audit.length && <p className="py-6 text-center text-sm text-gray-400">{t('tax.noAudit')}</p>}
+          {!audit.length && <p className="py-6 text-center text-sm text-gray-400">{t('noAudit')}</p>}
         </div>
       </section>
         </>

--- a/frontend/src/components/settings/WhatsAppEnableCard.tsx
+++ b/frontend/src/components/settings/WhatsAppEnableCard.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import api from '@/lib/api';
 import toast from 'react-hot-toast';
-import { useI18n } from '@/hooks/useI18n';
+import { useTranslations } from 'use-intl';
 import { usePosSettingsStore } from '@/store/pos-settings';
 
 /**
@@ -17,14 +17,15 @@ import { usePosSettingsStore } from '@/store/pos-settings';
  * whether to show it.
  */
 export function WhatsAppEnableCard() {
-  const { t } = useI18n();
+  const t = useTranslations('whatsapp.enable');
+  const tConnect = useTranslations('whatsapp.connect');
   const setWhatsappEnabled = usePosSettingsStore((s) => s.setWhatsappEnabled);
   const [ack, setAck] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const handleEnable = async () => {
     if (!ack) {
-      toast.error(t('whatsapp.enable.ackError'));
+      toast.error(t('ackError'));
       return;
     }
     setSubmitting(true);
@@ -32,10 +33,10 @@ export function WhatsAppEnableCard() {
       await api.post('/whatsapp/enable');
       setWhatsappEnabled(true);
       setAck(false);
-      toast.success(t('whatsapp.enable.success'));
+      toast.success(t('success'));
     } catch (err: unknown) {
       console.warn('[WhatsAppEnable] Enable failed:', (err as Error)?.message || err);
-      toast.error(t('whatsapp.enable.failed'));
+      toast.error(t('failed'));
     } finally {
       setSubmitting(false);
     }
@@ -47,13 +48,13 @@ export function WhatsAppEnableCard() {
         <div className="flex items-center gap-2">
           <MessageCircle size={20} className="text-brand" />
           <div>
-            <h2 className="font-semibold text-gray-900">{t('whatsapp.enable.title')}</h2>
-            <p className="text-xs text-gray-500 mt-0.5">{t('whatsapp.enable.description')}</p>
+            <h2 className="font-semibold text-gray-900">{t('title')}</h2>
+            <p className="text-xs text-gray-500 mt-0.5">{t('description')}</p>
           </div>
         </div>
         <div className="rounded-md border bg-muted/40 p-4 text-sm space-y-3">
-          <p>{t('whatsapp.enable.riskNote')}</p>
-          <p className="text-muted-foreground">{t('whatsapp.enable.floHelps')}</p>
+          <p>{t('riskNote')}</p>
+          <p className="text-muted-foreground">{t('floHelps')}</p>
         </div>
         <label className="flex items-start gap-3 text-sm cursor-pointer">
           <input
@@ -62,11 +63,11 @@ export function WhatsAppEnableCard() {
             checked={ack}
             onChange={(e) => setAck(e.target.checked)}
           />
-          <span>{t('whatsapp.enable.acknowledge')}</span>
+          <span>{t('acknowledge')}</span>
         </label>
         <div className="flex">
           <Button onClick={handleEnable} disabled={!ack || submitting}>
-            {submitting ? t('whatsapp.connect.connecting') : t('whatsapp.enable.cta')}
+            {submitting ? tConnect('connecting') : t('cta')}
           </Button>
         </div>
       </CardContent>

--- a/frontend/src/lib/i18n-enums.ts
+++ b/frontend/src/lib/i18n-enums.ts
@@ -24,15 +24,18 @@ export { ORDER_TYPE_LABEL_KEYS };
 
 type OrdersKey = keyof AppConfig['Messages']['orders'];
 type TablesKey = keyof AppConfig['Messages']['tables'];
+type StaffKey = keyof AppConfig['Messages']['staff'];
+type CommonKey = keyof AppConfig['Messages']['common'];
+type BusinessTypeKey = keyof AppConfig['Messages']['businessType'];
 
 /** Staff/tenant role → label. Used in login tenant picker, staff table, etc. */
-export const ROLE_LABEL_KEYS: Record<string, string> = {
-  owner: 'staff.roleOwner',
-  manager: 'staff.roleManager',
-  cashier: 'staff.roleCashier',
-  chef: 'staff.roleChef',
-  server: 'staff.roleServer',
-};
+export const ROLE_LABEL_KEYS = {
+  owner: 'roleOwner',
+  manager: 'roleManager',
+  cashier: 'roleCashier',
+  chef: 'roleChef',
+  server: 'roleServer',
+} as const satisfies Record<'owner' | 'manager' | 'cashier' | 'chef' | 'server', StaffKey>;
 
 /** Order-level status → label (exhaustively typed against `Order['status']`). */
 export const ORDER_STATUS_LABEL_KEYS = {
@@ -70,20 +73,20 @@ export const TABLE_STATUS_LABEL_KEYS = {
 } as const satisfies Record<Table['status'], TablesKey>;
 
 /** Tenant/business status → label. */
-export const TENANT_STATUS_LABEL_KEYS: Record<string, string> = {
-  active: 'common.active',
-  inactive: 'common.inactive',
-  suspended: 'common.inactive',
-};
+export const TENANT_STATUS_LABEL_KEYS = {
+  active: 'active',
+  inactive: 'inactive',
+  suspended: 'inactive',
+} as const satisfies Record<'active' | 'inactive' | 'suspended', CommonKey>;
 
 /** Business type → label. Currently only 'restaurant' is valid. */
-export const BUSINESS_TYPE_LABEL_KEYS: Record<string, string> = {
-  restaurant: 'businessType.restaurant',
-};
+export const BUSINESS_TYPE_LABEL_KEYS = {
+  restaurant: 'restaurant',
+} as const satisfies Record<'restaurant', BusinessTypeKey>;
 
 /** Payment status → label. */
-export const PAYMENT_STATUS_LABEL_KEYS: Record<string, string> = {
-  paid: 'orders.paid',
-  partial: 'orders.partiallyPaid',
-  unpaid: 'orders.unpaidBadge',
-};
+export const PAYMENT_STATUS_LABEL_KEYS = {
+  paid: 'paid',
+  partial: 'partiallyPaid',
+  unpaid: 'unpaidBadge',
+} as const satisfies Record<'paid' | 'partial' | 'unpaid', OrdersKey>;

--- a/frontend/src/lib/i18n-enums.ts
+++ b/frontend/src/lib/i18n-enums.ts
@@ -7,10 +7,8 @@
  * translator (`useTranslations()` leaf keys or legacy `t()` dotted keys) so
  * every language shows a localized label.
  *
- * Migrated status maps (`ORDER_STATUS_LABEL_KEYS`, `ITEM_STATUS_LABEL_KEYS`,
- * `TABLE_STATUS_LABEL_KEYS`) are exhaustively typed against use-intl leaf keys.
- * Unmigrated maps retain dotted keys for legacy `t()` callers until their
- * batches migrate.
+ * Status, role, tenant, and payment maps in this module are exhaustively
+ * typed against use-intl leaf keys (`AppConfig['Messages']`).
  *
  * Unknown values fall back to the raw string, so a new backend status never
  * crashes the UI — it just shows in English until a translation key is added.

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Intent

Migrate the settings, admin, catalog, staff, support, WhatsApp, and print-test pages/components from the legacy useI18n()/t() engine to useTranslations() from use-intl (issue #380, Phase 3 batch 5E of epic #372).

Files (15 + 1 infra):
- app/(dashboard)/settings/page.tsx
- app/(dashboard)/products/page.tsx
- app/(dashboard)/addon-groups/page.tsx
- app/(dashboard)/staff/page.tsx
- app/(dashboard)/support/page.tsx
- app/(dashboard)/whatsapp/page.tsx
- app/(dashboard)/print-test/page.tsx
- components/settings/HealthCheckDialog.tsx
- components/settings/InitializeDatabaseDialog.tsx
- components/settings/LocalePreferencesPanel.tsx
- components/settings/MasterPinPrompt.tsx
- components/settings/PaymentMethodsSettings.tsx
- components/settings/TaxConfigurationPanel.tsx
- components/settings/WhatsAppEnableCard.tsx
- components/products/ImageUploader.tsx
- lib/i18n-enums.ts (type the remaining status/role maps to use-intl leaf keys)

Rules:
- Use const t = useTranslations('namespace') with compile-time type-safe keys verified against AppConfig.
- Eliminate template-literal dynamic keys; use exhaustively typed lookup maps.
- Settings language selector derives options from the LANGUAGES registry (filter selectable: true) instead of hardcoded arrays.
- Do NOT route tenant money/number/date/time business formatting through useFormatter() or the UI locale; business values stay governed by tenant country/currency/timezone. useFormatter() only where formatting intentionally follows UI language.
- Do NOT remove the legacy useI18n hook or the compatibility bridge in lib/i18n.ts (issue #381 owns that).
- Do NOT alter translation wording or settings storage contracts.

Dynamic keys (whatsapp/page.tsx):
- Message statuses and kinds use typed WHATSAPP_STATUS_KEYS / WHATSAPP_KIND_KEYS maps (no template literals).
- whatsapp.apiError.* is a real nested namespace resolved with a typed isWhatsAppApiErrorKey guard.

Verification: npm run lint, npm run build:frontend, npm test, npm run test:rtl-setup-auth-settings, npm run test:translations, npm run test:locale-chunks.

## What Changed

- Migrated dashboard pages and components for settings, products, addon-groups, staff, support, WhatsApp, and print-test from legacy `useI18n` to `use-intl`'s `useTranslations()`.
- Updated `frontend/src/lib/i18n-enums.ts` and WhatsApp status mappings to exhaustively type role, status, business type, and payment keys against `use-intl` leaf message keys instead of template-literal strings.
- Added E2E test suite `frontend/e2e/i18n-batch-5e.spec.ts` and updated `rtl-setup-auth-settings.spec.ts` to verify localized rendering and language switching across the migrated surfaces.

## Risk Assessment

✅ Low: The changes cleanly migrate 15 frontend pages and components plus shared i18n enums to useTranslations without altering runtime behavior, business formatting, or translation contracts.

## Testing

Executed targeted translation validation, RTL direction compliance suites, and end-to-end browser tests across English, Spanish, and Persian. Verified that all migrated components resolve localized keys without raw fallback tokens, correctly derive selectable language options from the LANGUAGES registry, and handle typed enum lookups. Captured 22 full-page visual screenshot artifacts across LTR and RTL locales with all checks passing.

- Evidence: Settings Page (English) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-settings-en.png</code>)
- Evidence: Settings Page (Spanish) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-settings-es.png</code>)
- Evidence: Settings Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-settings-fa.png</code>)
- Evidence: Settings Tax Configuration (English) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-settings-tax-en.png</code>)
- Evidence: Settings Payment Methods (English) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-settings-payments-en.png</code>)
- Evidence: Products Page (English) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-products-en.png</code>)
- Evidence: Products Page (Spanish) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-products-es.png</code>)
- Evidence: Products Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-products-fa.png</code>)
- Evidence: Addon Groups Page (English) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-addon-groups-en.png</code>)
- Evidence: Addon Groups Page (Spanish) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-addon-groups-es.png</code>)
- Evidence: Addon Groups Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-addon-groups-fa.png</code>)
- Evidence: Staff Page (English) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-staff-en.png</code>)
- Evidence: Staff Page (Spanish) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-staff-es.png</code>)
- Evidence: Staff Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-staff-fa.png</code>)
- Evidence: Support Page (English) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-support-en.png</code>)
- Evidence: Support Page (Spanish) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-support-es.png</code>)
- Evidence: Support Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-support-fa.png</code>)
- Evidence: WhatsApp Page (English) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-whatsapp-en.png</code>)
- Evidence: WhatsApp Page (Spanish) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-whatsapp-es.png</code>)
- Evidence: WhatsApp Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-whatsapp-fa.png</code>)
- Evidence: Print Test Page (English) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-print-test-en.png</code>)
- Evidence: Print Test Page (Spanish) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-print-test-es.png</code>)
- Evidence: Print Test Page (Persian RTL) (local file: <code>/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M0DFPDSSXXR8V1EG3NZ1HGEC/batch-5e-print-test-fa.png</code>)
- Outcome: ⚠️ 1 info across 1 run (6m2s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d25aa2a6afe22cef1d04170a3930474e116ea25c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `frontend/e2e/i18n-batch-5e.spec.ts` - new test file written by agent: frontend/e2e/i18n-batch-5e.spec.ts
- `npm run test:translations`
- `npm run test:locale-chunks`
- `npm run test:rtl-setup-auth-settings`
- `npm run test:rtl-kds-server-whatsapp`
- `npx playwright test frontend/e2e/i18n-batch-5e.spec.ts`
- `npx playwright test frontend/e2e/rtl-setup-auth-settings.spec.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
