### PR TITLE
feat(updates): add beta channel opt-in and safe restart guard

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -24,6 +24,17 @@ Beta and nightly installations are intentionally isolated from stable: if their
 channel has no published release, electron-updater reports no channel update
 instead of silently falling back to stable.
 
+Desktop builds that expose the beta-channel IPC contract provide a beta
+pre-release toggle in **Settings > Updates**. The toggle reads and persists its
+state through the main process; older builds without that contract show the
+control as disabled with an explanation. When a downloaded update is ready,
+restarting from Settings or the update badge requires manager or owner Master
+PIN approval in the main process. The confirmation warns that POS, KDS,
+printing, and reports are unavailable while the update installs, that the
+service returns automatically after restart, and that installation should not
+be started during business hours. Cancelling or failing PIN approval leaves the
+app running.
+
 GitHub's `Latest` release pointer and electron-updater's channel manifests are
 separate concepts. Every release is created with `--draft --latest=false`.
 After all platform uploads have completed, CI downloads each manifest and every

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -22,6 +22,7 @@ import { COUNTRIES, getCountryByCode, getLocalizedCountryName, sortCountriesByLo
 import { dialCodeFor, normalizeOptionalPhone } from '@/lib/phone';
 import { useConfirm } from '@/hooks/use-confirm';
 import { MasterPinPrompt } from '@/components/settings/MasterPinPrompt';
+import BetaChannelToggle from '@/components/settings/BetaChannelToggle';
 import { HealthCheckDialog } from '@/components/settings/HealthCheckDialog';
 import { InitializeDatabaseDialog } from '@/components/settings/InitializeDatabaseDialog';
 import { WhatsAppEnableCard } from '@/components/settings/WhatsAppEnableCard';
@@ -4999,6 +5000,12 @@ export default function SettingsPage() {
               </div>
             )}
           </div>
+
+          {/* #463: beta/pre-release channel opt-in; feature-detects the
+              beta-release-channel IPC contract and degrades visibly when absent. */}
+          {isElectron && (
+            <BetaChannelToggle />
+          )}
           </div>
         </TabsContent>
 

--- a/frontend/src/components/layout/UpdateBadge.tsx
+++ b/frontend/src/components/layout/UpdateBadge.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Download, Sparkles } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { Button } from '@/components/ui/button';
 import {
@@ -18,9 +19,13 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useUpdateStatus } from '@/hooks/useUpdateStatus';
+import { UpdateInstallGuardDialog } from '@/components/updates/UpdateInstallGuardDialog';
 
 export default function UpdateBadge() {
   const { updateStatus, appVersion, restartAndInstall } = useUpdateStatus();
+  // #463: restart-to-install always goes through the PIN-guarded confirmation
+  // dialog; the dropdown item only opens it and can never restart directly.
+  const [guardOpen, setGuardOpen] = useState(false);
   const t = useTranslations('update');
 
   const status = updateStatus?.status;
@@ -80,12 +85,18 @@ export default function UpdateBadge() {
         {isReady && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={restartAndInstall} className="text-sm cursor-pointer">
+            <DropdownMenuItem onClick={() => setGuardOpen(true)} className="text-sm cursor-pointer">
               {t('restartNow')}
             </DropdownMenuItem>
           </>
         )}
       </DropdownMenuContent>
+
+      <UpdateInstallGuardDialog
+        open={guardOpen}
+        onCancel={() => setGuardOpen(false)}
+        onRequestRestart={(pin) => restartAndInstall(pin)}
+      />
     </DropdownMenu>
   );
 }

