### PR TITLE
fix(printer): skip WebUSB printers in KOT routing

### DIFF
--- a/main/routes/printers.ts
+++ b/main/routes/printers.ts
@@ -483,7 +483,10 @@ export function routeItemsToStations(db: any, orderItems: any[]): { stationName:
       } catch {
         categoryIds = [];
       }
-      const printer = db.prepare('SELECT * FROM printers WHERE id = ?').get(s.printer_id);
+      const printer = db.prepare(
+        `SELECT * FROM printers
+         WHERE id = ? AND connection_type != 'webusb'`,
+      ).get(s.printer_id);
       return { ...s, categoryIds, printer };
     })
     .filter((s) => s.categoryIds.length > 0 && s.printer);
@@ -531,7 +534,12 @@ router.post('/print-kot', requireRole('owner', 'manager', 'cashier'), asyncHandl
     }
 
     const db = getDatabase();
-    const printer = db.prepare('SELECT * FROM printers WHERE is_default = 1').get();
+    const printer = db.prepare(
+      `SELECT * FROM printers
+       WHERE connection_type != 'webusb'
+       ORDER BY is_default DESC, name
+       LIMIT 1`,
+    ).get();
 
     if (!printer) {
       return res.status(400).json({ error: 'No default printer configured. Add a printer in Settings.' });

--- a/tests/issue-134-station-routing.test.ts
+++ b/tests/issue-134-station-routing.test.ts
@@ -115,6 +115,18 @@ function main() {
     assertEqual(groups[0].stationName, 'Kitchen', 'E: unlinked Dessert station is ignored in favor of the configured one');
   }
 
+  console.log('\n─── Scenario F: WebUSB station printer is skipped for backend KOT routing ───');
+  {
+    db.prepare('UPDATE kitchen_stations SET is_active = 0').run();
+    db.prepare(`INSERT INTO printers (id, name, connection_type, ip_address, port) VALUES ('pr-webusb', 'Browser WebUSB', 'webusb', null, null)`).run();
+    db.prepare(`INSERT INTO kitchen_stations (id, name, category_ids, printer_id, is_active) VALUES ('stn-webusb', 'Browser Bar', ?, 'pr-webusb', 1)`).run(JSON.stringify(['cat-bev']));
+
+    const groups = routeItemsToStations(db, [{ product_id: 'prod-bev' }]);
+    assertEqual(groups.length, 1, 'F: WebUSB station falls back to one generic Kitchen group');
+    assertEqual(groups[0].stationName, 'Kitchen', 'F: WebUSB station does not receive backend KOT items');
+    assert(groups[0].printer === null, 'F: fallback group leaves printer selection to the backend fallback');
+  }
+
   closeDatabase();
   fs.rmSync(testDir, { recursive: true, force: true });
 

--- a/tests/printer-fallback-and-popup-verification.ts
+++ b/tests/printer-fallback-and-popup-verification.ts
@@ -209,6 +209,16 @@ async function run() {
     assert('POST /print-bill with no default printer resolves a non-WebUSB printer and returns 200', fallbackDefaultRes.status === 200);
     assert('backend fallback skips WebUSB and selects the first usable printer', fallbackDefaultRes.body.printer?.name === 'Front Desk Network');
 
+    db.prepare('DELETE FROM printers').run();
+    db.prepare(`INSERT INTO printers (name, connection_type, ip_address, port, paper_width, is_default, created_at, updated_at)
+                VALUES ('Kitchen WebUSB', 'webusb', null, null, '80mm', 1, datetime('now'), datetime('now'))`).run();
+    const kotWebUsbOnlyRes = await request(app).post('/api/printers/print-kot').send({
+      orderId,
+      stationName: 'Kitchen',
+      items: [{ product_name: 'Cappuccino', quantity: 1, unit_price: 25, total: 27.5 }],
+    });
+    assert('KOT rejects a WebUSB-only printer list before backend dispatch', kotWebUsbOnlyRes.status === 400);
+
     closeDatabase();
   }
 


### PR DESCRIPTION
## Summary

This follow-up closes the remaining printer-routing gap identified by Greptile in PR #418. Backend KOT printing must never send a browser-managed WebUSB printer to the Electron ESC/POS dispatcher.

## What changed

- Backend KOT default-printer selection now excludes WebUSB printers and keeps default-first, name-based ordering among backend-compatible printers.
- Kitchen stations linked to WebUSB printers are treated as unavailable for backend routing. Their items use the generic Kitchen fallback, which then resolves through compatible backend-printer selection.
- A WebUSB-only printer configuration now returns a clear 400 no-printer response before backend dispatch is attempted.

## Why

WebUSB printers are managed by the browser and cannot be dispatched by the Electron backend. Previously, KOT routing could select a WebUSB printer as the default or pass one through a kitchen-station assignment, causing backend printing to fail even when the printer was valid for browser-based printing.

## Scope

This change is limited to backend KOT printer selection and routing. It adds no database migration and does not change the browser WebUSB printing flow.

## Verification

- Backend lint: npm run lint:backend
- TypeScript build: npm run build
- Printer fallback verification: 33/33 passed
- Station routing: 23/23 passed
- Printer API: 39/39 passed
- Bills print API: 23/23 passed
- CI: 12 passed, 0 failed, 1 skipped
- Greptile Review: passed