### PR TITLE
test(frontend): fix race condition in KDS kanban skip confirmation E2E test

### DIFF
--- a/frontend/e2e/kds-kanban-skip-confirm.spec.ts
+++ b/frontend/e2e/kds-kanban-skip-confirm.spec.ts
@@ -28,6 +28,7 @@ test('KDS kanban requires confirmation when skipping preparation stages', async 
 
   // 2. Open standalone KDS
   await page.goto(`${E2E_KDS_BASE_URL}/kds-standalone`);
+  await expect(page.getByTestId('kds-login-form').or(page.getByTestId('kds-workspace'))).toBeVisible();
   if (await page.getByTestId('kds-login-form').isVisible()) {
     await page.getByTestId('kds-login-email').fill('manager@flo.local');
     await page.getByTestId('kds-login-password').fill('E2ePass123!');


### PR DESCRIPTION
## Intent

Fix race condition in KDS kanban skip confirmation E2E test by awaiting login form or workspace visibility before checking auth state

## What Changed

- Added an explicit expectation in `frontend/e2e/kds-kanban-skip-confirm.spec.ts` to wait for either `kds-login-form` or `kds-workspace` to be visible after navigating to `/kds-standalone` before checking authentication state.

## Risk Assessment

✅ Low: The change is a straightforward, single-line E2E test synchronization fix that resolves a race condition by awaiting either the login form or workspace element before branching on authentication state.

## Testing

Exercised the KDS kanban skip confirmation and login E2E test flows along with backend KDS integration and contract tests; all tests passed cleanly with visual evidence captured in the evidence directory.

- Evidence: KDS Standalone Login Form (local file: <code>~/.no-mistakes/evidence/01M0X57PDJGTD78JEA2AVV840W/01-kds-standalone-login-form.png</code>)
- Evidence: KDS Kanban Initial Waiting Stage (local file: <code>~/.no-mistakes/evidence/01M0X57PDJGTD78JEA2AVV840W/02-kds-kanban-initial-waiting.png</code>)
- Evidence: KDS Kanban Skip Stage Confirmation Modal (local file: <code>~/.no-mistakes/evidence/01M0X57PDJGTD78JEA2AVV840W/03-kds-kanban-skip-confirmation-modal.png</code>)
- Evidence: KDS Kanban Stage Delivered (local file: <code>~/.no-mistakes/evidence/01M0X57PDJGTD78JEA2AVV840W/04-kds-kanban-stage-delivered.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e7d942c52c6f510e2afaf5089187598889cdfb08","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd frontend && npx playwright test e2e/kds-kanban-skip-confirm.spec.ts`
- `cd frontend && npx playwright test e2e/kds-login.spec.ts`
- `npm run test:kds-integration`
- `npm run test:kds-contract`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
