### PR TITLE
docs: document server app port configuration and fallback guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@
 # KDS server port (default: 3002)
 # KDS_PORT=3002
 
+# Server / waiter app port (default: 3003)
+# SERVER_APP_PORT=3003
+
 # Node environment: development, production, test (default: development)
 # NODE_ENV=development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # FloCafe agent guide
 
-FloCafe is an open-source, offline-first Electron desktop POS. `main/` contains the Electron main process, Express API (`:3001`), standalone KDS server (`:3002`), SQLite database, printing, and background services. `frontend/` is a statically exported Next.js 16 and React 19 application. `tests/` contains backend, integration, and release test suites.
+FloCafe is an open-source, offline-first Electron desktop POS. `main/` contains the Electron main process, Express API (`:3001`), standalone KDS server (`:3002`), server app (`:3003`), SQLite database, printing, and background services. `frontend/` is a statically exported Next.js 16 and React 19 application. `tests/` contains backend, integration, and release test suites.
 
 ## Progressive disclosure
 
@@ -61,7 +61,7 @@ FloCafe requires **Node.js 22 or later**.
 
 ```sh
 npm run dev              # Full Electron app (cleans ports, builds frontend & backend)
-node dev-server.js       # Backend only (Express API on :3001, KDS on :3002)
+node dev-server.js       # Backend only (Express API on :3001, KDS on :3002, Server App on :3003)
 npm run dev:frontend     # Frontend browser development server
 npm run lint             # Lint backend (main/) and frontend (frontend/)
 npm run build            # Compile TypeScript backend to dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,13 +75,15 @@ npm run dev
 
 ```sh
 npm run dev              # Build frontend & backend, launch Electron
-node dev-server.js       # Backend only (Express API on :3001, KDS on :3002)
+node dev-server.js       # Backend only (Express API on :3001, KDS on :3002, Server App on :3003)
 npm run dev:frontend     # Frontend development server in browser
 npm run lint             # Lint backend and frontend
 npm run build            # Compile TypeScript backend to dist/
 npm run build:frontend   # Export static Next.js frontend
 npm test                 # Run default test suite
 ```
+
+> **Port configuration:** FloCafe uses ports `3001` (Main API), `3002` (KDS), and `3003` (Server App). If these ports are in use (e.g. by Docker), FloCafe automatically falls back to subsequent available ports. You can also customize them via `PORT`, `KDS_PORT`, and `SERVER_APP_PORT` in `.env`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ npm run dev
 Electron main process
 ├── Express API and WebSocket server       :3001
 ├── Standalone kitchen-display server      :3002
+├── Server / waiter app server             :3003
 └── SQLite database, migrations, and printing
                  ↕ HTTP and WebSocket
 Next.js renderer

--- a/dev-server.js
+++ b/dev-server.js
@@ -143,7 +143,7 @@ process.on('unhandledRejection', (err) => {
     console.log(`[DevServer] ✅ KDS Server running on http://localhost:${getKdsPort()}`);
     console.log(`[DevServer] ✅ Server App running on http://localhost:${getServerAppPort()}`);
     console.log('[DevServer]    Frontend dev server: http://localhost:3000');
