### PR TITLE
release: prepare 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Flo Cafe are documented here. Dates are release dates, not commit dates. Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [3.3.0] - 2026-08-21
+
+### Added
+- Expanded locale/currency/dial-code coverage from 33 to 117 countries in the country registry, including Guatemala (GTQ, +502) and full Eurozone coverage (EUR), broadening the Setup wizard's country list and currency formatting. Tax-pack compliance remains a separate, per-country opt-in and is unaffected by this change.
+
+### Changed
+- Removed the Greptile badge from the README.
+
 ## [3.2.3] - 2026-08-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "3.2.3",
+      "version": "3.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- Bumps `package.json`/`package-lock.json` to 3.3.0.
- Adds the 3.3.0 CHANGELOG entry covering #429 (117-country locale/currency/dial-code expansion, including Guatemala GTQ/+502, and full Eurozone EUR coverage) plus the README Greptile-badge removal.

## Test plan
- [x] `tests/release-config.test.ts` passes with the new version
- [x] `npm run lint`, `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)