### PR TITLE
fix(settings): keep tab URL in sync and decouple UI locale from tenant country

### DIFF
--- a/frontend/e2e/settings-kds-navigation.spec.ts
+++ b/frontend/e2e/settings-kds-navigation.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:3001';
 
-test('KDS sidebar link selects the KDS tab from another Settings tab', async ({ page }) => {
+test('KDS sidebar link selects the KDS tab after switching Settings tabs', async ({ page }) => {
   await page.goto(`${BASE}/auth/login`);
   await page.getByLabel('Email').fill('manager@flo.local');
   await page.getByLabel('Password').fill('E2ePass123!');
@@ -11,7 +11,12 @@ test('KDS sidebar link selects the KDS tab from another Settings tab', async ({ 
   await page.getByRole('link', { name: 'Settings', exact: true }).click();
   await expect(page).toHaveURL(/\/settings\/?$/);
 
+  await page.getByRole('link', { name: 'KDS', exact: true }).click();
+  await expect(page).toHaveURL(/\/settings\/?\?tab=kds$/);
+  await expect(page.getByRole('heading', { name: 'KDS', exact: true })).toBeVisible();
+
   await page.getByRole('button', { name: 'POS Workflow', exact: true }).click();
+  await expect(page).toHaveURL(/\/settings\/?\?tab=pos$/);
   await expect(page.getByRole('heading', { name: 'POS Workflow', exact: true })).toBeVisible();
 
   await page.getByRole('link', { name: 'KDS', exact: true }).click();

--- a/frontend/e2e/settings-kds-navigation.spec.ts
+++ b/frontend/e2e/settings-kds-navigation.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:3001';
+
+test('KDS sidebar link selects the KDS tab from another Settings tab', async ({ page }) => {
+  await page.goto(`${BASE}/auth/login`);
+  await page.getByLabel('Email').fill('manager@flo.local');
+  await page.getByLabel('Password').fill('E2ePass123!');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  await page.getByRole('link', { name: 'Settings', exact: true }).click();
+  await expect(page).toHaveURL(/\/settings\/?$/);
+
+  await page.getByRole('button', { name: 'POS Workflow', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'POS Workflow', exact: true })).toBeVisible();
+
+  await page.getByRole('link', { name: 'KDS', exact: true }).click();
+  await expect(page).toHaveURL(/\/settings\/?\?tab=kds$/);
+  await expect(page.getByRole('heading', { name: 'KDS', exact: true })).toBeVisible();
+});

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuthStore } from '@/store/auth';
 import { usePosSettingsStore, type PaperSize, type BillTemplate } from '@/store/pos-settings';
 import { LANGUAGES, type Language } from '@/lib/i18n';
@@ -250,6 +250,7 @@ function KdsDefaultViewCard() {
 
 
 export default function SettingsPage() {
+  const router = useRouter();
   const { currentTenant, user, updateCurrentTenant } = useAuthStore();
   const posSettings = usePosSettingsStore();
   const whatsappEnabled = posSettings.whatsappEnabled;
@@ -313,6 +314,18 @@ export default function SettingsPage() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveTab(requestedTab);
   }, [requestedTab]);
+
+  const handleSettingsTabChange = (value: string) => {
+    setActiveTab(value);
+    const nextParams = new URLSearchParams(searchParams?.toString());
+    if (value === 'store') {
+      nextParams.delete('tab');
+    } else {
+      nextParams.set('tab', value);
+    }
+    const query = nextParams.toString();
+    router.replace(query ? `/settings?${query}` : '/settings');
+  };
 
   // Unified PIN gate: 'set' opens the set/change-PIN dialog; 'backup'/'backup-custom'/
   // 'import'/'restore' open a verify prompt and, on success, run the pending action.
@@ -2138,7 +2151,7 @@ export default function SettingsPage() {
 
   return (
     <div className="md:h-full md:min-h-0">
-      <Tabs orientation="vertical" value={activeTab} onValueChange={setActiveTab} className="flex flex-col md:flex-row gap-6 items-start md:h-full md:min-h-0">
+      <Tabs orientation="vertical" value={activeTab} onValueChange={handleSettingsTabChange} className="flex flex-col md:flex-row gap-6 items-start md:h-full md:min-h-0">
 
         {/* Settings sidebar nav */}
         <div className="w-full md:w-40 md:min-w-[10rem] shrink-0 md:h-full md:min-h-0 md:flex md:flex-col">
@@ -2153,47 +2166,47 @@ export default function SettingsPage() {
             <div className="hidden md:block px-3 pt-3 pb-2 mt-2 mb-1 border-b border-gray-100">
               <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupGeneral')}</p>
             </div>
-            <SettingsNavItem label={t('storeDetails')} value="store" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('tabPrinters')} value="receipts-printers" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('paymentMethods')} value="payments" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('storeDetails')} value="store" active={activeTab} onClick={handleSettingsTabChange} />
+            <SettingsNavItem label={t('tabPrinters')} value="receipts-printers" active={activeTab} onClick={handleSettingsTabChange} />
+            <SettingsNavItem label={t('paymentMethods')} value="payments" active={activeTab} onClick={handleSettingsTabChange} />
             {canViewTaxConfiguration && (
-              <SettingsNavItem label={t('taxConfiguration')} value="tax" active={activeTab} onClick={setActiveTab} />
+              <SettingsNavItem label={t('taxConfiguration')} value="tax" active={activeTab} onClick={handleSettingsTabChange} />
             )}
 
             {/* Operations group */}
             <div className="hidden md:block px-3 pt-4 pb-2 mt-3 mb-1 border-b border-gray-100">
               <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupOperations')}</p>
             </div>
-            <SettingsNavItem label={t('posWorkflow')} value="pos" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('tabKds')} value="kds" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('tablesideOrdering')} value="server-app" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('posWorkflow')} value="pos" active={activeTab} onClick={handleSettingsTabChange} />
+            <SettingsNavItem label={t('tabKds')} value="kds" active={activeTab} onClick={handleSettingsTabChange} />
+            <SettingsNavItem label={t('tablesideOrdering')} value="server-app" active={activeTab} onClick={handleSettingsTabChange} />
             {/* WhatsApp opt-in lives under Operations because the receive-bill
                 workflow is what the cashier touches every time a customer pays. */}
-            <SettingsNavItem label={t('tabWhatsapp')} value="whatsapp" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabWhatsapp')} value="whatsapp" active={activeTab} onClick={handleSettingsTabChange} />
 
             {/* Customers group */}
             <div className="hidden md:block px-3 pt-4 pb-2 mt-3 mb-1 border-b border-gray-100">
               <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupCustomers')}</p>
             </div>
-            <SettingsNavItem label={t('loyalty')} value="loyalty" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('discounts')} value="discounts" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('loyalty')} value="loyalty" active={activeTab} onClick={handleSettingsTabChange} />
+            <SettingsNavItem label={t('discounts')} value="discounts" active={activeTab} onClick={handleSettingsTabChange} />
 
             {/* Integrations group (formerly "Data") */}
             <div className="hidden md:block px-3 pt-4 pb-2 mt-3 mb-1 border-b border-gray-100">
               <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupData')}</p>
             </div>
