### PR TITLE
fix(frontend): offset toast notifications below desktop title bar and add time-drain progress bar

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -174,6 +174,83 @@ html[data-flo-desktop-titlebar='true'] {
   --flo-sidebar-block-start: var(--flo-titlebar-height);
 }
 
+/* Modern minimalist toast styling (Linear / Sonner aesthetic) */
+.flo-toast-card {
+  position: relative !important;
+  overflow: hidden !important;
+  background: rgba(255, 255, 255, 0.96) !important;
+  backdrop-filter: blur(12px) !important;
+  -webkit-backdrop-filter: blur(12px) !important;
+  border: 1px solid oklch(0.922 0 0 / 0.9) !important;
+  border-radius: 12px !important;
+  padding: 10px 14px !important;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.05),
+    0 10px 20px -3px rgba(0, 0, 0, 0.06),
+    0 0 0 1px rgba(0, 0, 0, 0.03) !important;
+  color: var(--foreground) !important;
+  font-family: var(--font-sans) !important;
+  font-size: 13.5px !important;
+  font-weight: 500 !important;
+  line-height: 1.4 !important;
+  max-width: 380px !important;
+}
+
+.dark .flo-toast-card {
+  background: rgba(24, 24, 27, 0.94) !important;
+  border-color: rgba(255, 255, 255, 0.12) !important;
+  color: #fafafa !important;
+}
+
+/* Toast time-drain progress bar: visual indicator running out linearly from 100% to 0%.
+ * Pauses on hover in sync with react-hot-toast's dismiss timer. */
+@keyframes flo-toast-drain {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+.flo-toast-drain {
+  position: absolute;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  inline-size: 100%;
+  block-size: 2.5px;
+  background-color: var(--sidebar-primary, #3248FF);
+  transform-origin: left center;
+  animation-name: flo-toast-drain;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+  pointer-events: none;
+}
+
+html[dir='rtl'] .flo-toast-drain {
+  transform-origin: right center;
+}
+
+.flo-toast-card:hover .flo-toast-drain,
+div:hover > .flo-toast-drain,
+[data-rht-toaster]:hover .flo-toast-drain {
+  animation-play-state: paused;
+}
+
+.flo-toast-drain--success {
+  background-color: #10b981;
+}
+
+.flo-toast-drain--error {
+  background-color: #f43f5e;
+}
+
+.flo-toast-drain--blank {
+  background-color: var(--sidebar-primary, #3248FF);
+}
+
+
+
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;

--- a/frontend/src/components/layout/DirectionalToaster.tsx
+++ b/frontend/src/components/layout/DirectionalToaster.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { Toaster } from 'react-hot-toast';
+import { ToastBar, Toaster } from 'react-hot-toast';
 import { useLocale } from 'use-intl';
 import { getLanguageDirection, getLanguageFromLocale } from '@/lib/i18n';
 
 /**
- * Direction-aware toast host (Batch E, Refs #241).
+ * Direction-aware toast host with bottom time-drain progress bar.
  *
  * react-hot-toast's `position` prop is physical (`top-right` / `top-left`),
  * so it must follow the active document direction: RTL languages (Persian)
@@ -20,5 +20,46 @@ export function DirectionalToaster() {
   const locale = useLocale();
   const language = getLanguageFromLocale(locale) ?? 'en';
   const rtl = getLanguageDirection(language) === 'rtl';
-  return <Toaster position={rtl ? 'top-left' : 'top-right'} />;
+
+  return (
+    <Toaster
+      position={rtl ? 'top-left' : 'top-right'}
+      containerStyle={{
+        top: 'calc(var(--flo-sidebar-block-start, 0px) + 16px)',
+      }}
+      toastOptions={{
+        className: 'flo-toast-card',
+        duration: 4000,
+        success: {
+          duration: 2500,
+        },
+      }}
+    >
+      {(t) => (
+        <ToastBar
+          toast={t}
+          style={{
+            position: 'relative',
+            overflow: 'hidden',
+          }}
+        >
+          {({ icon, message }) => (
+            <>
+              {icon}
+              {message}
+              {t.type !== 'loading' && t.duration !== Infinity && (
+                <span
+                  aria-hidden="true"
+                  className={`flo-toast-drain flo-toast-drain--${t.type}`}
+                  style={{
+                    animationDuration: `${t.duration || (t.type === 'success' ? 2000 : 4000)}ms`,
+                  }}
+                />
+              )}
+            </>
+          )}
+        </ToastBar>
+      )}
+    </Toaster>
+  );
 }

--- a/tests/rtl-dashboard-pos-common.test.ts
+++ b/tests/rtl-dashboard-pos-common.test.ts
@@ -191,7 +191,7 @@ function run(): void {
 
   React.useSyncExternalStore = (_subscribe: any, getSnapshot: () => any) => getSnapshot();
 
-  function renderDirectionalToaster(locale: string): { position?: string; markup: string } {
+  function renderDirectionalToaster(locale: string): { position?: string; containerStyle?: any; markup: string } {
     let capturedProps: any;
     function Probe() {
       const elem = DirectionalToaster();
@@ -201,7 +201,7 @@ function run(): void {
     const markup = ReactDOMServer.renderToStaticMarkup(
       React.createElement(IntlProvider, { locale }, React.createElement(Probe))
     );
-    return { position: capturedProps?.position, markup };
+    return { position: capturedProps?.position, containerStyle: capturedProps?.containerStyle, markup };
   }
 
   usePosSettingsStore.getState().setLanguage('fa');
@@ -209,6 +209,10 @@ function run(): void {
   assert(
     renderedFa.position === 'top-left',
     `DirectionalToaster must set position="top-left" (inline-end) for Persian (fa), got: ${renderedFa.position}`
+  );
+  assert(
+    renderedFa.containerStyle?.top === 'calc(var(--flo-sidebar-block-start, 0px) + 16px)',
+    `DirectionalToaster must set containerStyle.top with titlebar offset, got: ${renderedFa.containerStyle?.top}`
   );
   assert(
     typeof renderedFa.markup === 'string' && renderedFa.markup.length > 0,
@@ -223,11 +227,15 @@ function run(): void {
       `DirectionalToaster must set position="top-right" for ${ltrLang}, got: ${renderedLtr.position}`
     );
     assert(
+      renderedLtr.containerStyle?.top === 'calc(var(--flo-sidebar-block-start, 0px) + 16px)',
+      `DirectionalToaster must set containerStyle.top with titlebar offset, got: ${renderedLtr.containerStyle?.top}`
+    );
+    assert(
       typeof renderedLtr.markup === 'string' && renderedLtr.markup.length > 0,
       `DirectionalToaster must render static markup for ${ltrLang}`
     );
   }
-  console.log('  ✓ DirectionalToaster dynamically adapts toast placement across RTL/LTR languages');
+  console.log('  ✓ DirectionalToaster dynamically adapts toast placement across RTL/LTR languages with titlebar offset');
 
   // 5. Executable Ltr component rendering for POS/operational values.
   const orderRender = ReactDOMServer.renderToStaticMarkup(


### PR DESCRIPTION
## What Changed

- Positioned `DirectionalToaster` container with a top offset using `calc(var(--flo-sidebar-block-start, 0px) + 16px)` to prevent toast notifications from overlapping desktop title bar controls.
- Added a linear time-drain progress bar (`.flo-toast-drain`) to toast notifications that respects RTL layout orientation, pauses on hover, and applies status-specific accent colors.
- Introduced modern `.flo-toast-card` styling with backdrop blur and dark mode support, and updated unit tests to assert the top container offset across locales.

## Risk Assessment

✅ Low: The change is a well-bounded UI styling and layout enhancement that cleanly offsets toast positioning for desktop titlebars and adds a direction-aware time-drain progress bar.

## Testing

Exercised DirectionalToaster with desktop titlebar offsets and bottom time-drain progress bar animations across LTR and RTL orientations, capturing high-resolution visual evidence artifacts and verifying automated RTL/LTR test suites. All checks passed with 16px titlebar clearance and synchronized hover pausing.

<details>
<summary>Evidence: Verification Metrics JSON</summary>

`{"desktopTitlebarClearance":{"titlebarHeight":40,"toasterTop":56,"clearancePx":16,"passed":true},"rtlSupport":{"toasterTop":56,"toasterLeft":16,"passed":true},"drainStyling":{"hoverPaused":true}}`

```text
{
  "timestamp": "2026-08-25T22:04:18.038Z",
  "status": "PASSED",
  "checks": {
    "desktopTitlebarClearance": {
      "titlebarHeight": 40,
      "titlebarBottom": 40,
      "toasterTop": 56,
      "clearancePx": 16,
      "expectedOffset": 16,
      "passed": true
    },
    "rtlSupport": {
      "toasterTop": 56,
      "toasterLeft": 16,
      "drainTransformOrigin": "265.891px 1.25px",
      "passed": true
    },
    "drainStyling": {
      "cards": [
        {
          "type": "success",
          "drainBgColor": "rgb(16, 185, 129)",
          "drainHeight": "2.5px",
          "drainAnimationName": "flo-toast-drain",
          "borderRadius": "12px"
        },
        {
          "type": "error",
          "drainBgColor": "rgb(244, 63, 94)",
          "drainHeight": "2.5px",
          "drainAnimationName": "flo-toast-drain",
          "borderRadius": "12px"
        },
        {
          "type": "blank",
          "drainBgColor": "rgb(50, 72, 255)",
          "drainHeight": "2.5px",
          "drainAnimationName": "flo-toast-drain",
          "borderRadius": "12px"
        }
      ],
      "hoverPaused": true
    }
  },
  "evidenceArtifacts": [
    "~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-desktop-offset-ltr.png",
    "~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-desktop-offset-rtl.png",
    "~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-dark-mode.png",
    "~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-progress-drain-sequence.png",
    "~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-hover-paused.png"
  ]
}
```
</details>

- Evidence: Desktop Toast Offset (LTR - English) (local file: <code>~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-desktop-offset-ltr.png</code>)
- Evidence: Desktop Toast Offset (RTL - Persian) (local file: <code>~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-desktop-offset-rtl.png</code>)
- Evidence: Time-Drain Progress Bar Progression Sequence (local file: <code>~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-progress-drain-sequence.png</code>)
- Evidence: Toast Dark Mode Aesthetic (local file: <code>~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-dark-mode.png</code>)
- Evidence: Toast Hover Paused State (local file: <code>~/.no-mistakes/evidence/01M0XF27546G450NSEG4BBPAS7/toast-hover-paused.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e2c7a27167f88a3c292e83c832925e8e64710a6f","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:rtl-dashboard-pos-common`
- `npm run test:rtl-foundation`
- `npm run test:rtl-setup-auth-settings`
- `npm run test:rtl-kds-server-whatsapp`
- <code>Playwright visual end-to-end rendering and geometry verification (`toast-desktop-offset-ltr.png`, `toast-desktop-offset-rtl.png`, `toast-progress-drain-sequence.png`, `toast-dark-mode.png`, `toast-hover-paused.png`)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
