### PR TITLE
chore(release): bump version to 3.3.1-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.3.1-beta.3",
+  "version": "3.3.1-beta.4",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
Version bump for the 3.3.1-beta.4 release.

**Commits since 3.3.1-beta.3:**
- fix(main): support EACCES in server port fallback (#541)
- fix: force repaint on system resume to prevent white screen on macOS wake (#536)
- fix(printer): surface real print errors and fix WebUSB connectivity (#535)
- fix: require staff email and surface save errors (#529)
- docs: document server app port configuration and fallback guidance (#540)
- docs: remove reddit community links (#539)
- test: add dedicated native Electron Playwright harness (#531)
- test: align security staff fixture with required email (#530)