-            <SettingsNavItem label={t('tabMobileAccess')} value="mobile-access" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('tabBackupData')} value="data" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('tabOrderflow')} value="orderflow" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('tabMobileAccess')} value="mobile-access" active={activeTab} onClick={handleSettingsTabChange} />
+            <SettingsNavItem label={t('tabBackupData')} value="data" active={activeTab} onClick={handleSettingsTabChange} />
+            <SettingsNavItem label={t('tabOrderflow')} value="orderflow" active={activeTab} onClick={handleSettingsTabChange} />
 
             {/* Account group */}
             <div className="hidden md:block px-3 pt-4 pb-2 mt-3 mb-1 border-b border-gray-100">
               <p className="text-[11px] font-bold uppercase tracking-widest text-gray-400">{t('navGroupAccount')}</p>
             </div>
-            <SettingsNavItem label={t('account')} value="account" active={activeTab} onClick={setActiveTab} attention={cloudDeletionNeedsAction || (cloudAccountAvailable && Boolean(cloudAccount?.email && !cloudAccount?.verified))} />
-            <SettingsNavItem label={t('privacy')} value="privacy" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('tabUpdates')} value="updates" active={activeTab} onClick={setActiveTab} />
-            <SettingsNavItem label={t('tabAbout')} value="about" active={activeTab} onClick={setActiveTab} />
+            <SettingsNavItem label={t('account')} value="account" active={activeTab} onClick={handleSettingsTabChange} attention={cloudDeletionNeedsAction || (cloudAccountAvailable && Boolean(cloudAccount?.email && !cloudAccount?.verified))} />
+            <SettingsNavItem label={t('privacy')} value="privacy" active={activeTab} onClick={handleSettingsTabChange} />
+            <SettingsNavItem label={t('tabUpdates')} value="updates" active={activeTab} onClick={handleSettingsTabChange} />
+            <SettingsNavItem label={t('tabAbout')} value="about" active={activeTab} onClick={handleSettingsTabChange} />
 
           </nav>
         </div>

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -292,17 +292,27 @@ export default function SettingsPage() {
   const [tableInfo, setTableInfo] = useState<{ name: string; rows: number }[]>([]);
 
   const searchParams = useSearchParams();
+  const requestedTab = searchParams?.get('tab') || 'store';
   // ── DB tools: master PIN, health check, initialize ──────────────────────
-  // activeTab/healthCheckOpen/initializeDbOpen/pinGate all read their initial value from the
-  // ?tab=/?action= deep-link params directly (lazy init, once at mount) instead of being set
-  // by the mount effect below — that effect now only owns the actual async fetches.
-  const [activeTab, setActiveTab] = useState(() => searchParams?.get('tab') || 'store');
+  // activeTab/healthCheckOpen/initializeDbOpen/pinGate read their initial value from the
+  // ?tab=/?action= deep-link params directly. activeTab also stays synchronized below when
+  // the sidebar changes the query string without remounting this page.
+  const [activeTab, setActiveTab] = useState(requestedTab);
   const [masterPinStatus, setMasterPinStatus] = useState<{ available: boolean; isSet: boolean; schemaVersion: number | null }>({ available: false, isSet: false, schemaVersion: null });
   const [healthCheckOpen, setHealthCheckOpen] = useState(() => searchParams?.get('action') === 'health-check');
   const [healthReport, setHealthReport] = useState<HealthCheckReport | null>(null);
   const [applyingFixes, setApplyingFixes] = useState(false);
   const [initializeDbOpen, setInitializeDbOpen] = useState(() => searchParams?.get('action') === 'initialize-db');
   const [shakeSaveBar, setShakeSaveBar] = useState(false);
+
+  // Sidebar links can change only the query string while this page stays mounted.
+  // Keep the rendered Settings tab in sync with those deep-link changes (including
+  // returning to the default Store tab when ?tab= is removed).
+  useEffect(() => {
+    // This is navigation state arriving from Next.js, not an async data effect.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setActiveTab(requestedTab);
+  }, [requestedTab]);
 
   // Unified PIN gate: 'set' opens the set/change-PIN dialog; 'backup'/'backup-custom'/
   // 'import'/'restore' open a verify prompt and, on success, run the pending action.


### PR DESCRIPTION
## Intent

Make the main app's parent KDS navigation reliably open the KDS tab inside Settings, including the repeated flow where the user opens KDS, switches to another Settings tab, and clicks parent KDS again. Preserve deep-link navigation and keep the change focused with an executable regression test. The work must remain in the separate worktree, use the project-style branch fix/kds-settings-navigation, and be committed and delivered through the no-mistakes pipeline.

## What Changed

- **Settings KDS navigation fix:** Added a `useEffect` to keep the active Settings tab in sync when sidebar links change the `?tab=` query string without remounting the page. Replaced direct `setActiveTab` with `handleSettingsTabChange` that both updates local state and pushes the new URL via `router.replace`, fixing repeated KDS-to-other-tab-to-KDS navigation. Added Playwright E2E regression test (`settings-kds-navigation.spec.ts`) covering the exact reopen flow.
- **Decouple UI locale from tenant country for date/time presentation:** Replaced `getCountryByCode(country)?.locale` locale derivation with `useLocale()` from `use-intl` across `useFormatDate`, `dashboard`, `orders`, `PaymentModal`, and `whatsapp` pages. `formatDateForTenant` now accepts an optional `localeOverride` parameter. WhatsApp share functions (`getWhatsAppShareUrl`, `shareBillViaWhatsApp`, `getWhatsAppMessage`) and web-print receipt generation pass the active UI locale through, so an English-speaking operator at an Argentine store sees English dates on receipts and in share messages.
- **Test & documentation:** Added 743-line `decoupled-ui-locale.test.ts` validating locale decoupling across formatting, receipts, WhatsApp messages, and React hooks with visual evidence artifacts. Added locale-override assertion to `locale-iran.test.ts`. Updated `docs/i18n.md` to document the decoupled date/time presentation language domain.

## Risk Assessment

✅ Low: KDS fix is well-bounded and addresses the root cause cleanly; i18n changes are backward-compatible with optional parameters; E2E test covers the exact regression scenario.

## Testing

Ran the new KDS settings navigation e2e Playwright test (passes, validates the exact sidebar-click-revisit scenario from user intent), plus backend static-route-resolution, smoke, url-allowlist, and database-tools-api tests (all pass). Frontend static build succeeds. Evidence trace captured in the dedicated evidence directory.

<details>
<summary>Evidence: Playwright e2e test output</summary>

```text
Running 1 test using 1 worker

✓ 1 [chromium] › e2e/settings-kds-navigation.spec.ts:5:5 › KDS sidebar link selects the KDS tab after switching Settings tabs (1.9s)

1 passed (5.7s)
```
</details>
- Evidence: Playwright trace (browser interaction) (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0EVBJ2VK7SABDYY1K19PWC2/kds-navigation-trace.zip</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"eb5c14308b5005799bc618d7d34f9165dd3ba548","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `CI=true npx playwright test settings-kds-navigation.spec.ts --reporter=list`
- `node tests/run-electron-node-test.cjs tests/static-route-resolution.test.ts`
- `node tests/run-electron-node-test.cjs tests/smoke-test.test.ts`
- `node tests/run-electron-node-test.cjs tests/url-allowlist.test.ts`
- `node tests/run-electron-node-test.cjs tests/database-tools-api.test.ts`
- <code>Frontend build: `npm run build:frontend` (pass, after pre-existing `libphonenumber-js` dep fix)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
