### PR TITLE
fix: verify uploaded release updater assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,6 +289,17 @@ jobs:
           SNAPCRAFT_BUILD_ENVIRONMENT: lxd
           FLO_LINUX_ARCH: ${{ matrix.arch }}
 
+      - name: Verify Linux release assets
+        run: |
+          MANIFEST_PREFIX="${{ needs.create-release.outputs.manifest_prefix }}"
+          MANIFEST_NAME="${MANIFEST_PREFIX}-linux.yml"
+          if [ "${{ matrix.arch }}" = "arm64" ]; then MANIFEST_NAME="${MANIFEST_PREFIX}-linux-arm64.yml"; fi
+          test -f "release/${MANIFEST_NAME}" || { echo "::error::release/${MANIFEST_NAME} is missing — Linux auto-update would be broken for this release"; exit 1; }
+          find release -maxdepth 1 -type f -name "*linux-${{ matrix.arch }}.appimage" -print -quit | grep -q . || {
+            echo "::error::no Linux AppImage for ${{ matrix.arch }} — Linux auto-update would be broken for this release"
+            exit 1
+          }
+
       - name: Upload Linux assets to GitHub release
         # Each matrix entry uploads its own arch-tagged artifacts. The release
         # override uses the safe x64/arm64 matrix labels, so entries never
@@ -719,6 +730,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
+
+      - name: Install verifier dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Download and verify every release manifest and referenced artifact
         # Stable verification covers latest.yml, latest-mac.yml, latest-linux.yml,

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -52,15 +52,20 @@ Stable clients keep `allowPrerelease` and `allowDowngrade` disabled.
    `[a-z0-9.-]+`; Linux release jobs use the safe matrix labels `x64` and
    `arm64` in the electron-builder template, and artifacts are not renamed
    after electron-builder creates them.
-3. Platform jobs upload installers, update manifests, blockmaps, and required
-   store packages to the draft release.
-   Microsoft Store AppX submission runs only for stable tag pushes. Beta and
-   nightly AppX packages remain outside the Store submission path because their
-   four-part MSIX versions would otherwise collide with stable and with later
-   prereleases.
-4. `scripts/verify-release-assets.cjs` fetches manifests and referenced assets
-   back through the GitHub API and verifies their SHA-512 values. It also checks
-   the expected installer/store/uninstaller inventory and HTTP availability for
+3. Each self-updating platform job asserts that its local updater manifest
+   and representative installer exist before upload. Platform jobs upload
+   installers, update manifests, blockmaps, and required store packages to the
+   draft release. Microsoft Store AppX submission runs only for stable tag
+   pushes. Beta and nightly AppX packages remain outside the Store submission
+   path because their four-part MSIX versions would otherwise collide with
+   stable and with later prereleases.
+4. `scripts/verify-release-assets.cjs` fetches the draft release metadata, then
+   downloads manifests and every referenced asset back through the GitHub API.
+   It parses each manifest as YAML, requires every referenced asset to resolve
+   to HTTP 200 in that same release, and recomputes the manifest SHA-512 for
+   every self-updating artifact. Missing or malformed manifests, unavailable
+   references, and checksum mismatches fail the workflow. It also checks the
+   expected installer/store/uninstaller inventory and HTTP availability for
    uploaded assets that are not referenced by an updater manifest. Those
 non-manifest assets are checked for positive size and HTTP availability; their
 SHA-512 is not independently recomputed because GitHub/electron-builder does

--- a/scripts/verify-release-assets.cjs
+++ b/scripts/verify-release-assets.cjs
@@ -10,9 +10,7 @@
  */
 
 const crypto = require('node:crypto');
