### PR TITLE
feat(server-app): allow management roles in standalone login

### DIFF
--- a/frontend/src/app/server-standalone/page.tsx
+++ b/frontend/src/app/server-standalone/page.tsx
@@ -300,6 +300,7 @@ export default function ServerStandalonePage() {
               {loginLoading ? tAuth('signingIn') : tAuth('signIn')}
             </button>
           </div>
+          <p className="mt-4 text-center text-xs text-gray-500">{t('loginHint')}</p>
         </form>
       </div>
     );

--- a/frontend/src/lib/i18n/messages/en.json
+++ b/frontend/src/lib/i18n/messages/en.json
@@ -950,6 +950,7 @@
     "guestFallbackName": "Guest {last4}",
     "itemNotePlaceholder": "Item note",
     "kitchen": "Kitchen",
+    "loginHint": "Tableside ordering for server, manager, and owner accounts",
     "loginSubtitle": "Tableside ordering for service staff",
     "newItems": "New items",
     "openOrder": "Open order",

--- a/frontend/src/lib/i18n/messages/es.json
+++ b/frontend/src/lib/i18n/messages/es.json
@@ -950,6 +950,7 @@
     "guestFallbackName": "Invitado {last4}",
     "itemNotePlaceholder": "Nota del ítem",
     "kitchen": "Cocina",
+    "loginHint": "Pedidos desde la mesa para cuentas de mesero, encargado y propietario",
     "loginSubtitle": "Pedidos desde la mesa para el personal de servicio",
     "newItems": "Ítems nuevos",
     "openOrder": "Pedido abierto",

--- a/frontend/src/lib/i18n/messages/fa.json
+++ b/frontend/src/lib/i18n/messages/fa.json
@@ -950,6 +950,7 @@
     "guestFallbackName": "میهمان {last4}",
     "itemNotePlaceholder": "یادداشت کالا",
     "kitchen": "آشپزخانه",
+    "loginHint": "ثبت سفارش کنار میز برای حساب‌های گارسون، سرپرست و دارنده",
     "loginSubtitle": "ثبت سفارش کنار میز برای کارکنان خدمات",
     "newItems": "کالاهای تازه",
     "openOrder": "سفارش باز",

--- a/frontend/src/lib/i18n/messages/pt.json
+++ b/frontend/src/lib/i18n/messages/pt.json
@@ -950,6 +950,7 @@
     "guestFallbackName": "Convidado {last4}",
     "itemNotePlaceholder": "Nota do item",
     "kitchen": "Cozinha",
+    "loginHint": "Pedidos à mesa para contas de garçom, gerente e proprietário",
     "loginSubtitle": "Pedidos à mesa para a equipe de serviço",
     "newItems": "Novos itens",
     "openOrder": "Pedido aberto",

--- a/main/server-app.ts
+++ b/main/server-app.ts
@@ -20,7 +20,7 @@ let stopPromise: Promise<void> | null = null;
 let startReject: ((error: Error) => void) | null = null;
 let stopping = false;
 const SERVER_APP_PORT = getDefaultServerAppPort();
