### PR TITLE
fix: issue #393 tax id followups

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -840,10 +840,26 @@ Update business settings.
 
 `timezone` is validated as an IANA identifier; invalid values return HTTP 400 with `"Invalid timezone, currency, or country"`.
 
+When `tax_registration_number` is provided, the backend validates it against the active country pack's registration format. A mismatch returns HTTP 400:
+
+```json
+{
+  "error": "Tax ID does not match the expected IN format: 15-digit GSTIN",
+  "tax_id_format": { "pattern": "...", "description": "..." }
+}
+```
+
 ---
 
 ### GET `/api/settings/tax`
 Get tax settings.
+
+---
+
+### PUT `/api/settings/tax`
+Update tax settings (owner/manager only).
+
+Validates `tax_registration_number` against the active country pack format, same as `PUT /api/settings/business`.
 
 ---
 

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -1182,8 +1182,8 @@ export default function SettingsPage() {
   const [form, setForm] = useState<BusinessForm>(savedBusiness);
   const [savingBusiness, setSavingBusiness] = useState(false);
   // Server-resolved: the active country tax pack's format if it declares
-  // one, else the static countries.ts fallback, else null. Never blocks
-  // the save — just drives the non-blocking warning below the field.
+  // one, else the static countries.ts fallback, else null. The backend is
+  // authoritative; this drives immediate warning feedback below the field.
   const [taxIdFormat, setTaxIdFormat] = useState<{ pattern: string; description: string } | null>(null);
   // check 25 (main/routes/tax-packs.ts) rejects the textbook nested-
   // quantifier ReDoS shape at pack-activation time, but that's a known-shape
@@ -1973,11 +1973,13 @@ export default function SettingsPage() {
         number_digits: form.numberDigits,
         calendar: form.calendar,
       });
