### PR TITLE
docs(printing): add non-Latin ESC/POS capability study and hardware-test plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,6 @@ This index classifies documentation in `docs/` so contributors and AI agents kno
 | [tax-packs.md](tax-packs.md) | Tax pack schema, authoring guide, cryptographic signing, and catalog distribution workflow. | CURRENT |
 | [i18n.md](i18n.md) | Internationalization guide, translation editing, language scaffolding (`npm run i18n:add`), and RTL layout support. | CURRENT |
 | [merchant-print-templates.md](merchant-print-templates.md) | Merchant print template schema (v1), validation/compatibility policy, provenance and trust model, and bill-template selection identity. Cross-links the compliance `escpos-line-template-v1` contract (#445). | CURRENT |
-| [printing-nonlatin-capabilities.md](printing-nonlatin-capabilities.md) | Capability study and decision record for non-Latin scripts (Arabic/Persian, Hebrew, CJK, Indic) on ESC/POS hardware: approach comparison, recommended capability-tiered raster-fallback architecture (#446), community hardware-test matrix, and test-page raster probe spec. Not yet implemented. | FORWARD-LOOKING |
 
 ### Active design & forward-looking plans
 
@@ -35,6 +34,7 @@ This index classifies documentation in `docs/` so contributors and AI agents kno
 | --- | --- | --- |
 | [tax-engine-v2-spec.md](tax-engine-v2-spec.md) | Architectural specification for Tax Engine v2, data-only country packs, and future capability plugin boundaries. *(Note: 2026-07-31 amendment establishes that country packs are catalog-only and not auto-bundled).* | ACTIVE DESIGN |
 | [cloud-v2-plan.md](cloud-v2-plan.md) | Client integration plan for FloAdmin v2 cloud coordination. Phase 1 client work is implemented in code; forward-looking multi-device sync and FloAdmin contracts remain in design/specs. | ACTIVE DESIGN / FORWARD-LOOKING |
+| [printing-nonlatin-capabilities.md](printing-nonlatin-capabilities.md) | Capability study and decision record for non-Latin scripts (Arabic/Persian, Hebrew, CJK, Indic) on ESC/POS hardware: approach comparison, recommended capability-tiered raster-fallback architecture (#446), community hardware-test matrix, and test-page raster probe spec. Not yet implemented. | FORWARD-LOOKING |
 
 ### Historical records
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This index classifies documentation in `docs/` so contributors and AI agents kno
 | [tax-packs.md](tax-packs.md) | Tax pack schema, authoring guide, cryptographic signing, and catalog distribution workflow. | CURRENT |
 | [i18n.md](i18n.md) | Internationalization guide, translation editing, language scaffolding (`npm run i18n:add`), and RTL layout support. | CURRENT |
 | [merchant-print-templates.md](merchant-print-templates.md) | Merchant print template schema (v1), validation/compatibility policy, provenance and trust model, and bill-template selection identity. Cross-links the compliance `escpos-line-template-v1` contract (#445). | CURRENT |
+| [printing-nonlatin-capabilities.md](printing-nonlatin-capabilities.md) | Capability study and decision record for non-Latin scripts (Arabic/Persian, Hebrew, CJK, Indic) on ESC/POS hardware: approach comparison, recommended capability-tiered raster-fallback architecture (#446), community hardware-test matrix, and test-page raster probe spec. Not yet implemented. | FORWARD-LOOKING |
 
 ### Active design & forward-looking plans
 

--- a/docs/printers.md
+++ b/docs/printers.md
@@ -24,6 +24,8 @@ Receipt labels (invoice title, bill number, date, totals, payment methods) and k
 - **Kitchen tickets** resolve their label language independently through the stored `kot_language_policy`. A fixed kitchen language (for example English) keeps tickets in that language even when the storefront runs in another language.
 - Invalid or missing policy values always fall back to the store language; printing never fails because of a malformed policy.
 
+For the full study of non-Latin script support on thermal printers — including the recommended raster fallback architecture, community hardware-test checklist, and open decisions — see [printing-nonlatin-capabilities.md](printing-nonlatin-capabilities.md).
+
 Lines the printer cannot render under the script rules above are skipped with an explicit warning — content is never silently dropped. The printed document itself carries every line plus its text direction, so direction-aware layouts (right-to-left base with left-to-right amounts and order numbers) can be expressed by any renderer without changing the underlying data.
 
 ## Kitchen printing

--- a/docs/printers.md
+++ b/docs/printers.md
@@ -24,9 +24,9 @@ Receipt labels (invoice title, bill number, date, totals, payment methods) and k
 - **Kitchen tickets** resolve their label language independently through the stored `kot_language_policy`. A fixed kitchen language (for example English) keeps tickets in that language even when the storefront runs in another language.
 - Invalid or missing policy values always fall back to the store language; printing never fails because of a malformed policy.
 
-For the full study of non-Latin script support on thermal printers — including the recommended raster fallback architecture, community hardware-test checklist, and open decisions — see [printing-nonlatin-capabilities.md](printing-nonlatin-capabilities.md).
-
 Lines the printer cannot render under the script rules above are skipped with an explicit warning — content is never silently dropped. The printed document itself carries every line plus its text direction, so direction-aware layouts (right-to-left base with left-to-right amounts and order numbers) can be expressed by any renderer without changing the underlying data.
+
+For the full study of non-Latin script support on thermal printers — including the recommended raster fallback architecture, community hardware-test checklist, and open decisions — see [printing-nonlatin-capabilities.md](printing-nonlatin-capabilities.md).
 
 ## Kitchen printing
 

--- a/docs/printing-nonlatin-capabilities.md
+++ b/docs/printing-nonlatin-capabilities.md
@@ -74,7 +74,7 @@ Send pre-shaped presentation forms (Unicode Arabic Presentation Forms-B) in visu
 Render the receipt (or parts) to a 1-bit bitmap and print it with `GS v 0 m xL xH yL yH`.
 
 - `GS v 0` is the mechanism every printer uses for logos; it is implemented across the entire ESC/POS clone ecosystem, including the cheapest hardware. Density mode `m=0` (8 dots/mm both axes) matches standard 203 dpi receipt heads.
-- Reference implementation scale test: Odoo's IoT box converts every receipt image to greyscale → 1-bit → `GS v 0` → cut ([odoo/odoo `PrinterDriver.print_receipt`](https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver.py)); their commit replacing the old ESC/POS text encoder states: *"We now transform the receipts to JPGs, transform these JPGs into ESCPOS commands and send them via Cups."* This runs across one of the largest heterogeneous open-source POS fleets in existence.
+- Reference implementation scale test: Odoo's IoT box converts every receipt image to greyscale → 1-bit → `GS v 0` → cut ([odoo/odoo `PrinterDriver.print_receipt`](https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py)); their commit replacing the old ESC/POS text encoder states: *"We now transform the receipts to JPGs, transform these JPGs into ESCPOS commands and send them via Cups."* This runs across one of the largest heterogeneous open-source POS fleets in existence.
 
 | Criterion | Assessment |
 | --- | --- |
@@ -108,7 +108,7 @@ The browser print path already renders every script correctly (the browser does 
 
 | System | Multilingual receipt strategy | Evidence |
 | --- | --- | --- |
-| Odoo POS (IoT box) | Whole-receipt raster for everything; old ESC/POS text encoder retired | [`PrinterDriver.print_receipt` source](https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver.py), [hw_escpos replacement commit](https://github.com/odoo/odoo/commit/03b2f7b77dc6189bb485e0b834dba5f6d3d4da2c) |
+| Odoo POS (IoT box) | Whole-receipt raster for everything; old ESC/POS text encoder retired | [`PrinterDriver.print_receipt` source](https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py), [hw_escpos replacement commit](https://github.com/odoo/odoo/commit/03b2f7b77dc6189bb485e0b834dba5f6d3d4da2c) |
 | escpos-php | Unicode→code-page auto-mapping; official Arabic example renders **images** instead of text lines | [Arabic example](https://github.com/mike42/escpos-php/blob/master/example/specific/6-arabic-epos-tep-220m.php) |
 | python-escpos | Exposes charcode selection only; recurring Arabic mojibake issues resolved by users switching to raster | [#37](https://github.com/python-escpos/python-escpos/issues/37), [#633](https://github.com/python-escpos/python-escpos/issues/633) |
 | node-thermal-printer | iconv-lite code-page translation; shaping/bidi unsupported; Arabic/Thai requests open for years | [PR #81](https://github.com/Klemen1337/node-thermal-printer/pull/81), [#180](https://github.com/Klemen1337/node-thermal-printer/issues/180) |
@@ -209,7 +209,7 @@ Implementation note for that future change: reuse the profile-derived dots-per-l
 
 - Epson ESC/POS command reference, `FS &`: <https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/fs_ampersand.html>
 - ReceiptPrinterEncoder Arabic thread: <https://github.com/NielsLeenheer/ReceiptPrinterEncoder/issues/26>
-- Odoo IoT printer driver: <https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver.py> · replacement rationale: <https://github.com/odoo/odoo/commit/03b2f7b77dc6189bb485e0b834dba5f6d3d4da2c>
+- Odoo IoT printer driver: <https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py> · replacement rationale: <https://github.com/odoo/odoo/commit/03b2f7b77dc6189bb485e0b834dba5f6d3d4da2c>
 - escpos-php Arabic example: <https://github.com/mike42/escpos-php/blob/master/example/specific/6-arabic-epos-tep-220m.php>
 - node-thermal-printer code-page translation: <https://github.com/Klemen1337/node-thermal-printer/pull/81>
 - python-escpos Arabic issues: <https://github.com/python-escpos/python-escpos/issues/37>, <https://github.com/python-escpos/python-escpos/issues/633>

--- a/docs/printing-nonlatin-capabilities.md
+++ b/docs/printing-nonlatin-capabilities.md
@@ -84,7 +84,7 @@ Render the receipt (or parts) to a 1-bit bitmap and print it with `GS v 0 m xL x
 | Performance | Payload grows from ~1–2 KB (text receipt) to ≈ 72 B × ~1150 dot rows ≈ 80 KB (80 mm) / ≈ 55 KB (58 mm). Transfer over TCP 9100 / USB bulk is sub-second; head time is unchanged because the same paper area prints either way. Slow MCUs on clones can stutter on very large single images — solved by banding (Section 5). |
 | Paper width / density | Requires dots-per-line knowledge: 384 (58 mm) vs 576 (80 mm) at 203 dpi. Derivable from the existing paper-width profile data. |
 | Transport support | Identical byte stream on TCP, USB RAW queues, and WebUSB — it is ordinary bytes after init. OS spooler RAW pass-through is proven by Odoo/CUPS. No WebUSB-specific work. |
-| Package size impact | None at the protocol layer. Cost lives in the host rendering engine and bundled script fonts (a dependency question — see Section 7). |
+| Package size impact | None at the protocol layer. Cost lives in the host rendering engine and bundled script fonts (a dependency question — see Section 8). |
 | Maintenance burden | One renderer consuming the semantic print kernel; new scripts become font additions, not logic changes. |
 | Failure/fallback mode | Falls back to today's exact behavior (native attempt + explicit warning). Never worse than status quo. |
 
@@ -102,7 +102,7 @@ The browser print path already renders every script correctly (the browser does 
 | Native code pages | ✗ | ✗ isolated forms | ✗ | all | none | garbage, `?` |
 | UTF-8 pass-through | varies | varies | varies | all | none | mojibake |
 | Host shaping + bidi text | ✗ (glyph gap) | partial | hard | all | small | blank/garbage |
-| **Raster `GS v 0`** | **✓** | **✓** | **✓** | **all raw transports** | rendering engine (Section 7) | falls back to skip+warn |
+| **Raster `GS v 0`** | **✓** | **✓** | **✓** | **all raw transports** | rendering engine (Section 8) | falls back to skip+warn |
 
 ## 4. What other systems do
 
@@ -173,7 +173,8 @@ Paper width:              58mm / 80mm      Firmware date (if known):
 [ ] 5. Firmware Arabic shaping probe: unshaped-but-reversed Persian
        looks connected?  yes / no
 [ ] 6. Raster probe (test page band, Section 7): prints?  yes / no
-[ ] 7. Raster width: band fills the printable width edge-to-edge?
+[ ] 7. Raster width: solid bar spans full width except the small
+       designed inset (~1mm/side)?  full / shrunk / clipped
 [ ] 8. Banded raster (multi-strip image): continuous, no gaps/stutter?
 [ ] 9. Mixed sample: Latin text lines + Persian raster lines interleave
        at consistent line height?

--- a/docs/printing-nonlatin-capabilities.md
+++ b/docs/printing-nonlatin-capabilities.md
@@ -1,0 +1,217 @@
+# Non-Latin thermal receipt printing — capability study and decision record
+
+**Refs:** #446 (research issue) · epic #438
+**Status of this document:** Study and decision record. It describes a *recommended* target architecture that is **not yet implemented**; production renderers are unchanged. Any prototype or dependency adoption requires separate review (see Section 8, *Open decisions*).
+
+---
+
+## 1. Problem
+
+Raw thermal printing of Persian/Arabic — and non-Latin scripts generally — currently degrades to a stopgap: a per-profile `arabicShaping` passthrough plus skip-with-warning behavior.
+
+Current code (verified at the time of writing):
+
+| Location | Behavior |
+| --- | --- |
+| `main/printers/profiles.ts` (`SupportedPrinterProfile.arabicShaping`) | Profile flag declaring firmware Arabic shaping; unset/false on all four shipped profiles. |
+| `main/printers/thermal.ts` (`buildEscPos`) | Lines whose non-currency content is not ASCII are skipped with a warning, unless `arabicShaping` passes the strict Arabic-only rule. |
+| `frontend/src/lib/printer/warnings.ts` (`safePrinterText`, `isArabicShapingSafeLine`) | Browser/WebUSB encoders mirror the same guard so both paths degrade identically. |
+| `shared/print/direction.ts` | Direction model: per-document/block/value direction with conservative LTR-island classification (`isLtrIsland`, `containsRtlScript`). |
+
+Why generic ESC/POS printers fail non-Latin text:
+
+1. **Missing glyphs.** Cheap 58 mm / 80 mm clones carry small font ROMs covering CP437/CP850-class sets. Arabic, Hebrew, Devanagari, Thai, and CJK glyphs are absent, so bytes print as garbage or blank.
+2. **No contextual shaping.** Arabic/Persian requires contextual letter forms; printer firmware renders isolated forms at best.
+3. **No bidirectional reordering.** Printers emit left-to-right only; logical-order RTL text prints reversed.
+4. **Code pages do not save us** (evidence below).
+
+The end-state contract from epic #438 is **no silent data loss**: native render, explicitly supported fallback, or an explicit warning/error — never quiet omission of financial content.
+
+## 2. Method
+
+- Code paths above were read directly; line-level references reflect the state after #443/#473/#474/#472 landed.
+- External evidence: Epson's official ESC/POS command reference, the ReceiptPrinterEncoder/escpos-php/python-escpos/node-thermal-printer issue trackers, Odoo's IoT printer driver source, and qzind/tray. Links inline.
+- First-class user requirements come from real reports by @MaMaDTHUG82 (Iran, Meva TP-UN hardware): #437, #241, discussions #239/#326.
+
+## 3. Approach comparison
+
+### 3.1 Printer-native Arabic/Persian shaping (the `arabicShaping` profile flag)
+
+The flag means: *this specific printer's firmware performs contextual shaping and bidi ordering*. It must stay default-off and be set true only after a real print on the specific hardware proves shaped output. Reality:
+
+- Generic ESC/POS firmware does none of this. Even on models that accept Arabic bytes, output is isolated forms printed left-to-right unless the host pre-shapes and pre-reverses.
+- The qzind/tray experience (Epson TM-T88VI + vendor utility + ICU mapping down to IBM864 with byte swapping) shows even best-case native support is model-specific and fragile ([ReceiptPrinterEncoder issue #26](https://github.com/NielsLeenheer/ReceiptPrinterEncoder/issues/26)).
+
+**Verdict:** keep as an opt-in passthrough tier for proven hardware only. Not a general solution.
+
+### 3.2 Printer-native code pages (CP1256 / CP720 / CP864 / kanji modes)
+
+- Epson's reference states the `FS &` kanji mode *"can be used only for the Japanese, Simplified Chinese, Traditional Chinese models, and Korean models"* — regional firmware variants our users do not own ([Epson ESC/POS reference](https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/fs_ampersand.html)).
+- Arabic code pages contain base/isolated glyph forms only → visibly broken letters for native readers; right-to-left ordering is still the host's problem.
+- Table identity ≠ glyph layout across vendors; unmappable characters silently become `?` (iconv-lite translation in [node-thermal-printer PR #81](https://github.com/Klemen1337/node-thermal-printer/pull/81); [ReceiptPrinterEncoder #26](https://github.com/NielsLeenheer/ReceiptPrinterEncoder/issues/26)).
+
+**Verdict:** dead end for quality; unmaintainable across clone vendors.
+
+### 3.3 UTF-8 pass-through
+
+Some modern firmware accepts raw multi-byte UTF-8 against internal fonts. Coverage and shaping vary per model and revision; there is no discovery mechanism, and cheap clones fail unpredictably. Useful as a *reported capability* on the hardware test matrix (Section 6), never as an assumed baseline.
+
+### 3.4 Host-side shaping + bidi reordering before emission
+
+Send pre-shaped presentation forms (Unicode Arabic Presentation Forms-B) in visual order as text bytes.
+
+| Criterion | Assessment |
+| --- | --- |
+| Printer requirement | Printer must accept multi-byte UTF-8 **and** have glyphs for the shaped codepoints. Cheap clones fail both — shaped Arabic arrives as U+FE7x–U+FExx which their font ROMs lack. |
+| Fidelity | Correct *when* glyphs exist; host must reverse visual order itself. |
+| Mixed-script rows | Hard: visual-order strings break column math and truncation (cutting visual order cuts the logical start). The kernel's LTR-island model helps alignment, not truncation. |
+| Dependency footprint | Lightweight tier exists: `bidi-js` (~20 kB pure JS) plus an Arabic reshaper covers Arabic/Hebrew receipts. Full HarfBuzz via WASM (`harfbuzzjs`, subset build ≈ 613 kB) is only needed for complex Indic/Khmer conjuncts. |
+
+**Verdict:** a *necessary component* of any non-Latin pipeline (something must produce correctly shaped, ordered pixels), but **insufficient alone** — it does not reach printers without the glyphs.
+
+### 3.5 Raster rendering (`GS v 0`)
+
+Render the receipt (or parts) to a 1-bit bitmap and print it with `GS v 0 m xL xH yL yH`.
+
+- `GS v 0` is the mechanism every printer uses for logos; it is implemented across the entire ESC/POS clone ecosystem, including the cheapest hardware. Density mode `m=0` (8 dots/mm both axes) matches standard 203 dpi receipt heads.
+- Reference implementation scale test: Odoo's IoT box converts every receipt image to greyscale → 1-bit → `GS v 0` → cut ([odoo/odoo `PrinterDriver.print_receipt`](https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver.py)); their commit replacing the old ESC/POS text encoder states: *"We now transform the receipts to JPGs, transform these JPGs into ESCPOS commands and send them via Cups."* This runs across one of the largest heterogeneous open-source POS fleets in existence.
+
+| Criterion | Assessment |
+| --- | --- |
+| Printer requirement | Effectively universal (logo path). |
+| Fidelity | Pixel-exact for any script, digits, mixed-direction rows, logos. Shaping/bidi correctness becomes whatever the host canvas draws — the browser/canvas applies the Unicode bidi algorithm natively. |
+| Mixed-script correctness | Trivial: no column math on RTL text; truncation becomes measured pixel width with ellipsis. |
+| Performance | Payload grows from ~1–2 KB (text receipt) to ≈ 72 B × ~1150 dot rows ≈ 80 KB (80 mm) / ≈ 55 KB (58 mm). Transfer over TCP 9100 / USB bulk is sub-second; head time is unchanged because the same paper area prints either way. Slow MCUs on clones can stutter on very large single images — solved by banding (Section 5). |
+| Paper width / density | Requires dots-per-line knowledge: 384 (58 mm) vs 576 (80 mm) at 203 dpi. Derivable from the existing paper-width profile data. |
+| Transport support | Identical byte stream on TCP, USB RAW queues, and WebUSB — it is ordinary bytes after init. OS spooler RAW pass-through is proven by Odoo/CUPS. No WebUSB-specific work. |
+| Package size impact | None at the protocol layer. Cost lives in the host rendering engine and bundled script fonts (a dependency question — see Section 7). |
+| Maintenance burden | One renderer consuming the semantic print kernel; new scripts become font additions, not logic changes. |
+| Failure/fallback mode | Falls back to today's exact behavior (native attempt + explicit warning). Never worse than status quo. |
+
+**Verdict:** the only approach satisfying "universal system that supports ALL printers".
+
+### 3.6 HTML/browser fallback
+
+The browser print path already renders every script correctly (the browser does shaping and bidi). It remains a steering target when raw printing is unacceptable, but it cannot serve instant raw-cut workflows, KOT station routing, or spooler-free checkout speed. Out of scope for further comparison.
+
+### 3.7 Criteria matrix summary
+
+| Approach | Works on cheap clones | Correct Arabic/Persian | Mixed rows | Transport coverage | Extra deps | Failure mode |
+| --- | --- | --- | --- | --- | --- | --- |
+| Native shaping flag | ✗ rare | ✓ only on proven units | partial | all | none | garbled/skip |
+| Native code pages | ✗ | ✗ isolated forms | ✗ | all | none | garbage, `?` |
+| UTF-8 pass-through | varies | varies | varies | all | none | mojibake |
+| Host shaping + bidi text | ✗ (glyph gap) | partial | hard | all | small | blank/garbage |
+| **Raster `GS v 0`** | **✓** | **✓** | **✓** | **all raw transports** | rendering engine (Section 7) | falls back to skip+warn |
+
+## 4. What other systems do
+
+| System | Multilingual receipt strategy | Evidence |
+| --- | --- | --- |
+| Odoo POS (IoT box) | Whole-receipt raster for everything; old ESC/POS text encoder retired | [`PrinterDriver.print_receipt` source](https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver.py), [hw_escpos replacement commit](https://github.com/odoo/odoo/commit/03b2f7b77dc6189bb485e0b834dba5f6d3d4da2c) |
+| escpos-php | Unicode→code-page auto-mapping; official Arabic example renders **images** instead of text lines | [Arabic example](https://github.com/mike42/escpos-php/blob/master/example/specific/6-arabic-epos-tep-220m.php) |
+| python-escpos | Exposes charcode selection only; recurring Arabic mojibake issues resolved by users switching to raster | [#37](https://github.com/python-escpos/python-escpos/issues/37), [#633](https://github.com/python-escpos/python-escpos/issues/633) |
+| node-thermal-printer | iconv-lite code-page translation; shaping/bidi unsupported; Arabic/Thai requests open for years | [PR #81](https://github.com/Klemen1337/node-thermal-printer/pull/81), [#180](https://github.com/Klemen1337/node-thermal-printer/issues/180) |
+| ReceiptPrinterEncoder | Maintainer guidance: proper Arabic printing = draw a bitmap | [#26](https://github.com/NielsLeenheer/ReceiptPrinterEncoder/issues/26) |
+| Loyverse | Prints through manufacturer SDKs, which render bitmaps internally on mobile | [supported printers](https://help.loyverse.com/help/supported-printers) |
+| qzind/tray | ICU-based host shaping down to IBM864 + byte swap; author notes most projects give up and send rasters | [PR #339 discussion](https://github.com/qzind/tray/pull/339#issuecomment-404016953) |
+
+Consensus: host-rendered bitmaps are the universal fallback; code pages are a dead end for Arabic/Persian.
+
+## 5. Recommended architecture (decision record)
+
+**Primary approach: capability-tiered hybrid with raster as the universal guarantee.**
+
+```
+PrintDocument ──► renderer decides per line/block:
+   Tier 1  Pure Latin/ASCII            → native ESC/POS text (unchanged bytes, fastest)
+   Tier 2  Non-Latin + profile proves
+           firmware shaping            → existing arabicShaping passthrough (semantics unchanged)
+   Tier 3  Everything else             → host-shaped, bidi-correct RASTER band(s) via GS v 0
+                                         [mixed mode; default for non-Latin content]
+   Tier 4  Whole-receipt raster        → opt-in compatibility toggle / fallback if mixed
+                                         mode misbehaves on specific hardware
+   Tier 5  Skip-with-warning           → retained last resort; never silent
+```
+
+Per transport: identical strategy everywhere — TCP 9100, USB RAW, and WebUSB all move the same byte stream. The browser HTML path needs nothing.
+
+Migration implications for the legacy skip-with-warning path: once raster is proven on real hardware, tiers shift upward (skipped lines become raster bands); skip-with-warning remains the terminal fallback when raster is disabled or fails, preserving the no-silent-data-loss contract.
+
+Integration notes for the future implementation crew (descriptive, no code changed by this document):
+
+- A raster renderer is another consumer of the shared print kernel (`shared/print/document.ts`), like the existing classic/compact/KOT/merchant renderers; it receives semantic blocks, not business truth.
+- The natural seam is the line-emission guard in the backend encoder and its frontend mirror (`safePrinterText`): doomed lines convert to raster bands instead of warnings.
+- Capability flags belong on `SupportedPrinterProfile` alongside `arabicShaping` (for example a raster-support flag and dots-per-line derived from paper width), consistent with epic principle 8.
+- Bundled open script fonts (Noto family subsets) satisfy offline-first principle 1 — no remote fonts.
+
+Risks and mitigations:
+
+| Risk | Mitigation |
+| --- | --- |
+| Print speed on slow MCU clones | Band images into ≤ ~200-dot-row strips; mixed mode keeps most of a typical Persian receipt native text. |
+| Low-end printer memory | Same banding; Odoo ships whole-image raster across a huge fleet, so residual risk is low. |
+| Density/DPI variance | Derive dots-per-line from paper width; verify visually via the test-page raster probe (Section 7). Avoid `m≠0` density modes until hardware-proven. |
+| Cutter position | Existing feed-before-cut sequence retained (Odoo likewise uses feed + partial cut). |
+| Baseline mismatch between native text lines and raster bands | Render bands at multiples of the 24-dot Font A line height; emulate double width/height by scaling pixels. |
+| RTL truncation/column math | Disappears inside raster bands (pixel-measured ellipsis); kernel island logic continues to govern native-text alignment. |
+| Regression risk for English receipts | Tier 1 keeps current byte streams; parity tests assert ASCII byte-identity (extends the #439 harness). |
+
+## 6. Community hardware-test matrix checklist
+
+Owners of real printers: run this checklist and report results (issue comment or discussion post) with a photo of each printout. One row per printer model.
+
+```
+Printer model:            Connection:      network / usb / webusb
+Paper width:              58mm / 80mm      Firmware date (if known):
+
+[ ] 1. ASCII text receipt prints cleanly (baseline)
+[ ] 2. Test page prints; column ruler aligns to paper edges
+[ ] 3. UTF-8 pass-through: paste of "فارسی Hello עברית ไทย हिन्दी"
+       prints as…  correct / reversed / boxes / blank / garbage
+[ ] 4. Code page probe (if the app exposes it): CP1256 result ___
+[ ] 5. Firmware Arabic shaping probe: unshaped-but-reversed Persian
+       looks connected?  yes / no
+[ ] 6. Raster probe (test page band, Section 7): prints?  yes / no
+[ ] 7. Raster width: band fills the printable width edge-to-edge?
+[ ] 8. Banded raster (multi-strip image): continuous, no gaps/stutter?
+[ ] 9. Mixed sample: Latin text lines + Persian raster lines interleave
+       at consistent line height?
+[ ] 10. Cut position correct after raster tail?  full / partial / failed
+[ ] 11. Timing: text receipt ___ s ; raster receipt ___ s
+[ ] 12. Photo(s) attached
+```
+
+Seed validators: @MaMaDTHUG82 (Meva TP-UN, Iran — reporter of #437), plus FloCafe customers in Morocco and India. Priority unknowns: whether budget clones handle banded `GS v 0` without stutter (expected yes), and which models mishandle non-default density modes.
+
+## 7. Test-page raster probe specification
+
+A future test-page enhancement (flag-gated; **not part of this change**) adds a diagnostic band so remote users can validate raster support with a single photo:
+
+1. After the existing ruler/edge-probe section, emit a solid black rectangle: `widthDots - 16` dots wide, 48 dot rows tall, as one `GS v 0` band (`m=0`, xL/xH = `(widthBytes)` little-endian, yL/yH = 48 little-endian).
+2. Follow with a second band containing inverted checkerboard (8×8 dot cells) to reveal dithering/density misconfiguration.
+3. Emit a third band scaled to half height (24 rows) to expose vertical density mismatch (`m=0` assumes square dots at 203 dpi).
+4. Close with the standard feed + cut sequence so cutter position is validated in the same printout.
+5. Expected result on healthy hardware: crisp solid bar, uniform checkerboard, correct proportions, clean cut. Any band missing, skewed, or stretched indicates a raster/density defect to report in the checklist above.
+
+Implementation note for that future change: reuse the profile-derived dots-per-line rather than hardcoding 384/576, and route through the same dispatch used by ordinary receipts so all transports are exercised.
+
+## 8. Open decisions requiring a human call
+
+- **Rendering-engine dependency** for the host side (needed by Tiers 3–4, evaluated separately per #446 rules; nothing was added to `package.json` in this change):
+  - (a) canvas library in the Electron main process (full shaping + bidi via Skia; native binary weight);
+  - (b) pure-JS stack: WASM-shaped HarfBuzz subset (~613 kB) + outline rasterization (zero native deps, most implementation effort);
+  - (c) render in the renderer process over IPC (no new deps, coupling/latency cost).
+- Whether Tier 4 whole-receipt raster should ship as a user-facing compatibility toggle from day one or remain internal fallback until telemetry justifies exposure.
+
+## 9. References
+
+- Epson ESC/POS command reference, `FS &`: <https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/fs_ampersand.html>
+- ReceiptPrinterEncoder Arabic thread: <https://github.com/NielsLeenheer/ReceiptPrinterEncoder/issues/26>
+- Odoo IoT printer driver: <https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver.py> · replacement rationale: <https://github.com/odoo/odoo/commit/03b2f7b77dc6189bb485e0b834dba5f6d3d4da2c>
+- escpos-php Arabic example: <https://github.com/mike42/escpos-php/blob/master/example/specific/6-arabic-epos-tep-220m.php>
+- node-thermal-printer code-page translation: <https://github.com/Klemen1337/node-thermal-printer/pull/81>
+- python-escpos Arabic issues: <https://github.com/python-escpos/python-escpos/issues/37>, <https://github.com/python-escpos/python-escpos/issues/633>
+- qzind/tray IBM864 approach: <https://github.com/qzind/tray/pull/339#issuecomment-404016953>
+- Loyverse supported printers: <https://help.loyverse.com/help/supported-printers>
+- FloCafe user cases: #437 (Persian items dropped from bills; Meva TP-UN), #241 (mixed-script bidi scramble example «برای شروع QR کد را اسکن کنید»; Persian digits/Toman/Shamsi preferences), discussions #239/#326.


### PR DESCRIPTION
## Intent

Ship the #446 docs deliverables for epic #438: add docs/printing-nonlatin-capabilities.md — an evidence-based capability study and decision record for non-Latin scripts on ESC/POS thermal printers — plus the community hardware-test matrix checklist and test-page raster probe specification, and link the study from docs/printers.md and docs/README.md. Scope constraints set by the captain: documentation only; do NOT touch production renderers and do NOT add any dependency (the rendering-engine dependency decision stays a captain call, listed as an open decision in the doc). PR body must carry Fixes #446 Refs #438.

## What Changed

- Add `docs/printing-nonlatin-capabilities.md`, an evidence-based capability study and decision record for non-Latin scripts (Arabic/Persian, Hebrew, CJK, Indic) on ESC/POS thermal printers: compares the candidate approaches (printer-native `arabicShaping` passthrough, legacy code pages, UTF-8 pass-through, host-side shaping + bidi reordering, `GS v 0` raster rendering, HTML/browser fallback) and recommends a capability-tiered architecture that keeps pure Latin output on native ESC/POS bytes while falling back to host-shaped, bidi-correct raster bands for non-Latin content.
- Include the community hardware-test matrix checklist (one row per printer model: connection, paper width, firmware, per-script results reported with photos) and a flag-gated test-page raster probe specification (solid black band, inverted checkerboard, half-height band) for remote raster/density validation, plus an open-decisions section headed by the rendering-engine dependency choice (canvas in the Electron main process vs pure-JS WASM HarfBuzz stack vs renderer-process IPC).
- Link the new study from `docs/printers.md` and index it as FORWARD-LOOKING in `docs/README.md`; the delta touches documentation only, changing no production renderer code and adding no dependency.

Fixes #446. Refs #438.

## Risk Assessment

✅ Low: Documentation-only change whose three prior findings are each verified fixed against current file contents (all section cross-references resolve correctly, the FORWARD-LOOKING row sits in the correct index table, and the checklist inset figure matches the specified widthDots - 16 probe at ~1 mm per side), with every code-location claim spot-checked as accurate and intent constraints fully satisfied.

## Testing

Exercised the change end-to-end as a reader would see it: confirmed the diff is exactly three docs files (documentation-only, no dependency, no renderer changes), validated the study's code-behavior claims against the live source, ran a link/section-reference resolver proving every relative link, anchor, and Section N cross-reference resolves including the two new cross-links, cross-checked the deliverables against issue #446's mandate, then rendered all three documents through marked/GFM and captured Chrome screenshots of the key sections and both link sites. All checks passed; artifacts are in /Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH and the worktree is left clean.

- Evidence: Screenshot: study title, status banner, and verified current-code table (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH/study-01-title-status-problem.png</code>)
- Evidence: Screenshot: Section 3.7 criteria matrix and Section 4 evidence table (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH/study-02-criteria-matrix.png</code>)
- Evidence: Screenshot: Section 5 decision record with capability tiers and risk table (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH/study-03-decision-record.png</code>)
- Evidence: Screenshot: Section 6 community hardware-test checklist and Section 7 probe spec (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH/study-04-hardware-checklist.png</code>)
- Evidence: Screenshot: Section 7 test-page raster probe specification detail (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH/study-05-raster-probe-spec.png</code>)
- Evidence: Full-page render of the complete study document (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH/study-full-page.jpeg</code>)
- Evidence: Screenshot: new linking paragraph in docs/printers.md (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH/link-site-printers-doc.png</code>)
- Evidence: Screenshot: new FORWARD-LOOKING index row in docs/README.md (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH/link-site-readme-index.png</code>)

<details>
<summary>Evidence: Rendered HTML of the full study document</summary>

```text
<!doctype html>
<html><head><meta charset="utf-8"><title>printing-nonlatin-capabilities</title>
<style>
  :root { color-scheme: light; }
  body { margin: 0; background: #fff; color: #1f2328;
    font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
    -webkit-font-smoothing: antialiased; }
  main { max-width: 980px; margin: 0 auto; padding: 32px 32px 96px; }
  h1, h2 { line-height: 1.25; border-bottom: 1px solid #d1d9de; padding-bottom: .3em; }
  h1 { font-size: 2em; } h2 { font-size: 1.5em; margin-top: 24px; }
  h3 { font-size: 1.25em; margin-top: 24px; }
  table { border-collapse: collapse; margin: 16px 0; display: block; overflow-x: auto; max-width: 100%; }
  th, td { border: 1px solid #d1d9de; padding: 6px 13px; }
  th { background: #f6f8fa; font-weight: 600; }
  tr:nth-child(2n) td { background: #f6f8fa; }
  code { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
    font-size: 85%; background: rgba(129,139,152,.12); padding: .2em .4em; border-radius: 6px; }
  pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; line-height: 1.45; }
  pre code { background: none; padding: 0; font-size: 100%; }
  blockquote { border-left: 4px solid #d1d9de; color: #656d76; margin: 0 0 16px; padding: 0 1em; }
  li { margin: .25em 0; }
  li input[type=checkbox] { margin-right: .5em; }
  hr { height: .25em; background: #d1d9de; border: 0; margin: 24px 0; }
  a { color: #0969da; text-decoration: none; } a:hover { text-decoration: underline; }
</style></head><body><main><h1 id="non-latin-thermal-receipt-printing-capability-study-and-decision-record">Non-Latin thermal receipt printing — capability study and decision record</h1>
<p><strong>Refs:</strong> #446 (research issue) · epic #438
<strong>Status of this document:</strong> Study and decision record. It describes a <em>recommended</em> target architecture that is <strong>not yet implemented</strong>; production renderers are unchanged. Any prototype or dependency adoption requires separate review (see Section 8, <em>Open decisions</em>).</p>
<hr>
<h2 id="1-problem">1. Problem</h2>
<p>Raw thermal printing of Persian/Arabic — and non-Latin scripts generally — currently degrades to a stopgap: a per-profile <code>arabicShaping</code> passthrough plus skip-with-warning behavior.</p>
<p>Current code (verified at the time of writing):</p>
<table>
<thead>
<tr>
<th>Location</th>
<th>Behavior</th>
</tr>
</thead>
<tbody><tr>
<td><code>main/printers/profiles.ts</code> (<code>SupportedPrinterProfile.arabicShaping</code>)</td>
<td>Profile flag declaring firmware Arabic shaping; unset/false on all four shipped profiles.</td>
</tr>
<tr>
<td><code>main/printers/thermal.ts</code> (<code>buildEscPos</code>)</td>
<td>Lines whose non-currency content is not ASCII are skipped with a warning, unless <code>arabicShaping</code> passes the strict Arabic-only rule.</td>
</tr>
<tr>
<td><code>frontend/src/lib/printer/warnings.ts</code> (<code>safePrinterText</code>, <code>isArabicShapingSafeLine</code>)</td>
<td>Browser/WebUSB encoders mirror the same guard so both paths degrade identically.</td>
</tr>
<tr>
<td><code>shared/print/direction.ts</code></td>
<td>Direction model: per-document/block/value direction with conservative LTR-island classification (<code>isLtrIsland</code>, <code>containsRtlScript</code>).</td>
</tr>
</tbody></table>
<p>Why generic ESC/POS printers fail non-Latin text:</p>
<ol>
<li><strong>Missing glyphs.</strong> Cheap 58 mm / 80 mm clones carry small font ROMs covering CP437/CP850-class sets. Arabic, Hebrew, Devanagari, Thai, and CJK glyphs are absent, so bytes print as garbage or blank.</li>
<li><strong>No contextual shaping.</strong> Arabic/Persian requires contextual letter forms; printer firmware renders isolated forms at best.</li>
<li><strong>No bidirectional reordering.</strong> Printers emit left-to-right only; logical-order RTL text prints reversed.</li>
<li><strong>Code pages do not save us</strong> (evidence below).</li>
</ol>
<p>The end-state contract from epic #438 is <strong>no silent data loss</strong>: native render, explicitly supported fallback, or an explicit warning/error — never quiet omission of financial content.</p>
<h2 id="2-method">2. Method</h2>
<ul>
<li>Code paths above were read directly; line-level references reflect the state after #443/#473/#474/#472 landed.</li>
<li>External evidence: Epson&#39;s official ESC/POS command reference, the ReceiptPrinterEncoder/escpos-php/python-escpos/node-thermal-printer issue trackers, Odoo&#39;s IoT printer driver source, and qzind/tray. Links inline.</li>
<li>First-class user requirements come from real reports by @MaMaDTHUG82 (Iran, Meva TP-UN hardware): #437, #241, discussions #239/#326.</li>
</ul>
<h2 id="3-approach-comparison">3. Approach comparison</h2>
<h3 id="31-printer-native-arabicpersian-shaping-the-arabicshaping-profile-flag">3.1 Printer-native Arabic/Persian shaping (the <code>arabicShaping</code> profile flag)</h3>
<p>The flag means: <em>this specific printer&#39;s firmware performs contextual shaping and bidi ordering</em>. It must stay default-off and be set true only after a real print on the specific hardware proves shaped output. Reality:</p>
<ul>
<li>Generic ESC/POS firmware does none of this. Even on models that accept Arabic bytes, output is isolated forms printed left-to-right unless the host pre-shapes and pre-reverses.</li>
<li>The qzind/tray experience (Epson TM-T88VI + vendor utility + ICU mapping down to IBM864 with byte swapping) shows even best-case native support is model-specific and fragile (<a href="https://github.com/NielsLeenheer/ReceiptPrinterEncoder/issues/26">ReceiptPrinterEncoder issue #26</a>).</li>
</ul>
<p><strong>Verdict:</strong> keep as an opt-in passthrough tier for proven hardware only. Not a general solution.</p>
<h3 id="32-printer-native-code-pages-cp1256-cp720-cp864-kanji-modes">3.2 Printer-native code pages (CP1256 / CP720 / CP864 / kanji modes)</h3>
<ul>
<li>Epson&#39;s reference states the <code>FS &amp;</code> kanji mode <em>&quot;can be used only for the Japanese, Simplified Chinese, Traditional Chinese models, and Korean models&quot;</em> — regional firmware variants our users do not own (<a href="https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/fs_ampersand.html">Epson ESC/POS reference</a>).</li>
<li>Arabic code pages contain base/isolated glyph forms only → visibly broken letters for native readers; right-to-left ordering is still the host&#39;s problem.</li>
<li>Table identity ≠ glyph layout across vendors; unmappable characters silently become <code>?</code> (iconv-lite translation in <a href="https://github.com/Klemen1337/node-thermal-printer/pull/81">node-thermal-printer PR #81</a>; <a href="https://github.com/NielsLeenheer/ReceiptPrinterEncoder/issues/26">ReceiptPrinterEncoder #26</a>).</li>
</ul>
<p><strong>Verdict:</strong> dead end for quality; unmaintainable across clone vendors.</p>
<h3 id="33-utf-8-pass-through">3.3 UTF-8 pass-through</h3>
<p>Some modern firmware accepts raw multi-byte UTF-8 against internal fonts. Coverage and shaping vary per model and revision; there is no discovery mechanism, and cheap clones fail unpredictably. Useful as a <em>reported capability</em> on the hardware test matrix (Section 6), never as an assumed baseline.</p>
<h3 id="34-host-side-shaping-bidi-reordering-before-emission">3.4 Host-side shaping + bidi reordering before emission</h3>
<p>Send pre-shaped presentation forms (Unicode Arabic Presentation Forms-B) in visual order as text bytes.</p>
<table>
<thead>
<tr>
<th>Criterion</th>
<th>Assessment</th>
</tr>
</thead>
<tbody><tr>
<td>Printer requirement</td>
<td>Printer must accept multi-byte UTF-8 <strong>and</strong> have glyphs for the shaped codepoints. Cheap clones fail both — shaped Arabic arrives as U+FE7x–U+FExx which their font ROMs lack.</td>
</tr>
<tr>
<td>Fidelity</td>
<td>Correct <em>when</em> glyphs exist; host must reverse visual order itself.</td>
</tr>
<tr>
<td>Mixed-script rows</td>
<td>Hard: visual-order strings break column math and truncation (cutting visual order cuts the logical start). The kernel&#

... [8933 bytes truncated] ...

ul>
<li>A raster renderer is another consumer of the shared print kernel (<code>shared/print/document.ts</code>), like the existing classic/compact/KOT/merchant renderers; it receives semantic blocks, not business truth.</li>
<li>The natural seam is the line-emission guard in the backend encoder and its frontend mirror (<code>safePrinterText</code>): doomed lines convert to raster bands instead of warnings.</li>
<li>Capability flags belong on <code>SupportedPrinterProfile</code> alongside <code>arabicShaping</code> (for example a raster-support flag and dots-per-line derived from paper width), consistent with epic principle 8.</li>
<li>Bundled open script fonts (Noto family subsets) satisfy offline-first principle 1 — no remote fonts.</li>
</ul>
<p>Risks and mitigations:</p>
<table>
<thead>
<tr>
<th>Risk</th>
<th>Mitigation</th>
</tr>
</thead>
<tbody><tr>
<td>Print speed on slow MCU clones</td>
<td>Band images into ≤ ~200-dot-row strips; mixed mode keeps most of a typical Persian receipt native text.</td>
</tr>
<tr>
<td>Low-end printer memory</td>
<td>Same banding; Odoo ships whole-image raster across a huge fleet, so residual risk is low.</td>
</tr>
<tr>
<td>Density/DPI variance</td>
<td>Derive dots-per-line from paper width; verify visually via the test-page raster probe (Section 7). Avoid <code>m≠0</code> density modes until hardware-proven.</td>
</tr>
<tr>
<td>Cutter position</td>
<td>Existing feed-before-cut sequence retained (Odoo likewise uses feed + partial cut).</td>
</tr>
<tr>
<td>Baseline mismatch between native text lines and raster bands</td>
<td>Render bands at multiples of the 24-dot Font A line height; emulate double width/height by scaling pixels.</td>
</tr>
<tr>
<td>RTL truncation/column math</td>
<td>Disappears inside raster bands (pixel-measured ellipsis); kernel island logic continues to govern native-text alignment.</td>
</tr>
<tr>
<td>Regression risk for English receipts</td>
<td>Tier 1 keeps current byte streams; parity tests assert ASCII byte-identity (extends the #439 harness).</td>
</tr>
</tbody></table>
<h2 id="6-community-hardware-test-matrix-checklist">6. Community hardware-test matrix checklist</h2>
<p>Owners of real printers: run this checklist and report results (issue comment or discussion post) with a photo of each printout. One row per printer model.</p>
<pre><code>Printer model:            Connection:      network / usb / webusb
Paper width:              58mm / 80mm      Firmware date (if known):

[ ] 1. ASCII text receipt prints cleanly (baseline)
[ ] 2. Test page prints; column ruler aligns to paper edges
[ ] 3. UTF-8 pass-through: paste of &quot;فارسی Hello עברית ไทย हिन्दी&quot;
       prints as…  correct / reversed / boxes / blank / garbage
[ ] 4. Code page probe (if the app exposes it): CP1256 result ___
[ ] 5. Firmware Arabic shaping probe: unshaped-but-reversed Persian
       looks connected?  yes / no
[ ] 6. Raster probe (test page band, Section 7): prints?  yes / no
[ ] 7. Raster width: solid bar spans full width except the small
       designed inset (~1mm/side)?  full / shrunk / clipped
[ ] 8. Banded raster (multi-strip image): continuous, no gaps/stutter?
[ ] 9. Mixed sample: Latin text lines + Persian raster lines interleave
       at consistent line height?
[ ] 10. Cut position correct after raster tail?  full / partial / failed
[ ] 11. Timing: text receipt ___ s ; raster receipt ___ s
[ ] 12. Photo(s) attached
</code></pre>
<p>Seed validators: @MaMaDTHUG82 (Meva TP-UN, Iran — reporter of #437), plus FloCafe customers in Morocco and India. Priority unknowns: whether budget clones handle banded <code>GS v 0</code> without stutter (expected yes), and which models mishandle non-default density modes.</p>
<h2 id="7-test-page-raster-probe-specification">7. Test-page raster probe specification</h2>
<p>A future test-page enhancement (flag-gated; <strong>not part of this change</strong>) adds a diagnostic band so remote users can validate raster support with a single photo:</p>
<ol>
<li>After the existing ruler/edge-probe section, emit a solid black rectangle: <code>widthDots - 16</code> dots wide, 48 dot rows tall, as one <code>GS v 0</code> band (<code>m=0</code>, xL/xH = <code>(widthBytes)</code> little-endian, yL/yH = 48 little-endian).</li>
<li>Follow with a second band containing inverted checkerboard (8×8 dot cells) to reveal dithering/density misconfiguration.</li>
<li>Emit a third band scaled to half height (24 rows) to expose vertical density mismatch (<code>m=0</code> assumes square dots at 203 dpi).</li>
<li>Close with the standard feed + cut sequence so cutter position is validated in the same printout.</li>
<li>Expected result on healthy hardware: crisp solid bar, uniform checkerboard, correct proportions, clean cut. Any band missing, skewed, or stretched indicates a raster/density defect to report in the checklist above.</li>
</ol>
<p>Implementation note for that future change: reuse the profile-derived dots-per-line rather than hardcoding 384/576, and route through the same dispatch used by ordinary receipts so all transports are exercised.</p>
<h2 id="8-open-decisions-requiring-a-human-call">8. Open decisions requiring a human call</h2>
<ul>
<li><strong>Rendering-engine dependency</strong> for the host side (needed by Tiers 3–4, evaluated separately per #446 rules; nothing was added to <code>package.json</code> in this change):<ul>
<li>(a) canvas library in the Electron main process (full shaping + bidi via Skia; native binary weight);</li>
<li>(b) pure-JS stack: WASM-shaped HarfBuzz subset (~613 kB) + outline rasterization (zero native deps, most implementation effort);</li>
<li>(c) render in the renderer process over IPC (no new deps, coupling/latency cost).</li>
</ul>
</li>
<li>Whether Tier 4 whole-receipt raster should ship as a user-facing compatibility toggle from day one or remain internal fallback until telemetry justifies exposure.</li>
</ul>
<h2 id="9-references">9. References</h2>
<ul>
<li>Epson ESC/POS command reference, <code>FS &amp;</code>: <a href="https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/fs_ampersand.html">https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/fs_ampersand.html</a></li>
<li>ReceiptPrinterEncoder Arabic thread: <a href="https://github.com/NielsLeenheer/ReceiptPrinterEncoder/issues/26">https://github.com/NielsLeenheer/ReceiptPrinterEncoder/issues/26</a></li>
<li>Odoo IoT printer driver: <a href="https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver.py">https://github.com/odoo/odoo/blob/master/addons/iot_drivers/iot_handlers/drivers/printer_driver.py</a> · replacement rationale: <a href="https://github.com/odoo/odoo/commit/03b2f7b77dc6189bb485e0b834dba5f6d3d4da2c">https://github.com/odoo/odoo/commit/03b2f7b77dc6189bb485e0b834dba5f6d3d4da2c</a></li>
<li>escpos-php Arabic example: <a href="https://github.com/mike42/escpos-php/blob/master/example/specific/6-arabic-epos-tep-220m.php">https://github.com/mike42/escpos-php/blob/master/example/specific/6-arabic-epos-tep-220m.php</a></li>
<li>node-thermal-printer code-page translation: <a href="https://github.com/Klemen1337/node-thermal-printer/pull/81">https://github.com/Klemen1337/node-thermal-printer/pull/81</a></li>
<li>python-escpos Arabic issues: <a href="https://github.com/python-escpos/python-escpos/issues/37">https://github.com/python-escpos/python-escpos/issues/37</a>, <a href="https://github.com/python-escpos/python-escpos/issues/633">https://github.com/python-escpos/python-escpos/issues/633</a></li>
<li>qzind/tray IBM864 approach: <a href="https://github.com/qzind/tray/pull/339#issuecomment-404016953">https://github.com/qzind/tray/pull/339#issuecomment-404016953</a></li>
<li>Loyverse supported printers: <a href="https://help.loyverse.com/help/supported-printers">https://help.loyverse.com/help/supported-printers</a></li>
<li>FloCafe user cases: #437 (Persian items dropped from bills; Meva TP-UN), #241 (mixed-script bidi scramble example «برای شروع QR کد را اسکن کنید»; Persian digits/Toman/Shamsi preferences), discussions #239/#326.</li>
</ul>

</main></body></html>
```
</details>
<details>
<summary>Evidence: Rendered HTML of docs/printers.md</summary>

```text
<!doctype html>
<html><head><meta charset="utf-8"><title>printers</title>
<style>
  :root { color-scheme: light; }
  body { margin: 0; background: #fff; color: #1f2328;
    font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
    -webkit-font-smoothing: antialiased; }
  main { max-width: 980px; margin: 0 auto; padding: 32px 32px 96px; }
  h1, h2 { line-height: 1.25; border-bottom: 1px solid #d1d9de; padding-bottom: .3em; }
  h1 { font-size: 2em; } h2 { font-size: 1.5em; margin-top: 24px; }
  h3 { font-size: 1.25em; margin-top: 24px; }
  table { border-collapse: collapse; margin: 16px 0; display: block; overflow-x: auto; max-width: 100%; }
  th, td { border: 1px solid #d1d9de; padding: 6px 13px; }
  th { background: #f6f8fa; font-weight: 600; }
  tr:nth-child(2n) td { background: #f6f8fa; }
  code { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
    font-size: 85%; background: rgba(129,139,152,.12); padding: .2em .4em; border-radius: 6px; }
  pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; line-height: 1.45; }
  pre code { background: none; padding: 0; font-size: 100%; }
  blockquote { border-left: 4px solid #d1d9de; color: #656d76; margin: 0 0 16px; padding: 0 1em; }
  li { margin: .25em 0; }
  li input[type=checkbox] { margin-right: .5em; }
  hr { height: .25em; background: #d1d9de; border: 0; margin: 24px 0; }
  a { color: #0969da; text-decoration: none; } a:hover { text-decoration: underline; }
</style></head><body><main><h1 id="printer-setup">Printer setup</h1>
<p>FloCafe prints receipts and kitchen order tickets from the desktop app. Configure printers in <strong>Settings → Printers</strong>, then use <strong>Test Print</strong> before service.</p>
<h2 id="connection-types">Connection types</h2>
<table>
<thead>
<tr>
<th>Type</th>
<th>Use it for</th>
<th>What you need</th>
</tr>
</thead>
<tbody><tr>
<td>Network</td>
<td>Receipt or kitchen printers on the local network</td>
<td>Printer IP address and port; most ESC/POS printers use port <code>9100</code></td>
</tr>
<tr>
<td>USB / OS Queue</td>
<td>Direct USB printers and OS-managed printer queues</td>
<td>Direct USB connection or a configured OS print queue (Windows Spooler or CUPS)</td>
</tr>
<tr>
<td>WebUSB</td>
<td>A browser-connected printer</td>
<td>A compatible browser and a user-selected device; the browser sends the print bytes</td>
</tr>
</tbody></table>
<p>Set the paper width to match the printer: 58 mm or 80 mm. The first configured printer becomes the default; choose another default in Settings when a different printer should receive ordinary receipts. If no hardware printer is configured, FloCafe automatically falls back to system print when printing bills.</p>
<h2 id="arabic-and-persian-text">Arabic and Persian text</h2>
<p>In <strong>Settings → Printers</strong>, enable <strong>Printer supports Arabic/Persian shaping</strong> only for a thermal printer whose firmware performs Arabic/Persian contextual shaping and bidirectional ordering. With this setting enabled, receipt, tax-bill, and kitchen-ticket lines containing Arabic or Persian text are sent to the printer for it to shape; the setting is off by default for generic ESC/POS hardware. Without it, unsupported lines are skipped instead of being sent as garbled bytes, and FloCafe displays a warning after printing. Lines that also contain another unsupported script remain skipped.</p>
<h2 id="receipt-and-kitchen-ticket-languages">Receipt and kitchen-ticket languages</h2>
<p>Receipt labels (invoice title, bill number, date, totals, payment methods) and kitchen-ticket labels are resolved from the tenant&#39;s language configuration at print time:</p>
<ul>
<li><strong>Receipts</strong> follow the tenant <strong>language</strong> setting combined with the stored <code>bill_language_policy</code> (<code>inherit</code> follows the store language; <code>fixed</code> pins one configured language; an optional second <code>additional</code> language is carried on the document for future bilingual layouts). Tenants whose language is fa or es receive localized receipt labels end-to-end.</li>
<li><strong>Kitchen tickets</strong> resolve their label language independently through the stored <code>kot_language_policy</code>. A fixed kitchen language (for example English) keeps tickets in that language even when the storefront runs in another language.</li>
<li>Invalid or missing policy values always fall back to the store language; printing never fails because of a malformed policy.</li>
</ul>
<p>For the full study of non-Latin script support on thermal printers — including the recommended raster fallback architecture, community hardware-test checklist, and open decisions — see <a href="printing-nonlatin-capabilities.md">printing-nonlatin-capabilities.md</a>.</p>
<p>Lines the printer cannot render under the script rules above are skipped with an explicit warning — content is never silently dropped. The printed document itself carries every line plus its text direction, so direction-aware layouts (right-to-left base with left-to-right amounts and order numbers) can be expressed by any renderer without changing the underlying data.</p>
<h2 id="kitchen-printing">Kitchen printing</h2>
<p>FloCafe can print kitchen order tickets to the default printer or route items to configured kitchen stations. A station needs an active printer and the product categories it handles. Items without a matching station fall back to the default kitchen route.</p>
<p>KOT printing can be disabled for the business. When it is disabled, neither automatic nor manual KOT print requests are sent.</p>
<h2 id="troubleshooting">Troubleshooting</h2>
<h3 id="quick-checks">Quick checks</h3>
<ol>
<li>Use <strong>Settings → Printers → Test Print</strong> to verify printer connectivity before live service.</li>
<li>Ensure FloCafe&#39;s local API and network printers are confined to your private business network.</li>
</ol>
<h3 id="network-printers">Network printers</h3>
<ul>
<li>Confirm FloCafe&#39;s machine can reach the printer on the trusted/local business network.</li>
<li>Verify the printer&#39;s IP address has not changed (check your router&#39;s DHCP lease table or configure a static IP / DHCP reservation).</li>
<li>Verify the configured port (default ESC/POS port is usually <code>9100</code>).</li>
</ul>
<h3 id="windows-usb-amp-spooler-printers">Windows USB &amp; spooler printers</h3>
<p>FloCafe sends raw ESC/POS byte streams directly to the Windows print queue, bypassing the printer driver. This requires the queue&#39;s <em>Print Processor</em> to be set to <code>winprint</code> with datatype <code>RAW</code>.</p>
<p>Manufacturer driver packages (such as Epson APD or Star) often install GDI graphics drivers that register proprietary print processors or reject raw byte streams. If prints fail or print garbled output:</p>
<ol>
<li>Right-click the printer in Windows → <strong>Printer Properties → Advanced tab → Print Processor</strong> → confirm it is set to <code>winprint</code> with datatype <code>RAW</code>.</li>
<li>If issues persist, reinstall the printer using Windows&#39; built-in <strong>&quot;Generic / Text Only&quot;</strong> driver (or the manufacturer&#39;s dedicated raw/ESC-POS mode).</li>
<li>Re-select the printer in FloCafe&#39;s printer settings, as renaming or reinstalling changes the stored queue identifier.</li>
</ol>
<h3 id="macos-and-linux-cups-printers">macOS and Linux (CUPS) printers</h3>
<ul>
<li>If a printer was unplugged, the CUPS print queue may be placed in a disabled/paused state. Re-enable the queue in your operating system printer settings; FloCafe will resume sending print jobs once the queue is active.</li>
<li>For Linux USB permissions, ensure your user account is in the <code>lp</code> group (<code>sudo usermod -aG lp $USER</code>). See <a href="linux.md#printing">Linux installation and support</a> for more details.</li>
</ul>
<h3 id="bluetooth-amp-os-paired-printers">Bluetooth &amp; OS-paired printers</h3>
<p>FloCafe does not manage standalone Bluetooth RFCOMM transport or discovery. To use a Bluetooth receipt printer, pair the device in your operating system so it registers as an active printer queue (via CUPS on macOS/Linux or Windows Print Spooler). FloCafe will then detect and dispatch print jobs through that OS-managed queue.</p>
<h3 id="webusb-printers">WebUSB printers</h3>
<p>WebUSB printers are paired through the POS toolbar in a supported browser. The saved printer entry retains formatting preferences, but browser permissions control physical device access.</p>
<h3 id="diagnostic-logs">Diagnostic logs</h3>
<p>If printing still fails:</p>
<ol>
<li>Open <strong>Help → Open Logs Folder</strong> (or check <code>main.log</code>).</li>
<li>Search for lines starting with <code>[Printer]</code> around the time of the failure to find the exact error code or stage.</li>
<li>If opening an issue, include the <code>[Printer]</code> log snippet, your OS, printer make/model, connection type, and paper width.</li>
</ol>
<h2 id="country-pack-compliance-receipt-templates-escpos-line-template-v1">Country-pack compliance receipt templates (<code>escpos-line-template-v1</code>)</h2>
<p>Signed country tax packs can ship compliance receipt templates that render through FloCafe&#39;s built-in ESC/POS line renderer (<code>renderEscposLineTemplateV1</code>, renderer id <code>flocafe-thermal-receipt-template</code>).</p>
<blockquote>
<p><strong>Status: legacy/compliance-oriented.</strong> <code>escpos-line-template-v1</code> exists to keep signed, jurisdiction-specific compliance receipts working. It is <strong>not</strong> the merchant-facing template format; see the current <a href="merchant-print-templates.md">merchant print template model</a>. Do not build merchant-facing template features on this contract.</p>
</blockquote>
<h3 id="payload-fields">Payload fields</h3>
<table>
<thead>
<tr>
<th>Field</th>
<th>Type</th>
<th>Required</th>
<th>Behavior</th>
</tr>
</thead>
<tbody><tr>
<td><code>format</code></td>
<td><code>&quot;escpos-line-template-v1&quot;</code></td>
<td>yes</td>
<td>Contract identifier; must match exactly</td>
</tr>
<tr>
<td><code>widthProfiles</code></td>
<td>array</td>
<td>yes</td>
<td>Per-printer-width column layouts (32–48 columns); at least one profile must cover each declared <code>paperColumns</code> width</td>
</tr>
<tr>
<td><code>header</code></td>
<td>object</td>
<td>no</td>
<td>Optional author strings: <code>businessNameTransform</code> (<code>uppercase</code>), <code>taxTitleWhenTaxPresent</code>, <code>titleWhenTaxAbsent</code></td>
</tr>
<tr>
<td><code>fields.taxRegistrationNumberLabel</code></td>
<td>string</td>
<td>no</td>
<td>Author label for the tax registration line</td>
</tr>
<tr>
<td><code>totals.grandTotalLabel</code></td>
<td>string</td>
<td>no</td>
<td>Author label for the bold grand-total row</td>
</tr>
<tr>
<td><code>totals.showSubtotal</code>, <code>totals.showDiscount</code></td>
<td>boolean</td>
<td>no</td>
<td>Toggle subtotal/discount rows (default on)</td>
</tr>
<tr>
<td><code>totals.showTaxRegistrationNumber</code></td>
<td>string</td>
<td>no</td>
<td><code>when_tax_present_or_enabled</code> or default visibility rule</td>
</tr>
<tr>
<td><code>footer.defaultMessage</code></td>
<td>string</td>
<td>no</td>
<td>Author footer message used when no configured footer note applies</td>
</tr>
<tr>
<td><code>footer.useConfiguredFooterNote</code></td>
<td>boolean</td>
<td>no</td>
<td>Prefer the merchant&#39;s configured footer note (default on)</td>
</tr>
<tr>
<td><code>footer.includePoweredByFloPOS</code></td>
<td>boolean</td>
<td>no</td>
<td>Append the FloPOS branding footer (default on)</td>
</tr>
<tr>
<td><code>labels</code></td>
<td>object</td>
<td>no</td>
<td>Optional map of semantic label id → override string, see below (#445)</td>
</tr>
</tbody></table>
<p>Unknown fields are tolerated at render time so older app versions keep rendering newer signed packs.</p>
<h3 id="the-optional-labels-map-445">The optional <code>labels</code> map (#445)</h3>
<p>Packs may ship a payload-root <code>labels</code> map to override built-in fallback labels with their own copy:</p>
<pre><code class="language-json">{
  &quot;format&quot;: &quot;escpos-line-template-v1&quot;,
  &quot;widthProfiles&quot;: [{ &quot;columns&quot;: 48, &quot;layout&quot;: {} }],
  &quot;labels&quot;: {
    &quot;total&quot;: &quot;SUMA TOTAL&quot;,
    &quot;footerThanks&quot;: &quot;¡Gracias por su visita!&quot;
  }
}
</code></pre>
<p>Supported semantic ids (stable public identifiers — never internal i18n keys): <code>invoice</code>, <code>taxInvoice</code>, <code>subtotal</code>, <code>discount</code>, <code>tax</code>, <code>total</code>, <code>taxIncluded</code>, <code>footerThanks</code>. Once shipped, an id never changes meaning.</p>
<p>Resolution order for each label: the pack&#39;s structural author string (for example <code>totals.grandTotalLabel</code>) wins first, then the matching <code>labels</code> entry, then the built-in default localized through the canonical print-labels catalog using the receipt language. English defaults are byte-identical to the pre-#445 hardcoded strings.</p>
<p>Validation at install time is <strong>fail-closed</strong>: the map must be an object, contain at most 64 entries of known semantic ids, and every value must be a non-empty string of at most 120 characters. Violations reject the pack install with a clear error. At render time, labels are sanitized (reserved printer control tokens such as <code>{CUT}</code>, <code>{FEED}</code>, <code>{INIT}</code> and styling braces are stripped) and clamped/truncated to fit the selected column width profile (32–48 columns). Renderer version stays 1 — this field is additive and optional; packs without it render identically on old and new versions.</p>
<h2 id="api">API</h2>
<p>The printer endpoints are documented in <a href="API.md#printers">API.md</a>. They cover configured printers, detection, supported profiles, test printing, receipt printing, and kitchen tickets.</p>

</main></body></html>
```
</details>

- Evidence: Rendered HTML of docs/README.md (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0PNQXQXATJ1SQVD3P2YN6KH/README.html</code>)

<details>
<summary>Evidence: Link and cross-reference verification transcript</summary>

`OK section refs 5/6/7/8 -> matching headings; OK docs/printers.md -> printing-nonlatin-capabilities.md; OK docs/README.md -> printing-nonlatin-capabilities.md; +13 pre-existing README links all OK; ALL LINKS AND SECTION REFS RESOLVE. git diff --check exit 0. Diff touches only the three docs files.`

```text
Link + cross-reference verification over the three changed docs
(docs/printing-nonlatin-capabilities.md, docs/printers.md, docs/README.md)

Relative links resolve against each file's own directory (GitHub behavior);
"Section N" plain-text refs are matched against the numbered ## headings:

OK section ref "Section 8" -> "Open decisions requiring a human call"
OK section ref "Section 6" -> "Community hardware-test matrix checklist"
OK section ref "Section 5" -> "Recommended architecture (decision record)"
OK section ref "Section 7" -> "Test-page raster probe specification"
OK docs/printers.md -> printing-nonlatin-capabilities.md   (new study link)
OK docs/printers.md -> linux.md#printing
OK docs/printers.md -> merchant-print-templates.md
OK docs/printers.md -> API.md#printers
OK docs/README.md -> printing-nonlatin-capabilities.md     (new index row)
(+ 13 further pre-existing README index links, all OK)

ALL LINKS AND SECTION REFS RESOLVE

git diff --check 8efa5aa..24166a0  -> exit 0 (no whitespace/conflict markers)
Diff touches only: docs/README.md, docs/printers.md,
docs/printing-nonlatin-capabilities.md  (documentation-only scope confirmed;
no package.json change => no dependency added)
```
</details>
- Outcome: ⚠️ 1 info across 1 run (14m52s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5777745d435a32c4ebf7ed90668fd43c795c4924","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `docs/printing-nonlatin-capabilities.md:87` - Two internal cross-references point to the wrong section: line 87 says the rendering-engine cost is &#34;a dependency question — see Section 7&#34; and the criteria matrix at line 105 lists the extra dep as &#34;rendering engine (Section 7)&#34;, but Section 7 is the Test-page raster probe specification. The rendering-engine dependency question lives in Section 8, Open decisions requiring a human call (lines 199-204) - the very section this decision-record tells readers (line 4) to consult. Anyone following these two pointers lands on the diagnostic-band spec instead of the open decision they are meant to evaluate.
- ⚠️ `docs/README.md:30` - The new catalog row labels the study FORWARD-LOOKING but was added to the &#34;Current documentation&#34; table (heading at docs/README.md:18), whose rows otherwise all carry Scope CURRENT and describe supported runtime behavior. The same file defines a dedicated &#34;Active design &amp; forward-looking plans&#34; table (docs/README.md:32) for exactly this status, and AGENTS.md directs agents to use this index to distinguish current runtime behavior from planned designs. Misfiling a not-yet-implemented architecture recommendation under Current documentation works against the index&#39;s own stated purpose even though the Scope cell itself reads FORWARD-LOOKING.
- ℹ️ `docs/printing-nonlatin-capabilities.md:176` - Community checklist item 7 asks testers to confirm the raster band &#34;fills the printable width edge-to-edge&#34;, but Section 7 step 1 (line 191) specifies the solid band deliberately inset to widthDots - 16 dots (~2 mm total margin). A tester validating against the specified probe will observe margins by design and report item 7 as failed on healthy hardware. Item 7 should be reworded to match the intended expectation (full-scale width with the small symmetric inset, i.e. detecting shrink/clip rather than literal edge-to-edge fill).

🔧 Fix: Fix non-Latin study section refs, README table placement, checklist width wording
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ Acceptance requires the PR body to carry &#39;Fixes #446 Refs #438&#39;. No PR exists yet and PR creation belongs to the delivery phase, so this could not be verified here; the outer executor must include both trailers when composing the PR description.
- <code>`git diff --stat 8efa5aa..24166a0` - scope check confirming only docs/README.md, docs/printers.md, and docs/printing-nonlatin-capabilities.md changed (documentation-only, no renderer or package.json edits)</code>
- <code>`git diff --check 8efa5aa..24166a0` - clean, no whitespace/conflict-marker errors</code>
- `Node script resolving every relative markdown link and #anchor against each file's own directory across the three changed docs, plus validating every plain-text 'Section N' reference against actual numbered headings - all resolve`
- <code>Source-claim verification of the doc&#39;s &#39;current code&#39; table via grep/read: `main/printers/profiles.ts:24` (arabicShaping flag, none set on the four shipped profiles), `main/printers/thermal.ts:1528` buildEscPos and `thermal.ts:1572-1593` non-ASCII skip-with-warning guard, `frontend/src/lib/printer/warnings.ts:43,127`, `shared/print/direction.ts:83,92`, existence of `shared/print/document.ts`</code>
- <code>Cross-checked deliverables against the authoritative research mandate via `gh-axi issue view 446 --full` (decision record per transport, hardware-test matrix, migration implications for skip-with-warning, open hardware questions)</code>
- <code>Rendered the three changed markdown files through `npx marked --gfm` into GitHub-style standalone HTML with heading anchors, opened each in Chrome via chrome-devtools-axi at 1280x1000, and captured viewport screenshots at the title/status banner, Section 3.7 criteria matrix, Section 5 decision record, Section 6 hardware checklist, Section 7 raster probe spec, plus a full-page capture and both cross-link locations</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
