### PR TITLE
docs(readme): restore uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ For Linux package choices, updates, FUSE setup, printing permissions, and tray b
 
 Node.js is only required to develop FloCafe, not to run a packaged release.
 
+<details>
+<summary>Uninstall a direct-download build</summary>
+
+App Store and Microsoft Store installs should be removed through the relevant store or operating system.
+
+```sh
+# macOS
+curl -fsSL https://github.com/FreeOpenSourcePOS/FloCafe/releases/latest/download/uninstall-macos.sh -o uninstall-macos.sh
+chmod +x uninstall-macos.sh
+./uninstall-macos.sh
+```
+
+```powershell
+# Windows PowerShell
+irm https://github.com/FreeOpenSourcePOS/FloCafe/releases/latest/download/uninstall-windows.ps1 -OutFile uninstall-windows.ps1
+powershell -ExecutionPolicy Bypass -File .\uninstall-windows.ps1
+```
+
+Both scripts ask whether to keep application data. Do not choose their data-purge options unless you intend to remove the local database and backups.
+
+</details>
+
 ## Highlights
 
 - **Order workflows:** Counter, dine-in, takeaway, and delivery orders with table management and held orders.


### PR DESCRIPTION
## Summary
- Restores the "Uninstall a direct-download build" `<details>` section to README.md, dropped as unintentional collateral damage in 213a9b9 (#394), a broad docs restructure that wasn't about uninstall docs.
- The `scripts/uninstallers/uninstall-macos.sh` and `uninstall-windows.ps1` scripts it documents are still shipped as release assets and still support the same `--purge-data`/`-PurgeData` and `--dry-run`/`-DryRun` flags, so the restored text matches current script behavior.

## Test plan
- [x] `git diff --check` on README.md (no whitespace issues)
- [x] Verified `scripts/uninstallers/uninstall-macos.sh` and `uninstall-windows.ps1` still exist and support the flags referenced in the restored text

🤖 Generated with [Claude Code](https://claude.com/claude-code)