+      let resolvedTaxIdFormat = putRes.data?.tax_id_format || null;
       if (savedBusiness.countryCode !== form.countryCode) {
         const taxSetting = await api.get('/settings/taxes_enabled').catch(() => null);
         if (taxSetting?.data.setting?.value === 'true') {
           try {
-            await api.post('/tax-packs/ensure-country', { country: form.countryCode });
+            const ensureRes = await api.post('/tax-packs/ensure-country', { country: form.countryCode });
+            resolvedTaxIdFormat = ensureRes.data?.tax_id_format || null;
           } catch (error) {
             const status = (error as { response?: { status?: number } }).response?.status;
             if (status === 404) {
@@ -2005,7 +2007,7 @@ export default function SettingsPage() {
       const updatedForm = { ...form, businessPhone: normalizedBusinessPhone };
       setSavedBusiness(updatedForm);
       setForm(updatedForm);
-      setTaxIdFormat(putRes.data?.tax_id_format || null);
+      setTaxIdFormat(resolvedTaxIdFormat);
       posSettings.setBillTaxRegistrationNumber(form.taxRegistrationNumber);
       posSettings.setBillAddress(form.businessAddress);
       posSettings.setBillPhone(normalizedBusinessPhone);

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -1185,6 +1185,7 @@ export default function SettingsPage() {
   // one, else the static countries.ts fallback, else null. The backend is
   // authoritative; this drives immediate warning feedback below the field.
   const [taxIdFormat, setTaxIdFormat] = useState<{ pattern: string; description: string } | null>(null);
+  const [taxIdFormatCountryCode, setTaxIdFormatCountryCode] = useState('');
   // check 25 (main/routes/tax-packs.ts) rejects the textbook nested-
   // quantifier ReDoS shape at pack-activation time, but that's a known-shape
   // heuristic, not a formal safety proof. This runs on every keystroke, so
@@ -1195,10 +1196,10 @@ export default function SettingsPage() {
   const TAX_ID_WARNING_MAX_LENGTH = 24;
   const taxIdWarning = (() => {
     const value = form.taxRegistrationNumber.trim();
-    // taxIdFormat was resolved for savedBusiness.countryCode; if the country
-    // field has since been edited (not yet saved), the format is stale and
-    // must not be shown against the newly selected country's label.
-    if (!taxIdFormat || !value || form.countryCode !== savedBusiness.countryCode) return null;
+    // Do not show a format against a country other than the one for which the
+    // server resolved it. This also keeps a rejected country-change response
+    // visible for the submitted country without mislabeling it after a revert.
+    if (!taxIdFormat || !value || form.countryCode !== taxIdFormatCountryCode) return null;
     if (value.length > TAX_ID_WARNING_MAX_LENGTH) return null;
     try {
       return new RegExp(taxIdFormat.pattern, 'i').test(value) ? null : taxIdFormat.description;
@@ -1372,6 +1373,7 @@ export default function SettingsPage() {
       setSavedBusiness(loaded);
       setForm(loaded);
       setTaxIdFormat(d.tax_id_format || null);
+      setTaxIdFormatCountryCode(loaded.countryCode);
       const billDisplay = {
         billShowName: d.bill_show_name !== false,
         billShowAddress: d.bill_show_address !== false,
@@ -1648,6 +1650,7 @@ export default function SettingsPage() {
       setSavedBusiness(loaded);
       setForm(loaded);
       setTaxIdFormat(d.tax_id_format || null);
+      setTaxIdFormatCountryCode(loaded.countryCode);
       // Sync to pos-settings store for bill printing
       const billDisplay = {
         billShowName: d.bill_show_name !== false,
@@ -2008,6 +2011,7 @@ export default function SettingsPage() {
       setSavedBusiness(updatedForm);
       setForm(updatedForm);
       setTaxIdFormat(resolvedTaxIdFormat);
+      setTaxIdFormatCountryCode(form.countryCode);
       posSettings.setBillTaxRegistrationNumber(form.taxRegistrationNumber);
       posSettings.setBillAddress(form.businessAddress);
       posSettings.setBillPhone(normalizedBusinessPhone);
@@ -2026,6 +2030,7 @@ export default function SettingsPage() {
       }
       if (serverError?.tax_id_format) {
         setTaxIdFormat(serverError.tax_id_format);
+        setTaxIdFormatCountryCode(form.countryCode);
       }
       throw err;
     } finally {

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -2015,10 +2015,14 @@ export default function SettingsPage() {
       posSettings.setTablesRequired(form.tablesRequired);
       updateCurrentTenant({ currency: form.currency, timezone: form.timezone, country: form.countryCode, currency_display: form.currencyDisplay, number_digits: form.numberDigits, calendar: form.calendar });
       if (!silent) toast.success(t('storeSaved'));
-    } catch (err) {
+    } catch (err: any) {
       if (!silent) {
-        const message = t('saveFailed');
+        const serverError = err?.response?.data;
+        const message = serverError?.error || t('saveFailed');
         toast.error(message);
+        if (serverError?.tax_id_format) {
+          setTaxIdFormat(serverError.tax_id_format);
+        }
       }
       throw err;
     } finally {

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -2015,14 +2015,17 @@ export default function SettingsPage() {
       posSettings.setTablesRequired(form.tablesRequired);
       updateCurrentTenant({ currency: form.currency, timezone: form.timezone, country: form.countryCode, currency_display: form.currencyDisplay, number_digits: form.numberDigits, calendar: form.calendar });
       if (!silent) toast.success(t('storeSaved'));
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const responseData = (err as { response?: { data?: unknown } }).response?.data;
+      const serverError = responseData && typeof responseData === 'object'
+        ? responseData as { error?: string; tax_id_format?: { pattern: string; description: string } }
+        : null;
       if (!silent) {
-        const serverError = err?.response?.data;
         const message = serverError?.error || t('saveFailed');
         toast.error(message);
-        if (serverError?.tax_id_format) {
-          setTaxIdFormat(serverError.tax_id_format);
-        }
+      }
+      if (serverError?.tax_id_format) {
+        setTaxIdFormat(serverError.tax_id_format);
       }
       throw err;
     } finally {

--- a/main/routes/settings.ts
+++ b/main/routes/settings.ts
@@ -5,7 +5,7 @@ import { cloudSync, DEFAULT_CLOUD_SERVER_URL, normalizeCloudServerUrl } from '..
 import { googleDrive } from '../services/google-drive';
 import { requireRole } from '../middleware/security';
 import { requireMasterPin } from '../middleware/master-pin';
-import { resolveTaxIdFormat } from '../services/tax';
+import { resolveTaxIdFormat, validateTaxRegistrationNumber } from '../services/tax';
 import { sendEvent } from '../services/telemetry';
 import { getCountryByCode, getCurrencySymbol, isValidTimeZone } from '../countries';
 import { getHttpRequestSignal, trackHttpRequestWork } from '../shutdown';
@@ -140,9 +140,9 @@ function businessShape(s: Record<string, string>) {
     currency_display: s.currency_display || 'rial',
     number_digits: s.number_digits || 'locale',
     calendar: s.calendar || 'locale',
-    // Informational only — the active country pack's format if it declares
-    // one, else the static main/countries.ts fallback, else null. Never
-    // blocks the save; the UI uses this to show a non-blocking warning.
+    // The active country pack's format if it declares one, else the static
+    // main/countries.ts fallback, else null. The backend validates submitted
+    // tax IDs against this format; the UI also uses it for immediate feedback.
     tax_id_format: resolveTaxIdFormat(s.country || 'IN'),
   };
 }
@@ -192,6 +192,16 @@ router.put('/business', requireRole('owner', 'manager'), (req: Request, res: Res
     const currentSettings = getAllSettings(db);
     const effectiveCountry = country || currentSettings.country || 'IN';
     const effectiveCurrency = currency || currentSettings.currency || 'INR';
+
+    if (tax_registration_number) {
+      const { valid, format } = validateTaxRegistrationNumber(effectiveCountry, tax_registration_number);
+      if (!valid && format) {
+        return res.status(400).json({
+          error: `Tax ID does not match the expected ${effectiveCountry} format: ${format.description}`,
+          tax_id_format: format,
+        });
+      }
+    }
 
     let normalizedPhone: string | undefined = undefined;
     if (business_phone !== undefined) {
@@ -244,6 +254,16 @@ router.put('/tax', requireRole('owner', 'manager'), (req: Request, res: Response
 
     const db = getDatabase();
     const currentSettings = getAllSettings(db);
+    const effectiveCountry = country || currentSettings.country || 'IN';
+    if (tax_registration_number) {
+      const { valid, format } = validateTaxRegistrationNumber(effectiveCountry, tax_registration_number);
+      if (!valid && format) {
+        return res.status(400).json({
+          error: `Tax ID does not match the expected ${effectiveCountry} format: ${format.description}`,
+          tax_id_format: format,
+        });
+      }
+    }
     upsertSettings(db, {
       tax_registered,
       tax_registration_number,

--- a/main/routes/tax-packs.ts
+++ b/main/routes/tax-packs.ts
@@ -4,6 +4,7 @@ import Decimal from 'decimal.js';
 import { getDatabase, getSettingValue, now, upsertSettings, withTxn } from '../db';
 import { requireRole } from '../middleware/security';
 import { TaxEngine } from '../services/tax-engine';
+import { resolveTaxIdFormat } from '../services/tax';
 import type { CountryPack, PluginPrintTemplate, TaxBehavior, TaxCategory, TaxRule } from '../tax-packs/types';
 import { BUNDLED_COUNTRY_PACKS } from '../tax-packs/bundled';
 import {
@@ -915,7 +916,13 @@ router.post('/ensure-country', requireRole('owner', 'manager'), asyncHandler(asy
         .run(definition.defaultCategories.addon);
     });
     upsertSettings({ taxes_enabled: 'true' });
-    return res.json({ enabled: true, country, pack_id: pack.id, version: version.version });
+    return res.json({
+      enabled: true,
+      country,
+      pack_id: pack.id,
+      version: version.version,
+      tax_id_format: resolveTaxIdFormat(country),
+    });
   } catch (error: any) {
     const statusCode = error.statusCode || 502;
     return res.status(statusCode).json({ error: error.message || 'Could not install the country tax plugin' });

--- a/tests/tax-pack-management.test.ts
+++ b/tests/tax-pack-management.test.ts
@@ -1004,7 +1004,52 @@ async function main() {
       publisher: 'FreeOpenSourcePOS',
       registrationNumberFormat: overrideFormat,
     };
+    LEGACY_TRUSTED_PACK_DIGESTS[formatOverridePack.id] = taxPackSha256(JSON.stringify(formatOverridePack));
     installAndActivateTestTaxPack(db, formatOverridePack);
+
+    const invalidBusinessRes = await api(baseUrl, '/api/settings/business', {
+      method: 'PUT',
+      headers: owner.authHeader,
+      body: { country: 'IN', tax_registration_number: 'GSTIN-INVALID' },
+    });
+    assertEqual(invalidBusinessRes.status, 400, 'business settings reject a tax ID that fails the active pack format');
+    assertEqual(
+      JSON.stringify(invalidBusinessRes.data.tax_id_format),
+      JSON.stringify(overrideFormat),
+      'business validation returns the active pack format for the caller',
+    );
+    assertEqual(
+      db.prepare("SELECT value FROM settings WHERE key = 'tax_registration_number'").get()?.value || '',
+      '',
+      'rejected business settings do not persist the invalid tax ID',
+    );
+
+    const validBusinessRes = await api(baseUrl, '/api/settings/business', {
+      method: 'PUT',
+      headers: owner.authHeader,
+      body: { country: 'IN', tax_registration_number: 'TESTPACKFMT-1234' },
+    });
+    assertEqual(validBusinessRes.status, 200, 'business settings accept a tax ID matching the active pack format');
+
+    const invalidTaxRes = await api(baseUrl, '/api/settings/tax', {
+      method: 'PUT',
+      headers: owner.authHeader,
+      body: { country: 'IN', tax_registration_number: 'GSTIN-INVALID' },
+    });
+    assertEqual(invalidTaxRes.status, 400, 'tax settings reject a tax ID that fails the active pack format');
+
+    const ensuredCountryRes = await api(baseUrl, '/api/tax-packs/ensure-country', {
+      method: 'POST',
+      headers: owner.authHeader,
+      body: { country: 'IN' },
+    });
+    assertEqual(ensuredCountryRes.status, 200, 'ensuring an already-installed country pack succeeds');
+    assertEqual(
+      JSON.stringify(ensuredCountryRes.data.tax_id_format),
+      JSON.stringify(overrideFormat),
+      'country-pack activation returns the newly active registration format',
+    );
+
     assertEqual(
       JSON.stringify(resolveTaxIdFormat('IN')),
       JSON.stringify(overrideFormat),


### PR DESCRIPTION
## Intent

Enforce signed tax registration formats at the settings API and refresh the UI after country-pack activation

## What Changed

Final changed paths and statuses:

```text
M	docs/API.md
M	frontend/src/app/(dashboard)/settings/page.tsx
M	main/routes/settings.ts
M	main/routes/tax-packs.ts
M	tests/tax-pack-management.test.ts
```

## Risk Assessment

✅ Low: Change is well-bounded: adds server-side format validation to two settings endpoints with correct guard conditions (skips when no format exists, skips for empty tax ID), returns format in ensure-country response, and frontend correctly surfaces server error messages and updates the format hint. Previous finding was correctly fixed. Test coverage exercises the new validation paths.

## Testing

Ran tax-pack-management integration test (166/166 pass) which covers the new section 9 assertions: invalid tax ID rejected at PUT /api/settings/business (400 + tax_id_format returned + DB unchanged), valid tax ID accepted (200), PUT /api/settings/tax rejects invalid tax ID (400), ensure-country returns tax_id_format, resolveTaxIdFormat/validateTaxRegistrationNumber unit assertions. Also ran 5 related test suites (all pass) and confirmed backend compiles cleanly.

<details>
<summary>Evidence: tax-pack-management test output</summary>

```text

> flo-desktop@3.3.0 test:tax-pack-management
> node tests/run-electron-node-test.cjs tests/tax-pack-management.test.ts

Tax Pack Management Integration Tests
========================================================
[DB] Opening database at: /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-tax-pack-manager-mCmO4c/flo.db
[DB] Schema: v0 → v71
[DB] Triggering auto-backup before migrating v0 → v71...
[DB] Auto-backup before migrating v0 → v71 created at /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-tax-pack-manager-mCmO4c/backups/flo-backup-2026-08-20T23-44-14-841Z-pre-v0-to-v71.db
[DB] Applying migration v1: initial_schema
[DB] Install defaults loaded; first-run setup pending
[DB] Migration v1 complete
[DB] Applying migration v2: hash_plaintext_pins
[DB] Migration v2 complete
[DB] Applying migration v3: cloud_identity_and_outbox
[DB] Migration v3 complete
[DB] Applying migration v4: add_notes_limits_settings
[DB] Migration v4 complete
[DB] Applying migration v5: add_print_logs_table
[DB] Migration v5 complete
[DB] Applying migration v6: add_loyalty_settings
[DB] Migration v6 complete
[DB] Applying migration v7: add_discount_settings
[DB] Migration v7 complete
[DB] Applying migration v8: add_loyalty_index
[DB] Migration v8 complete
[DB] Applying migration v9: add_sequences_table
[DB] Migration v9 complete
[DB] Applying migration v10: fix_sequences_composite_key
[DB] Migration v10 complete
[DB] Applying migration v11: first_run_setup_uses_welcome_form
[DB] Migration v11 complete
[DB] Applying migration v12: fix_table_integer_ids
[DB] Migration v12 complete
[DB] Applying migration v13: fix_null_table_ids
[DB] Migration v13 complete
[DB] Applying migration v14: simplify_loyalty_settings
[DB] Migration v14 complete
[DB] Applying migration v15: add_instagram_handle_setting
[DB] Migration v15 complete
[DB] Applying migration v16: add_terms_accepted_at_to_users
[DB] Migration v16 complete
[DB] Applying migration v17: add_held_orders_table
[DB] Migration v17 complete
[DB] Applying migration v18: fix_null_category_ids
[DB] Migration v18 complete
[DB] Applying migration v19: backfill_product_cb_percent_and_tags
[DB] Migration v19 complete
[DB] Applying migration v20: add_tables_is_active
[DB] Migration v20 complete
[DB] Applying migration v21: clear_legacy_loyalty_expiry
[DB] Migration v21 complete
[DB] Applying migration v22: add_customers_phone_digits
[DB] Migration v22 complete
[DB] Applying migration v23: normalize_customer_phones
[MIGRATION v23] normalized: 0, unparseable: 0
[MIGRATION v23] merged 0 duplicate customer(s)
[MIGRATION v23] verification: 0 customers, 0 still non-E.164
[DB] Migration v23 complete
[DB] Applying migration v24: normalize_customer_phones_retry
[MIGRATION v24] normalized: 0, unparseable: 0
[DB] Migration v24 complete
[DB] Applying migration v25: add_order_item_addons_table
[MIGRATION v25] backfilled addons for 0 order items (0 unparseable, skipped)
[DB] Migration v25 complete
[DB] Applying migration v26: add_kds_default_view
[DB] Migration v26 complete
[DB] Applying migration v27: add_station_printer_link_and_user_stations
[DB] Migration v27 complete
[DB] Applying migration v28: seed_telemetry_settings
[DB] Migration v28 complete
[DB] Applying migration v29: whatsapp_messaging
[DB] Migration v29 complete
[DB] Applying migration v30: drop_order_items_addons_json_column
[MIGRATION v30] backfilled 0 order_item(s) still missing a normalized addons snapshot
[MIGRATION v30] Dropped order_items.addons — order_item_addons is now the only place selected addons live.
[DB] Migration v30 complete
[DB] Applying migration v31: add_customers_tag_counts_column
[DB] Migration v31 complete
[DB] Applying migration v32: add_kds_and_kot_printing_toggles
[DB] Migration v32 complete
[DB] Applying migration v33: add_addon_groups_allow_multiple_quantities
[DB] Migration v33 complete
[DB] Applying migration v34: add_order_items_voided_at
[DB] Migration v34 complete
[DB] Applying migration v35: add_tax_pack_configuration_tables
[DB] Migration v35 complete
[DB] Applying migration v36: add_product_and_addon_tax_categories
[DB] Migration v36 complete
[DB] Applying migration v37: add_transaction_tax_snapshots_and_charge_categories
[DB] Migration v37 complete
[DB] Applying migration v38: register_bundled_tax_pack_versions
[DB] Migration v38 complete
[DB] Applying migration v39: add_users_tokens_valid_after
[DB] Migration v39 complete
[DB] Applying migration v40: v2_cloud_defaults_and_tax_toggle
[DB] Migration v40 complete
[DB] Applying migration v41: support_ticket_outbox
[DB] Migration v41 complete
[DB] Applying migration v42: add_global_cashback_percent
[DB] Migration v42 complete
[DB] Applying migration v43: telemetry_default_on_for_new_installs
[DB] Migration v43 complete
[DB] Applying migration v44: store_diagnostics_outbox
[DB] Migration v44 complete
[DB] Applying migration v45: add_performance_indexes_and_normalize_timestamps
[DB] Migration v45 complete
[DB] Applying migration v46: normalize_cloud_enabled_flags_to_01
[DB] Migration v46 complete
[DB] Applying migration v47: store_diagnostics_enabled_by_default
[DB] Migration v47 complete
[DB] Applying migration v48: deactivate_reusable_demo_credentials
[DB] Migration v48 complete
[DB] Applying migration v49: add_payment_idempotency_records
[DB] Migration v49 complete
[DB] Applying migration v50: add_order_idempotency_records
[DB] Migration v50 complete
[DB] Applying migration v51: enforce_global_payment_transaction_refs
[DB] Migration v51 complete
[DB] Applying migration v52: restore_method_scoped_transaction_refs
[DB] Migration v52 complete
[DB] Applying migration v53: scope_idempotency_records_to_user
[DB] Migration v53 complete
[DB] Applying migration v54: repair_retry_ownership_and_payment_reference_history
[DB] Migration v54 complete
[DB] Applying migration v55: durable_token_revocations
[DB] Migration v55 complete
[DB] Applying migration v56: persist_station_assignment_scope
[DB] Migration v56 complete
[DB] Applying migration v57: rename_gstin_to_generic_tax_registration_number
[DB] Migration v57 complete
[DB] Applying migration v58: configurable_manual_payment_methods
[DB] Migration v58 complete
[DB] Applying migration v59: split_checks_by_item_quantity
[DB] Migration v59 complete
[DB] Applying migration v60: seed_split_checks_disabled_setting
[DB] Migration v60 complete
[DB] Applying migration v61: seed_server_app_enabled_setting
[DB] Migration v61 complete
[DB] Applying migration v62: normalize_cloud_last_error
[DB] Migration v62 complete
[DB] Applying migration v63: seed_printer_trim_decimals_setting
[DB] Migration v63 complete
[DB] Applying migration v64: drop_unused_printer_usb_device_path
[DB] Migration v64 complete
[DB] Applying migration v65: seed_bill_content_visibility_settings
[DB] Migration v65 complete
[DB] Applying migration v66: seed_bill_template_settings
[DB] Migration v66 complete
[DB] Applying migration v67: persist_order_item_inventory_deductions
[DB] Migration v67 complete
[DB] Applying migration v68: add_invoice_numbering_settings
[DB] Migration v68 complete
[DB] Applying migration v69: installed_plugin_print_templates
[DB] Migration v69 complete
[DB] Applying migration v70: rename_waiter_role_to_server
[DB] Migration v70 complete
[DB] Applying migration v71: repair_durable_token_revocations
[DB] Migration v71 complete
[DB] integrity_check: ok
[DB] foreign_key_check: clean
[Auth] Generated new JWT secret for this install

1. Fresh installs start generic; explicitly installed packs are readable
  ✓ manager can view installed packs
  ✓ only the generic pack is preinstalled
  ✓ the preinstalled pack is generic
  ✓ generic no-tax behavior is active
  ✓ legacy pack is listed
  ✓ legacy pack version is shown
  ✓ legacy pack is active for its configured country
  ✓ manager can view active pack details
  ✓ categories are available for reference
  ✓ rules are available for reference
  ✓ all 25 activation checks are reported
  ✓ an exact legacy unsigned artifact remains trusted after upgrade
  ✓ test-legacy-th-pack details are readable
  ✓ test-legacy-th-pack reports all 25 activation checks
  ✓ test-legacy-th-pack passes activat

... [2793 bytes truncated] ...

tem discount does not scale charge tax
  ✓ item discount and order discount preserve charge totals
  ✓ bill generation copies the charge-tax rollup
  ✓ generated bill retains charge tax
  ✓ generated bill matches the order
  ✓ bill discount recomputes configured charges
  ✓ bill discount leaves charge tax unscaled
  ✓ bill discount scales items but not charges
  ✓ charge category can return to the no-tax default
  ✓ charge category can return to the no-tax default
  ✓ charge category can return to the no-tax default
  ✓ unconfigured charge order remains valid
  ✓ unconfigured charges remain untaxed
  ✓ unconfigured charge total is unchanged

6. Activation/rollback are owner-gated and installed-only
  ✓ manager cannot activate a pack
  ✓ owner can select an already-installed version
  ✓ selecting the active version is a safe no-op
  ✓ rollback is blocked when no previous installed version exists

7. Every override mutation is audited
  ✓ manager can view tax audit history
  ✓ create override audit exists
  ✓ update override audit exists
  ✓ reset override audit exists
  ✓ audit identifies the acting user

8. Signed catalog packs install without activating
  ✓ manager cannot install a catalog pack
  ✓ verified downloaded version is installed
  ✓ download uses the existing 25-check validation
  ✓ signed download passes all activation validation
  ✓ downloaded version is installed, not active
  ✓ verified catalog digest is persisted
  ✓ detached signature is persisted
  ✓ install does not implicitly activate the downloaded version
  ✓ downloaded categories are installed
  ✓ downloaded rules are installed
  ✓ download installation is audited
  ✓ install audit identifies the owner
  ✓ plain legacy CountryPack installs without plugin print templates
  ✓ wrapped plugin artifact installs its tax pack
  ✓ wrapped artifact persists the inner CountryPack JSON
  ✓ wrapped artifact digest is persisted
  ✓ wrapped artifact signature is persisted
  ✓ wrapped artifact install does not auto-activate
  ✓ wrapped artifact persists print template metadata
  ✓ template is keyed to the installed pack version
  ✓ template display name is persisted
  ✓ template printable columns are persisted
  ✓ template renderer metadata is persisted
  ✓ manager can list available bill templates
  ✓ core exposes only generic built-in templates
  ✓ installed plugin template is exposed to settings
  ✓ settings exposes plugin template display name
  ✓ settings exposes plugin template printable columns
  ✓ settings rejects uninstalled plugin template ids
  ✓ settings accepts installed plugin template ids
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-1 bill: BILL-GST-1
[Printer] formatReceipt - items count: 1 cols: 48
  ✓ installed GST plugin template renders a tax invoice title
  ✓ installed GST plugin template renders the plugin item-table layout
  ✓ installed GST plugin template renders GSTIN
  ✓ installed GST plugin template renders tax components
  ✓ installed GST plugin template renders plugin grand total label
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-EXACT bill: BILL-GST-EXACT
[Printer] formatReceipt - items count: 1 cols: 42
  ✓ plugin renderer supports an exact 42-column profile
  ✓ exact plugin width profile does not warn
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-SMALLER bill: BILL-GST-SMALLER
[Printer] formatReceipt - items count: 1 cols: 46
  ✓ plugin renderer uses nearest smaller width profile instead of squeezing 48 columns
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-32 bill: BILL-GST-32
[Printer] formatReceipt - items count: 1 cols: 32
  ✓ plugin renderer keeps 32-column profile within printable width
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-36 bill: BILL-GST-36
[Printer] formatReceipt - items count: 1 cols: 36
  ✓ plugin renderer keeps 36-column profile within printable width
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-40 bill: BILL-GST-40
[Printer] formatReceipt - items count: 1 cols: 40
  ✓ plugin renderer keeps 40-column profile within printable width
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-42 bill: BILL-GST-42
[Printer] formatReceipt - items count: 1 cols: 42
  ✓ plugin renderer keeps 42-column profile within printable width
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-44 bill: BILL-GST-44
[Printer] formatReceipt - items count: 1 cols: 44
  ✓ plugin renderer keeps 44-column profile within printable width
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-48 bill: BILL-GST-48
[Printer] formatReceipt - items count: 1 cols: 48
  ✓ plugin renderer keeps 48-column profile within printable width

8b. Reinstalling a plugin repairs a missing billing template without changing its version
  ✓ simulated desync: the billing template row is gone even though the pack version is still installed
  ✓ billing template is not exposed to settings while its row is missing
  ✓ reinstall keeps the same installed version, it does not upgrade
  ✓ reinstall reports the restored template count
  ✓ reinstall re-creates the missing billing template row
  ✓ restored template is keyed to the same pack version
  ✓ reinstall does not duplicate categories
  ✓ reinstall does not duplicate rules
  ✓ billing template is exposed to settings again after reinstall
  ✓ reinstall is audited
  ✓ reinstall audit identifies the acting user
  ✓ reinstalling a local/manual pack is rejected, it has nothing to redownload
  ✓ settings rejects plugin templates from unusable versions
[Printer] formatReceipt - template: in.gst.tax-invoice.v1
[Printer] formatReceipt - order: ORD-GST-2 bill: BILL-GST-2
[Printer] formatReceipt - items count: 1 cols: 48
  ✓ unusable plugin template falls back to a core receipt renderer
  ✓ fallback core receipt remains printable
  ✓ a genuinely new pack id passes activation validation on its own declared data
  ✓ a correctly signed pack still fails when the 24-check validation rejects it
  ✓ the failed compatibility check is returned to the caller
  ✓ failed validation leaves no installed version behind

9. resolveTaxIdFormat() versions registration-number format with the active country pack (#393)
  ✓ static countries.ts declares a taxIdFormat for IN (test precondition)
  ✓ a v1 pack lacking registrationNumberFormat falls back to the static countries.ts format
  ✓ business settings reject a tax ID that fails the active pack format
  ✓ business validation returns the active pack format for the caller
  ✓ rejected business settings do not persist the invalid tax ID
  ✓ business settings accept a tax ID matching the active pack format
  ✓ tax settings reject a tax ID that fails the active pack format
  ✓ ensuring an already-installed country pack succeeds
  ✓ country-pack activation returns the newly active registration format
  ✓ an active pack declaring registrationNumberFormat takes priority over the static countries.ts fallback
  ✓ validateTaxRegistrationNumber accepts a matching value under the length bound
  ✓ validateTaxRegistrationNumber rejects an over-length value before the pack-declared regex runs (ReDoS bound)
  ✓ check 25 accepts a well-formed, non-catastrophic registrationNumberFormat pattern
  ✓ check 25 rejects a nested-quantifier (catastrophic-backtracking) registrationNumberFormat pattern
  ✓ a country with neither a pack format nor a static format resolves to null (pass-through, never rejects)
  ✓ resolveTaxIdFormat never enforces a pattern while the taxes_enabled toggle is off
[DB] Database closed

========================================================
166/166 passed, 0 failed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c04e13afbf28fa32973a9306c854ff84b03366a9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `frontend/src/app/(dashboard)/settings/page.tsx:2018` - When PUT /settings/business returns 400 (tax ID fails format validation), the catch block shows only a generic `t(&#39;saveFailed&#39;)` toast, discarding the server&#39;s specific error message (`&#34;Tax ID does not match the expected XX format: description&#34;`) and the `tax_id_format` object. The user gets no actionable feedback about what format is expected. Additionally, `setTaxIdFormat` is only called on the success path (line 2010), so if the user changed country but the save failed, the UI continues showing the old country&#39;s format rather than the expected format from the 400 response. The server already sends `tax_id_format` in the 400 body specifically for this use case.

🔧 Fix: Show server 400 error message and tax_id_format on business save failure
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:tax-pack-management`
- `npm run test:redos-hardening`
- `npm run test:tax-engine`
- `npm run test:tax-components`
- `npm run test:tax-pack-catalog`
- `npm run test:legacy-tax-pack-digest`
- `npm run build`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