--- a/frontend/src/components/settings/BetaChannelToggle.tsx
+++ b/frontend/src/components/settings/BetaChannelToggle.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+/**
+ * Beta/pre-release update channel toggle for the Settings → Updates panel
+ * (#463). Feature-detects the `updates:get-beta-channel` /
+ * `updates:set-beta-channel` IPC contract owned by the beta-release-channel
+ * workstream: when the exposed `electronAPI` lacks those methods, the toggle
+ * renders visibly disabled with a short explanation instead of failing.
+ *
+ * Persisted state lives in the main process; this component only reflects
+ * what `getBetaChannel` returns and optimistically updates after a
+ * successful `setBetaChannel`.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'use-intl';
+import toast from 'react-hot-toast';
+import { readBetaChannelState, writeBetaChannelState } from '@/lib/updates/beta-channel';
+
+export default function BetaChannelToggle() {
+  const t = useTranslations('update');
+  // Tri-state: null until the initial get resolves (or proves unsupported).
+  const [supported, setSupported] = useState<boolean | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    readBetaChannelState(typeof window !== 'undefined' ? window.electronAPI : undefined)
+      .then((state) => {
+        if (cancelled) return;
+        setSupported(state.supported);
+        if (state.enabled !== null) setEnabled(state.enabled);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleChange = async (next: boolean) => {
+    if (!supported || busy) return;
+    setBusy(true);
+    const result = await writeBetaChannelState(window.electronAPI, next);
+    if (result.ok && result.enabled !== null) {
+      setEnabled(result.enabled);
+    } else if (!result.ok) {
+      toast.error(t('betaToggleFailed'));
+    }
+    setBusy(false);
+  };
+
+  // Not inside Electron at all: updates are desktop-only, hide entirely
+  // (same policy as the #467 update controls).
+  if (typeof window === 'undefined') return null;
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-100 p-6" data-testid="beta-channel-toggle">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="font-semibold text-gray-900">{t('betaTitle')}</h3>
+          <p className="text-sm text-gray-500 mt-1">{t('betaDescription')}</p>
+          {supported === false && (
+            <p className="text-xs text-amber-600 mt-2">{t('betaUnavailable')}</p>
+          )}
+        </div>
+        <label className="inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            checked={enabled}
+            disabled={supported !== true || busy}
+            onChange={(e) => void handleChange(e.target.checked)}
+            data-testid="beta-channel-checkbox"
+            aria-label={t('betaTitle')}
+            className="sr-only peer"
+          />
+          <span className={`relative w-9 h-5 rounded-full transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-brand ${
+            enabled ? 'bg-brand' : 'bg-gray-300'
+          } ${supported === true ? '' : 'opacity-40 cursor-not-allowed'}`}>
+            <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+              enabled ? 'translate-x-4' : ''
+            }`} />
+          </span>
+          <span className="ml-2 text-sm font-medium text-gray-700">
+            {enabled ? t('betaOn') : t('betaOff')}
+          </span>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/updates/UpdateInstallGuardDialog.tsx
+++ b/frontend/src/components/updates/UpdateInstallGuardDialog.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+/**
+ * Restart-to-install confirmation guard (#463).
+ *
+ * Every UI path that can restart the app to install a downloaded update must
+ * go through this dialog. It shows a prominent RED warning that all systems
+ * go down while the update installs, and requires an explicit manager or
+ * owner PIN confirmation before the restart is requested.
+ *
+ * The PIN is verified in the main process (`authorizeMasterPin` inside the
+ * `restart-and-install` handler); a wrong PIN, a rate limit, or cancelling
+ * the dialog simply keeps the app running — there is no path from this
+ * dialog to `quitAndInstall` without an approved PIN.
+ */
+
+import { useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { useTranslations } from 'use-intl';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  canSubmitRestartInstall,
+  normalizeRestartInstallResult,
+} from '@/lib/updates/restart-install';
+
+interface UpdateInstallGuardDialogProps {
+  open: boolean;
+  onCancel: () => void;
+  /** Performs the guarded IPC call; resolves with the normalized result. */
+  onRequestRestart: (pin: string) => Promise<unknown>;
+}
+
+export function UpdateInstallGuardDialog({ open, onCancel, onRequestRestart }: UpdateInstallGuardDialogProps) {
+  const t = useTranslations('update');
+  const [pin, setPin] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setPin('');
+    setError(null);
+    setSubmitting(false);
+  };
+
+  const handleCancel = () => {
+    if (submitting) return;
+    reset();
+    onCancel();
+  };
+
+  const handleSubmit = async () => {
+    // Explicit confirm only: an empty/invalid PIN can never reach the IPC
+    // layer, so dismissing or fat-fingering this dialog cannot restart the app.
+    if (!canSubmitRestartInstall(pin, submitting)) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const result = normalizeRestartInstallResult(await onRequestRestart(pin));
+      if (!result.ok) {
+        setError(result.error || t('installGuardFailedGeneric'));
+        setPin('');
+        setSubmitting(false);
+      }
+      // On success the app quits; leave the dialog in its busy state.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setPin('');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && handleCancel()}>
+      <DialogContent className="sm:max-w-md" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{t('installGuardTitle')}</DialogTitle>
+          <DialogDescription>{t('installGuardDescription')}</DialogDescription>
+        </DialogHeader>
+
+        {/* Prominent red warning: restarting to install takes the whole POS down. */}
+        <div className="rounded-lg border-2 border-red-600 bg-red-50 p-4" role="alert" data-testid="update-install-warning">
+          <div className="flex items-start gap-2">
+            <AlertTriangle size={20} className="mt-0.5 shrink-0 text-red-600" aria-hidden />
+            <div className="space-y-1.5 text-sm text-red-700">
+              <p className="font-semibold text-red-800">{t('installWarnTitle')}</p>
+              <ul className="list-disc space-y-1 pl-4">
+                <li>{t('installWarnSystemsDown')}</li>
+                <li>{t('installWarnAutoRestart')}</li>
+                <li>{t('installWarnBusinessHours')}</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="update-install-pin">{t('installPinLabel')}</Label>
+          <Input
+            id="update-install-pin"
+            type="password"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            maxLength={4}
+            autoFocus
+            value={pin}
+            onChange={(e) => setPin(e.target.value.replace(/\D/g, '').slice(0, 4))}
+            onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+            placeholder="••••"
+            disabled={submitting}
+            className="text-center text-lg tracking-[0.5em]"
+          />
+          {error && <p className="text-sm font-medium text-red-600">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel} disabled={submitting}>
+            {t('installCancelButton')}
+          </Button>
+          <Button
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmitRestartInstall(pin, submitting)}
+            data-testid="update-install-confirm"
+          >
+            {submitting ? t('installRestarting') : t('installConfirmButton')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/useUpdateStatus.ts
+++ b/frontend/src/hooks/useUpdateStatus.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import type { UpdateStatus } from '@/types/electron';
+import type { ElectronActionResult, UpdateStatus } from '@/types/electron';
 import { shouldApplyInitialUpdateStatus } from './update-status-sync';
 
 /**
@@ -52,10 +52,14 @@ export function useUpdateStatus() {
     }
   };
 
-  const restartAndInstall = () => {
+  // #463: the main process authorizes the manager/owner PIN inside the
+  // `restart-and-install` handler; this only forwards it and returns the
+  // normalized result so the confirmation dialog can stay open on failure.
+  const restartAndInstall = (pin?: string) => {
     if (typeof window !== 'undefined' && window.electronAPI) {
-      window.electronAPI.restartAndInstall();
+      return window.electronAPI.restartAndInstall(pin);
     }
+    return Promise.resolve({ success: false, error: 'not-available' } satisfies ElectronActionResult);
   };
 
   return { updateStatus, appVersion, isElectron, checkForUpdates, restartAndInstall };

--- a/frontend/src/lib/i18n/messages/en.json
+++ b/frontend/src/lib/i18n/messages/en.json
@@ -2120,7 +2120,24 @@
     "readyBadge": "Update ready",
     "restartNow": "Restart Now",
     "sectionLabel": "App Update",
-    "versionReady": "Version {version} is ready to install"
+    "versionReady": "Version {version} is ready to install",
+    "installGuardTitle": "Restart to install update?",
+    "installGuardDescription": "This requires manager or owner approval before the app restarts.",
+    "installWarnTitle": "Warning: everything goes offline during the update",
+    "installWarnSystemsDown": "All systems (POS, KDS, printing, reports) go down while the update installs.",
+    "installWarnAutoRestart": "Service comes back automatically once the app restarts with the new version.",
+    "installWarnBusinessHours": "Do not do this during business hours.",
+    "installPinLabel": "Manager or owner PIN",
+    "installConfirmButton": "Approve & restart",
+    "installCancelButton": "Cancel",
+    "installRestarting": "Restarting...",
+    "installGuardFailedGeneric": "Could not start the update. Try again.",
+    "betaTitle": "Beta updates (pre-releases)",
+    "betaDescription": "Get pre-release versions of Flo Desktop before they are broadly available. Beta builds may contain unfinished features.",
+    "betaUnavailable": "Beta channel switching is not available in this app build yet. Update the desktop app to opt in.",
+    "betaOn": "On",
+    "betaOff": "Off",
+    "betaToggleFailed": "Could not change the beta channel setting."
   },
   "whatsapp": {
     "active": {

--- a/frontend/src/lib/i18n/messages/es.json
+++ b/frontend/src/lib/i18n/messages/es.json
@@ -2120,7 +2120,24 @@
     "readyBadge": "Actualización lista",
     "restartNow": "Reiniciar ahora",
     "sectionLabel": "Actualización de la app",
-    "versionReady": "La versión {version} está lista para instalar"
+    "versionReady": "La versión {version} está lista para instalar",
+    "installGuardTitle": "¿Reiniciar para instalar la actualización?",
+    "installGuardDescription": "Se requiere aprobación del encargado o propietario antes de reiniciar la aplicación.",
+    "installWarnTitle": "Advertencia: todo queda fuera de línea durante la actualización",
+    "installWarnSystemsDown": "Todos los sistemas (POS, KDS, impresión, informes) se detienen mientras se instala la actualización.",
+    "installWarnAutoRestart": "El servicio vuelve automáticamente cuando la aplicación se reinicia con la nueva versión.",
+    "installWarnBusinessHours": "No lo hagas durante el horario de atención.",
+    "installPinLabel": "PIN del encargado o propietario",
+    "installConfirmButton": "Aprobar y reiniciar",
+    "installCancelButton": "Cancelar",
+    "installRestarting": "Reiniciando...",
+    "installGuardFailedGeneric": "No se pudo iniciar la actualización. Inténtalo de nuevo.",
+    "betaTitle": "Actualizaciones beta (prelanzamientos)",
+    "betaDescription": "Recibe versiones preliminares de Flo Desktop antes de su disponibilidad general. Las versiones beta pueden incluir funciones sin terminar.",
+    "betaUnavailable": "Cambiar al canal beta aún no está disponible en esta versión de la aplicación. Actualiza la aplicación de escritorio para participar.",
+    "betaOn": "Activado",
+    "betaOff": "Desactivado",
+    "betaToggleFailed": "No se pudo cambiar la configuración del canal beta."
   },
   "whatsapp": {
     "active": {

--- a/frontend/src/lib/i18n/messages/fa.json
+++ b/frontend/src/lib/i18n/messages/fa.json
@@ -2120,7 +2120,24 @@
     "readyBadge": "به‌روزرسانی آماده است",
     "restartNow": "راه‌اندازی دوباره",
     "sectionLabel": "به‌روزرسانی برنامه",
-    "versionReady": "نسخه {version} برای نصب آماده است"
+    "versionReady": "نسخه {version} برای نصب آماده است",
+    "installGuardTitle": "راه‌اندازی دوباره برای نصب به‌روزرسانی؟",
+    "installGuardDescription": "پیش از راه‌اندازی دوباره برنامه، تأیید مدیر یا مالک لازم است.",
+    "installWarnTitle": "هشدار: در طول به‌روزرسانی همه چیز آفلاین می‌شود",
+    "installWarnSystemsDown": "همه سامانه‌ها (POS، KDS، چاپ، گزارش‌ها) هنگام نصب به‌روزرسانی از کار می‌افتند.",
+    "installWarnAutoRestart": "سرویس به‌طور خودکار وقتی برنامه با نسخه جدید راه‌اندازی دوباره شود برمی‌گردد.",
+    "installWarnBusinessHours": "این کار را در ساعات کاری انجام ندهید.",
+    "installPinLabel": "پین مدیر یا مالک",
+    "installConfirmButton": "تأیید و راه‌اندازی دوباره",
+    "installCancelButton": "لغو",
+    "installRestarting": "در حال راه‌اندازی دوباره...",
+    "installGuardFailedGeneric": "شروع به‌روزرسانی ممکن نشد. دوباره تلاش کنید.",
+    "betaTitle": "به‌روزرسانی‌های بتا (پیش‌انتشار)",
+    "betaDescription": "نسخه‌های پیش‌انتشار Flo Desktop را پیش از عرضه عمومی دریافت کنید. نسخه‌های بتا ممکن است ویژگی‌های ناتمام داشته باشند.",
+    "betaUnavailable": "تغییر کانال بتا هنوز در این نسخه برنامه در دسترس نیست. برای عضویت، برنامه دسکتاپ را به‌روز کنید.",
+    "betaOn": "روشن",
+    "betaOff": "خاموش",
+    "betaToggleFailed": "تغییر تنظیمات کانال بتا ممکن نشد."
   },
   "whatsapp": {
     "active": {

--- a/frontend/src/lib/i18n/messages/pt.json
+++ b/frontend/src/lib/i18n/messages/pt.json
@@ -2120,7 +2120,24 @@
     "readyBadge": "Atualização pronta",
     "restartNow": "Reiniciar agora",
     "sectionLabel": "Atualização do app",
-    "versionReady": "A versão {version} está pronta para instalar"
+    "versionReady": "A versão {version} está pronta para instalar",
+    "installGuardTitle": "Reiniciar para instalar a atualização?",
+    "installGuardDescription": "É necessária a aprovação do gerente ou proprietário antes de reiniciar o aplicativo.",
+    "installWarnTitle": "Atenção: tudo fica fora do ar durante a atualização",
+    "installWarnSystemsDown": "Todos os sistemas (POS, KDS, impressão, relatórios) ficam indisponíveis enquanto a atualização é instalada.",
+    "installWarnAutoRestart": "O serviço volta automaticamente quando o aplicativo reinicia com a nova versão.",
+    "installWarnBusinessHours": "Não faça isso durante o horário de funcionamento.",
+    "installPinLabel": "PIN do gerente ou proprietário",
+    "installConfirmButton": "Aprovar e reiniciar",
+    "installCancelButton": "Cancelar",
+    "installRestarting": "Reiniciando...",
+    "installGuardFailedGeneric": "Não foi possível iniciar a atualização. Tente novamente.",
+    "betaTitle": "Atualizações beta (pré-lançamentos)",
+    "betaDescription": "Receba versões de pré-lançamento do Flo Desktop antes da disponibilidade geral. Versões beta podem conter recursos inacabados.",
+    "betaUnavailable": "A mudança para o canal beta ainda não está disponível nesta versão do aplicativo. Atualize o aplicativo desktop para participar.",
+    "betaOn": "Ativado",
+    "betaOff": "Desativado",
+    "betaToggleFailed": "Não foi possível alterar a configuração do canal beta."
   },
   "whatsapp": {
     "active": {

--- a/frontend/src/lib/updates/beta-channel.ts
+++ b/frontend/src/lib/updates/beta-channel.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure helpers for the beta/pre-release update channel toggle (#463).
+ *
+ * The `updates:get-beta-channel` / `updates:set-beta-channel` IPC contract
+ * (and its preload bindings) is owned by the beta-release-channel workstream.
+ * This module lets the renderer feature-detect that API so the Settings
+ * toggle stays correct whether or not the sibling implementation has landed.
+ *
+ * Everything here is deliberately tolerant of unknown result shapes: the
+ * sibling crew owns the exact response envelope, so we only commit to
+ * "boolean-ish" values and `{ success, error? }`-style action results.
+ */
+
+export interface BetaChannelApi {
+  getBetaChannel?: () => Promise<unknown>;
+  setBetaChannel?: (enabled: boolean) => Promise<unknown>;
+}
+
+/** True only when BOTH sides of the contract are callable on the exposed API. */
+export function betaChannelApiSupported(api: BetaChannelApi | null | undefined): boolean {
+  return typeof api?.getBetaChannel === 'function'
+    && typeof api?.setBetaChannel === 'function';
+}
+
+/**
+ * Coerce a get/set payload into a tri-state: true/false when a boolean is
+ * recoverable, null when the value is missing or malformed (callers treat
+ * null as "unsupported" and fall back to the disabled UI).
+ */
+export function normalizeBetaChannelValue(raw: unknown): boolean | null {
+  if (typeof raw === 'boolean') return raw;
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw === 'object') {
+    const record = raw as Record<string, unknown>;
+    if ('enabled' in record) return normalizeBetaChannelValue(record.enabled);
+    if ('success' in record && record.success === false) return null;
+    if ('error' in record) return null;
+  }
+  return null;
+}
+
+export interface WriteBetaChannelResult {
+  ok: boolean;
+  /** New persisted state when known; null when the response was unusable. */
+  enabled: boolean | null;
+  error?: string;
+}
+
+/** Normalize a set-beta-channel response into an optimistic-update decision. */
+export function normalizeBetaChannelWriteResult(raw: unknown, requested: boolean): WriteBetaChannelResult {
+  if (raw === undefined) {
+    // Legacy void resolution: assume the request landed with the asked-for value.
+    return { ok: true, enabled: requested };
+  }
+  if (typeof raw !== 'object') {
+    return { ok: false, enabled: null, error: String(raw) };
+  }
+  const record = raw as Record<string, unknown>;
+  if (record.success === false) {
+    const error = typeof record.error === 'string' && record.error.length > 0
+      ? record.error
+      : undefined;
+    return { ok: false, enabled: null, error };
+  }
+  const enabled = 'enabled' in record ? normalizeBetaChannelValue(record.enabled) : requested;
+  return { ok: true, enabled: enabled ?? requested };
+}
+
+export interface ReadBetaChannelResult {
+  supported: boolean;
+  enabled: boolean | null;
+}
+
+/** Read the current channel state; unsupported/unreadable APIs report supported=false. */
+export async function readBetaChannelState(api: BetaChannelApi | null | undefined): Promise<ReadBetaChannelResult> {
+  if (!betaChannelApiSupported(api)) return { supported: false, enabled: null };
+  try {
+    const enabled = normalizeBetaChannelValue(await api!.getBetaChannel!());
+    return { supported: enabled !== null, enabled };
+  } catch {
+    return { supported: false, enabled: null };
+  }
+}
+
+/**
+ * Optimistic-update helper for the Settings toggle: returns the state to
+ * render after the IPC call settles. Only a confirmed success moves the
+ * toggle; failures keep the previously rendered value.
+ */
+export async function writeBetaChannelState(
+  api: BetaChannelApi | null | undefined,
+  enabled: boolean,
+): Promise<WriteBetaChannelResult> {
+  if (!betaChannelApiSupported(api)) {
+    return { ok: false, enabled: null, error: 'beta-channel-unavailable' };
+  }
+  try {
+    return normalizeBetaChannelWriteResult(await api!.setBetaChannel!(enabled), enabled);
+  } catch (error) {
+    return { ok: false, enabled: null, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/frontend/src/lib/updates/restart-install.ts
+++ b/frontend/src/lib/updates/restart-install.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure helpers for the restart-to-install confirmation guard (#463).
+ *
+ * The authoritative gate lives in the main process (`restart-and-install`
+ * authorizes the manager/owner PIN via `authorizeMasterPin` before calling
+ * `quitAndInstall`). These helpers only normalize the IPC result and enforce
+ * the renderer-side preconditions so the dialog can never submit an
+ * obviously invalid request.
+ */
+
+export const MANAGER_PIN_REGEX = /^\d{4}$/;
+
+export interface RestartInstallResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Normalize what `restartAndInstall(pin)` resolved to.
+ *
+ * Older preload builds resolved the invoke with `undefined` (fire and
+ * forget), while the guarded contract resolves `{ success, error? }`. Both
+ * must keep working so this UI stays correct across a rolling update.
+ */
+export function normalizeRestartInstallResult(raw: unknown): RestartInstallResult {
+  if (raw === undefined || raw === null) {
+    // Legacy void resolution: the main process used to just quit.
+    return { ok: true };
+  }
+  if (typeof raw !== 'object') {
+    return { ok: false, error: String(raw) };
+  }
+  const record = raw as { success?: unknown; error?: unknown };
+  if (record.success === true) return { ok: true };
+  const error = typeof record.error === 'string' && record.error.length > 0
+    ? record.error
+    : undefined;
+  return { ok: false, error };
+}
+
+/** Renderer-side precondition: exactly 4 digits, matching the Master PIN format. */
+export function isValidManagerPinInput(pin: string): boolean {
+  return MANAGER_PIN_REGEX.test(pin);
+}
+
+/**
+ * Whether the confirm action may fire: a well-formed PIN is required and no
+ * submission may already be in flight. The dialog stays open on failure, so
+ * a failed or cancelled attempt can never turn into a restart.
+ */
+export function canSubmitRestartInstall(pin: string, busy: boolean): boolean {
+  return !busy && isValidManagerPinInput(pin);
+}

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -40,7 +40,16 @@ export interface ElectronAPI {
   onUpdateStatus: (callback: (status: UpdateStatus) => void) => (() => void);
   getUpdateStatus: () => Promise<{ status: UpdateStatus['status']; version?: string; percent?: number; reason?: UpdateFailureReason; error?: string; info: { version: string } }>;
   checkForUpdates: () => Promise<void>;
-  restartAndInstall: () => Promise<void>;
+  // #463: the main process authorizes the manager/owner PIN before quitting
+  // to install; a denied request resolves with success:false instead of restarting.
+  restartAndInstall: (pin?: string) => Promise<ElectronActionResult>;
+
+  // Beta/pre-release update channel (#463). Main process + preload bindings are
+  // owned by the beta-release-channel workstream (`updates:get-beta-channel` /
+  // `updates:set-beta-channel`). Optional on purpose: renderers must feature-
+  // detect these and degrade gracefully until that implementation lands.
+  getBetaChannel?: () => Promise<unknown>;
+  setBetaChannel?: (enabled: boolean) => Promise<unknown>;
 
   // Platform
   platform: string;

--- a/main/index.ts
+++ b/main/index.ts
@@ -13,6 +13,7 @@ import { startKdsServer, stopKdsServer, getKdsPort, isKdsServerRunning } from '.
 import { startServerApp, stopServerApp, getServerAppPort, isServerAppRunning } from './server-app';
 import { initPrinter } from './printers/thermal';
 import { registerIpcHandlers } from './ipc';
+import { authorizeMasterPin } from './services/master-pin';
 import { initFromDb as initWhatsAppFromDb, requestShutdown as requestWhatsAppShutdown, shutdown as shutdownWhatsApp } from './services/whatsapp';
 import log from 'electron-log/main';
 import { autoUpdater } from 'electron-updater';
@@ -780,13 +781,24 @@ async function initialize(): Promise<void> {
       checkForUpdates();
     });
 
-    ipcMain.handle('restart-and-install', () => {
+    // #463: restarting to install takes the whole POS down (server, KDS,
+    // printing) until the app comes back up, so it is gated behind manager or
+    // owner PIN approval. The PIN check runs here in the main process — the
+    // same authorizeMasterPin used by every other master-PIN-gated IPC
+    // handler — so no renderer path can bypass the guard.
+    ipcMain.handle('restart-and-install', (_event, pin?: unknown) => {
       if (!isInstallReady(storedUpdateStatus, stagedUpdateReady)) {
         log.warn('[Update] Ignoring install request before an update is downloaded');
-        return;
+        return { success: false, error: 'No downloaded update is ready to install.' };
+      }
+      const auth = authorizeMasterPin(typeof pin === 'string' ? pin : undefined, 'ipc:restart-and-install');
+      if (!auth.ok) {
+        log.warn(`[Update] Restart-to-install denied by Master PIN gate: ${auth.error}`);
+        return { success: false, error: auth.error };
       }
       isQuitting = true;
       autoUpdater.quitAndInstall();
+      return { success: true };
     });
 
     ipcMain.handle('get-status', () => {

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -19,15 +19,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getStatus: () => ipcRenderer.invoke('get-status'),
 
   getPrinters: () => ipcRenderer.invoke('get-printers'),
-  savePrinter: (printer: any) => ipcRenderer.invoke('save-printer', printer),
+  savePrinter: (printer: unknown) => ipcRenderer.invoke('save-printer', printer),
 
   getDailySummary: () => ipcRenderer.invoke('get-daily-summary'),
 
   getUpdateStatus: () => ipcRenderer.invoke('get-update-status'),
   checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
   restartAndInstall: (pin?: string) => ipcRenderer.invoke('restart-and-install', pin),
-  onUpdateStatus: (callback: (status: any) => void) => {
-    const handler = (_event: any, status: any) => callback(status);
+  onUpdateStatus: (callback: (status: unknown) => void) => {
+    const handler = (_event: unknown, status: unknown) => callback(status);
     ipcRenderer.on('update-status', handler);
     return () => { ipcRenderer.removeListener('update-status', handler); };
   },

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -25,7 +25,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   getUpdateStatus: () => ipcRenderer.invoke('get-update-status'),
   checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
-  restartAndInstall: () => ipcRenderer.invoke('restart-and-install'),
+  restartAndInstall: (pin?: string) => ipcRenderer.invoke('restart-and-install', pin),
   onUpdateStatus: (callback: (status: any) => void) => {
     const handler = (_event: any, status: any) => callback(status);
     ipcRenderer.on('update-status', handler);

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "test:country-localization": "ts-node --transpile-only -P tests/tsconfig.json tests/country-localization.test.ts",
     "test:currency": "ts-node --transpile-only -P tests/tsconfig.json tests/currency.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/country-profile.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/locale-iran.test.ts",
     "test:update-state": "ts-node --transpile-only -P tests/tsconfig.json tests/update-state.test.ts",
+    "test:update-ui": "ts-node --transpile-only -P tests/tsconfig.json tests/update-ui.test.ts",
     "test:tax-engine": "ts-node --transpile-only -P tests/tsconfig.json tests/tax-engine.test.ts",
     "test:tax-components": "ts-node --transpile-only -P tests/tsconfig.json tests/tax-components.test.ts",
     "test:tax-pack-catalog": "ts-node --transpile-only -P tests/tsconfig.json tests/tax-pack-catalog.test.ts",

--- a/tests/update-ui.test.ts
+++ b/tests/update-ui.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the in-app update UX guard logic (#463, child of epic #463).
+ *
+ * Covers the pure renderer modules:
+ *  - frontend/src/lib/updates/restart-install.ts — normalization of the
+ *    guarded `restart-and-install` IPC result and the renderer-side
+ *    preconditions (valid PIN format, no accidental submit);
+ *  - frontend/src/lib/updates/beta-channel.ts — feature detection of the
+ *    sibling-owned `updates:get/set-beta-channel` contract, tri-state value
+ *    normalization, and optimistic-update decisions for the Settings toggle.
+ *
+ * Run: npm run test:update-ui
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  canSubmitRestartInstall,
+  isValidManagerPinInput,
+  normalizeRestartInstallResult,
+} from '../frontend/src/lib/updates/restart-install';
+import {
+  betaChannelApiSupported,
+  normalizeBetaChannelValue,
+  normalizeBetaChannelWriteResult,
+  readBetaChannelState,
+  writeBetaChannelState,
+} from '../frontend/src/lib/updates/beta-channel';
+
+// ── Restart-to-install result normalization ─────────────────────────────────
+
+test('normalizeRestartInstallResult: guarded success payload resolves ok', () => {
+  assert.deepEqual(normalizeRestartInstallResult({ success: true }), { ok: true });
+});
+
+test('normalizeRestartInstallResult: denial keeps the dialog open with the error', () => {
+  const result = normalizeRestartInstallResult({ success: false, error: 'Invalid Master PIN' });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, 'Invalid Master PIN');
+});
+
+test('normalizeRestartInstallResult: legacy void resolution still counts as accepted', () => {
+  assert.deepEqual(normalizeRestartInstallResult(undefined), { ok: true });
+  assert.deepEqual(normalizeRestartInstallResult(null), { ok: true });
+});
+
+test('normalizeRestartInstallResult: malformed payloads never count as success', () => {
+  assert.equal(normalizeRestartInstallResult({ success: false }).ok, false);
+  assert.equal(normalizeRestartInstallResult('boom').ok, false);
+  assert.equal(normalizeRestartInstallResult(42).ok, false);
+  assert.equal(normalizeRestartInstallResult({}).ok, false);
+});
+
+// ── Renderer-side preconditions (the main process re-verifies the PIN) ──────
+
+test('isValidManagerPinInput accepts exactly four digits', () => {
+  assert.equal(isValidManagerPinInput('1234'), true);
+  assert.equal(isValidManagerPinInput('123'), false);
+  assert.equal(isValidManagerPinInput('12345'), false);
+  assert.equal(isValidManagerPinInput('12a4'), false);
+  assert.equal(isValidManagerPinInput(''), false);
+});
+
+test('canSubmitRestartInstall requires an explicit valid confirmation', () => {
+  // No PIN -> cannot confirm; dismissing can never restart.
+  assert.equal(canSubmitRestartInstall('', false), false);
+  assert.equal(canSubmitRestartInstall('12', false), false);
+  assert.equal(canSubmitRestartInstall('1234', false), true);
+  // A submission already in flight blocks a second one.
+  assert.equal(canSubmitRestartInstall('1234', true), false);
+});
+
+// ── Beta channel feature detection (#503 IPC contract) ──────────────────────
+
+test('betaChannelApiSupported is false when the sibling preload API is absent', () => {
+  assert.equal(betaChannelApiSupported(undefined), false);
+  assert.equal(betaChannelApiSupported(null), false);
+  assert.equal(betaChannelApiSupported({}), false);
+  assert.equal(betaChannelApiSupported({ getBetaChannel: () => Promise.resolve(true) }), false);
+  assert.equal(betaChannelApiSupported({ setBetaChannel: () => Promise.resolve() }), false);
+});
+
+test('betaChannelApiSupported is true only when both contract methods exist', () => {
+  assert.equal(betaChannelApiSupported({
+    getBetaChannel: () => Promise.resolve(false),
+    setBetaChannel: () => Promise.resolve(),
+  }), true);
+});
+
+// ── Beta channel value normalization ────────────────────────────────────────
+
+test('normalizeBetaChannelValue passes booleans through and rejects junk', () => {
+  assert.equal(normalizeBetaChannelValue(true), true);
+  assert.equal(normalizeBetaChannelValue(false), false);
+  assert.equal(normalizeBetaChannelValue(undefined), null);
+  assert.equal(normalizeBetaChannelValue(null), null);
+  assert.equal(normalizeBetaChannelValue('yes'), null);
+  assert.equal(normalizeBetaChannelValue(1), null);
+});
+
+test('normalizeBetaChannelValue unwraps { enabled } envelopes', () => {
+  assert.equal(normalizeBetaChannelValue({ enabled: true }), true);
+  assert.equal(normalizeBetaChannelValue({ enabled: false }), false);
+  assert.equal(normalizeBetaChannelValue({ enabled: undefined }), null);
+});
+
+test('normalizeBetaChannelValue treats error envelopes as unknown state', () => {
+  assert.equal(normalizeBetaChannelValue({ success: false, error: 'nope' }), null);
+  assert.equal(normalizeBetaChannelValue({ error: 'nope' }), null);
+});
+
+// ── Beta channel write results (optimistic update decisions) ────────────────
+
+test('normalizeBetaChannelWriteResult: confirmed success adopts reported state', () => {
+  assert.deepEqual(normalizeBetaChannelWriteResult({ success: true, enabled: true }, false), { ok: true, enabled: true });
+  assert.deepEqual(normalizeBetaChannelWriteResult({ success: true }, true), { ok: true, enabled: true });
+  assert.deepEqual(normalizeBetaChannelWriteResult({ success: true }, false), { ok: true, enabled: false });
+});
+
+test('normalizeBetaChannelWriteResult: legacy void assumes the requested value landed', () => {
+  assert.deepEqual(normalizeBetaChannelWriteResult(undefined, true), { ok: true, enabled: true });
+  assert.deepEqual(normalizeBetaChannelWriteResult(undefined, false), { ok: true, enabled: false });
+});
+
+test('normalizeBetaChannelWriteResult: failure keeps the previously rendered value', () => {
+  const result = normalizeBetaChannelWriteResult({ success: false, error: 'denied' }, true);
+  assert.equal(result.ok, false);
+  assert.equal(result.enabled, null);
+  assert.equal(result.error, 'denied');
+});
+
+// ── Read/write orchestration against the feature-detected API ───────────────
+
+test('readBetaChannelState reports unsupported when the contract is missing', async () => {
+  assert.deepEqual(await readBetaChannelState(undefined), { supported: false, enabled: null });
+  assert.deepEqual(await readBetaChannelState({}), { supported: false, enabled: null });
+});
+
+test('readBetaChannelState round-trips the persisted boolean when present', async () => {
+  const api = { getBetaChannel: () => Promise.resolve(true), setBetaChannel: () => Promise.resolve() };
+  assert.deepEqual(await readBetaChannelState(api), { supported: true, enabled: true });
+});
+
+test('readBetaChannelState degrades to unsupported on a rejected get', async () => {
+  const api = {
+    getBetaChannel: () => Promise.reject(new Error('gone')),
+    setBetaChannel: () => Promise.resolve(),
+  };
+  assert.deepEqual(await readBetaChannelState(api), { supported: false, enabled: null });
+});
+
+test('writeBetaChannelState refuses to call a missing setBetaChannel', async () => {
+  let called = false;
+  const api = { getBetaChannel: () => { called = true; return Promise.resolve(false); } };
+  const result = await writeBetaChannelState(api as never, true);
+  assert.equal(result.ok, false);
+  assert.equal(called, false);
+});
+
+test('writeBetaChannelState returns the new state after a successful set', async () => {
+  let stored = false;
+  const api = {
+    getBetaChannel: () => Promise.resolve(stored),
+    setBetaChannel: (enabled: boolean) => { stored = enabled; return Promise.resolve({ success: true, enabled }); },
+  };
+  const before = await readBetaChannelState(api);
+  assert.deepEqual(before, { supported: true, enabled: false });
+  const result = await writeBetaChannelState(api, true);
+  assert.equal(result.ok, true);
+  assert.equal(result.enabled, true);
+  assert.deepEqual(await readBetaChannelState(api), { supported: true, enabled: true });
+});


### PR DESCRIPTION
## Intent

Implement the in-app update UX for FloCafe's beta channel and safe restarts (epic #463, policy decision #503).

1) Restart-to-install confirmation guard: before quitAndInstall() runs, require manager or owner PIN approval reusing the app's existing master-PIN mechanism (authorizeMasterPin in main/services/master-pin.ts) - do not invent a parallel credential store. The confirmation dialog must show a prominent RED warning stating: all systems (POS, KDS, printing, reports) go down while the update installs; service comes back automatically once the app restarts; and this should not be done during business hours. If PIN approval fails or is cancelled, do not restart - there must be no UI path to restart-to-install without approval. This builds on the honest update-state model from #467 (main/index.ts restart-and-install handler, frontend settings updates panel); the guard is a gate before quitAndInstall, not a new update status.

2) Beta channel opt-in toggle in Settings > Updates: calls the IPC contract owned by the sibling flocafe-beta-release-channel workstream: updates:set-beta-channel(enabled: boolean) and updates:get-beta-channel(): boolean. That crew owns main-process + preload implementation of those channels, so this PR must NOT implement them and must feature-detect: if window.electronAPI lacks these methods (getBetaChannel/setBetaChannel), render the toggle visibly disabled with a short explanation so the PR stays correct whether or not the sibling PR has landed. Persisted state lives on the main-process side; the renderer only reflects what get-beta-channel returns and optimistically updates after a successful set.

Acceptance criteria: restart-to-install without manager/owner PIN approval is impossible from any UI path; red warning copy present and readable with explicit confirm required (cannot be dismissed into a restart by accident); toggle renders per feature-detection rules; new UI strings go through i18n (en/es/pt/fa json files, npm run i18n:check passes); unit tests for new guard/toggle logic following existing node:test patterns (tests/update-ui.test.ts, npm run test:update-ui); lint and builds pass. Constraints: no changes to release workflows or electron-builder config (sibling crew owns those); no changes to the beta-channel IPC main/preload implementation itself.

Environment notes for pipeline agents: the pipeline worktree starts WITHOUT node_modules - run npm ci at repo root before running any test/build/lint step. Evidence must be assertion/log-based only - do NOT attempt browser screenshot capture.

## What Changed

- Added Settings > Updates beta-channel opt-in with IPC feature detection, disabled-state guidance, persisted-state loading, optimistic updates, and localized strings.
- Added manager/owner PIN-gated restart-to-install confirmation with a prominent red downtime warning before `quitAndInstall()` can run.
- Wired update behavior through the Electron bridge, documented the beta release process, and added focused update UI tests.

## Risk Assessment

✅ Low: The change is bounded and correctly enforces the PIN gate before quitAndInstall while safely feature-detecting the sibling beta-channel API.

## Testing

Validated renderer guard and beta-channel logic, update-state readiness, preload contract, Master PIN authorization, translations across en/es/pt/fa, and the main-process restart gate. Missing or wrong PINs did not call quitAndInstall; approved PIN did. Evidence was assertion/log-based per the explicit environment requirement; no screenshots were attempted.

<details>
<summary>Evidence: Main guard evidence</summary>

<code>Main IPC guard exercised actual handler and `authorizeMasterPin`: missing PIN denied, wrong PIN denied, approved PIN restarted once.</code>

```text
[Log] Log files location: /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flocafe-update-handler-q1hw4s/
[Flo] Initializing...
[Flo] Initializing database...
[Flo] Starting local server...
[Flo] Starting KDS server on port 3002...
[Flo] Starting Server App on port 3003...
[Flo] Initializing WhatsApp service...
[Flo] Starting mDNS advertisement...
[mDNS] Advertising flo.local:3001  (IP fallback: http://127.0.0.1:3001)
[mDNS] KDS available at http://flo.local:3002  (IP fallback: http://127.0.0.1:3002)
[mDNS] Server App available at http://flo.local:3003  (IP fallback: http://127.0.0.1:3003)
[Flo] Initializing printer...
[Flo] Registering IPC handlers...
[Flo] Creating window...
[Flo] Ready!
Main IPC guard: missing PIN denied; wrong PIN denied; approved Master PIN restarted once.
Main IPC guard exercised actual main/index handler and actual authorizeMasterPin().
```
</details>
<details>
<summary>Evidence: Focused update UI tests</summary>

```text

> flo-desktop@3.3.0 test:update-ui
> ts-node --transpile-only -P tests/tsconfig.json tests/update-ui.test.ts

✔ normalizeRestartInstallResult: guarded success payload resolves ok (1.516959ms)
✔ normalizeRestartInstallResult: denial keeps the dialog open with the error (0.092459ms)
✔ normalizeRestartInstallResult: legacy void resolution still counts as accepted (0.067583ms)
✔ normalizeRestartInstallResult: malformed payloads never count as success (0.075875ms)
✔ isValidManagerPinInput accepts exactly four digits (0.114583ms)
✔ canSubmitRestartInstall requires an explicit valid confirmation (0.062875ms)
✔ betaChannelApiSupported is false when the sibling preload API is absent (0.069875ms)
✔ betaChannelApiSupported is true only when both contract methods exist (0.05225ms)
✔ normalizeBetaChannelValue passes booleans through and rejects junk (0.077834ms)
✔ normalizeBetaChannelValue unwraps { enabled } envelopes (0.109ms)
✔ normalizeBetaChannelValue treats error envelopes as unknown state (0.058958ms)
✔ normalizeBetaChannelWriteResult: confirmed success adopts reported state (0.090334ms)
✔ normalizeBetaChannelWriteResult: legacy void assumes the requested value landed (0.05275ms)
✔ normalizeBetaChannelWriteResult: failure keeps the previously rendered value (0.046625ms)
✔ readBetaChannelState reports unsupported when the contract is missing (0.081958ms)
✔ readBetaChannelState round-trips the persisted boolean when present (0.0755ms)
✔ readBetaChannelState degrades to unsupported on a rejected get (0.100208ms)
✔ writeBetaChannelState refuses to call a missing setBetaChannel (0.078125ms)
✔ writeBetaChannelState returns the new state after a successful set (0.110125ms)
ℹ tests 19
ℹ suites 0
ℹ pass 19
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 12.438916
```
</details>
<details>
<summary>Evidence: Translation integrity tests</summary>

```text

> flo-desktop@3.3.0 test:translations
> ts-node --transpile-only -P tests/tsconfig.json tests/translations.test.ts

Translation integrity: en <-> es <-> pt <-> fa
  ✓ registry ↔ files consistent (4 languages, 4 files)
  en.json: 2214 leaf keys
  es.json: 2214 leaf keys
  pt.json: 2214 leaf keys
  fa.json: 2214 leaf keys
  ✓ no duplicate keys within translation files
  ✓ exact leaf key parity with en.json (no missing, no orphan keys)
  ✓ all leaves are non-empty strings (no empty objects/arrays/null/booleans/numbers)
  ✓ no malformed values
  ✓ all messages parse as valid ICU (plurals, selects, brackets)
  ✓ placeholder arguments and plural/select selectors match en.json in all locales
  ✓ rich-text tags match en.json in all locales
  ✓ no undefined keys (1828 literal t() calls covered)
  ✓ no unsafe template-literal t() calls (all dynamic keys exhaustively cast)
  ✓ no active frontend consumers import the legacy i18n bridge
  ✓ messages.d.ts AppConfig augmentation present (compile-time key checks active)
  ✓ no untranslated fa.json values (31 intentional shared values)

✅ All translation integrity checks passed.

Negative tests (fixture-based):
  ✓ all negative fixtures detected by their validators

✅ All translation integrity checks + negative tests passed.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4b1662ca780dbfc17800ae718cc300740ab8f63d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm ci`
- `npm run test:update-ui`
- `npm run test:update-state`
- `npm run test:master-pin`
- `npm run test:electron-api-contract`
- `npm run test:translations`
- <code>Disposable mocked-Electron execution of the actual `main/index.ts` restart handler with actual `authorizeMasterPin()`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
