### PR TITLE
test: use portable evidence output directories

### DIFF
--- a/tests/browser-receipts.test.ts
+++ b/tests/browser-receipts.test.ts
@@ -5,10 +5,13 @@
  */
 
 import fs from 'node:fs';
+import * as os from 'node:os';
 import path from 'node:path';
 import type { Bill, Order, Tenant, OrderItem, Customer, Table } from '../frontend/src/lib/types';
 
-const EVIDENCE_DIR = process.env.EVIDENCE_DIR || '/Users/gurkiratkhaira/.no-mistakes/evidence/01M0EAZP7Q6BWADVK3WPM4HZDV';
+const EVIDENCE_DIR =
+  process.env.EVIDENCE_DIR ||
+  path.join(os.tmpdir(), 'no-mistakes-evidence', '01M0EAZP7Q6BWADVK3WPM4HZDV');
 
 // Dynamic resolver for frontend modules
 function loadFrontendModules() {

--- a/tests/issue-241-localized-errors.test.ts
+++ b/tests/issue-241-localized-errors.test.ts
@@ -15,11 +15,14 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'node:os';
 import * as path from 'path';
 import { spawnSync } from 'node:child_process';
 
 const ROOT = path.join(__dirname, '..');
-const EVIDENCE_DIR = '/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M08VG78CNJN3CHGY6B42Q05W';
+const EVIDENCE_DIR =
+  process.env.EVIDENCE_DIR ||
+  path.join(os.tmpdir(), 'no-mistakes-evidence', '01M08VG78CNJN3CHGY6B42Q05W');
 
 const Module = require('module');
 const frontendRequire = Module.createRequire(path.join(ROOT, 'frontend/package.json'));

--- a/tests/kds-window-hardening.test.ts
+++ b/tests/kds-window-hardening.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 const Module = require('module');
@@ -239,7 +240,9 @@ async function run(): Promise<void> {
   log('\n✅ All KDS window hardening and IPC security checks passed successfully.');
 
   // Write evidence to output directory if present
-  const evidenceDir = '/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M03SG09151P3VMMYNWFRVWA2';
+  const evidenceDir =
+    process.env.EVIDENCE_DIR ||
+    path.join(os.tmpdir(), 'no-mistakes-evidence', '01M03SG09151P3VMMYNWFRVWA2');
   try {
     fs.mkdirSync(evidenceDir, { recursive: true });
     const evidencePath = path.join(evidenceDir, 'kds-window-hardening-verification.txt');
@@ -258,4 +261,3 @@ run()
   .finally(() => {
     Module._load = originalLoad;
   });
-

--- a/tests/payment-modal-currency-adapter.test.ts
+++ b/tests/payment-modal-currency-adapter.test.ts
@@ -14,6 +14,7 @@
  */
 
 import fs from 'node:fs';
+import * as os from 'node:os';
 import path from 'node:path';
 import assert from 'node:assert/strict';
 import {
@@ -23,7 +24,9 @@ import {
   formatNumberForTenant,
 } from '../main/countries';
 
-const EVIDENCE_DIR = '/var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/no-mistakes-evidence/01M09EG8J030YCK62W10XAD7D6';
+const EVIDENCE_DIR =
+  process.env.EVIDENCE_DIR ||
+  path.join(os.tmpdir(), 'no-mistakes-evidence', '01M09EG8J030YCK62W10XAD7D6');
 
 function runUnitTests() {
   console.log('--- 1. Currency Unit Adapter Unit Tests ---');


### PR DESCRIPTION
## Summary

This test-only cleanup makes evidence artifact output portable across developers, operating systems, and CI environments.

## What changed

- Replaced hardcoded author- and machine-specific evidence paths with paths based on os.tmpdir().
- Preserved the EVIDENCE_DIR environment-variable override for CI and local review workflows.
- Kept generated HTML and PNG evidence outside the repository by default.

## Files changed

- tests/browser-receipts.test.ts
- tests/payment-modal-currency-adapter.test.ts
- tests/issue-241-localized-errors.test.ts
- tests/kds-window-hardening.test.ts

## Why

The previous paths depended on one developer’s home directory or a specific macOS temporary-directory name. That made the tests non-portable and could cause evidence generation to fail on another machine or runner.

## Scope

This PR changes test evidence-output locations only. It does not change application runtime behavior, printer behavior, translations, or database logic.

## Verification

- Project lint: npm run lint
- KDS window hardening test: passed
- Payment modal currency evidence test: passed
- Issue #241 localized-errors evidence test: passed; 16 artifacts generated
- Browser receipts test: 37/37 passed
- CI: 12 passed, 0 failed, 1 skipped
- Greptile Review: passed