### PR TITLE
fix: require staff email and surface save errors

### DIFF
--- a/frontend/src/app/(dashboard)/staff/page.tsx
+++ b/frontend/src/app/(dashboard)/staff/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import axios from 'axios';
 import api from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import toast from 'react-hot-toast';
@@ -27,6 +28,14 @@ const roleColors: Record<string, string> = {
 function roleLabel(role: string, t: (key: StaffKey) => string): string {
   const key = ROLE_LABEL_KEYS[role];
   return key ? t(key) : role;
+}
+
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError(error)) {
+    const apiError = error.response?.data?.error;
+    if (typeof apiError === 'string' && apiError.trim()) return apiError;
+  }
+  return fallback;
 }
 
 export default function StaffPage() {
@@ -109,7 +118,7 @@ export default function StaffPage() {
       if (editingStaff) {
         await api.put(`/staff/${editingStaff.id}`, {
           name: form.name,
-          email: form.email || null,
+          email: form.email,
           role: form.role,
           ...(form.password ? { password: form.password } : {}),
           ...(form.pin ? { pin: form.pin } : {}),
@@ -118,7 +127,7 @@ export default function StaffPage() {
       } else {
         await api.post('/staff', {
           name: form.name,
-          email: form.email || null,
+          email: form.email,
           password: form.password,
           role: form.role,
           ...(form.pin ? { pin: form.pin } : {}),
@@ -127,8 +136,8 @@ export default function StaffPage() {
       }
       closeForm();
       fetchStaff();
-    } catch {
-      toast.error(t('failedToSave'));
+    } catch (error: unknown) {
+      toast.error(extractErrorMessage(error, t('failedToSave')));
     }
   };
 
@@ -142,8 +151,8 @@ export default function StaffPage() {
       await api.put(`/staff/${resetPwStaff.id}`, { password: newPassword });
       toast.success(t('resetPasswordToast'));
       closeResetPassword();
-    } catch {
-      toast.error(t('failedToReset'));
+    } catch (error: unknown) {
+      toast.error(extractErrorMessage(error, t('failedToReset')));
     }
   };
 
@@ -231,9 +240,12 @@ export default function StaffPage() {
                 className="w-full px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand" required
               />
               <input
-                type="email" placeholder={`${tAuth('email')} (${tCommon('optional')})`} value={form.email}
+                type="email" placeholder={tAuth('email')} value={form.email}
                 onChange={(e) => setForm({ ...form, email: e.target.value })}
                 className="w-full px-3 py-2 border rounded-lg outline-none focus:ring-2 focus:ring-brand"
+                autoComplete="email"
+                dir="ltr"
+                required
               />
               <div className="relative">
                 <input

--- a/main/routes/staff.ts
+++ b/main/routes/staff.ts
@@ -9,6 +9,7 @@ import bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 import { getDatabase, now } from '../db';
 import { requireRole, validatePassword, authRateLimit, invalidateUserAuthCache } from '../middleware/security';
+import { isValidEmail } from './auth';
 import { ROLE_ACCESS, ROLE_KEYS, OPERATIONAL_ROLES, hasRole } from '../../shared/role-permissions';
 
 const router = Router();
@@ -32,6 +33,10 @@ function hasNonEmptyPin(pin: unknown): boolean {
 
 function isValidPin(pin: unknown): boolean {
   return /^\d{4,6}$/.test(String(pin));
+}
+
+function normalizeStaffEmail(email: unknown): string {
+  return String(email || '').trim().toLowerCase();
 }
 
 // ── List ──────────────────────────────────────────────────────────────────────
@@ -97,9 +102,13 @@ router.get('/:id', requireRole(...ROLE_ACCESS.ownerManager), (req: Request, res:
 router.post('/', requireRole(...ROLE_ACCESS.ownerManager), authRateLimit(), (req: Request, res: Response) => {
   try {
     const { name, email, password, role, pin } = req.body;
+    const normalizedEmail = normalizeStaffEmail(email);
 
-    if (!name || !password || !role) {
-      return res.status(400).json({ error: 'name, password, and role are required' });
+    if (!name || !normalizedEmail || !password || !role) {
+      return res.status(400).json({ error: 'name, email, password, and role are required' });
+    }
+    if (!isValidEmail(normalizedEmail)) {
+      return res.status(400).json({ error: 'Enter a valid email address' });
     }
     if (!validatePassword(password)) {
       return res.status(400).json({ error: 'Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number.' });
@@ -123,11 +132,9 @@ router.post('/', requireRole(...ROLE_ACCESS.ownerManager), authRateLimit(), (req
 
     const db = getDatabase();
 
-    if (email) {
-      const existing = db.prepare('SELECT id FROM users WHERE email = ?').get(email);
-      if (existing) {
-        return res.status(400).json({ error: 'Email already in use' });
-      }
+    const existing = db.prepare('SELECT id FROM users WHERE email = ?').get(normalizedEmail);
+    if (existing) {
+      return res.status(400).json({ error: 'Email already in use' });
     }
 
     const id = uuidv4();
@@ -138,7 +145,7 @@ router.post('/', requireRole(...ROLE_ACCESS.ownerManager), authRateLimit(), (req
     db.prepare(`
       INSERT INTO users (id, name, email, password, role, pin_hash, is_active, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
-    `).run(id, name, email || null, hashedPassword, role, hashedPin, now(), now());
+    `).run(id, name, normalizedEmail, hashedPassword, role, hashedPin, now(), now());
 
     const member = db.prepare(
       `SELECT ${STAFF_SELECT_FIELDS} FROM users WHERE id = ?`
@@ -156,6 +163,8 @@ router.post('/', requireRole(...ROLE_ACCESS.ownerManager), authRateLimit(), (req
 router.put('/:id', requireRole(...ROLE_ACCESS.ownerManager), authRateLimit(), (req: Request, res: Response) => {
   try {
     const { name, email, password, role, pin, is_active } = req.body;
+    const emailProvided = email !== undefined;
+    const normalizedEmail = emailProvided ? normalizeStaffEmail(email) : undefined;
     const db = getDatabase();
 
     if (is_active !== undefined) {
@@ -189,8 +198,14 @@ router.put('/:id', requireRole(...ROLE_ACCESS.ownerManager), authRateLimit(), (r
       return res.status(400).json({ error: 'PIN must be between 4 and 6 numeric digits' });
     }
 
-    if (email && email !== member.email) {
-      const existing = db.prepare('SELECT id FROM users WHERE email = ? AND id != ?').get(email, req.params.id);
+    if (emailProvided && !normalizedEmail) {
+      return res.status(400).json({ error: 'email is required' });
+    }
+    if (normalizedEmail && !isValidEmail(normalizedEmail)) {
+      return res.status(400).json({ error: 'Enter a valid email address' });
+    }
+    if (normalizedEmail && normalizedEmail !== member.email) {
+      const existing = db.prepare('SELECT id FROM users WHERE email = ? AND id != ?').get(normalizedEmail, req.params.id);
       if (existing) {
         return res.status(400).json({ error: 'Email already in use' });
       }
@@ -229,7 +244,7 @@ router.put('/:id', requireRole(...ROLE_ACCESS.ownerManager), authRateLimit(), (r
           OR (SELECT COUNT(*) FROM users WHERE role = 'owner' AND is_active = 1) > 1
         )
     `).run(
-      name || null, email || null, hashedPassword,
+      name || null, normalizedEmail || null, hashedPassword,
       role || null, hashedPin, tokensValidAfter,
       now(), req.params.id, demotesActiveOwner ? 1 : 0,
     );

--- a/tests/staff-authz.test.ts
+++ b/tests/staff-authz.test.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 const Module = require('module');
 const originalLoad = Module._load;
 const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-staff-authz-'));
+process.env.FLO_AUTH_RATE_LIMIT_MAX = process.env.FLO_AUTH_RATE_LIMIT_MAX || '100';
 
 Module._load = function (request: string, parent: unknown, isMain: boolean) {
   if (request === 'electron') {
@@ -120,6 +121,28 @@ async function main() {
     });
     assertEqual(result.status, 200, `manager can edit ${role}`);
   }
+
+  result = await request(app).post('/api/staff').set(managerAuth).send({
+    name: 'Missing email server', password: 'StrongPass1', role: 'server',
+  });
+  assertEqual(result.status, 400, 'staff creation requires email');
+  assertEqual(result.body.error, 'name, email, password, and role are required', 'missing email returns a clear validation error');
+
+  result = await request(app).post('/api/staff').set(managerAuth).send({
+    name: 'Invalid email server', email: 'not-an-email', password: 'StrongPass1', role: 'server',
+  });
+  assertEqual(result.status, 400, 'staff creation rejects invalid email');
+  assertEqual(result.body.error, 'Enter a valid email address', 'invalid email returns a clear validation error');
+
+  result = await request(app).post('/api/staff').set(managerAuth).send({
+    name: 'Normalized email server', email: '  Mixed.Server@Test.Local  ', password: 'StrongPass1', role: 'server',
+  });
+  assertEqual(result.status, 201, 'staff creation trims and normalizes required email');
+  assertEqual(result.body.staff.email, 'mixed.server@test.local', 'created staff email is stored normalized');
+
+  result = await request(app).put(`/api/staff/${managerCreated.server}`).set(managerAuth).send({ email: '   ' });
+  assertEqual(result.status, 400, 'staff update rejects blank email');
+  assertEqual(result.body.error, 'email is required', 'blank email update returns a clear validation error');
 
   result = await request(app).post('/api/staff').set(managerAuth).send({
     name: 'Pinned cashier', email: 'pinned-cashier@test.local', password: 'StrongPass1', role: 'cashier', pin: '1234',


### PR DESCRIPTION
## Summary
- require and validate staff email on create/update
- normalize staff emails before duplicate checks and storage
- show backend validation messages in staff save/reset flows
- add regression coverage for mandatory staff email behavior

## Verification
- npm run test:staff-authz
- npm run build
- npm run build:frontend
- npm run lint
- git diff --check

Closes #528