### PR TITLE
feat(main): sync native title-bar theme

### DIFF
--- a/docs/title-bar-phase1.md
+++ b/docs/title-bar-phase1.md
@@ -18,4 +18,4 @@ The renderer `ElectronAPI` declaration stays in parity with the existing preload
 
 ## Explicit Phase 2 exclusions
 
-Phase 1 does not add HTML window-control buttons or broad window-control IPC, Linux HTML fallback controls, clock/cloud-sync indicators, title-bar printer/server polling, vibrancy/transparency, dynamic theme synchronization, or cross-platform manual validation. Those remain bounded follow-up work if platform testing identifies a need.
+Phase 1 does not add HTML window-control buttons or broad window-control IPC, Linux HTML fallback controls, clock/cloud-sync indicators, title-bar printer/server polling, vibrancy/transparency, or cross-platform manual validation. Those remain bounded follow-up work if platform testing identifies a need.

--- a/docs/title-bar-phase1.md
+++ b/docs/title-bar-phase1.md
@@ -2,6 +2,8 @@
 
 **Status: CURRENT implementation note (Refs #457)**
 
+**Phase 2 update (#458):** the overlay colors now resolve from shared tokens in `main/title-bar-theme.ts` instead of inline constants, a `nativeTheme` listener applies light/dark overlay updates at runtime on macOS/Windows (no-op elsewhere), and macOS traffic lights sit vertically centered in the 40px bar via `trafficLightPosition`.
+
 Phase 1 gives the main POS Electron window a small native-controls title-bar foundation without removing the OS window frame:
 
 - macOS uses `hiddenInset`; Windows and Linux use `hidden`.

--- a/main/index.ts
+++ b/main/index.ts
@@ -398,7 +398,12 @@ function createWindow(): void {
   // the same run instead of only on the next full relaunch.
   clearStaleRenderCachesOnVersionChange(app.getPath('userData'), process.versions.electron, log);
 
-  mainWindow = createMainWindow(BrowserWindow, path.join(__dirname, 'preload.js'));
+  mainWindow = createMainWindow(
+    BrowserWindow,
+    path.join(__dirname, 'preload.js'),
+    process.platform,
+    nativeTheme.shouldUseDarkColors,
+  );
 
   mainWindow.once('ready-to-show', () => {
     mainWindow?.show();

--- a/main/index.ts
+++ b/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, Menu, Tray, nativeImage, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, Menu, Tray, nativeImage, nativeTheme, shell } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -34,6 +34,7 @@ import {
 } from './update-state';
 import { clearStaleRenderCachesOnVersionChange } from './startup-cache';
 import { createLocalWindowOpenHandler, createMainWindow } from './window-options';
+import { attachTitleBarThemeSync } from './title-bar-theme';
 import {
   createShutdownCoordinator,
   createShutdownEntrypoints,
@@ -799,6 +800,11 @@ async function initialize(): Promise<void> {
 
     console.log('[Flo] Registering IPC handlers...');
     registerIpcHandlers(shutdownSignal);
+
+    // Keep the title-bar overlay colors following the OS light/dark theme at
+    // runtime (no-op on unsupported platforms such as Linux). Attached once in
+    // initialize(); createWindow() may run again on crash recovery.
+    attachTitleBarThemeSync(nativeTheme, () => mainWindow);
 
     ipcMain.handle('get-update-status', () =>
       // #467: return the real persisted state (including not-checked-yet and

--- a/main/title-bar-theme.ts
+++ b/main/title-bar-theme.ts
@@ -1,0 +1,92 @@
+import type { NativeTheme } from 'electron';
+
+/**
+ * Title-bar theme tokens and helpers for the native-controls title bar
+ * (Refs #457, Phase 2 theme synchronization).
+ *
+ * The overlay colors mirror the renderer CSS custom properties defined in
+ * `frontend/src/app/globals.css` so the native Window Controls Overlay stays
+ * visually continuous with the `.flo-title-bar` surface:
+ * - light: Phase 1 tokens (`--background` oklch(1 0 0) -> #ffffff, slate
+ *   symbol color #475569).
+ * - dark: `--background` oklch(0.145 0 0) -> #0a0a0a and `--foreground`
+ *   oklch(0.985 0 0) -> #fafafa.
+ *
+ * Keep this module free of Electron runtime imports so the color resolution
+ * stays unit-testable without launching Electron.
+ */
+
+export const TITLE_BAR_HEIGHT = 40;
+
+export interface TitleBarOverlayColors {
+  readonly color: string;
+  readonly symbolColor: string;
+}
+
+export const TITLE_BAR_OVERLAY_COLORS: Readonly<Record<'light' | 'dark', TitleBarOverlayColors>> = {
+  light: { color: '#ffffff', symbolColor: '#475569' },
+  dark: { color: '#0a0a0a', symbolColor: '#fafafa' },
+};
+
+export function resolveTitleBarOverlayColors(isDark: boolean): TitleBarOverlayColors {
+  return isDark ? TITLE_BAR_OVERLAY_COLORS.dark : TITLE_BAR_OVERLAY_COLORS.light;
+}
+
+/**
+ * `BrowserWindow.setTitleBarOverlay` is supported on Windows and macOS. On
+ * Linux the window controls are composited differently and older Electron
+ * releases reject the call, so the dynamic overlay update no-ops there.
+ */
+export function supportsTitleBarOverlay(platform: NodeJS.Platform): boolean {
+  return platform === 'darwin' || platform === 'win32';
+}
+
+type OverlayCapableWindow = {
+  setTitleBarOverlay?: (options: { color: string; symbolColor: string; height?: number }) => void;
+};
+
+/**
+ * Applies the overlay colors for the given theme mode. Returns true when the
+ * call was attempted successfully, false when unsupported or rejected.
+ */
+export function applyTitleBarOverlayTheme(
+  win: unknown,
+  isDark: boolean,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (!supportsTitleBarOverlay(platform)) return false;
+  const candidate = win as OverlayCapableWindow | null | undefined;
+  if (!candidate || typeof candidate.setTitleBarOverlay !== 'function') return false;
+  try {
+    candidate.setTitleBarOverlay({ ...resolveTitleBarOverlayColors(isDark), height: TITLE_BAR_HEIGHT });
+    return true;
+  } catch {
+    // Some window-manager combinations reject runtime overlay changes even
+    // when the API exists; keep the last applied colors instead of crashing.
+    return false;
+  }
+}
+
+type ThemeLike = Pick<NativeTheme, 'shouldUseDarkColors'> & {
+  on(event: 'updated', listener: () => void): unknown;
+};
+
+/**
+ * Subscribes to OS theme changes so the main window's title-bar overlay keeps
+ * following light/dark at runtime. Returns an unsubscribe function. No-ops on
+ * platforms where the overlay cannot be updated.
+ */
+export function attachTitleBarThemeSync(
+  nativeTheme: ThemeLike,
+  getWindow: () => OverlayCapableWindow | null | undefined,
+  platform: NodeJS.Platform = process.platform,
+): () => void {
+  if (!supportsTitleBarOverlay(platform)) return () => {};
+  const onUpdated = (): void => {
+    applyTitleBarOverlayTheme(getWindow(), nativeTheme.shouldUseDarkColors, platform);
+  };
+  nativeTheme.on('updated', onUpdated);
+  return () => {
+    (nativeTheme as ThemeLike & { off?(event: 'updated', listener: () => void): unknown }).off?.('updated', onUpdated);
+  };
+}

--- a/main/title-bar-theme.ts
+++ b/main/title-bar-theme.ts
@@ -7,8 +7,8 @@ import type { NativeTheme } from 'electron';
  * The overlay colors mirror the renderer CSS custom properties defined in
  * `frontend/src/app/globals.css` so the native Window Controls Overlay stays
  * visually continuous with the `.flo-title-bar` surface:
- * - light: Phase 1 tokens (`--background` oklch(1 0 0) -> #ffffff, slate
- *   symbol color #475569).
+ * - light: `--background` oklch(1 0 0) -> #ffffff and `--foreground`
+ *   oklch(0.145 0 0) -> #0a0a0a.
  * - dark: `--background` oklch(0.145 0 0) -> #0a0a0a and `--foreground`
  *   oklch(0.985 0 0) -> #fafafa.
  *
@@ -24,7 +24,7 @@ export interface TitleBarOverlayColors {
 }
 
 export const TITLE_BAR_OVERLAY_COLORS: Readonly<Record<'light' | 'dark', TitleBarOverlayColors>> = {
-  light: { color: '#ffffff', symbolColor: '#475569' },
+  light: { color: '#ffffff', symbolColor: '#0a0a0a' },
   dark: { color: '#0a0a0a', symbolColor: '#fafafa' },
 };
 

--- a/main/window-options.ts
+++ b/main/window-options.ts
@@ -11,6 +11,7 @@ export function createMainWindow(
   BrowserWindowConstructor: BrowserWindowConstructor,
   preload: string,
   platform: NodeJS.Platform = process.platform,
+  isDark = false,
 ): BrowserWindow {
   return new BrowserWindowConstructor({
     width: 1400,
@@ -20,7 +21,7 @@ export function createMainWindow(
     title: 'Flo',
     titleBarStyle: platform === 'darwin' ? 'hiddenInset' : 'hidden',
     titleBarOverlay: {
-      ...resolveTitleBarOverlayColors(false),
+      ...resolveTitleBarOverlayColors(isDark),
       height: TITLE_BAR_HEIGHT,
     },
     ...(platform === 'darwin' ? { trafficLightPosition: MAC_TRAFFIC_LIGHT_POSITION } : {}),

--- a/main/window-options.ts
+++ b/main/window-options.ts
@@ -1,6 +1,11 @@
 import type { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
+import { resolveTitleBarOverlayColors, TITLE_BAR_HEIGHT } from './title-bar-theme';
 
 export type BrowserWindowConstructor = new (options: BrowserWindowConstructorOptions) => BrowserWindow;
+
+// macOS traffic-light buttons are 12px tall; y = (40 - 12) / 2 centers them in
+// the 40px title bar. x keeps the standard inset margin from the window edge.
+const MAC_TRAFFIC_LIGHT_POSITION = { x: 16, y: 14 } as const;
 
 export function createMainWindow(
   BrowserWindowConstructor: BrowserWindowConstructor,
@@ -15,10 +20,10 @@ export function createMainWindow(
     title: 'Flo',
     titleBarStyle: platform === 'darwin' ? 'hiddenInset' : 'hidden',
     titleBarOverlay: {
-      color: '#ffffff',
-      symbolColor: '#475569',
-      height: 40,
+      ...resolveTitleBarOverlayColors(false),
+      height: TITLE_BAR_HEIGHT,
     },
+    ...(platform === 'darwin' ? { trafficLightPosition: MAC_TRAFFIC_LIGHT_POSITION } : {}),
     webPreferences: {
       preload,
       contextIsolation: true,

--- a/tests/titlebar-window-options.test.ts
+++ b/tests/titlebar-window-options.test.ts
@@ -1,6 +1,14 @@
 import * as assert from 'node:assert/strict';
 import { isAllowedLocalWindowUrl } from '../main/security/url-allowlist';
 import {
+  applyTitleBarOverlayTheme,
+  attachTitleBarThemeSync,
+  resolveTitleBarOverlayColors,
+  supportsTitleBarOverlay,
+  TITLE_BAR_HEIGHT,
+  TITLE_BAR_OVERLAY_COLORS,
+} from '../main/title-bar-theme';
+import {
   createKdsWindow,
   createLocalWindowOpenHandler,
   createMainWindow,
@@ -27,6 +35,11 @@ assert.equal(macMainWindow.options.webPreferences.contextIsolation, true);
 assert.equal(macMainWindow.options.webPreferences.nodeIntegration, false);
 assert.equal(macMainWindow.options.webPreferences.sandbox, false);
 assert.equal('frame' in macMainWindow.options, false, 'the native-controls design does not remove the window frame');
+
+// macOS traffic lights are vertically centered in the 40px bar (buttons are 12px tall).
+assert.deepEqual(macMainWindow.options.trafficLightPosition, { x: 16, y: 14 });
+assert.equal('trafficLightPosition' in windowsMainWindow.options, false, 'trafficLightPosition is macOS-only');
+assert.equal('trafficLightPosition' in linuxMainWindow.options, false, 'trafficLightPosition is macOS-only');
 
 const localWindowOpenHandler = createLocalWindowOpenHandler(
   isAllowedLocalWindowUrl,
@@ -64,3 +77,97 @@ assert.equal('titleBarOverlay' in kdsWindow.options, false, 'KDS keeps stock win
 assert.equal('frame' in kdsWindow.options, false, 'KDS keeps stock window chrome');
 
 console.log('Title-bar main-window options and popup/KDS exclusions are preserved.');
+
+// ── Theme-following overlay colors (#458) ────────────────────────────────────
+
+// The static constructor options use the light tokens.
+assert.deepEqual(resolveTitleBarOverlayColors(false), TITLE_BAR_OVERLAY_COLORS.light);
+assert.deepEqual(resolveTitleBarOverlayColors(true), TITLE_BAR_OVERLAY_COLORS.dark);
+assert.deepEqual(TITLE_BAR_OVERLAY_COLORS.light, { color: '#ffffff', symbolColor: '#475569' });
+assert.deepEqual(TITLE_BAR_OVERLAY_COLORS.dark, { color: '#0a0a0a', symbolColor: '#fafafa' });
+assert.equal(TITLE_BAR_HEIGHT, 40);
+
+// Platform gating: overlay updates only where setTitleBarOverlay works.
+assert.equal(supportsTitleBarOverlay('darwin'), true);
+assert.equal(supportsTitleBarOverlay('win32'), true);
+assert.equal(supportsTitleBarOverlay('linux'), false);
+
+function makeOverlaySpy(): { calls: unknown[]; win: unknown } {
+  const calls: unknown[] = [];
+  return {
+    calls,
+    win: {
+      setTitleBarOverlay(options: unknown) {
+        calls.push(options);
+      },
+    },
+  };
+}
+
+const darkCall = makeOverlaySpy();
+assert.equal(applyTitleBarOverlayTheme(darkCall.win, true, 'darwin'), true);
+assert.deepEqual(darkCall.calls, [{ color: '#0a0a0a', symbolColor: '#fafafa', height: 40 }]);
+
+const lightCall = makeOverlaySpy();
+assert.equal(applyTitleBarOverlayTheme(lightCall.win, false, 'win32'), true);
+assert.deepEqual(lightCall.calls, [{ color: '#ffffff', symbolColor: '#475569', height: 40 }]);
+
+// Unsupported platform and missing/unusable API must no-op without throwing.
+const linuxCall = makeOverlaySpy();
+assert.equal(applyTitleBarOverlayTheme(linuxCall.win, true, 'linux'), false);
+assert.equal(linuxCall.calls.length, 0);
+assert.equal(applyTitleBarOverlayTheme({}, true, 'darwin'), false);
+assert.equal(applyTitleBarOverlayTheme(null, true, 'win32'), false);
+const throwingWin = {
+  setTitleBarOverlay() {
+    throw new Error('overlay rejected');
+  },
+};
+assert.equal(applyTitleBarOverlayTheme(throwingWin, true, 'darwin'), false, 'runtime rejection degrades to no-op');
+
+// Theme sync wiring follows nativeTheme 'updated' events with live state.
+function makeFakeNativeTheme(initialDark: boolean): {
+  shouldUseDarkColors: boolean;
+  listeners: Array<() => void>;
+  emitUpdated(): void;
+} {
+  return {
+    shouldUseDarkColors: initialDark,
+    listeners: [],
+    emitUpdated() {
+      for (const listener of this.listeners) listener();
+    },
+    on(_event: string, listener: () => void) {
+      this.listeners.push(listener);
+      return this;
+    },
+    off(_event: string, listener: () => void) {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+      return this;
+    },
+  } as any;
+}
+
+const syncTheme = makeFakeNativeTheme(false);
+const synced = makeOverlaySpy();
+const unsubscribe = attachTitleBarThemeSync(syncTheme, () => synced.win, 'darwin');
+syncTheme.shouldUseDarkColors = true;
+syncTheme.emitUpdated();
+assert.deepEqual(synced.calls, [{ color: '#0a0a0a', symbolColor: '#fafafa', height: 40 }]);
+syncTheme.shouldUseDarkColors = false;
+syncTheme.emitUpdated();
+assert.deepEqual(synced.calls[1], { color: '#ffffff', symbolColor: '#475569', height: 40 });
+unsubscribe();
+syncTheme.emitUpdated();
+assert.equal(synced.calls.length, 2, 'unsubscribed listeners stop receiving updates');
+
+// No listener is registered on unsupported platforms, and missing windows no-op.
+const linuxTheme = makeFakeNativeTheme(true);
+const linuxUnsubscribe = attachTitleBarThemeSync(linuxTheme, () => null, 'linux');
+linuxUnsubscribe(); // must be safe even when nothing was subscribed
+assert.equal(linuxTheme.listeners.length, 0, 'Linux does not subscribe to nativeTheme updates');
+const missingWindowTheme = makeFakeNativeTheme(true);
+attachTitleBarThemeSync(missingWindowTheme, () => null, 'darwin');
+missingWindowTheme.emitUpdated(); // must not throw while the window is absent
+
+console.log('Title-bar dynamic theme overlay resolution and platform guards pass.');

--- a/tests/titlebar-window-options.test.ts
+++ b/tests/titlebar-window-options.test.ts
@@ -21,13 +21,19 @@ class FakeBrowserWindow {
 const macMainWindow = createMainWindow(FakeBrowserWindow as any, '/tmp/preload.js', 'darwin');
 const windowsMainWindow = createMainWindow(FakeBrowserWindow as any, '/tmp/preload.js', 'win32');
 const linuxMainWindow = createMainWindow(FakeBrowserWindow as any, '/tmp/preload.js', 'linux');
+const darkMainWindow = createMainWindow(FakeBrowserWindow as any, '/tmp/preload.js', 'darwin', true);
 
 assert.equal(macMainWindow.options.titleBarStyle, 'hiddenInset');
 assert.equal(windowsMainWindow.options.titleBarStyle, 'hidden');
 assert.equal(linuxMainWindow.options.titleBarStyle, 'hidden');
 assert.deepEqual(macMainWindow.options.titleBarOverlay, {
   color: '#ffffff',
-  symbolColor: '#475569',
+  symbolColor: '#0a0a0a',
+  height: 40,
+});
+assert.deepEqual(darkMainWindow.options.titleBarOverlay, {
+  color: '#0a0a0a',
+  symbolColor: '#fafafa',
   height: 40,
 });
 assert.equal(macMainWindow.options.webPreferences.preload, '/tmp/preload.js');
@@ -83,7 +89,7 @@ console.log('Title-bar main-window options and popup/KDS exclusions are preserve
 // The static constructor options use the light tokens.
 assert.deepEqual(resolveTitleBarOverlayColors(false), TITLE_BAR_OVERLAY_COLORS.light);
 assert.deepEqual(resolveTitleBarOverlayColors(true), TITLE_BAR_OVERLAY_COLORS.dark);
-assert.deepEqual(TITLE_BAR_OVERLAY_COLORS.light, { color: '#ffffff', symbolColor: '#475569' });
+assert.deepEqual(TITLE_BAR_OVERLAY_COLORS.light, { color: '#ffffff', symbolColor: '#0a0a0a' });
 assert.deepEqual(TITLE_BAR_OVERLAY_COLORS.dark, { color: '#0a0a0a', symbolColor: '#fafafa' });
 assert.equal(TITLE_BAR_HEIGHT, 40);
 
@@ -110,7 +116,7 @@ assert.deepEqual(darkCall.calls, [{ color: '#0a0a0a', symbolColor: '#fafafa', he
 
 const lightCall = makeOverlaySpy();
 assert.equal(applyTitleBarOverlayTheme(lightCall.win, false, 'win32'), true);
-assert.deepEqual(lightCall.calls, [{ color: '#ffffff', symbolColor: '#475569', height: 40 }]);
+assert.deepEqual(lightCall.calls, [{ color: '#ffffff', symbolColor: '#0a0a0a', height: 40 }]);
 
 // Unsupported platform and missing/unusable API must no-op without throwing.
 const linuxCall = makeOverlaySpy();
@@ -156,7 +162,7 @@ syncTheme.emitUpdated();
 assert.deepEqual(synced.calls, [{ color: '#0a0a0a', symbolColor: '#fafafa', height: 40 }]);
 syncTheme.shouldUseDarkColors = false;
 syncTheme.emitUpdated();
-assert.deepEqual(synced.calls[1], { color: '#ffffff', symbolColor: '#475569', height: 40 });
+assert.deepEqual(synced.calls[1], { color: '#ffffff', symbolColor: '#0a0a0a', height: 40 });
 unsubscribe();
 syncTheme.emitUpdated();
 assert.equal(synced.calls.length, 2, 'unsubscribed listeners stop receiving updates');


### PR DESCRIPTION
## Intent

Land Phase 2 title-bar work for epic #457 on branch fm/flocafe-457-slice1-theme-bar (Fixes #458): make the Electron main window's native title-bar overlay colors follow the active OS light/dark theme at runtime instead of the hardcoded white overlay, and vertically center macOS traffic lights in the 40px bar. Requirements: overlay color values must come from shared theme tokens mirroring frontend/src/app/globals.css (--background/--foreground), implemented as a pure unit-testable color-resolution module main/title-bar-theme.ts; a nativeTheme 'updated' listener in initialize() applies setTitleBarOverlay with platform gating (macOS/Windows only, safe no-op on Linux and when the API is missing or rejects at runtime); macOS trafficLightPosition {x:16,y:14} centers 12px lights in the 40px bar; extend tests/titlebar-window-options.test.ts for the new option shapes; do NOT touch windowAction IPC or HTML fallback controls (owned by sibling crew flocafe-457-slice2-linux-fallback); no renderer TitleBar layout changes unless required by theme sync; keep browser/LAN behavior unchanged; all existing suites (electron-api-contract, kds-window-hardening, titlebar-window-options) plus lint/build/i18n must stay green. Environment notes for validation: pipeline worktree starts without node_modules so run npm ci before testing; assertion/log-based evidence only, no screenshot capture. After CI green, resolve any Greptile/CodeQL review conversations; merge is handled by firstmate.

## What Changed

- Added a pure title-bar theme module with shared light/dark overlay tokens, platform gating, and safe runtime update handling.
- Wired OS theme updates into the Electron main process and centered macOS traffic lights at `{ x: 16, y: 14 }` within the 40px title bar.
- Expanded title-bar tests for theme resolution, platform behavior, runtime failures, listener cleanup, and updated the Phase 2 implementation note.

## Risk Assessment

🚨 High: The core macOS runtime behavior is ambiguous against the pinned Electron API and may fail silently.

## Testing

Validated title-bar light/dark colors, runtime theme updates, platform/API guards, macOS traffic-light geometry, and adjacent Electron contracts via focused assertion/log tests. No screenshot was captured because the intent requires assertion/log evidence; lint, build, i18n, and the full suite were not run in this targeted test phase.

<details>
<summary>Evidence: Title-bar focused test</summary>

```text
Title-bar dynamic theme overlay resolution and platform guards pass.
```
</details>
<details>
<summary>Evidence: Adjacent Electron tests</summary>

```text
Electron API contract and KDS window hardening verification completed successfully.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e45b2206046be6bd0eef0892b0e1cb4bdc3ea84a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `main/window-options.ts:23` - `createMainWindow` always resolves the light palette, while the listener is attached before the window is created and only reacts to future `updated` events. A dark OS at launch—or a dark-mode crash/activation recreation—therefore leaves the overlay light until another theme change. Apply the current theme at window creation and retain the listener for later changes.
- 🚨 `main/title-bar-theme.ts:27` - The required shared-token criterion is contradicted: the light token keeps `symbolColor: &#39;#475569&#39;`, while `globals.css` defines light `--foreground` as `oklch(0.145 0 0)`. This remains the old hardcoded Phase 1 symbol color rather than the shared foreground token. Please confirm the intended canonical light token.

🔧 Fix: Fix title-bar startup theme and shared foreground token
1 error still open:

- 🚨 `main/title-bar-theme.ts:41` - Electron 43.4.1 declares `setTitleBarOverlay` and configurable overlay colors for Windows/Linux, not macOS. The new gate treats macOS as supported, so macOS theme updates may be rejected or ignored and silently leave stale colors; the test only uses a fake macOS API. Confirm whether macOS is intentionally a no-op or provide a supported mechanism.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm ci`
- `npm run test:titlebar-window-options`
- `npm run test:electron-api-contract`
- `npm run test:kds-window-hardening`
- `git diff --check HEAD`
- <code>Final `git status --short --branch` check</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
