### PR TITLE
docs(i18n): add comprehensive contributor guide for internationalization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,8 @@ FloCafe currently provides translations for English (`en`), Spanish (`es`), Braz
 
 The validation command is fully offline and checks registry/file consistency, exact English key parity, string and ICU validity, placeholder/tag parity, Persian fallback safeguards, and frontend translation-key safety.
 
+For complete authoring, scaffolding, RTL support, and verification instructions, see the [Internationalization and translation guide](docs/i18n.md).
+
 ---
 
 ## Tax packs and compliance contributions

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ FloCafe includes UI translations for:
 - Brazilian Portuguese
 - Persian (Farsi), including RTL support
 
-UI language is independent of store country and regional settings, and tax calculation rules remain a separate concern.
+UI language is independent of store country and regional settings, and tax calculation rules remain a separate concern. For details on contributing translations or adding languages, see the [Internationalization and translation guide](docs/i18n.md).
 
 ## Tax support
 
@@ -146,6 +146,7 @@ If FloCafe is useful to you, consider starring the repository.
 - **Documentation index:** [docs/README.md](docs/README.md)
 - **Printer guide & troubleshooting:** [docs/printers.md](docs/printers.md)
 - **Linux setup & support:** [docs/linux.md](docs/linux.md)
+- **Internationalization & translations:** [docs/i18n.md](docs/i18n.md)
 - **Google Drive backup setup:** [docs/google-drive-setup.md](docs/google-drive-setup.md)
 - **Community discussion:** [Reddit r/FloPOS](https://www.reddit.com/r/FloPOS/)
 - **Bug reports & feature proposals:** [GitHub Issues](https://github.com/FreeOpenSourcePOS/FloCafe/issues)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ This index classifies documentation in `docs/` so contributors and AI agents kno
 | [google-drive-setup.md](google-drive-setup.md) | Maintainer setup for the optional Google Drive backup OAuth client. | CURRENT |
 | [mac-app-store-publishing.md](mac-app-store-publishing.md) | Fastlane, Transporter, and GitHub Actions publishing workflow for the Mac App Store build. | CURRENT |
 | [tax-packs.md](tax-packs.md) | Tax pack schema, authoring guide, cryptographic signing, and catalog distribution workflow. | CURRENT |
+| [i18n.md](i18n.md) | Internationalization guide, translation editing, language scaffolding (`npm run i18n:add`), and RTL layout support. | CURRENT |
 
 ### Active design & forward-looking plans
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,286 @@
+# Internationalization (i18n) and translation guide
+
+FloCafe provides an offline-first, Git-native internationalization architecture built on [`use-intl`](https://www.npmjs.com/package/use-intl) v4. Translations are managed as static JSON files committed directly to the repository, requiring zero external software-as-a-service (SaaS) platforms, API tokens, or network connectivity.
+
+This guide explains how translators and developers can edit existing translations, add new languages, support right-to-left (RTL) layouts, and run repository-native validation.
+
+---
+
+## Architectural overview
+
+```text
+Static JSON Message Files
+(frontend/src/lib/i18n/messages/<lang>.json)
+                    │
+                    ▼
+Centralized Language Registry
+(frontend/src/lib/i18n/languages.ts)
+                    │
+                    ▼
+Active Locale Lazy Loader & Cache
+(frontend/src/lib/i18n/loader.ts)
+                    │
+                    ▼
+use-intl Runtime & Context
+(I18nProvider.tsx -> useTranslations() / createTranslator)
+                    │
+                    ▼
+React UI Components, POS, KDS, & Printing
+```
+
+### Core design principles
+
+1. **100% Repository-native & offline-first:** Translation files live in `frontend/src/lib/i18n/messages/`. All scaffolding, translation, and verification work runs locally using standard Node.js scripts without third-party translation platforms (no Crowdin, Weblate, Tolgee, or external APIs).
+2. **Centralized language registry:** [`frontend/src/lib/i18n/languages.ts`](../frontend/src/lib/i18n/languages.ts) is the single source of truth for language identifiers, BCP-47 locale tags, native display names, text direction (`'ltr'` vs `'rtl'`), user-facing selectability, and dynamic module chunk loaders.
+3. **Active locale lazy loading:** Only the active locale bundle is loaded during initial application boot. Other languages load on demand via deduplicated chunk loaders and are cached in memory in [`frontend/src/lib/i18n/loader.ts`](../frontend/src/lib/i18n/loader.ts).
+4. **Canonical English schema & strict 100% leaf parity:** [`frontend/src/lib/i18n/messages/en.json`](../frontend/src/lib/i18n/messages/en.json) defines the canonical structure. Every committed locale in the repository must maintain **exact 100% leaf key parity** with `en.json`.
+5. **Decoupled domains:** UI language, tenant regional settings (store timezone and currency), and tax compliance rules are decoupled domains:
+   - **UI Language:** How buttons, labels, and dialogs are translated.
+   - **Tenant Settings:** Store-level currency, business timezone, and contact info.
+   - **Tax Compliance:** Regional tax rules and country packs ([docs/tax-packs.md](tax-packs.md)).
+   Changing the UI language never alters store currency formatting or tax calculations.
+6. **Compile-time key safety:** TypeScript translation key safety is enforced at build time via `use-intl` `AppConfig` interface augmentation in [`frontend/src/lib/i18n/messages.d.ts`](../frontend/src/lib/i18n/messages.d.ts).
+7. **Standalone server synchronization:** Standalone surfaces (such as the standalone KDS on `:3002` and the Server App) dynamically synchronize their UI language with the main tenant via [`useSyncServerLanguage`](../frontend/src/lib/i18n/server-language.ts).
+
+---
+
+## For translators: editing or improving existing translations
+
+If you are correcting typos, refining wording, or improving existing translations (such as Spanish `es.json`, Brazilian Portuguese `pt.json`, or Persian `fa.json`):
+
+### 1. Locate the message file
+
+Open the corresponding file in `frontend/src/lib/i18n/messages/<lang>.json`:
+- English (canonical): [`frontend/src/lib/i18n/messages/en.json`](../frontend/src/lib/i18n/messages/en.json)
+- Spanish: [`frontend/src/lib/i18n/messages/es.json`](../frontend/src/lib/i18n/messages/es.json)
+- Brazilian Portuguese: [`frontend/src/lib/i18n/messages/pt.json`](../frontend/src/lib/i18n/messages/pt.json)
+- Persian: [`frontend/src/lib/i18n/messages/fa.json`](../frontend/src/lib/i18n/messages/fa.json)
+
+### 2. Rules for translating values
+
+Only edit the string values (the text to the right of the `:`).
+
+> [!IMPORTANT]
+> **What must NOT be changed:**
+> - **JSON keys and namespace names:** Do not alter keys (e.g. `"title"`, `"saveButton"`, `"pos"`).
+> - **ICU placeholder variable names:** Keep variable names identical to English (e.g. `{count}`, `{amount}`, `{name}`, `{time}`).
+> - **HTML and rich-text tags:** Keep tag names identical to English (e.g. `<bold>...</bold>`, `<link>...</link>`, `<ltr>...</ltr>`).
+
+### 3. ICU MessageFormat syntax
+
+FloCafe uses ICU MessageFormat strings for plurals and variable interpolation:
+
+- **Simple interpolation:**
+  ```json
+  "welcome": "Hello, {name}!"
+  ```
+- **Pluralization:**
+  ```json
+  "itemCount": "{count, plural, one {# item} other {# items}}"
+  ```
+  The `#` symbol represents the formatted number.
+- **Select format:**
+  ```json
+  "genderGreeting": "{gender, select, male {He} female {She} other {They}} approved the order."
+  ```
+
+### 4. Verify your changes locally
+
+Run the repository verification command:
+```sh
+npm run i18n:check
+```
+This tests JSON syntax, ICU parse validity, variable name consistency, and rich-text tag matching.
+
+---
+
+## For developers: adding a new language
+
+Adding a new language to FloCafe is a standardized 6-step workflow.
+
+### Step 1: Scaffold the message file
+
+Run the zero-dependency scaffolding helper using the lowercase 2- or 3-letter ISO 639 language code (e.g. `de` for German, `fr` for French, `ar` for Arabic):
+
+```sh
+npm run i18n:add -- de
+```
+
+This creates `frontend/src/lib/i18n/messages/de.json` containing the canonical structure copied from `en.json`. The script uses atomic creation (`COPYFILE_EXCL`) and will never overwrite an existing file.
+
+### Step 2: Register the language in the registry
+
+Open [`frontend/src/lib/i18n/languages.ts`](../frontend/src/lib/i18n/languages.ts) and add the new language definition:
+
+```ts
+export const LANGUAGES = {
+  en: { ... },
+  es: { ... },
+  pt: { ... },
+  fa: { ... },
+  de: {
+    id: 'de',
+    name: 'German',
+    nativeName: 'Deutsch',
+    locale: 'de-DE',
+    dir: 'ltr',
+    selectable: true,
+    load: () => import('./messages/de.json').then((m) => m.default),
+  },
+} as const satisfies Record<string, LanguageConfig>;
+```
+
+#### Field reference:
+- `id`: Lowercase ISO language code matching the JSON filename.
+- `name`: English name of the language.
+- `nativeName`: Endonym displayed in the language switcher (e.g. `'Deutsch'`, `'فارسی'`).
+- `locale`: Default BCP-47 locale tag used for number/currency/date formatting defaults (e.g. `'de-DE'`, `'es-ES'`, `'pt-BR'`).
+- `dir`: Text direction (`'ltr'` or `'rtl'`).
+- `selectable`: Set `true` to offer it in Setup and Settings language dropdowns. Set `false` if the translation is in progress and undergoing review.
+- `load`: Dynamic chunk loader returning a promise that resolves to the message JSON.
+
+### Step 3: Translate leaf values
+
+Translate all string values in `frontend/src/lib/i18n/messages/<lang>.json`.
+- Maintain 100% key parity with `en.json`.
+- Preserve all ICU variable placeholders (`{var}`) and tags (`<tag>`).
+
+### Step 4: Run repository-native validation
+
+```sh
+npm run i18n:check
+```
+
+The validator checks:
+1. **Registry ↔ File consistency:** Ensures every registered language has a matching message file, and every message file is registered in `languages.ts`.
+2. **Exact leaf key parity:** Confirms zero missing keys and zero extra/orphan keys against `en.json`.
+3. **Valid string leaves:** Verifies that all leaves are non-empty strings.
+4. **ICU syntax & selector matching:** Validates that ICU plural/select formats parse correctly and use identical selector names.
+5. **Tag parity:** Confirms rich-text tags (`<bold>`, `<ltr>`, etc.) match canonical English tags.
+6. **Compile-time TypeScript checks:** Runs `tsc --noEmit` across frontend source code.
+
+### Step 5: Test the UI
+
+Launch the development app to test your new language:
+```sh
+npm run dev
+```
+1. Navigate to **Settings → Store Settings → Language** (or the Setup Wizard at `/setup`).
+2. Switch to your new language.
+3. Verify that labels, modals, POS cart, KDS, and table management render without raw key fallbacks or truncated text.
+
+### Step 6: Submit a Pull Request
+
+Commit your changes and open a pull request:
+```sh
+git checkout -b feat/i18n-add-german
+git add frontend/src/lib/i18n/messages/de.json frontend/src/lib/i18n/languages.ts
+git commit -m "feat(i18n): add German language translation"
+```
+
+---
+
+## Right-to-Left (RTL) language support guidelines
+
+FloCafe natively supports bidirectional and RTL languages (such as Persian / Farsi `fa`, Arabic `ar`, Hebrew `he`, Urdu `ur`).
+
+### 1. Document direction synchronization
+
+When an RTL language is selected:
+- [`languages.ts`](../frontend/src/lib/i18n/languages.ts) specifies `dir: 'rtl'`.
+- [`I18nProvider.tsx`](../frontend/src/components/providers/I18nProvider.tsx) and [`HtmlLangSync.tsx`](../frontend/src/components/layout/HtmlLangSync.tsx) automatically set `<html dir="rtl" lang="...">` once messages have loaded atomically.
+- Direction-aware toasts ([`DirectionalToaster`](../frontend/src/components/layout/DirectionalToaster.tsx)) dynamically adapt toast positioning.
+
+### 2. Logical CSS properties & Tailwind utilities
+
+Always use CSS logical properties instead of physical directions:
+
+| Physical (Avoid) | Logical (Use) | Purpose |
+| --- | --- | --- |
+| `ml-4`, `mr-2` | `ms-4`, `me-2` | Margin inline-start / inline-end |
+| `pl-3`, `pr-3` | `ps-3`, `pe-3` | Padding inline-start / inline-end |
+| `left-0`, `right-0` | `start-0`, `end-0` | Absolute positioning |
+| `text-left`, `text-right` | `text-start`, `text-end` | Text alignment |
+| `border-l`, `border-r` | `border-s`, `border-e` | Border inline-start / inline-end |
+| `rounded-l`, `rounded-r` | `rounded-s`, `rounded-e` | Corner rounding |
+
+### 3. Mirroring directional icons (`.rtl-flip`)
+
+Icons that indicate spatial progression (e.g. forward arrows, back buttons, next-step chevrons) must be mirrored in RTL. Add the `.rtl-flip` CSS utility to the icon:
+
+```tsx
+<ChevronRight className="h-4 w-4 rtl-flip" />
+```
+
+> [!NOTE]
+> Do **not** mirror non-directional icons (such as search magnifying glasses, printer icons, shopping carts, or currency symbols).
+
+### 4. Isolating naturally LTR content (`<Ltr>`)
+
+Certain values are inherently LTR regardless of UI direction (e.g. order numbers, phone numbers, IP addresses, receipt transaction IDs, email addresses, code snippets, timestamps):
+
+Wrap them with the polymorphic [`<Ltr>`](../frontend/src/components/layout/Ltr.tsx) component:
+
+```tsx
+import { Ltr } from '@/components/layout/Ltr';
+
+<p>Order ID: <Ltr>#1042</Ltr></p>
+<Ltr as="span" className="font-mono">{customerPhone}</Ltr>
+<Ltr as="code">192.168.1.50</Ltr>
+```
+
+In rich-text ICU translation strings, use the `<ltr>` tag:
+```json
+"connectedTo": "Connected to <ltr>{ipAddress}</ltr>"
+```
+
+### 5. Running RTL test suites
+
+FloCafe includes automated RTL verification test suites:
+```sh
+npm run test:rtl-foundation
+npm run test:rtl-setup-auth-settings
+npm run test:rtl-dashboard-pos-common
+npm run test:rtl-kds-server-whatsapp
+```
+
+---
+
+## Language enablement vs. strict repository completeness
+
+FloCafe enforces two complementary rules for language quality:
+
+1. **Strict 100% key parity (All committed languages):**
+   Every language file in `frontend/src/lib/i18n/messages/` must have 100% of the keys present in `en.json`. Partial files with missing keys fail CI.
+2. **Selectability flag (`selectable: false`):**
+   If a new language translation is technically complete in the repository but undergoing UX testing, font verification, or regional review, mark it with `selectable: false` in `languages.ts`. This allows the bundle to be tested programmatically without exposing an unfinished option to production counter staff.
+
+---
+
+## UI language vs. country profiles and tax packs
+
+UI language translation is strictly decoupled from business country profiles and tax calculation engines:
+
+- **UI Language:** Controls the text strings in the interface (English, Spanish, Portuguese, Persian, etc.).
+- **Country Profiles & Tax Packs:** Located in `main/tax-packs/` and `main/countries.ts`, controlling tax registration number formats, tax rate schedules, currency symbols, and national fiscal rules.
+
+Translating FloCafe into Japanese or German does not require creating a tax pack, and adding a tax pack for a new country does not require adding a new UI language.
+
+For tax pack authoring, see [docs/tax-packs.md](tax-packs.md).
+
+---
+
+## Command cheat sheet
+
+| Command | Description |
+| --- | --- |
+| `npm run i18n:add -- <lang>` | Scaffold a new message file from canonical `en.json` |
+| `npm run i18n:check` | Run all translation integrity, ICU, parity, and key safety checks |
+| `npm run test:translations` | Run backend translation unit tests |
+| `npm run test:rtl-foundation` | Run RTL CSS logical properties and `<Ltr>` foundation checks |
+| `npm run test:rtl-setup-auth-settings` | Run RTL checks for Setup, Auth, and Settings screens |
+| `npm run test:rtl-dashboard-pos-common` | Run RTL checks for POS, Dashboard, and common UI |
+| `npm run test:rtl-kds-server-whatsapp` | Run RTL checks for KDS, Server App, and WhatsApp |
+| `npm run lint` | Run ESLint across backend and frontend |
+| `npm run build:frontend` | Build and export static Next.js frontend |
+| `npm test` | Run full FloCafe test suite |

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -119,23 +119,19 @@ export const LANGUAGES = {
   pt: { ... },
   fa: { ... },
   de: {
-    id: 'de',
-    name: 'German',
-    nativeName: 'Deutsch',
     locale: 'de-DE',
-    dir: 'ltr',
+    nativeName: 'Deutsch',
+    direction: 'ltr',
     selectable: true,
-    load: () => import('./messages/de.json').then((m) => m.default),
+    load: () => import('./messages/de.json'),
   },
 } as const satisfies Record<string, LanguageConfig>;
 ```
 
 #### Field reference:
-- `id`: Lowercase ISO language code matching the JSON filename.
-- `name`: English name of the language.
-- `nativeName`: Endonym displayed in the language switcher (e.g. `'Deutsch'`, `'فارسی'`).
 - `locale`: Default BCP-47 locale tag used for number/currency/date formatting defaults (e.g. `'de-DE'`, `'es-ES'`, `'pt-BR'`).
-- `dir`: Text direction (`'ltr'` or `'rtl'`).
+- `nativeName`: Endonym displayed in the language switcher (e.g. `'Deutsch'`, `'فارسی'`).
+- `direction`: Text direction (`'ltr'` or `'rtl'`).
 - `selectable`: Set `true` to offer it in Setup and Settings language dropdowns. Set `false` if the translation is in progress and undergoing review.
 - `load`: Dynamic chunk loader returning a promise that resolves to the message JSON.
 
@@ -187,7 +183,7 @@ FloCafe natively supports bidirectional and RTL languages (such as Persian / Far
 ### 1. Document direction synchronization
 
 When an RTL language is selected:
-- [`languages.ts`](../frontend/src/lib/i18n/languages.ts) specifies `dir: 'rtl'`.
+- [`languages.ts`](../frontend/src/lib/i18n/languages.ts) specifies `direction: 'rtl'`.
 - [`I18nProvider.tsx`](../frontend/src/components/providers/I18nProvider.tsx) and [`HtmlLangSync.tsx`](../frontend/src/components/layout/HtmlLangSync.tsx) automatically set `<html dir="rtl" lang="...">` once messages have loaded atomically.
 - Direction-aware toasts ([`DirectionalToaster`](../frontend/src/components/layout/DirectionalToaster.tsx)) dynamically adapt toast positioning.
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -272,7 +272,7 @@ For tax pack authoring, see [docs/tax-packs.md](tax-packs.md).
 | --- | --- |
 | `npm run i18n:add -- <lang>` | Scaffold a new message file from canonical `en.json` |
 | `npm run i18n:check` | Run all translation integrity, ICU, parity, and key safety checks |
-| `npm run test:translations` | Run backend translation unit tests |
+| `npm run test:translations` | Run translation integrity, ICU parity, and frontend key-safety checks |
 | `npm run test:rtl-foundation` | Run RTL CSS logical properties and `<Ltr>` foundation checks |
 | `npm run test:rtl-setup-auth-settings` | Run RTL checks for Setup, Auth, and Settings screens |
 | `npm run test:rtl-dashboard-pos-common` | Run RTL checks for POS, Dashboard, and common UI |


### PR DESCRIPTION
## Intent

docs(i18n): add comprehensive contributor guide for internationalization (#384)

## What Changed

- Added `docs/i18n.md` providing contributor guidelines for internationalization, including architecture overview, translation editing, language scaffolding (`npm run i18n:add`), and RTL layout support.
- Updated `CONTRIBUTING.md`, `README.md`, and `docs/README.md` to link and index the new internationalization guide.

## Risk Assessment

✅ Low: The changes are documentation-only additions and updates covering internationalization workflows, with accurate code examples and verified links.

## Testing

Executed git diff whitespace checks, tested all relative markdown links across docs/i18n.md, docs/README.md, CONTRIBUTING.md, and README.md, verified npm run i18n:add scaffolding CLI options and atomic copy guarantees, validated cheat sheet script availability, and passed all i18n and RTL test suites with zero failures.

<details>
<summary>Evidence: i18n Documentation &amp; Scaffolding Verification Log</summary>

```text
=== Starting i18n Documentation & Architecture Verification ===

Checking relative markdown links in docs/i18n.md (18 total links)...
  ✓ All relative links in docs/i18n.md point to existing files.
Checking relative markdown links in docs/README.md (11 total links)...
  ✓ All relative links in docs/README.md point to existing files.
Checking relative markdown links in CONTRIBUTING.md (8 total links)...
  ✓ All relative links in CONTRIBUTING.md point to existing files.
Checking relative markdown links in README.md (15 total links)...
  ✓ All relative links in README.md point to existing files.
Testing npm run i18n:add helper behavior (scripts/i18n-add.cjs)...
  ✓ No-arg invocation outputs usage and exits 1
  ✓ Too many args invocation exits 1
  ✓ Invalid language codes rejected
  ✓ Refuses to overwrite existing language message files
  ✓ Scaffolding new language creates byte-for-byte canonical copy atomically
Verifying command cheat sheet in docs/i18n.md matches package.json...
  ✓ All 10 documented npm scripts exist in package.json.

✅ All i18n documentation, links, and command verifications passed.
```
</details>
<details>
<summary>Evidence: i18n Parity &amp; Integrity Check Log</summary>

```text

> flo-desktop@3.2.3 i18n:check
> npm run test:translations && tsc --noEmit -p frontend/tsconfig.json


> flo-desktop@3.2.3 test:translations
> ts-node --transpile-only -P tests/tsconfig.json tests/translations.test.ts

Translation integrity: en <-> es <-> pt <-> fa
  ✓ registry ↔ files consistent (4 languages, 4 files)
  en.json: 2061 leaf keys
  es.json: 2061 leaf keys
  pt.json: 2061 leaf keys
  fa.json: 2061 leaf keys
  ✓ no duplicate keys within translation files
  ✓ exact leaf key parity with en.json (no missing, no orphan keys)
  ✓ all leaves are non-empty strings (no empty objects/arrays/null/booleans/numbers)
  ✓ no malformed values
  ✓ all messages parse as valid ICU (plurals, selects, brackets)
  ✓ placeholder arguments and plural/select selectors match en.json in all locales
  ✓ rich-text tags match en.json in all locales
  ✓ no undefined keys (1790 literal t() calls covered)
  ✓ no unsafe template-literal t() calls (all dynamic keys exhaustively cast)
  ✓ no active frontend consumers import the legacy i18n bridge
  ✓ messages.d.ts AppConfig augmentation present (compile-time key checks active)
  ✓ no untranslated fa.json values (31 intentional shared values)

✅ All translation integrity checks passed.

Negative tests (fixture-based):
  ✓ all negative fixtures detected by their validators

✅ All translation integrity checks + negative tests passed.
```
</details>
<details>
<summary>Evidence: RTL Test Suites Verification Log</summary>

```text

> flo-desktop@3.2.3 test:rtl-foundation
> ts-node --transpile-only -P tests/tsconfig.json tests/rtl-foundation.test.ts

RTL/LTR UI foundation checks:
  ✓ shared components use logical direction utilities (2 allowlisted physical cases)
  ✓ globals.css defines .ltr-island and .rtl-flip
  ✓ Ltr component renders dir="ltr" LTR islands through React interface

✅ All RTL/LTR foundation checks passed.

> flo-desktop@3.2.3 test:rtl-setup-auth-settings
> ts-node --transpile-only -P tests/tsconfig.json tests/rtl-setup-auth-settings.test.ts

RTL/LTR Setup, Auth, and Settings checks:
  ✓ batch screens use logical direction utilities (1 allowlisted physical cases)
  ✓ directional arrows carry rtl-flip (2 file(s) with arrows)
  ✓ Ltr polymorphic rendering (as="a", as="code") verified through React interface
  ✓ getBrowserLanguage resolves fa for fa* locales and defaults correctly
  ✓ setup.languagePersian and settings.languageFa translate across en, es, pt, fa

✅ All RTL/LTR Setup, Auth, and Settings checks passed.

> flo-desktop@3.2.3 test:rtl-dashboard-pos-common
> ts-node --transpile-only -P tests/tsconfig.json tests/rtl-dashboard-pos-common.test.ts

RTL/LTR Dashboard, POS, and common flow checks:
  ✓ batch screens use logical direction utilities (0 allowlisted physical cases)
  ✓ directional icons carry rtl-flip (3 file(s) with directional icons)
  ✓ icon-before-text gaps use me-* (inline-end), not ms-*
  ✓ DirectionalToaster dynamically adapts toast placement across RTL/LTR languages
  ✓ Ltr component isolates POS operational values (order #, phone, IP, VID, table, JSON)
  ✓ getLanguageDirection resolves direction from shared language metadata

✅ All RTL/LTR Dashboard, POS, and common flow checks passed.

> flo-desktop@3.2.3 test:rtl-kds-server-whatsapp
> ts-node --transpile-only -P tests/tsconfig.json tests/rtl-kds-server-whatsapp.test.ts

RTL/LTR KDS, Server App, and WhatsApp checks:
  ✓ batch screens use logical direction utilities (0 allowlisted physical cases)
  ✓ directional icons carry rtl-flip (2 file(s) with directional icons)
  ✓ naturally LTR values are isolated with Ltr (order #, elapsed time, phones, pairing code, money, LAN URLs)
  ✓ standalone layouts sync document dir/lang (KdsHtmlLang / HtmlLangSync)
  ✓ KDS disabled screens use localized i18n keys
  ✓ Server App inherits tenant language via /api/server-app/info (useSyncServerLanguage path)

✅ All RTL/LTR KDS, Server App, and WhatsApp checks passed.
```
</details>
- Outcome: ⚠️ 1 info across 1 run (2m13s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8b43f04285844ff73d24f1da37f84e1f5a81fc81","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `docs/i18n.md:116` - In `docs/i18n.md` Step 2 (lines 116-140) and line 190, the example `LANGUAGES` configuration and field reference do not match the TypeScript `LanguageConfig` interface in `frontend/src/lib/i18n/languages.ts`: property `direction` is mistakenly written as `dir`, unnecessary properties `id` and `name` are listed in the object literal (which violates TypeScript&#39;s excess property checking), and `load` is written as returning `m.default` instead of matching `() =&gt; import(&#39;./messages/de.json&#39;)`. Contributors copying this example will encounter TypeScript errors during `npm run i18n:check`.

🔧 Fix: align i18n guide LANGUAGES example with LanguageConfig interface
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/i18n-docs-verification.test.ts` - new test file written by agent: tests/i18n-docs-verification.test.ts
- `git diff --check`
- `npx ts-node --transpile-only -P tests/tsconfig.json tests/i18n-docs-verification.test.ts`
- `npm run i18n:check`
- `npm run test:translations`
- `npm run test:rtl-foundation`
- `npm run test:rtl-setup-auth-settings`
- `npm run test:rtl-dashboard-pos-common`
- `npm run test:rtl-kds-server-whatsapp`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