-const SERVER_APP_ALLOWED_ROLES = new Set(['server']);
+const SERVER_APP_ALLOWED_ROLES = new Set(['server', 'manager', 'owner']);
 
 type ServerAppUser = {
   userId: string;
@@ -80,7 +80,7 @@ function requireServerAppAuth(req: Request, res: Response, next: NextFunction) {
       return res.status(401).json({ error: 'Invalid token' });
     }
     if (!SERVER_APP_ALLOWED_ROLES.has(user.role)) {
-      return res.status(403).json({ error: 'Access denied. Only service staff allowed.' });
+      return res.status(403).json({ error: 'Access denied. Only server, manager, or owner accounts allowed.' });
     }
 
     (req as any).user = {
@@ -208,7 +208,7 @@ export function startServerApp(): Promise<void> {
           return res.status(401).json({ error: 'Invalid credentials' });
         }
         if (!SERVER_APP_ALLOWED_ROLES.has(user.role)) {
-          return res.status(403).json({ error: 'Access denied. Only service staff allowed.' });
+          return res.status(403).json({ error: 'Access denied. Only server, manager, or owner accounts allowed.' });
         }
 
         const token = jwt.sign(

--- a/tests/server-app-server-role.test.ts
+++ b/tests/server-app-server-role.test.ts
@@ -1,4 +1,4 @@
-/** Server App auth must be limited to service staff (server role). */
+/** Server App auth must be limited to front-line + management staff (server, manager, owner). */
 import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as net from 'node:net';
@@ -73,26 +73,28 @@ async function main() {
   const baseUrl = `http://127.0.0.1:${getServerAppPort()}`;
 
   try {
-    for (const role of ['owner', 'manager', 'cashier', 'chef']) {
+    for (const role of ['cashier', 'chef']) {
       const response = await postJson(baseUrl, '/api/auth/login', {
         email: `${role}@server-app.test`,
         password: 'ServerPass123!',
       });
       assert.equal(response.status, 403, `${role} cannot log in to Server App`);
-      assert.match(String(response.body.error), /Only service staff/i);
+      assert.match(String(response.body.error), /Only server, manager, or owner/i);
     }
 
-    const serverLogin = await postJson(baseUrl, '/api/auth/login', {
-      email: 'server@server-app.test',
-      password: 'ServerPass123!',
-    });
-    assert.equal(serverLogin.status, 200, 'server can log in to Server App');
-    assert.equal(serverLogin.body.user.role, 'server', 'Server App returns server role');
-    assert.ok(serverLogin.body.access_token, 'Server App returns a token for server');
+    for (const role of ['server', 'manager', 'owner']) {
+      const login = await postJson(baseUrl, '/api/auth/login', {
+        email: `${role}@server-app.test`,
+        password: 'ServerPass123!',
+      });
+      assert.equal(login.status, 200, `${role} can log in to Server App`);
+      assert.equal(login.body.user.role, role, `Server App returns ${role} role`);
+      assert.ok(login.body.access_token, `Server App returns a token for ${role}`);
 
-    const me = await getJson(baseUrl, '/api/auth/me', serverLogin.body.access_token);
-    assert.equal(me.status, 200, 'server token remains valid on /api/auth/me');
-    assert.equal(me.body.user.role, 'server', '/api/auth/me returns server role');
+      const me = await getJson(baseUrl, '/api/auth/me', login.body.access_token);
+      assert.equal(me.status, 200, `${role} token remains valid on /api/auth/me`);
+      assert.equal(me.body.user.role, role, `/api/auth/me returns ${role} role`);
+    }
   } finally {
     await stopServerApp();
     closeDatabase();


### PR DESCRIPTION
## Intent

Implement the reviewed plan from the flocafe-serverapp-roles scout report: allow owner and manager to log in to the standalone Server App alongside server, mirroring KDS's front-line+management pattern.

Requirements:
1. main/server-app.ts: widen SERVER_APP_ALLOWED_ROLES from Set(['server']) to Set(['server', 'manager', 'owner']). Reword the 403 message at both occurrences (requireServerAppAuth middleware and POST /api/auth/login handler) together to name the roles: 'Access denied. Only server, manager, or owner accounts allowed.'
2. Add i18n key serverApp.loginHint (en: 'Tableside ordering for server, manager, and owner accounts') in all four locales frontend/src/lib/i18n/messages/{en,es,pt,fa}.json inside the existing serverApp block; render it under the login form in frontend/src/app/server-standalone/page.tsx. npm run i18n:check must pass.
3. tests/server-app-server-role.test.ts: expect 200 for owner and manager logins and verify /api/auth/me works with each token like the existing server assertions; keep 403 for cashier and chef.
Verified context: no privilege escalation - every proxied endpoint already authorizes manager/owner on the main API; chef is excluded because order creation would 403 at the main API (broken half-working login).

PR body must include: 'Fixes #472-review follow-up; implements captain-requested Server App role alignment' plus 'Refs #438'. Use a descriptive conventional-commit title.

## What Changed

- Expanded standalone Server App authentication to allow `server`, `manager`, and `owner` accounts, updated both 403 messages, and covered allowed/denied login plus `/api/auth/me` behavior.
- Added and rendered `serverApp.loginHint` with translations in English, Spanish, Portuguese, and Farsi to clarify eligible tableside-ordering accounts.
- Fixes #472-review follow-up; implements captain-requested Server App role alignment. Refs #438

## Risk Assessment

✅ Low: The bounded role, proxy, localization, and integration-test changes satisfy the stated source requirements; manager and owner requests remain constrained by the main API’s existing role checks.

## Testing

Fresh targeted integration, translation, and i18n checks passed. Live API behavior and rendered login/post-login surfaces were verified; generated dependencies, builds, and temporary database data were removed afterward.

<details>
<summary>Evidence: Server App role API transcript</summary>

```text
Live API evidence: owner, manager, and server login returned 200 with /api/auth/me returning 200; cashier and chef returned 403 with the required role message.
```
</details>

- Evidence: Server App login hint (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0QNYFJ22MWK159HJK7HRADG/server-app-login-en.png</code>)
- Evidence: Manager Server App session (local file: <code>/Users/gurkiratkhaira/.no-mistakes/evidence/01M0QNYFJ22MWK159HJK7HRADG/server-app-manager-session.png</code>)
- Outcome: ⚠️ 1 warning across 1 run (9m25s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1b23c84171f54dc940ed87ee769d320b9473631f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ No pull request exists for fm/flocafe-serverapp-roles, so the required PR body wording cannot be verified. The commit includes Refs #438 but not the required follow-up phrase.
- `npm run test:server-app-server-role`
- `npm run test:translations`
- `npm run i18n:check`
- <code>Live API checks for owner, manager, server, cashier, and chef login plus `/api/auth/me`</code>
- <code>Browser login using manager credentials on `/server-standalone/`</code>
- `Screenshots captured to the evidence directory`
- `git diff --check`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ Configured backend and frontend ESLint checks could not run because eslint is not installed in the worktree; no source lint issue was identifiable by inspection.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