-    console.log('[DevServer]    API health: http://localhost:3001/api/health');
+    console.log(`[DevServer]    API health: http://localhost:${getServerPort()}/api/health`);
   } catch (err) {
     console.error('[DevServer] Failed to start:', err);
     const code = err && (err.code === 'ERR_SHUTDOWN_ABORTED' || err.code === 'ABORT_ERR' || err.name === 'AbortError') ? 0 : 1;

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,7 @@
 
 **Frontend for FloCafe POS** — a Next.js 16 + React 19 application with Tailwind CSS v4 and shadcn/ui components.
 
-FloUI is the user interface for the FloCafe point-of-sale system. It runs as a static export inside Electron and communicates with the local Express backend (`:3001`) and KDS server (`:3002`).
+FloUI is the user interface for the FloCafe point-of-sale system. It runs as a static export inside Electron and communicates with the local Express backend (`:3001`), KDS server (`:3002`), and Server App (`:3003`).
 
 ## Features
 

--- a/kill-ports.js
+++ b/kill-ports.js
@@ -248,6 +248,9 @@ async function killPort(port) {
     console.log(
       `[kill-ports] Port ${port}: no Flo processes found. ${procs.length} other process(es) using this port.`
     );
+    console.log(
+      `[kill-ports] Note: Non-Flo process is holding port ${port}. FloCafe will attempt fallback ports automatically on startup, or you can configure custom ports (PORT, KDS_PORT, SERVER_APP_PORT) in .env.`
+    );
     return;
   }
 


### PR DESCRIPTION
## What Changed

- Documented the server app port (`3003`, `SERVER_APP_PORT`) across `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `frontend/README.md`, and `.env.example`.
- Added guidance in `CONTRIBUTING.md` and informational logging in `kill-ports.js` explaining automatic port fallback behavior and custom port configuration.
- Updated `dev-server.js` to dynamically log the API health check URL using `getServerPort()`.

## Risk Assessment

✅ Low: The changes are well-bounded documentation updates and minor log message adjustments clarifying port configuration and fallback behavior.

## Testing

Exercised dev tooling script unit tests, server port collision fallback tests, kill-ports process identity and non-Flo process conflict handling, and verified documentation and dev-server logging; all checks passed cleanly.

<details>
<summary>Evidence: Port Guidance &amp; Conflict Verification Log</summary>

<code>=== FloCafe Port Guidance &amp; Conflict Verification ===&#10;&#10;1. Testing kill-ports.js on free ports:&#10;[kill-ports] Port 39123 is free.&#10;[kill-ports] Port 39124 is free.&#10;[kill-ports] Port 39125 is free.&#10;-&gt; Pass&#10;&#10;2. Testing kill-ports.js behavior with non-Flo process holding port:&#10;[kill-ports] Port 39876: SKIP — PID 8269 (...) is not a Flo process.&#10;[kill-ports] Port 39876: no Flo processes found. 1 other process(es) using this port.&#10;[kill-ports] Note: Non-Flo process is holding port 39876. FloCafe will attempt fallback ports automatically on startup, or you can configure custom ports (PORT, KDS_PORT, SERVER_APP_PORT) in .env.&#10;-&gt; Pass (non-Flo process preserved and helpful guidance emitted)&#10;&#10;3. Verifying documentation updates:&#10;[x] .env.example contains SERVER_APP_PORT=3003&#10;[x] CONTRIBUTING.md documents ports 3001, 3002, 3003 and fallback guidance&#10;[x] README.md includes Server App port 3003 in architecture diagram&#10;[x] dev-server.js dynamically uses getServerPort() for health log&#10;&#10;-&gt; All checks passed successfully!</code>

```text
=== FloCafe Port Guidance & Conflict Verification ===

1. Testing kill-ports.js on free ports:
[kill-ports] Port 39123 is free.
[kill-ports] Port 39124 is free.
[kill-ports] Port 39125 is free.
-> Pass

2. Testing kill-ports.js behavior with non-Flo process holding port:
[kill-ports] Port 39876: SKIP — PID 8269 (/opt/homebrew/Cellar/node/26.7.0/bin/node -e \012    const http = require("http");\012    const server = http.createServer((req, res) => res.end("mock-response"));\012    server.listen(39876, "127.0.0.1", () => {\012      console.log("READY");\012    });\012) is not a Flo process.
[kill-ports] Port 39876: no Flo processes found. 1 other process(es) using this port.
[kill-ports] Note: Non-Flo process is holding port 39876. FloCafe will attempt fallback ports automatically on startup, or you can configure custom ports (PORT, KDS_PORT, SERVER_APP_PORT) in .env.
-> Pass (non-Flo process preserved and helpful guidance emitted)

3. Verifying documentation updates:
  [x] .env.example contains SERVER_APP_PORT=3003
  [x] CONTRIBUTING.md documents ports 3001, 3002, 3003 and fallback guidance
  [x] README.md includes Server App port 3003 in architecture diagram
  [x] dev-server.js dynamically uses getServerPort() for health log

-> All checks passed successfully!
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a166ee04d40d1c6ac76350f96c542234c3417864","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npx ts-node --transpile-only -P tests/tsconfig.json tests/dev-tooling-scripts.test.ts`
- `node tests/run-electron-node-test.cjs tests/server-port-collision.test.ts`
- `node kill-ports.js 3001 3002 3003`
- `Port conflict and documentation verification suite checking non-Flo port retention, fallback guidance logging, and documentation consistency`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
