### PR TITLE
docs: remove reddit community links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,9 +9,6 @@ contact_links:
   - name: Architecture & general discussions
     url: https://github.com/FreeOpenSourcePOS/FloCafe/discussions
     about: Propose architecture changes, ask questions, or discuss early ideas.
-  - name: Community support (Reddit)
-    url: https://www.reddit.com/r/FloPOS/
-    about: Share restaurant operator experiences and tips with the community.
   - name: Report a security vulnerability
     url: https://github.com/FreeOpenSourcePOS/FloCafe/security/advisories/new
     about: Report potential vulnerabilities privately per SECURITY.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,6 @@ For complete authoring instructions, see the [Tax packs developer guide](docs/ta
 
 ## Getting help
 
-- **Operator & general questions:** [GitHub Discussions](https://github.com/FreeOpenSourcePOS/FloCafe/discussions) or [Reddit r/FloPOS](https://www.reddit.com/r/FloPOS/)
+- **Operator & general questions:** [GitHub Discussions](https://github.com/FreeOpenSourcePOS/FloCafe/discussions)
 - **Bug reports & feature requests:** [GitHub Issues](https://github.com/FreeOpenSourcePOS/FloCafe/issues)
 - **Security vulnerabilities:** Report privately per [SECURITY.md](SECURITY.md) (do not open public issues)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
   <p>
     <a href="https://flopos.com">Website</a> ·
     <a href="https://github.com/FreeOpenSourcePOS/FloCafe/releases">Download</a> ·
-    <a href="https://github.com/FreeOpenSourcePOS/FloCafe/issues">Report a bug</a> ·
-    <a href="https://www.reddit.com/r/FloPOS/">Community</a>
+    <a href="https://github.com/FreeOpenSourcePOS/FloCafe/issues">Report a bug</a>
   </p>
   <p>
     <a href="https://github.com/FreeOpenSourcePOS/FloCafe/releases"><img src="https://img.shields.io/github/v/release/FreeOpenSourcePOS/FloCafe?label=latest%20release" alt="Latest release"></a>
@@ -300,7 +299,6 @@ If FloCafe is useful to you, consider starring the repository.
 - **Linux setup & support:** [docs/linux.md](docs/linux.md)
 - **Internationalization & translations:** [docs/i18n.md](docs/i18n.md)
 - **Google Drive backup setup:** [docs/google-drive-setup.md](docs/google-drive-setup.md)
-- **Community discussion:** [Reddit r/FloPOS](https://www.reddit.com/r/FloPOS/)
 - **Bug reports & feature proposals:** [GitHub Issues](https://github.com/FreeOpenSourcePOS/FloCafe/issues)
 - **General questions & ideas:** [GitHub Discussions](https://github.com/FreeOpenSourcePOS/FloCafe/discussions)
 


### PR DESCRIPTION
## Related work

Issue / Discussion: None (documentation update)

## Summary

Removed links and references to the Reddit community (`r/FloPOS`) across the repository:
- `README.md`: Removed top navigation link and community discussion entry under Help & documentation.
- `CONTRIBUTING.md`: Removed Reddit link under Getting help.
- `.github/ISSUE_TEMPLATE/config.yml`: Removed Reddit community support contact link.

## Scope

Code and functional logic are untouched; this change only touches documentation and issue template contact links.

## Verification

Commands run:
- `git diff --check`
- `npm run lint`

Results:
- `git diff --check` passed cleanly (exit code 0).
- `npm run lint` passed with 0 errors.

## Compatibility & data safety

- **Database/data impact:** None
- **Migration:** None
- **User-visible behavior:** None (documentation / links only)
- **Offline/network impact:** None

## Contributor checklist

- [x] This is a small isolated fix/doc update OR follows an approved issue/direction.
- [x] Unrelated cleanups, refactors, and dependency changes were kept out of this PR.
- [x] Tests were added or updated for any behavior changes.
- [x] Verification commands were run and documented above.
- [x] Customer data and upgrade safety were preserved (if touching database/storage).
- [x] Documentation or translations were updated where relevant.
- [x] I understand and can explain all submitted changes.