-const fs = require('node:fs');
-const os = require('node:os');
-const path = require('node:path');
+const YAML = require('js-yaml');
 
 function requiredArg(args, name) {
   const index = args.indexOf(name);
@@ -65,63 +63,78 @@ async function githubJson(url) {
   return (await githubRequest(url)).json();
 }
 
-function unquoteYamlScalar(value) {
-  const trimmed = value.trim();
-  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeSha512(value) {
+  return value.replace(/\s+/g, '');
+}
+
+function isSha512(value) {
+  const normalized = normalizeSha512(value);
+  return normalized.length % 4 === 0
+    && /^[A-Za-z0-9+/]+={0,2}$/.test(normalized)
+    && Buffer.from(normalized, 'base64').length === 64;
 }
 
 function parseManifest(text, name) {
-  const files = [];
-  let version = null;
-  let current = null;
-  let topLevelPath = null;
-  let topLevelSha512 = null;
-
-  for (const line of text.split(/\r?\n/)) {
-    const versionValue = line.match(/^version:\s*(.+?)\s*$/);
-    if (versionValue) {
-      version = unquoteYamlScalar(versionValue[1]);
-      continue;
-    }
-
-    const listUrl = line.match(/^\s*-\s+url:\s*(.+?)\s*$/);
-    const scalarUrl = line.match(/^\s+url:\s*(.+?)\s*$/);
-    if (listUrl || scalarUrl) {
-      current = { url: unquoteYamlScalar((listUrl || scalarUrl)[1]), sha512: null };
-      files.push(current);
-      continue;
-    }
-
-    const nestedSha = line.match(/^\s+sha512:\s*(.+?)\s*$/);
-    if (nestedSha && current) {
-      current.sha512 = unquoteYamlScalar(nestedSha[1]);
-      continue;
-    }
-
-    const pathValue = line.match(/^path:\s*(.+?)\s*$/);
-    if (pathValue) {
-      topLevelPath = unquoteYamlScalar(pathValue[1]);
-      continue;
-    }
-
-    const topSha = line.match(/^sha512:\s*(.+?)\s*$/);
-    if (topSha) topLevelSha512 = unquoteYamlScalar(topSha[1]);
+  let document;
+  try {
+    document = YAML.load(text, { json: false });
+  } catch (error) {
+    throw new Error(`${name} is not valid YAML: ${error instanceof Error ? error.message : String(error)}`);
   }
 
-  if (!version) throw new Error(`${name} does not declare a release version`);
-  if (topLevelPath && !files.some((file) => file.url === topLevelPath)) {
-    files.push({ url: topLevelPath, sha512: topLevelSha512 });
+  if (!isRecord(document)) throw new Error(`${name} must contain a YAML mapping`);
+  if (typeof document.version !== 'string' || document.version.trim() === '') {
+    throw new Error(`${name} does not declare a release version`);
   }
-  if (files.length === 0) throw new Error(`${name} does not reference any update artifact`);
-  for (const file of files) {
-    if (!file.url || !file.sha512) {
-      throw new Error(`${name} has an update artifact without both url and sha512`);
+  if (!Array.isArray(document.files) || document.files.length === 0) {
+    throw new Error(`${name} does not reference any update artifact`);
+  }
+
+  const files = document.files.map((file, index) => {
+    if (!isRecord(file)) throw new Error(`${name} has an invalid files[${index}] entry`);
+    if (typeof file.url !== 'string' || file.url.trim() === '') {
+      throw new Error(`${name} has an update artifact without a url`);
+    }
+    if (typeof file.sha512 !== 'string' || !isSha512(file.sha512)) {
+      throw new Error(`${name} has an update artifact without a valid SHA-512`);
+    }
+    return { url: file.url.trim(), sha512: normalizeSha512(file.sha512) };
+  });
+
+  const duplicateUrls = files
+    .map((file) => file.url)
+    .filter((url, index, urls) => urls.indexOf(url) !== index);
+  if (duplicateUrls.length > 0) {
+    throw new Error(`${name} references the same update artifact more than once: ${duplicateUrls.join(', ')}`);
+  }
+
+  // electron-builder repeats the preferred update artifact as top-level
+  // path/sha512. Keep that contract checked too: a disagreement here would
+  // make the updater use a different checksum than the files entry we verify.
+  if (document.path !== undefined || document.sha512 !== undefined) {
+    if (typeof document.path !== 'string' || document.path.trim() === '') {
+      throw new Error(`${name} has a top-level sha512 without a valid path`);
+    }
+    if (typeof document.sha512 !== 'string' || !isSha512(document.sha512)) {
+      throw new Error(`${name} has a top-level path without a valid SHA-512`);
+    }
+    const topLevelPath = document.path.trim();
+    const topLevelSha512 = normalizeSha512(document.sha512);
+    const matchingFile = files.find((file) => file.url === topLevelPath);
+    if (matchingFile) {
+      if (matchingFile.sha512 !== topLevelSha512) {
+        throw new Error(`${name} has different SHA-512 values for ${topLevelPath}`);
+      }
+    } else {
+      files.push({ url: topLevelPath, sha512: topLevelSha512 });
     }
   }
-  return { version, files };
+
+  return { version: document.version.trim(), files };
 }
 
 function expectedManifestNames(channel) {
@@ -225,88 +238,137 @@ function assertReleaseAssetInventory(assets, manifestNames, version) {
   }
 }
 
-async function verifyAssetAvailability(asset) {
-  const response = await githubRequest(asset.url, 'application/octet-stream');
-  if (!response.body) throw new Error(`GitHub returned no body for ${asset.name}`);
-  const reader = response.body.getReader();
-  await reader.read();
-  await reader.cancel();
+function defaultAssetRequest(asset) {
+  if (typeof asset.url !== 'string' || asset.url.trim() === '') {
+    throw new Error(`release asset ${asset.name} has no GitHub download URL`);
+  }
+  return githubRequest(asset.url, 'application/octet-stream');
 }
 
-async function readAsset(asset) {
-  const response = await githubRequest(asset.url, 'application/octet-stream');
-  return response.arrayBuffer();
+function assertHttp200(response, asset) {
+  if (Buffer.isBuffer(response) || response instanceof Uint8Array) return;
+  if (!response || response.status !== 200) {
+    const status = response && Number.isInteger(response.status) ? response.status : 'unknown';
+    throw new Error(`release asset ${asset.name} was not available at HTTP 200 (got ${status})`);
+  }
 }
 
-async function verifyArtifact(asset, expectedSha512) {
-  const response = await githubRequest(asset.url, 'application/octet-stream');
-  if (!response.body) throw new Error(`GitHub returned no body for ${asset.name}`);
+async function responseToBuffer(response, asset) {
+  assertHttp200(response, asset);
+  if (Buffer.isBuffer(response)) return response;
+  if (response instanceof Uint8Array) return Buffer.from(response);
+  if (typeof response.arrayBuffer !== 'function') {
+    throw new Error(`release asset ${asset.name} response has no readable body`);
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.length === 0) throw new Error(`release asset ${asset.name} returned an empty body`);
+  return bytes;
+}
+
+async function verifyAssetAvailability(asset, requestAsset) {
+  const response = await requestAsset(asset);
+  assertHttp200(response, asset);
+  if (Buffer.isBuffer(response) || response instanceof Uint8Array) {
+    if (response.length === 0) throw new Error(`release asset ${asset.name} returned an empty body`);
+    return;
+  }
+  if (response.body) {
+    const reader = response.body.getReader();
+    const firstChunk = await reader.read();
+    await reader.cancel();
+    if (firstChunk.done) throw new Error(`release asset ${asset.name} returned an empty body`);
+    return;
+  }
+  await responseToBuffer(response, asset);
+}
+
+async function readAsset(asset, requestAsset) {
+  return responseToBuffer(await requestAsset(asset), asset);
+}
+
+async function verifyArtifact(asset, expectedSha512, requestAsset) {
+  const response = await requestAsset(asset);
+  assertHttp200(response, asset);
   const hash = crypto.createHash('sha512');
   let bytes = 0;
-  for await (const chunk of response.body) {
-    hash.update(chunk);
-    bytes += chunk.length;
+  if (Buffer.isBuffer(response) || response instanceof Uint8Array) {
+    const buffer = Buffer.from(response);
+    hash.update(buffer);
+    bytes = buffer.length;
+  } else if (response.body) {
+    for await (const chunk of response.body) {
+      hash.update(chunk);
+      bytes += chunk.length;
+    }
+  } else {
+    const buffer = await responseToBuffer(response, asset);
+    hash.update(buffer);
+    bytes = buffer.length;
   }
+  if (bytes === 0) throw new Error(`release asset ${asset.name} returned an empty body`);
   const actual = hash.digest('base64');
-  if (actual !== expectedSha512.replace(/\s+/g, '')) {
+  if (actual !== normalizeSha512(expectedSha512)) {
     throw new Error(`SHA-512 mismatch for ${asset.name}: expected ${expectedSha512}, got ${actual}`);
   }
   return bytes;
+}
+
+async function verifyReleaseAssets(release, { channel, tag = release && release.tag_name, requestAsset = defaultAssetRequest } = {}) {
+  if (!release || release.draft !== true) {
+    throw new Error(`release ${tag || '(unknown)'} is not a draft; refusing to verify a mutable published release`);
+  }
+  if (typeof tag !== 'string' || tag === '') throw new Error('release verification requires a release tag');
+  if (release.tag_name && release.tag_name !== tag) {
+    throw new Error(`release metadata tag ${release.tag_name} does not match expected ${tag}`);
+  }
+
+  const assets = Array.isArray(release.assets) ? release.assets : [];
+  const assetsByName = new Map(assets.map((asset) => [asset.name, asset]));
+  const manifestNames = expectedManifestNames(channel);
+  for (const name of manifestNames) {
+    if (!assetsByName.has(name)) throw new Error(`release ${tag} is missing ${name}`);
+  }
+  assertReleaseAssetInventory(assets, manifestNames, tag);
+
+  // Inventory-only assets (store packages, blockmaps, and uninstall helpers)
+  // still have to be reachable from the uploaded draft, but do not have an
+  // independent checksum contract. Manifest references below are always read
+  // fully and hash-checked.
+  for (const asset of assets) {
+    if (!manifestNames.includes(asset.name)) await verifyAssetAvailability(asset, requestAsset);
+  }
+
+  for (const manifestName of manifestNames) {
+    const manifestAsset = assetsByName.get(manifestName);
+    const manifestBytes = await readAsset(manifestAsset, requestAsset);
+    const manifest = parseManifest(manifestBytes.toString('utf8'), manifestName);
+    if (manifest.version !== tag) {
+      throw new Error(`${manifestName} declares version ${manifest.version}, expected ${tag}`);
+    }
+    assertManifestPlatformMapping(manifestName, tag, manifest.files);
+
+    for (const file of manifest.files) {
+      if (file.url !== file.url.split('/').pop() || !/^[a-z0-9.-]+$/.test(file.url)) {
+        throw new Error(`${manifestName} references unsafe artifact URL ${file.url}`);
+      }
+      const artifact = assetsByName.get(file.url);
+      if (!artifact) {
+        throw new Error(`${manifestName} references ${file.url}, which is not an asset in release ${tag}`);
+      }
+      const bytes = await verifyArtifact(artifact, file.sha512, requestAsset);
+      console.log(`verified ${manifestName}: ${file.url} (${bytes} bytes, SHA-512 ok)`);
+    }
+  }
+
+  console.log(`release ${tag} channel ${channel} passed draft asset verification`);
+  return { tag, channel, manifests: manifestNames };
 }
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const apiBase = `https://api.github.com/repos/${options.repo}`;
   const release = await githubJson(`${apiBase}/releases/tags/${encodeURIComponent(options.tag)}`);
-  if (release.draft !== true) {
-    throw new Error(`release ${options.tag} is not a draft; refusing to verify a mutable published release`);
-  }
-
-  const assets = Array.isArray(release.assets) ? release.assets : [];
-  const assetsByName = new Map(assets.map((asset) => [asset.name, asset]));
-  const manifestNames = expectedManifestNames(options.channel);
-  for (const name of manifestNames) {
-    if (!assetsByName.has(name)) throw new Error(`release ${options.tag} is missing ${name}`);
-  }
-  assertReleaseAssetInventory(assets, manifestNames, options.tag);
-
-  for (const asset of assets) {
-    if (!manifestNames.includes(asset.name)) await verifyAssetAvailability(asset);
-  }
-
-  const verifyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flocafe-release-verify-'));
-  try {
-    for (const manifestName of manifestNames) {
-      const manifestAsset = assetsByName.get(manifestName);
-      const manifestBytes = Buffer.from(await readAsset(manifestAsset));
-      const manifestPath = path.join(verifyDir, manifestName);
-      fs.writeFileSync(manifestPath, manifestBytes);
-      const manifest = parseManifest(manifestBytes.toString('utf8'), manifestName);
-      if (manifest.version !== options.tag) {
-        throw new Error(`${manifestName} declares version ${manifest.version}, expected ${options.tag}`);
-      }
-      assertManifestPlatformMapping(manifestName, options.tag, manifest.files);
-
-      for (const file of manifest.files) {
-        if (path.basename(file.url) !== file.url || !/^[a-z0-9.-]+$/.test(file.url)) {
-          throw new Error(`${manifestName} references unsafe artifact URL ${file.url}`);
-        }
-        if (!file.url.includes(options.tag)) {
-          throw new Error(`${manifestName} references ${file.url}, which is not part of release ${options.tag}`);
-        }
-        const artifact = assetsByName.get(file.url);
-        if (!artifact) {
-          throw new Error(`${manifestName} references ${file.url}, which is not an asset in release ${options.tag}`);
-        }
-        const bytes = await verifyArtifact(artifact, file.sha512);
-        console.log(`verified ${manifestName}: ${file.url} (${bytes} bytes, SHA-512 ok)`);
-      }
-    }
-  } finally {
-    fs.rmSync(verifyDir, { recursive: true, force: true });
-  }
-
-  console.log(`release ${options.tag} channel ${options.channel} passed draft asset verification`);
+  await verifyReleaseAssets(release, { channel: options.channel, tag: options.tag });
 }
 
 if (require.main === module) {
@@ -322,4 +384,5 @@ module.exports = {
   expectedArtifactNames,
   expectedManifestNames,
   parseManifest,
+  verifyReleaseAssets,
 };

--- a/tests/release-asset-verifier.test.cjs
+++ b/tests/release-asset-verifier.test.cjs
@@ -1,102 +1,210 @@
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const {
   assertManifestPlatformMapping,
   assertReleaseAssetInventory,
   expectedManifestNames,
   parseManifest,
+  verifyReleaseAssets,
 } = require('../scripts/verify-release-assets.cjs');
 
-const names = [
-  'latest.yml',
-  'latest-mac.yml',
-  'latest-linux.yml',
-  'latest-linux-arm64.yml',
-  'uninstall-macos.sh',
-  'uninstall-windows.ps1',
-  'flocafe-3.3.0-win-x64.exe',
-  'flocafe-3.3.0-win-x64.exe.blockmap',
-  'flocafe-3.3.0-win-x64.appx',
-  'flocafe-3.3.0-win-arm64.appx',
-  'flocafe-3.3.0-mac-x64.dmg',
-  'flocafe-3.3.0-mac-arm64.dmg',
-  'flocafe-3.3.0-mac-x64.zip',
-  'flocafe-3.3.0-mac-arm64.zip',
-  'flocafe-3.3.0-mac-x64.zip.blockmap',
-  'flocafe-3.3.0-mac-arm64.zip.blockmap',
-  'flocafe-3.3.0-linux-x64.appimage',
-  'flocafe-3.3.0-linux-arm64.appimage',
-  'flocafe-3.3.0-linux-x64.deb',
-  'flocafe-3.3.0-linux-arm64.deb',
-  'flocafe-3.3.0-linux-x64.rpm',
-  'flocafe-3.3.0-linux-arm64.rpm',
-  'flocafe-3.3.0-linux-x64.snap',
-  'flocafe-3.3.0-linux-arm64.snap',
-];
-const assets = names.map((name) => ({ name, size: 1 }));
-const manifests = expectedManifestNames('latest');
+const VERSION = '3.3.0';
+const MANIFESTS = expectedManifestNames('latest');
 
-assert.doesNotThrow(() => assertReleaseAssetInventory(assets, manifests, '3.3.0'));
+function sha512(value) {
+  return crypto.createHash('sha512').update(value).digest('base64');
+}
+
+function manifestFor(files) {
+  const first = files[0];
+  return [
+    `version: ${VERSION}`,
+    'files:',
+    ...files.flatMap((file) => [
+      `  - url: ${file.url}`,
+      `    sha512: ${file.sha512}`,
+    ]),
+    `path: ${first.url}`,
+    `sha512: ${first.sha512}`,
+    'releaseDate: 2026-08-23T00:00:00.000Z',
+    '',
+  ].join('\n');
+}
+
+function makeFixture() {
+  const names = [
+    ...MANIFESTS,
+    'uninstall-macos.sh',
+    'uninstall-windows.ps1',
+    `flocafe-${VERSION}-win-x64.exe`,
+    `flocafe-${VERSION}-win-x64.exe.blockmap`,
+    `flocafe-${VERSION}-win-x64.appx`,
+    `flocafe-${VERSION}-win-arm64.appx`,
+    `flocafe-${VERSION}-mac-x64.dmg`,
+    `flocafe-${VERSION}-mac-arm64.dmg`,
+    `flocafe-${VERSION}-mac-x64.zip`,
+    `flocafe-${VERSION}-mac-arm64.zip`,
+    `flocafe-${VERSION}-mac-x64.zip.blockmap`,
+    `flocafe-${VERSION}-mac-arm64.zip.blockmap`,
+    `flocafe-${VERSION}-linux-x64.appimage`,
+    `flocafe-${VERSION}-linux-arm64.appimage`,
+    `flocafe-${VERSION}-linux-x64.deb`,
+    `flocafe-${VERSION}-linux-arm64.deb`,
+    `flocafe-${VERSION}-linux-x64.rpm`,
+    `flocafe-${VERSION}-linux-arm64.rpm`,
+    `flocafe-${VERSION}-linux-x64.snap`,
+    `flocafe-${VERSION}-linux-arm64.snap`,
+  ];
+  const payloads = new Map(names.map((name) => [name, Buffer.from(`uploaded:${name}`)]));
+  const filesByManifest = {
+    'latest.yml': [`flocafe-${VERSION}-win-x64.exe`],
+    'latest-mac.yml': [
+      `flocafe-${VERSION}-mac-x64.zip`,
+      `flocafe-${VERSION}-mac-arm64.zip`,
+    ],
+    'latest-linux.yml': [`flocafe-${VERSION}-linux-x64.appimage`],
+    'latest-linux-arm64.yml': [`flocafe-${VERSION}-linux-arm64.appimage`],
+  };
+  for (const [manifestName, fileNames] of Object.entries(filesByManifest)) {
+    payloads.set(manifestName, Buffer.from(manifestFor(fileNames.map((url) => ({
+      url,
+      sha512: sha512(payloads.get(url)),
+    })))));
+  }
+
+  const assets = names.map((name) => ({
+    name,
+    size: payloads.get(name).length,
+    url: `https://assets.test/${name}`,
+  }));
+  return {
+    release: { draft: true, tag_name: VERSION, assets },
+    payloads,
+    filesByManifest,
+  };
+}
+
+function requestFor(fixture, unavailable = new Set()) {
+  return async (asset) => {
+    const payload = fixture.payloads.get(asset.name);
+    if (!payload || unavailable.has(asset.name)) return new Response('unavailable', { status: 404 });
+    return new Response(payload, { status: 200 });
+  };
+}
+
+const fixture = makeFixture();
+const assets = fixture.release.assets;
+assert.doesNotThrow(() => assertReleaseAssetInventory(assets, MANIFESTS, VERSION));
 assert.throws(
-  () => assertReleaseAssetInventory(assets.filter((asset) => !asset.name.endsWith('.appx')), manifests, '3.3.0'),
+  () => assertReleaseAssetInventory(assets.filter((asset) => !asset.name.endsWith('.appx')), MANIFESTS, VERSION),
   /missing:.*appx/,
 );
 assert.throws(
   () => assertReleaseAssetInventory([
     ...assets,
-    { name: 'flocafe-3.2.9-win-x64.exe', size: 1 },
-  ], manifests, '3.3.0'),
+    { name: `flocafe-3.2.9-win-x64.exe`, size: 1 },
+  ], MANIFESTS, VERSION),
   /unexpected assets:.*3\.2\.9/,
 );
 
-const manifest = parseManifest(`
-version: 3.3.0
-files:
-  - url: flocafe-3.3.0-win-x64.exe
-    sha512: abc123
-path: flocafe-3.3.0-win-x64.exe
-sha512: abc123
-`, 'latest.yml');
-assert.deepEqual(manifest, {
-  version: '3.3.0',
-  files: [{ url: 'flocafe-3.3.0-win-x64.exe', sha512: 'abc123' }],
+const parsedManifest = parseManifest(fixture.payloads.get('latest.yml').toString('utf8'), 'latest.yml');
+assert.deepEqual(parsedManifest, {
+  version: VERSION,
+  files: [{
+    url: `flocafe-${VERSION}-win-x64.exe`,
+    sha512: sha512(fixture.payloads.get(`flocafe-${VERSION}-win-x64.exe`)),
+  }],
 });
 assert.throws(
-  () => parseManifest('files:\n  - url: flocafe-3.3.0-win-x64.exe\n    sha512: abc123\n', 'latest.yml'),
-  /does not declare a release version/,
+  () => parseManifest('files: not-a-list\nversion: 3.3.0\n', 'latest.yml'),
+  /does not reference any update artifact/,
+);
+assert.throws(
+  () => parseManifest('files:\n  - url: artifact.exe\n    sha512: not-a-sha512\nversion: 3.3.0\n', 'latest.yml'),
+  /valid SHA-512/,
 );
 
-assert.doesNotThrow(() => assertManifestPlatformMapping('latest.yml', '3.3.0', [
-  { url: 'flocafe-3.3.0-win-x64.exe' },
+assert.doesNotThrow(() => assertManifestPlatformMapping('latest.yml', VERSION, [
+  { url: `flocafe-${VERSION}-win-x64.exe` },
 ]));
-assert.doesNotThrow(() => assertManifestPlatformMapping('latest-mac.yml', '3.3.0', [
-  { url: 'flocafe-3.3.0-mac-x64.zip' },
-  { url: 'flocafe-3.3.0-mac-arm64.zip' },
-  { url: 'flocafe-3.3.0-mac-x64.dmg' },
-  { url: 'flocafe-3.3.0-mac-arm64.dmg' },
+assert.doesNotThrow(() => assertManifestPlatformMapping('latest-mac.yml', VERSION, [
+  { url: `flocafe-${VERSION}-mac-x64.zip` },
+  { url: `flocafe-${VERSION}-mac-arm64.zip` },
+  { url: `flocafe-${VERSION}-mac-x64.dmg` },
+  { url: `flocafe-${VERSION}-mac-arm64.dmg` },
 ]));
-assert.doesNotThrow(() => assertManifestPlatformMapping('latest-linux.yml', '3.3.0', [
-  { url: 'flocafe-3.3.0-linux-x64.appimage' },
+assert.doesNotThrow(() => assertManifestPlatformMapping('latest-linux.yml', VERSION, [
+  { url: `flocafe-${VERSION}-linux-x64.appimage` },
 ]));
-assert.doesNotThrow(() => assertManifestPlatformMapping('latest-linux-arm64.yml', '3.3.0', [
-  { url: 'flocafe-3.3.0-linux-arm64.appimage' },
+assert.doesNotThrow(() => assertManifestPlatformMapping('latest-linux-arm64.yml', VERSION, [
+  { url: `flocafe-${VERSION}-linux-arm64.appimage` },
 ]));
 assert.throws(
-  () => assertManifestPlatformMapping('latest.yml', '3.3.0', [
-    { url: 'flocafe-3.3.0-mac-x64.zip' },
+  () => assertManifestPlatformMapping('latest.yml', VERSION, [
+    { url: `flocafe-${VERSION}-mac-x64.zip` },
   ]),
   /another platform or architecture/,
 );
 assert.throws(
-  () => assertManifestPlatformMapping('latest-linux-arm64.yml', '3.3.0', [
-    { url: 'flocafe-3.3.0-linux-x64.appimage' },
+  () => assertManifestPlatformMapping('latest-linux-arm64.yml', VERSION, [
+    { url: `flocafe-${VERSION}-linux-x64.appimage` },
   ]),
   /another platform or architecture/,
 );
 assert.throws(
-  () => assertManifestPlatformMapping('latest-mac.yml', '3.3.0', [
-    { url: 'flocafe-3.3.0-mac-x64.zip' },
+  () => assertManifestPlatformMapping('latest-mac.yml', VERSION, [
+    { url: `flocafe-${VERSION}-mac-x64.zip` },
   ]),
   /missing required platform artifacts/,
 );
 
-console.log('✅ Draft release asset inventory checks passed');
+(async () => {
+  const requestedAssets = [];
+  await verifyReleaseAssets(fixture.release, {
+    channel: 'latest',
+    requestAsset: async (asset) => {
+      requestedAssets.push(asset.name);
+      return requestFor(fixture)(asset);
+    },
+  });
+  assert.ok(requestedAssets.includes('uninstall-macos.sh'), 'non-manifest assets must be availability-checked');
+  assert.ok(requestedAssets.includes(`flocafe-${VERSION}-win-x64.exe`), 'Windows representative must be downloaded and hashed');
+  assert.ok(requestedAssets.includes(`flocafe-${VERSION}-mac-x64.zip`), 'macOS representative must be downloaded and hashed');
+  assert.ok(requestedAssets.includes(`flocafe-${VERSION}-linux-x64.appimage`), 'Linux representative must be downloaded and hashed');
+
+  const missingManifest = makeFixture();
+  missingManifest.release.assets = missingManifest.release.assets.filter((asset) => asset.name !== 'latest-linux-arm64.yml');
+  await assert.rejects(
+    () => verifyReleaseAssets(missingManifest.release, { channel: 'latest', requestAsset: requestFor(missingManifest) }),
+    /missing latest-linux-arm64\.yml/,
+  );
+
+  const badUrl = makeFixture();
+  const badUrlName = `flocafe-${VERSION}-win-x64.exe`;
+  badUrl.payloads.set('latest.yml', Buffer.from(manifestFor([{
+    url: badUrlName,
+    sha512: sha512(badUrl.payloads.get(badUrlName)),
+  }])));
+  await assert.rejects(
+    () => verifyReleaseAssets(badUrl.release, {
+      channel: 'latest',
+      requestAsset: requestFor(badUrl, new Set([badUrlName])),
+    }),
+    /HTTP 200.*404/,
+  );
+
+  const badHash = makeFixture();
+  badHash.payloads.set('latest.yml', Buffer.from(manifestFor([{
+    url: badUrlName,
+    sha512: sha512(Buffer.from('different uploaded content')),
+  }])));
+  await assert.rejects(
+    () => verifyReleaseAssets(badHash.release, { channel: 'latest', requestAsset: requestFor(badHash) }),
+    /SHA-512 mismatch.*win-x64\.exe/,
+  );
+
+  console.log('✅ Draft release verifier success, missing-manifest, bad-URL, and bad-hash simulations passed');
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -108,6 +108,7 @@ function run() {
 
   const linuxJob = jobs['release-linux'];
   assertShellStep(linuxJob, 'Build Linux artifacts');
+  assertShellStep(linuxJob, 'Verify Linux release assets');
   assertShellStep(linuxJob, 'Upload Linux assets to GitHub release');
   assertShellStep(linuxJob, 'Prepend AppStream release entry');
   const snapPublish = findStep(linuxJob, 'Publish snap to the matching Snap Store channel');
@@ -133,6 +134,8 @@ function run() {
   assert.equal(storePublish.env.RELEASE_CHANNEL, undefined);
 
   const verifyJob = jobs['verify-release'];
+  const verifierDependencies = findStep(verifyJob, 'Install verifier dependencies');
+  assert.equal(verifierDependencies.run, 'npm ci --ignore-scripts --no-audit --no-fund');
   const publishJob = jobs['publish-release'];
   assert.deepEqual(verifyJob.needs, ['create-release', 'release-linux', 'release-mac', 'release-windows']);
   assert.deepEqual(publishJob.needs, ['create-release', 'release-linux', 'release-mac', 'release-windows', 'verify-release']);


### PR DESCRIPTION
## Intent

Implement FloCafe issue #465 under epic #463 by enforcing release verification for every shipped Windows, macOS, and Linux self-updating target. Verification must use the actual uploaded GitHub draft release, fail on missing or malformed latest*.yml manifests, unavailable referenced assets, or SHA-512 mismatches, while preserving the draft-until-verified flow from PR #488.

## What changed

- Parse and validate updater manifests as YAML, including platform mappings, checksums, and release asset inventory.
- Download manifests and referenced assets from the uploaded draft release, require HTTP 200, and recompute SHA-512 values.
- Add Linux architecture manifest gates and deterministic no-network success, malformed, missing-manifest, unavailable-URL, and bad-hash simulations.
- Document the manifest and post-upload verification contract.

Microsoft Store/Mac App Store publishing automation and Windows direct-download code signing are unchanged and not part of this change.

## Testing

- `npm run test:release-config`
- `npm run lint`
- `git diff --check`
- No-network executable-interface simulations cover Windows, macOS x64/arm64, Linux x64/arm64, plus failure paths.

Fixes #465
Refs #463