### PR TITLE
fix(main): preserve updater install state during shutdown

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -222,26 +222,12 @@ function setupAutoUpdater(): void {
     });
   });
 
-  autoUpdater.on('error', createAutoUpdaterErrorHandler((err) => {
-    // #467: classify by error code/phase — never emit up-to-date from an
-    // error path. The historical substring mask (404 / Cannot find latest /
-    // ENOENT => "up to date") hid real check failures from users.
-    const errorPhase = updaterPhase;
-    const classified = classifyUpdateError(err, errorPhase);
-    updaterPhase = 'check';
-    log.info(
-      `[Update] Updater error classified as ${classified.state}` +
-      `/${classified.reason}:`, classified.detail
-    );
-    if (isInstallReady(storedUpdateStatus, stagedUpdateReady)) {
-      log.info('[Update] Preserving ready-to-install status while staged update awaits installation');
-      return;
-    }
-    setUpdateStatus({
-      status: classified.state,
-      reason: classified.reason,
-      error: classified.detail
-    });
+  autoUpdater.on('error', createAutoUpdaterErrorHandler({
+    getPhase: () => updaterPhase,
+    setPhase: (phase) => { updaterPhase = phase; },
+    isInstallReady: () => isInstallReady(storedUpdateStatus, stagedUpdateReady),
+    setUpdateStatus,
+    logInfo: (message, detail) => log.info(message, detail),
   }));
 }
 

--- a/main/index.ts
+++ b/main/index.ts
@@ -100,6 +100,7 @@ let storedUpdateStatus: StoredUpdateStatus = initialUpdateState();
 let updaterPhase: UpdateErrorPhase = 'check';
 let stagedUpdateReady = false;
 let startupFailure = false;
+let isInstallingUpdate = false;
 let betaChannelTransitionTail: Promise<void> = Promise.resolve();
 
 // Beta-channel opt-in persistence (#463, decision #503). The preference lives
@@ -980,6 +981,7 @@ async function initialize(): Promise<void> {
         log.warn(`[Update] Restart-to-install denied by Master PIN gate: ${auth.error}`);
         return { success: false, error: auth.error };
       }
+      isInstallingUpdate = true;
       isQuitting = true;
       try {
         await runCleanup();
@@ -1124,7 +1126,16 @@ const cleanupCoordinator = createShutdownCoordinator(() => [
   // Database closure is deliberately last: all HTTP and WebSocket work must
   // have settled before handlers can lose access to SQLite.
   { name: 'database', run: () => closeDatabase(), databaseClose: true },
-], { onFatalTimeout: () => app.exit(1) });
+], {
+  onFatalTimeout: () => {
+    // When shutting down to install an update, do not force-kill the process
+    // via app.exit(1) on a timeout; let runCleanup() reject and hand off to
+    // autoUpdater.quitAndInstall() so the update can still proceed.
+    if (!isInstallingUpdate) {
+      app.exit(1);
+    }
+  },
+});
 
 const { runCleanup, isShutdownRequested, shutdownSignal } = createShutdownEntrypoints({
   app: app as unknown as ShutdownEntrypointApp,

--- a/main/index.ts
+++ b/main/index.ts
@@ -32,6 +32,7 @@ import {
   type StoredUpdateStatus,
   type UpdateErrorPhase,
 } from './update-state';
+import { createAutoUpdaterErrorHandler, createRestartAndInstallHandler, type UpdateShutdownState } from './updater-shutdown';
 import { clearStaleRenderCachesOnVersionChange } from './startup-cache';
 import { createLocalWindowOpenHandler, createMainWindow, resolveTitleBarMode, type TitleBarMode } from './window-options';
 import {
@@ -221,9 +222,7 @@ function setupAutoUpdater(): void {
     });
   });
 
-  autoUpdater.on('error', (err) => {
-    isInstallingUpdate = false;
-    isQuitting = false;
+  autoUpdater.on('error', createAutoUpdaterErrorHandler(updateShutdownState, (err) => {
     // #467: classify by error code/phase — never emit up-to-date from an
     // error path. The historical substring mask (404 / Cannot find latest /
     // ENOENT => "up to date") hid real check failures from users.
@@ -243,7 +242,7 @@ function setupAutoUpdater(): void {
       reason: classified.reason,
       error: classified.detail
     });
-  });
+  }));
 }
 
 function checkForUpdates(): void {
@@ -376,6 +375,10 @@ let usbDevicePermissionsRegistered = false;
 let resolvedTitleBarMode: TitleBarMode = 'native-overlay';
 let bonjour: InstanceType<typeof Bonjour> | null = null;
 let isQuitting = false;
+const updateShutdownState: UpdateShutdownState = {
+  setInstallingUpdate: (value) => { isInstallingUpdate = value; },
+  setQuitting: (value) => { isQuitting = value; },
+};
 
 function showMainWindow(): boolean {
   if (
@@ -973,37 +976,15 @@ async function initialize(): Promise<void> {
     // calls event.preventDefault() on the first will-quit (blocking the
     // installer's relaunch), then calls app.quit() a second time as a plain
     // quit with no relaunch - the new version is never launched.
-    ipcMain.handle('restart-and-install', async (_event, pin?: unknown) => {
-      if (!isInstallReady(storedUpdateStatus, stagedUpdateReady)) {
-        log.warn('[Update] Ignoring install request before an update is downloaded');
-        return { success: false, error: 'No downloaded update is ready to install.' };
-      }
-      const auth = authorizeMasterPin(typeof pin === 'string' ? pin : undefined, 'ipc:restart-and-install');
-      if (!auth.ok) {
-        log.warn(`[Update] Restart-to-install denied by Master PIN gate: ${auth.error}`);
-        return { success: false, error: auth.error };
-      }
-      isInstallingUpdate = true;
-      isQuitting = true;
-      try {
-        await runCleanup();
-      } catch (error) {
-        // Cleanup failure or timeout is logged but does not block the installer - the
-        // new version launching is more important than a clean drain.
-        log.error('[Update] Pre-install cleanup failed (proceeding with install):', error);
-      }
-      // isSilent=false shows the installer UI; isForceRunAfter=true ensures
-      // the new version relaunches on Windows (NSIS) and Linux (AppImage).
-      try {
-        autoUpdater.quitAndInstall(false, true);
-        return { success: true };
-      } catch (installError) {
-        isQuitting = false;
-        isInstallingUpdate = false;
-        log.error('[Update] quitAndInstall failed:', installError);
-        return { success: false, error: installError instanceof Error ? installError.message : String(installError) };
-      }
-    });
+    ipcMain.handle('restart-and-install', createRestartAndInstallHandler({
+      isInstallReady: () => isInstallReady(storedUpdateStatus, stagedUpdateReady),
+      authorize: (pin) => authorizeMasterPin(pin, 'ipc:restart-and-install'),
+      runCleanup,
+      quitAndInstall: (isSilent, isForceRunAfter) => autoUpdater.quitAndInstall(isSilent, isForceRunAfter),
+      updateState: updateShutdownState,
+      warn: (message) => log.warn(message),
+      error: (message, error) => log.error(message, error),
+    }));
 
     ipcMain.handle('get-status', () => {
       const mem = process.memoryUsage();

--- a/main/index.ts
+++ b/main/index.ts
@@ -970,7 +970,7 @@ async function initialize(): Promise<void> {
     // to relaunch the new version. Without this ordering, the coordinator
     // calls event.preventDefault() on the first will-quit (blocking the
     // installer's relaunch), then calls app.quit() a second time as a plain
-    // quit with no relaunch — the new version is never launched.
+    // quit with no relaunch - the new version is never launched.
     ipcMain.handle('restart-and-install', async (_event, pin?: unknown) => {
       if (!isInstallReady(storedUpdateStatus, stagedUpdateReady)) {
         log.warn('[Update] Ignoring install request before an update is downloaded');
@@ -991,7 +991,7 @@ async function initialize(): Promise<void> {
           }),
         ]);
       } catch (error) {
-        // Cleanup failure or timeout is logged but does not block the installer — the
+        // Cleanup failure or timeout is logged but does not block the installer - the
         // new version launching is more important than a clean drain.
         log.error('[Update] Pre-install cleanup failed (proceeding with install):', error);
       }

--- a/main/index.ts
+++ b/main/index.ts
@@ -32,7 +32,7 @@ import {
   type StoredUpdateStatus,
   type UpdateErrorPhase,
 } from './update-state';
-import { createRestartAndInstallHandler, type UpdateShutdownState } from './updater-shutdown';
+import { createAutoUpdaterErrorHandler, createRestartAndInstallHandler, type UpdateShutdownState } from './updater-shutdown';
 import { clearStaleRenderCachesOnVersionChange } from './startup-cache';
 import { createLocalWindowOpenHandler, createMainWindow, resolveTitleBarMode, type TitleBarMode } from './window-options';
 import {
@@ -222,7 +222,7 @@ function setupAutoUpdater(): void {
     });
   });
 
-  autoUpdater.on('error', (err) => {
+  autoUpdater.on('error', createAutoUpdaterErrorHandler((err) => {
     // #467: classify by error code/phase — never emit up-to-date from an
     // error path. The historical substring mask (404 / Cannot find latest /
     // ENOENT => "up to date") hid real check failures from users.
@@ -242,7 +242,7 @@ function setupAutoUpdater(): void {
       reason: classified.reason,
       error: classified.detail
     });
-  });
+  }));
 }
 
 function checkForUpdates(): void {

--- a/main/index.ts
+++ b/main/index.ts
@@ -990,6 +990,8 @@ async function initialize(): Promise<void> {
         // Cleanup failure or timeout is logged but does not block the installer - the
         // new version launching is more important than a clean drain.
         log.error('[Update] Pre-install cleanup failed (proceeding with install):', error);
+      } finally {
+        isInstallingUpdate = false;
       }
       // isSilent=false shows the installer UI; isForceRunAfter=true ensures
       // the new version relaunches on Windows (NSIS) and Linux (AppImage).
@@ -998,7 +1000,6 @@ async function initialize(): Promise<void> {
         return { success: true };
       } catch (installError) {
         log.error('[Update] quitAndInstall failed:', installError);
-        isInstallingUpdate = false;
         return { success: false, error: installError instanceof Error ? installError.message : String(installError) };
       }
     });

--- a/main/index.ts
+++ b/main/index.ts
@@ -984,12 +984,7 @@ async function initialize(): Promise<void> {
       isInstallingUpdate = true;
       isQuitting = true;
       try {
-        await Promise.race([
-          runCleanup(),
-          new Promise<void>((_, reject) => {
-            setTimeout(() => reject(new Error(`Pre-install cleanup timed out after ${SHUTDOWN_TIMEOUT_MS}ms`)), SHUTDOWN_TIMEOUT_MS);
-          }),
-        ]);
+        await runCleanup();
       } catch (error) {
         // Cleanup failure or timeout is logged but does not block the installer - the
         // new version launching is more important than a clean drain.
@@ -1162,6 +1157,7 @@ const { runCleanup, isShutdownRequested, shutdownSignal } = createShutdownEntryp
   destroyWindow: () => {
     if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
   },
+  isInstallingUpdate: () => isInstallingUpdate,
   reportFailure: (context, error) => {
     console.error(`[Flo] Cleanup failed before ${context}:`, error);
   },

--- a/main/index.ts
+++ b/main/index.ts
@@ -32,7 +32,7 @@ import {
   type StoredUpdateStatus,
   type UpdateErrorPhase,
 } from './update-state';
-import { createAutoUpdaterErrorHandler, createRestartAndInstallHandler, type UpdateShutdownState } from './updater-shutdown';
+import { createRestartAndInstallHandler, type UpdateShutdownState } from './updater-shutdown';
 import { clearStaleRenderCachesOnVersionChange } from './startup-cache';
 import { createLocalWindowOpenHandler, createMainWindow, resolveTitleBarMode, type TitleBarMode } from './window-options';
 import {
@@ -222,7 +222,7 @@ function setupAutoUpdater(): void {
     });
   });
 
-  autoUpdater.on('error', createAutoUpdaterErrorHandler(updateShutdownState, (err) => {
+  autoUpdater.on('error', (err) => {
     // #467: classify by error code/phase — never emit up-to-date from an
     // error path. The historical substring mask (404 / Cannot find latest /
     // ENOENT => "up to date") hid real check failures from users.
@@ -242,7 +242,7 @@ function setupAutoUpdater(): void {
       reason: classified.reason,
       error: classified.detail
     });
-  }));
+  });
 }
 
 function checkForUpdates(): void {

--- a/main/index.ts
+++ b/main/index.ts
@@ -984,9 +984,14 @@ async function initialize(): Promise<void> {
       isInstallingUpdate = true;
       isQuitting = true;
       try {
-        await runCleanup();
+        await Promise.race([
+          runCleanup(),
+          new Promise<void>((_, reject) => {
+            setTimeout(() => reject(new Error(`Pre-install cleanup timed out after ${SHUTDOWN_TIMEOUT_MS}ms`)), SHUTDOWN_TIMEOUT_MS);
+          }),
+        ]);
       } catch (error) {
-        // Cleanup failure is logged but does not block the installer — the
+        // Cleanup failure or timeout is logged but does not block the installer — the
         // new version launching is more important than a clean drain.
         log.error('[Update] Pre-install cleanup failed (proceeding with install):', error);
       }

--- a/main/index.ts
+++ b/main/index.ts
@@ -1157,7 +1157,6 @@ const { runCleanup, isShutdownRequested, shutdownSignal } = createShutdownEntryp
   destroyWindow: () => {
     if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
   },
-  isInstallingUpdate: () => isInstallingUpdate,
   reportFailure: (context, error) => {
     console.error(`[Flo] Cleanup failed before ${context}:`, error);
   },

--- a/main/index.ts
+++ b/main/index.ts
@@ -962,7 +962,15 @@ async function initialize(): Promise<void> {
     // owner PIN approval. The PIN check runs here in the main process — the
     // same authorizeMasterPin used by every other master-PIN-gated IPC
     // handler — so no renderer path can bypass the guard.
-    ipcMain.handle('restart-and-install', (_event, pin?: unknown) => {
+    //
+    // Cleanup runs *before* quitAndInstall so the shutdown coordinator's
+    // will-quit handler sees cleanupFinished=true and exits immediately,
+    // allowing the platform installer hook (Squirrel.Mac / NSIS / AppImage)
+    // to relaunch the new version. Without this ordering, the coordinator
+    // calls event.preventDefault() on the first will-quit (blocking the
+    // installer's relaunch), then calls app.quit() a second time as a plain
+    // quit with no relaunch — the new version is never launched.
+    ipcMain.handle('restart-and-install', async (_event, pin?: unknown) => {
       if (!isInstallReady(storedUpdateStatus, stagedUpdateReady)) {
         log.warn('[Update] Ignoring install request before an update is downloaded');
         return { success: false, error: 'No downloaded update is ready to install.' };
@@ -973,7 +981,16 @@ async function initialize(): Promise<void> {
         return { success: false, error: auth.error };
       }
       isQuitting = true;
-      autoUpdater.quitAndInstall();
+      try {
+        await runCleanup();
+      } catch (error) {
+        // Cleanup failure is logged but does not block the installer — the
+        // new version launching is more important than a clean drain.
+        log.error('[Update] Pre-install cleanup failed (proceeding with install):', error);
+      }
+      // isSilent=false shows the installer UI; isForceRunAfter=true ensures
+      // the new version relaunches on Windows (NSIS) and Linux (AppImage).
+      autoUpdater.quitAndInstall(false, true);
       return { success: true };
     });
 

--- a/main/index.ts
+++ b/main/index.ts
@@ -223,6 +223,7 @@ function setupAutoUpdater(): void {
 
   autoUpdater.on('error', (err) => {
     isInstallingUpdate = false;
+    isQuitting = false;
     // #467: classify by error code/phase — never emit up-to-date from an
     // error path. The historical substring mask (404 / Cannot find latest /
     // ENOENT => "up to date") hid real check failures from users.
@@ -990,8 +991,6 @@ async function initialize(): Promise<void> {
         // Cleanup failure or timeout is logged but does not block the installer - the
         // new version launching is more important than a clean drain.
         log.error('[Update] Pre-install cleanup failed (proceeding with install):', error);
-      } finally {
-        isInstallingUpdate = false;
       }
       // isSilent=false shows the installer UI; isForceRunAfter=true ensures
       // the new version relaunches on Windows (NSIS) and Linux (AppImage).
@@ -999,6 +998,8 @@ async function initialize(): Promise<void> {
         autoUpdater.quitAndInstall(false, true);
         return { success: true };
       } catch (installError) {
+        isQuitting = false;
+        isInstallingUpdate = false;
         log.error('[Update] quitAndInstall failed:', installError);
         return { success: false, error: installError instanceof Error ? installError.message : String(installError) };
       }

--- a/main/index.ts
+++ b/main/index.ts
@@ -222,6 +222,7 @@ function setupAutoUpdater(): void {
   });
 
   autoUpdater.on('error', (err) => {
+    isInstallingUpdate = false;
     // #467: classify by error code/phase — never emit up-to-date from an
     // error path. The historical substring mask (404 / Cannot find latest /
     // ENOENT => "up to date") hid real check failures from users.
@@ -992,8 +993,14 @@ async function initialize(): Promise<void> {
       }
       // isSilent=false shows the installer UI; isForceRunAfter=true ensures
       // the new version relaunches on Windows (NSIS) and Linux (AppImage).
-      autoUpdater.quitAndInstall(false, true);
-      return { success: true };
+      try {
+        autoUpdater.quitAndInstall(false, true);
+        return { success: true };
+      } catch (installError) {
+        log.error('[Update] quitAndInstall failed:', installError);
+        isInstallingUpdate = false;
+        return { success: false, error: installError instanceof Error ? installError.message : String(installError) };
+      }
     });
 
     ipcMain.handle('get-status', () => {

--- a/main/index.ts
+++ b/main/index.ts
@@ -1157,6 +1157,7 @@ const { runCleanup, isShutdownRequested, shutdownSignal } = createShutdownEntryp
   destroyWindow: () => {
     if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
   },
+  isInstallingUpdate: () => isInstallingUpdate,
   reportFailure: (context, error) => {
     console.error(`[Flo] Cleanup failed before ${context}:`, error);
   },

--- a/main/shutdown.ts
+++ b/main/shutdown.ts
@@ -391,6 +391,7 @@ export type ShutdownEntrypointOptions = {
   setQuitting: () => void;
   onShutdownRequested?: () => void;
   destroyWindow: () => void;
+  isInstallingUpdate?: () => boolean;
   reportFailure?: (context: 'quit' | 'signal', error: unknown) => void;
   getSignalExitCode?: () => number;
   getQuitExitCode?: () => number;
@@ -403,6 +404,7 @@ export function createShutdownEntrypoints({
   setQuitting,
   onShutdownRequested = () => {},
   destroyWindow,
+  isInstallingUpdate = () => false,
   reportFailure = () => {},
   getSignalExitCode = () => 0,
   getQuitExitCode = () => 0,
@@ -457,7 +459,9 @@ export function createShutdownEntrypoints({
       },
       (error) => {
         reportFailure('quit', error);
-        app.exit(1);
+        if (!isInstallingUpdate()) {
+          app.exit(1);
+        }
       },
     );
   };

--- a/main/shutdown.ts
+++ b/main/shutdown.ts
@@ -391,7 +391,6 @@ export type ShutdownEntrypointOptions = {
   setQuitting: () => void;
   onShutdownRequested?: () => void;
   destroyWindow: () => void;
-  isInstallingUpdate?: () => boolean;
   reportFailure?: (context: 'quit' | 'signal', error: unknown) => void;
   getSignalExitCode?: () => number;
   getQuitExitCode?: () => number;
@@ -404,7 +403,6 @@ export function createShutdownEntrypoints({
   setQuitting,
   onShutdownRequested = () => {},
   destroyWindow,
-  isInstallingUpdate = () => false,
   reportFailure = () => {},
   getSignalExitCode = () => 0,
   getQuitExitCode = () => 0,
@@ -469,7 +467,7 @@ export function createShutdownEntrypoints({
   });
 
   app.on('will-quit', (event: ShutdownEvent) => {
-    if (cleanupFinished || isInstallingUpdate()) {
+    if (cleanupFinished) {
       destroyWindow();
       return;
     }

--- a/main/shutdown.ts
+++ b/main/shutdown.ts
@@ -454,6 +454,7 @@ export function createShutdownEntrypoints({
       () => {
         const exitCode = getQuitExitCode();
         destroyWindow();
+        if (isInstallingUpdate()) return;
         if (exitCode === 0) app.quit();
         else app.exit(exitCode);
       },

--- a/main/shutdown.ts
+++ b/main/shutdown.ts
@@ -488,10 +488,15 @@ export function createShutdownEntrypoints({
     signalExitRequested = true;
     requestShutdown();
     void runCleanup().then(
-      () => process.exit(getSignalExitCode()),
+      () => {
+        if (isInstallingUpdate()) return;
+        process.exit(getSignalExitCode());
+      },
       (error) => {
         reportFailure('signal', error);
-        process.exit(1);
+        if (!isInstallingUpdate()) {
+          process.exit(1);
+        }
       },
     );
   };

--- a/main/shutdown.ts
+++ b/main/shutdown.ts
@@ -331,7 +331,8 @@ export async function runShutdownSteps(
   for (const step of steps) {
     if (step.databaseClose && databaseBlocked) continue;
     try {
-      await step.run();
+      const stepPromise = Promise.resolve().then(() => step.run());
+      await withShutdownTimeout(stepPromise, step.name, () => {}, SHUTDOWN_TIMEOUT_MS);
     } catch (error) {
       errors.push(error);
       console.error(`[Shutdown] ${step.name} failed:`, error);

--- a/main/shutdown.ts
+++ b/main/shutdown.ts
@@ -391,6 +391,7 @@ export type ShutdownEntrypointOptions = {
   setQuitting: () => void;
   onShutdownRequested?: () => void;
   destroyWindow: () => void;
+  isInstallingUpdate?: () => boolean;
   reportFailure?: (context: 'quit' | 'signal', error: unknown) => void;
   getSignalExitCode?: () => number;
   getQuitExitCode?: () => number;
@@ -403,6 +404,7 @@ export function createShutdownEntrypoints({
   setQuitting,
   onShutdownRequested = () => {},
   destroyWindow,
+  isInstallingUpdate = () => false,
   reportFailure = () => {},
   getSignalExitCode = () => 0,
   getQuitExitCode = () => 0,
@@ -467,7 +469,7 @@ export function createShutdownEntrypoints({
   });
 
   app.on('will-quit', (event: ShutdownEvent) => {
-    if (cleanupFinished) {
+    if (cleanupFinished || isInstallingUpdate()) {
       destroyWindow();
       return;
     }

--- a/main/updater-shutdown.ts
+++ b/main/updater-shutdown.ts
@@ -1,3 +1,9 @@
+import {
+  classifyUpdateError,
+  type StoredUpdateStatus,
+  type UpdateErrorPhase,
+} from './update-state';
+
 export type UpdateShutdownState = {
   setInstallingUpdate: (value: boolean) => void;
   setQuitting: (value: boolean) => void;
@@ -26,11 +32,40 @@ export function resetUpdateShutdownState(updateState: UpdateShutdownState): void
   updateState.setQuitting(false);
 }
 
+type AutoUpdaterErrorHandlerOptions = {
+  getPhase: () => UpdateErrorPhase;
+  setPhase: (phase: UpdateErrorPhase) => void;
+  isInstallReady: () => boolean;
+  setUpdateStatus: (next: StoredUpdateStatus) => void;
+  logInfo: (message: string, detail?: unknown) => void;
+};
+
 export function createAutoUpdaterErrorHandler(
-  handleError: (error: unknown) => void,
+  {
+    getPhase,
+    setPhase,
+    isInstallReady,
+    setUpdateStatus,
+    logInfo,
+  }: AutoUpdaterErrorHandlerOptions,
 ): (error: unknown) => void {
   return (error) => {
-    handleError(error);
+    const errorPhase = getPhase();
+    const classified = classifyUpdateError(error, errorPhase);
+    setPhase('check');
+    logInfo(
+      `[Update] Updater error classified as ${classified.state}` +
+      `/${classified.reason}:`, classified.detail
+    );
+    if (isInstallReady()) {
+      logInfo('[Update] Preserving ready-to-install status while staged update awaits installation');
+      return;
+    }
+    setUpdateStatus({
+      status: classified.state,
+      reason: classified.reason,
+      error: classified.detail
+    });
   };
 }
 

--- a/main/updater-shutdown.ts
+++ b/main/updater-shutdown.ts
@@ -26,16 +26,6 @@ export function resetUpdateShutdownState(updateState: UpdateShutdownState): void
   updateState.setQuitting(false);
 }
 
-export function createAutoUpdaterErrorHandler(
-  updateState: UpdateShutdownState,
-  handleError: (error: unknown) => void,
-): (error: unknown) => void {
-  return (error) => {
-    resetUpdateShutdownState(updateState);
-    handleError(error);
-  };
-}
-
 export function createRestartAndInstallHandler({
   isInstallReady,
   authorize,

--- a/main/updater-shutdown.ts
+++ b/main/updater-shutdown.ts
@@ -1,0 +1,74 @@
+export type UpdateShutdownState = {
+  setInstallingUpdate: (value: boolean) => void;
+  setQuitting: (value: boolean) => void;
+};
+
+type UpdateAuthorizationResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+type RestartAndInstallResult =
+  | { success: true }
+  | { success: false; error: string };
+
+type RestartAndInstallOptions = {
+  isInstallReady: () => boolean;
+  authorize: (pin: string | undefined) => UpdateAuthorizationResult;
+  runCleanup: () => Promise<void>;
+  quitAndInstall: (isSilent: boolean, isForceRunAfter: boolean) => void;
+  updateState: UpdateShutdownState;
+  warn: (message: string) => void;
+  error: (message: string, error: unknown) => void;
+};
+
+export function resetUpdateShutdownState(updateState: UpdateShutdownState): void {
+  updateState.setInstallingUpdate(false);
+  updateState.setQuitting(false);
+}
+
+export function createAutoUpdaterErrorHandler(
+  updateState: UpdateShutdownState,
+  handleError: (error: unknown) => void,
+): (error: unknown) => void {
+  return (error) => {
+    resetUpdateShutdownState(updateState);
+    handleError(error);
+  };
+}
+
+export function createRestartAndInstallHandler({
+  isInstallReady,
+  authorize,
+  runCleanup,
+  quitAndInstall,
+  updateState,
+  warn,
+  error,
+}: RestartAndInstallOptions): (event: unknown, pin?: unknown) => Promise<RestartAndInstallResult> {
+  return async (_event, pin) => {
+    if (!isInstallReady()) {
+      warn('[Update] Ignoring install request before an update is downloaded');
+      return { success: false, error: 'No downloaded update is ready to install.' };
+    }
+    const auth = authorize(typeof pin === 'string' ? pin : undefined);
+    if (!auth.ok) {
+      warn(`[Update] Restart-to-install denied by Master PIN gate: ${auth.error}`);
+      return { success: false, error: auth.error };
+    }
+    updateState.setInstallingUpdate(true);
+    updateState.setQuitting(true);
+    try {
+      await runCleanup();
+    } catch (cleanupError) {
+      error('[Update] Pre-install cleanup failed (proceeding with install):', cleanupError);
+    }
+    try {
+      quitAndInstall(false, true);
+      return { success: true };
+    } catch (installError) {
+      resetUpdateShutdownState(updateState);
+      error('[Update] quitAndInstall failed:', installError);
+      return { success: false, error: installError instanceof Error ? installError.message : String(installError) };
+    }
+  };
+}

--- a/main/updater-shutdown.ts
+++ b/main/updater-shutdown.ts
@@ -26,6 +26,14 @@ export function resetUpdateShutdownState(updateState: UpdateShutdownState): void
   updateState.setQuitting(false);
 }
 
+export function createAutoUpdaterErrorHandler(
+  handleError: (error: unknown) => void,
+): (error: unknown) => void {
+  return (error) => {
+    handleError(error);
+  };
+}
+
 export function createRestartAndInstallHandler({
   isInstallReady,
   authorize,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
  "name": "flo-desktop",
- "version": "3.3.1-beta.3",
+ "version": "3.3.1-beta.5",
  "lockfileVersion": 3,
  "requires": true,
  "packages": {
   "": {
    "name": "flo-desktop",
-   "version": "3.3.1-beta.3",
+   "version": "3.3.1-beta.5",
    "hasInstallScript": true,
    "license": "MIT",
    "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.3.1-beta.4",
+  "version": "3.3.1-beta.5",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -1003,6 +1003,34 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     assert.equal(reportedFailure, true, 'failure is reported');
     assert.deepEqual(app.exitCodes, [], 'app.exit was NOT called on concurrent quit rejection during update');
   }
+
+  // --- Concurrent quit during failing cleanup forces app.exit(1) when isInstallingUpdate is false ---
+  {
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    const failure = new Error('Cleanup failed during non-update concurrent quit');
+    let reportedFailure = false;
+
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => { throw failure; },
+      setQuitting: () => {},
+      destroyWindow: () => {},
+      isInstallingUpdate: () => false,
+      reportFailure: () => { reportedFailure = true; },
+    });
+
+    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+    app.emit('will-quit', willQuit);
+    assert.equal(willQuit.prevented, true, 'concurrent quit waits for in-flight cleanup');
+
+    await assert.rejects(entrypoints.runCleanup(), (err: unknown) => err === failure);
+    await delay(0);
+
+    assert.equal(reportedFailure, true, 'failure is reported');
+    assert.deepEqual(app.exitCodes, [1], 'app.exit(1) was called on concurrent quit rejection when not updating');
+  }
 }
 
 (async () => {

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -974,34 +974,40 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
       'will-quit is NOT blocked even if cleanup timed out (updater can still proceed to install)');
   }
 
-  // --- Safety race: hanging cleanup does not block quitAndInstall ---
+  // --- Updater quit is never blocked when isInstallingUpdate returns true ---
   {
-    let quitAndInstallCalled = false;
-    let quitAndInstallArgs: any[] = [];
-    const autoUpdaterDouble = {
-      quitAndInstall: (isSilent?: boolean, isForceRunAfter?: boolean) => {
-        quitAndInstallCalled = true;
-        quitAndInstallArgs = [isSilent, isForceRunAfter];
-      },
-    };
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    let cleanupCalls = 0;
+    let windowDestroyed = false;
+    let releaseCleanup: (() => void) | null = null;
+    const cleanupHeld = new Promise<void>((resolve) => { releaseCleanup = resolve; });
 
-    const hangingCleanup = new Promise<void>(() => {});
-    const testTimeoutMs = 10;
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => { cleanupCalls++; await cleanupHeld; },
+      setQuitting: () => {},
+      destroyWindow: () => { windowDestroyed = true; },
+      isInstallingUpdate: () => true,
+    });
 
-    try {
-      await Promise.race([
-        hangingCleanup,
-        new Promise<void>((_, reject) => {
-          setTimeout(() => reject(new Error(`Pre-install cleanup timed out after ${testTimeoutMs}ms`)), testTimeoutMs);
-        }),
-      ]);
-    } catch {
-      // Ignored / logged as in handler
-    }
-    autoUpdaterDouble.quitAndInstall(false, true);
+    // Cleanup starts (e.g. running in background or interrupted by quitAndInstall)
+    const cleanupPromise = entrypoints.runCleanup();
 
-    assert.equal(quitAndInstallCalled, true, 'quitAndInstall is called even when cleanup hangs');
-    assert.deepEqual(quitAndInstallArgs, [false, true], 'quitAndInstall is called with isSilent=false and isForceRunAfter=true');
+    // When isInstallingUpdate is true, will-quit is NOT blocked even if cleanup is still pending
+    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+    app.emit('will-quit', willQuit);
+    await delay(0);
+
+    assert.equal(willQuit.prevented, false,
+      'will-quit is NOT blocked when isInstallingUpdate is true even if cleanup has not settled');
+    assert.equal(windowDestroyed, true, 'destroyWindow is called on unblocked updater will-quit');
+
+    // Clean up pending promise
+    releaseCleanup?.();
+    await cleanupPromise;
+    await delay(0);
   }
 }
 

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -1128,4 +1128,3 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
   console.error(error);
   process.exit(1);
 });
-

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -426,6 +426,62 @@ async function testEntrypointCoverage(): Promise<void> {
     assert.equal(secondWillQuit.prevented, false, `${label} allows the resumed quit`);
   }
 
+  {
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    let isInstallingUpdate = false;
+    let cleanupStarted = false;
+    let releaseCleanup: (() => void) | null = null;
+    const cleanupHeld = new Promise<void>((resolve) => { releaseCleanup = resolve; });
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => {
+        cleanupStarted = true;
+        await cleanupHeld;
+      },
+      setQuitting: () => {},
+      destroyWindow: () => {},
+      isInstallingUpdate: () => isInstallingUpdate,
+    });
+
+    process.emit('SIGTERM');
+    await delay(0);
+    assert.equal(cleanupStarted, true, 'signal starts shared cleanup before updater handoff');
+    isInstallingUpdate = true;
+    releaseCleanup?.();
+    await entrypoints.runCleanup();
+    await delay(0);
+
+    assert.deepEqual(process.exitCodes, [], 'signal does not exit while updater handoff is active');
+  }
+
+  {
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    let isInstallingUpdate = false;
+    let rejectCleanup: ((error: Error) => void) | null = null;
+    const cleanupFailed = new Promise<void>((_resolve, reject) => { rejectCleanup = reject; });
+    const failure = new Error('signal cleanup failed during updater handoff');
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => { await cleanupFailed; },
+      setQuitting: () => {},
+      destroyWindow: () => {},
+      isInstallingUpdate: () => isInstallingUpdate,
+    });
+
+    process.emit('SIGTERM');
+    await delay(0);
+    isInstallingUpdate = true;
+    rejectCleanup?.(failure);
+    await assert.rejects(entrypoints.runCleanup(), (error: unknown) => error === failure);
+    await delay(0);
+
+    assert.deepEqual(process.exitCodes, [], 'signal does not exit after failed cleanup during updater handoff');
+  }
+
   await runScenario('SIGTERM');
   await runScenario('SIGINT');
 
@@ -877,57 +933,89 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
   {
     const app = new AppDouble();
     const process = new ProcessDouble();
+    let isInstallingUpdate = false;
     let cleanupCalls = 0;
+    let installCalls = 0;
+    let installWillQuitPrevented = false;
+    const updateState: UpdateShutdownState = {
+      setInstallingUpdate: (value) => { isInstallingUpdate = value; },
+      setQuitting: () => {},
+    };
     const entrypoints = createShutdownEntrypoints({
       app,
       process,
       cleanup: async () => { cleanupCalls++; },
       setQuitting: () => {},
       destroyWindow: () => {},
+      isInstallingUpdate: () => isInstallingUpdate,
+    });
+    const handler = createRestartAndInstallHandler({
+      isInstallReady: () => true,
+      authorize: () => ({ ok: true }),
+      runCleanup: entrypoints.runCleanup,
+      quitAndInstall: () => {
+        installCalls++;
+        const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+        app.emit('will-quit', willQuit);
+        installWillQuitPrevented = willQuit.prevented;
+      },
+      updateState,
+      warn: () => {},
+      error: () => {},
     });
 
-    // Simulate: await runCleanup() completes first (as the fixed handler does)
-    await entrypoints.runCleanup();
+    const result = await handler({}, '1234');
 
-    // Now quitAndInstall calls app.quit() → will-quit fires
-    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
-    app.emit('will-quit', willQuit);
-    await delay(0);
-
-    assert.equal(willQuit.prevented, false,
-      'will-quit is NOT blocked when cleanup already finished (installer can relaunch)');
+    assert.deepEqual(result, { success: true });
+    assert.equal(installCalls, 1, 'quitAndInstall runs once after handler cleanup');
+    assert.equal(installWillQuitPrevented, false,
+      'will-quit is NOT blocked after the handler cleanup (installer can relaunch)');
     assert.equal(cleanupCalls, 1, 'cleanup ran exactly once');
   }
 
-  // --- Regression: quitAndInstall fires will-quit before cleanup completes ---
+  // --- Handler waits for cleanup before installing ---
   {
     const app = new AppDouble();
     const process = new ProcessDouble();
-    let cleanupCalls = 0;
+    let isInstallingUpdate = false;
+    let cleanupFinished = false;
+    let installCalls = 0;
     let releaseCleanup: (() => void) | null = null;
     const cleanupHeld = new Promise<void>((resolve) => { releaseCleanup = resolve; });
+    const updateState: UpdateShutdownState = {
+      setInstallingUpdate: (value) => { isInstallingUpdate = value; },
+      setQuitting: () => {},
+    };
 
     const entrypoints = createShutdownEntrypoints({
       app,
       process,
-      cleanup: async () => { cleanupCalls++; await cleanupHeld; },
+      cleanup: async () => { await cleanupHeld; cleanupFinished = true; },
       setQuitting: () => {},
       destroyWindow: () => {},
+      isInstallingUpdate: () => isInstallingUpdate,
+    });
+    const handler = createRestartAndInstallHandler({
+      isInstallReady: () => true,
+      authorize: () => ({ ok: true }),
+      runCleanup: entrypoints.runCleanup,
+      quitAndInstall: () => { installCalls++; },
+      updateState,
+      warn: () => {},
+      error: () => {},
     });
 
-    // Simulate old (broken) ordering: quitAndInstall fires before cleanup
-    const cleanupPromise = entrypoints.runCleanup();
-    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
-    app.emit('will-quit', willQuit);
+    const installPromise = handler({}, '1234');
     await delay(0);
+    assert.equal(installCalls, 0, 'quitAndInstall waits for handler cleanup');
+    assert.equal(cleanupFinished, false, 'handler cleanup is still pending');
 
-    assert.equal(willQuit.prevented, true,
-      'will-quit IS blocked when cleanup is still in progress (regression: installer hook is lost)');
-
-    // Let cleanup finish so we don't leak
     releaseCleanup?.();
-    await cleanupPromise;
-    await delay(0);
+    const result = await installPromise;
+
+    assert.deepEqual(result, { success: true });
+    assert.equal(installCalls, 1, 'quitAndInstall runs after handler cleanup');
+    assert.equal(cleanupFinished, true, 'handler cleanup settles before installation');
   }
 
   // --- A concurrent normal quit does not preempt the updater handoff ---
@@ -1129,17 +1217,29 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
   {
     let isInstallingUpdate = true;
     let isQuitting = true;
-    let handledError: unknown;
-    const handleError = createAutoUpdaterErrorHandler((error) => {
-      handledError = error;
-      assert.equal(isInstallingUpdate, true, 'updater error preserves active install state during delivery');
-      assert.equal(isQuitting, true, 'updater error preserves quitting state during delivery');
+    let updaterPhase: 'check' | 'download' = 'download';
+    let reportedStatus: unknown;
+    const handleError = createAutoUpdaterErrorHandler({
+      getPhase: () => updaterPhase,
+      setPhase: (phase) => { updaterPhase = phase; },
+      isInstallReady: () => false,
+      setUpdateStatus: (status) => {
+        reportedStatus = status;
+        assert.equal(isInstallingUpdate, true, 'updater error preserves active install state during delivery');
+        assert.equal(isQuitting, true, 'updater error preserves quitting state during delivery');
+      },
+      logInfo: () => {},
     });
     const updaterError = new Error('Updater failed during background operation');
 
     handleError(updaterError);
 
-    assert.equal(handledError, updaterError, 'updater error callback runs');
+    assert.deepEqual(reportedStatus, {
+      status: 'check-failed',
+      reason: 'download-failed',
+      error: updaterError.message,
+    }, 'updater error callback updates status');
+    assert.equal(updaterPhase, 'check', 'updater error callback resets its phase');
     assert.equal(isInstallingUpdate, true, 'updater error preserves active install state');
     assert.equal(isQuitting, true, 'updater error preserves quitting state');
   }

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -18,7 +18,7 @@ import {
   trackHttpRequestWork,
   waitForHttpShutdownWork,
 } from '../main/shutdown';
-import { createRestartAndInstallHandler, resetUpdateShutdownState, type UpdateShutdownState } from '../main/updater-shutdown';
+import { createAutoUpdaterErrorHandler, createRestartAndInstallHandler, type UpdateShutdownState } from '../main/updater-shutdown';
 import { startStandaloneServers } from '../main/standalone-startup';
 
 const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-shutdown-lifecycle-'));
@@ -1129,17 +1129,19 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
   {
     let isInstallingUpdate = true;
     let isQuitting = true;
-    const updateState: UpdateShutdownState = {
-      setInstallingUpdate: (value) => { isInstallingUpdate = value; },
-      setQuitting: (value) => { isQuitting = value; },
-    };
+    let handledError: unknown;
+    const handleError = createAutoUpdaterErrorHandler((error) => {
+      handledError = error;
+      assert.equal(isInstallingUpdate, true, 'updater error preserves active install state during delivery');
+      assert.equal(isQuitting, true, 'updater error preserves quitting state during delivery');
+    });
+    const updaterError = new Error('Updater failed during background operation');
 
-    // An asynchronous error during background operations does not touch active install state
-    assert.equal(isInstallingUpdate, true, 'isInstallingUpdate remains active during pre-install cleanup');
-    assert.equal(isQuitting, true, 'isQuitting remains active during pre-install cleanup');
-    resetUpdateShutdownState(updateState);
-    assert.equal(isInstallingUpdate, false, 'resetUpdateShutdownState correctly clears state when explicitly invoked');
-    assert.equal(isQuitting, false, 'resetUpdateShutdownState correctly clears quitting state');
+    handleError(updaterError);
+
+    assert.equal(handledError, updaterError, 'updater error callback runs');
+    assert.equal(isInstallingUpdate, true, 'updater error preserves active install state');
+    assert.equal(isQuitting, true, 'updater error preserves quitting state');
   }
 }
 

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -928,6 +928,51 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     await cleanupPromise;
     await delay(0);
   }
+
+  // --- Timeout during pre-install cleanup: rejection settles and allows updater quit ---
+  {
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    const timeout = Object.assign(new Error('Cleanup step timed out'), { code: 'ERR_SHUTDOWN_TIMEOUT' });
+    let isInstallingUpdate = true;
+    let fatalExitCalled = false;
+
+    const coordinator = createShutdownCoordinator(() => [
+      {
+        name: 'timed out service',
+        run: () => { throw timeout; },
+      },
+    ], {
+      onFatalTimeout: () => {
+        if (!isInstallingUpdate) {
+          fatalExitCalled = true;
+          app.exit(1);
+        }
+      },
+    });
+
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: coordinator,
+      setQuitting: () => {},
+      destroyWindow: () => {},
+    });
+
+    // When isInstallingUpdate = true, runCleanup() rejects with the timeout error
+    // but onFatalTimeout does NOT force-kill the process via app.exit(1)
+    await assert.rejects(entrypoints.runCleanup(), (error: unknown) => error === timeout);
+    assert.equal(fatalExitCalled, false, 'pre-install timeout does not invoke fatal app.exit');
+    assert.deepEqual(app.exitCodes, [], 'app.exit was not called on pre-install cleanup timeout');
+
+    // Rejection still marks cleanup as finished, so subsequent quitAndInstall's will-quit is allowed
+    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+    app.emit('will-quit', willQuit);
+    await delay(0);
+
+    assert.equal(willQuit.prevented, false,
+      'will-quit is NOT blocked even if cleanup timed out (updater can still proceed to install)');
+  }
 }
 
 (async () => {

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -1031,6 +1031,21 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     assert.equal(reportedFailure, true, 'failure is reported');
     assert.deepEqual(app.exitCodes, [1], 'app.exit(1) was called on concurrent quit rejection when not updating');
   }
+
+  // --- Failed quitAndInstall resets isInstallingUpdate to avoid poisoning future shutdown ---
+  {
+    let isInstalling = false;
+    const simulateInstall = () => {
+      isInstalling = true;
+      try {
+        throw new Error('Squirrel failed to spawn installer');
+      } catch {
+        isInstalling = false;
+      }
+    };
+    simulateInstall();
+    assert.equal(isInstalling, false, 'isInstallingUpdate was reset to false after quitAndInstall exception');
+  }
 }
 
 (async () => {

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -18,7 +18,7 @@ import {
   trackHttpRequestWork,
   waitForHttpShutdownWork,
 } from '../main/shutdown';
-import { createAutoUpdaterErrorHandler, createRestartAndInstallHandler, type UpdateShutdownState } from '../main/updater-shutdown';
+import { createRestartAndInstallHandler, resetUpdateShutdownState, type UpdateShutdownState } from '../main/updater-shutdown';
 import { startStandaloneServers } from '../main/standalone-startup';
 
 const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-shutdown-lifecycle-'));
@@ -1125,39 +1125,21 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     assert.deepEqual(app.exitCodes, [1], 'subsequent shutdown exits after install failure reset');
   }
 
-  // --- AutoUpdater errors reset updater shutdown state ---
+  // --- AutoUpdater background errors do not clear in-flight install state ---
   {
-    const app = new AppDouble();
-    const process = new ProcessDouble();
     let isInstallingUpdate = true;
     let isQuitting = true;
     const updateState: UpdateShutdownState = {
       setInstallingUpdate: (value) => { isInstallingUpdate = value; },
       setQuitting: (value) => { isQuitting = value; },
     };
-    let errorHandled = false;
-    const handleError = createAutoUpdaterErrorHandler(updateState, () => { errorHandled = true; });
-    handleError(new Error('Updater failed during install'));
 
-    assert.equal(errorHandled, true, 'updater error callback runs');
-    assert.equal(isInstallingUpdate, false, 'updater error resets installing state');
-    assert.equal(isQuitting, false, 'updater error resets quitting state');
-
-    const entrypoints = createShutdownEntrypoints({
-      app,
-      process,
-      cleanup: async () => { throw new Error('Cleanup failed during later shutdown'); },
-      setQuitting: () => {},
-      destroyWindow: () => {},
-      isInstallingUpdate: () => isInstallingUpdate,
-    });
-
-    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
-    app.emit('will-quit', willQuit);
-    await assert.rejects(entrypoints.runCleanup());
-    await delay(0);
-
-    assert.deepEqual(app.exitCodes, [1], 'shutdown failure is not masked by prior updater error');
+    // An asynchronous error during background operations does not touch active install state
+    assert.equal(isInstallingUpdate, true, 'isInstallingUpdate remains active during pre-install cleanup');
+    assert.equal(isQuitting, true, 'isQuitting remains active during pre-install cleanup');
+    resetUpdateShutdownState(updateState);
+    assert.equal(isInstallingUpdate, false, 'resetUpdateShutdownState correctly clears state when explicitly invoked');
+    assert.equal(isQuitting, false, 'resetUpdateShutdownState correctly clears quitting state');
   }
 }
 

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -973,42 +973,6 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     assert.equal(willQuit.prevented, false,
       'will-quit is NOT blocked even if cleanup timed out (updater can still proceed to install)');
   }
-
-  // --- Updater quit is never blocked when isInstallingUpdate returns true ---
-  {
-    const app = new AppDouble();
-    const process = new ProcessDouble();
-    let cleanupCalls = 0;
-    let windowDestroyed = false;
-    let releaseCleanup: (() => void) | null = null;
-    const cleanupHeld = new Promise<void>((resolve) => { releaseCleanup = resolve; });
-
-    const entrypoints = createShutdownEntrypoints({
-      app,
-      process,
-      cleanup: async () => { cleanupCalls++; await cleanupHeld; },
-      setQuitting: () => {},
-      destroyWindow: () => { windowDestroyed = true; },
-      isInstallingUpdate: () => true,
-    });
-
-    // Cleanup starts (e.g. running in background or interrupted by quitAndInstall)
-    const cleanupPromise = entrypoints.runCleanup();
-
-    // When isInstallingUpdate is true, will-quit is NOT blocked even if cleanup is still pending
-    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
-    app.emit('will-quit', willQuit);
-    await delay(0);
-
-    assert.equal(willQuit.prevented, false,
-      'will-quit is NOT blocked when isInstallingUpdate is true even if cleanup has not settled');
-    assert.equal(windowDestroyed, true, 'destroyWindow is called on unblocked updater will-quit');
-
-    // Clean up pending promise
-    releaseCleanup?.();
-    await cleanupPromise;
-    await delay(0);
-  }
 }
 
 (async () => {

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -973,6 +973,36 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     assert.equal(willQuit.prevented, false,
       'will-quit is NOT blocked even if cleanup timed out (updater can still proceed to install)');
   }
+
+  // --- Safety race: hanging cleanup does not block quitAndInstall ---
+  {
+    let quitAndInstallCalled = false;
+    let quitAndInstallArgs: any[] = [];
+    const autoUpdaterDouble = {
+      quitAndInstall: (isSilent?: boolean, isForceRunAfter?: boolean) => {
+        quitAndInstallCalled = true;
+        quitAndInstallArgs = [isSilent, isForceRunAfter];
+      },
+    };
+
+    const hangingCleanup = new Promise<void>(() => {});
+    const testTimeoutMs = 10;
+
+    try {
+      await Promise.race([
+        hangingCleanup,
+        new Promise<void>((_, reject) => {
+          setTimeout(() => reject(new Error(`Pre-install cleanup timed out after ${testTimeoutMs}ms`)), testTimeoutMs);
+        }),
+      ]);
+    } catch {
+      // Ignored / logged as in handler
+    }
+    autoUpdaterDouble.quitAndInstall(false, true);
+
+    assert.equal(quitAndInstallCalled, true, 'quitAndInstall is called even when cleanup hangs');
+    assert.deepEqual(quitAndInstallArgs, [false, true], 'quitAndInstall is called with isSilent=false and isForceRunAfter=true');
+  }
 }
 
 (async () => {

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -863,6 +863,73 @@ async function testOwnedServerStopEntrypoints(): Promise<void> {
   }
 }
 
+// ── quitAndInstall ordering regression (#544) ────────────────────────────────
+// When restart-and-install is invoked, cleanup must run *before*
+// autoUpdater.quitAndInstall() calls app.quit(). If cleanup runs after, the
+// shutdown coordinator's will-quit handler blocks the first quit with
+// event.preventDefault() and later re-issues a plain app.quit() — causing the
+// platform installer (Squirrel.Mac / NSIS / AppImage) to never relaunch the
+// new version. This test verifies the coordinator's will-quit behaviour in
+// both orderings so a regression is immediately visible.
+async function testQuitAndInstallCleanupOrdering(): Promise<void> {
+  // --- Correct ordering: cleanup finishes before quitAndInstall's will-quit ---
+  {
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    let cleanupCalls = 0;
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => { cleanupCalls++; },
+      setQuitting: () => {},
+      destroyWindow: () => {},
+    });
+
+    // Simulate: await runCleanup() completes first (as the fixed handler does)
+    await entrypoints.runCleanup();
+
+    // Now quitAndInstall calls app.quit() → will-quit fires
+    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+    app.emit('will-quit', willQuit);
+    await delay(0);
+
+    assert.equal(willQuit.prevented, false,
+      'will-quit is NOT blocked when cleanup already finished (installer can relaunch)');
+    assert.equal(cleanupCalls, 1, 'cleanup ran exactly once');
+  }
+
+  // --- Regression: quitAndInstall fires will-quit before cleanup completes ---
+  {
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    let cleanupCalls = 0;
+    let releaseCleanup: (() => void) | null = null;
+    const cleanupHeld = new Promise<void>((resolve) => { releaseCleanup = resolve; });
+
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => { cleanupCalls++; await cleanupHeld; },
+      setQuitting: () => {},
+      destroyWindow: () => {},
+    });
+
+    // Simulate old (broken) ordering: quitAndInstall fires before cleanup
+    const cleanupPromise = entrypoints.runCleanup();
+    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+    app.emit('will-quit', willQuit);
+    await delay(0);
+
+    assert.equal(willQuit.prevented, true,
+      'will-quit IS blocked when cleanup is still in progress (regression: installer hook is lost)');
+
+    // Let cleanup finish so we don't leak
+    releaseCleanup?.();
+    await cleanupPromise;
+    await delay(0);
+  }
+}
+
 (async () => {
   console.log('phase coordinator');
   await testCoordinatorOrderingAndIdempotency();
@@ -885,8 +952,11 @@ async function testOwnedServerStopEntrypoints(): Promise<void> {
   await testDatabaseImportShutdownCancellation();
   console.log('phase owned servers');
   await testOwnedServerStopEntrypoints();
+  console.log('phase update install ordering');
+  await testQuitAndInstallCleanupOrdering();
   console.log('Shutdown lifecycle tests passed.');
 })().catch((error) => {
   console.error(error);
   process.exit(1);
 });
+

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -973,6 +973,36 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     assert.equal(willQuit.prevented, false,
       'will-quit is NOT blocked even if cleanup timed out (updater can still proceed to install)');
   }
+
+  // --- Concurrent quit during failing cleanup does not force app.exit when isInstallingUpdate is true ---
+  {
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    const failure = new Error('Cleanup failed during concurrent quit');
+    let reportedFailure = false;
+
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => { throw failure; },
+      setQuitting: () => {},
+      destroyWindow: () => {},
+      isInstallingUpdate: () => true,
+      reportFailure: () => { reportedFailure = true; },
+    });
+
+    // Concurrent quit triggers will-quit before cleanup completes
+    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+    app.emit('will-quit', willQuit);
+    assert.equal(willQuit.prevented, true, 'concurrent quit waits for in-flight cleanup');
+
+    // Let cleanup reject
+    await assert.rejects(entrypoints.runCleanup(), (err: unknown) => err === failure);
+    await delay(0);
+
+    assert.equal(reportedFailure, true, 'failure is reported');
+    assert.deepEqual(app.exitCodes, [], 'app.exit was NOT called on concurrent quit rejection during update');
+  }
 }
 
 (async () => {

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -1034,17 +1034,68 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
 
   // --- Failed quitAndInstall resets isInstallingUpdate to avoid poisoning future shutdown ---
   {
-    let isInstalling = false;
-    const simulateInstall = () => {
-      isInstalling = true;
-      try {
-        throw new Error('Squirrel failed to spawn installer');
-      } catch {
-        isInstalling = false;
-      }
-    };
-    simulateInstall();
-    assert.equal(isInstalling, false, 'isInstallingUpdate was reset to false after quitAndInstall exception');
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    let isInstallingUpdate = false;
+    let reportedFailure = false;
+
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => { throw new Error('Cleanup failure after updater failed'); },
+      setQuitting: () => {},
+      destroyWindow: () => {},
+      isInstallingUpdate: () => isInstallingUpdate,
+      reportFailure: () => { reportedFailure = true; },
+    });
+
+    // 1. Simulate restart-and-install handler flow where quitAndInstall throws
+    isInstallingUpdate = true;
+    try {
+      throw new Error('Squirrel failed to spawn installer');
+    } catch {
+      isInstallingUpdate = false;
+    }
+
+    // 2. Later, user triggers normal quit, which encounters failing cleanup
+    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+    app.emit('will-quit', willQuit);
+    assert.equal(willQuit.prevented, true, 'quit waits for in-flight cleanup');
+
+    await assert.rejects(entrypoints.runCleanup());
+    await delay(0);
+
+    assert.equal(reportedFailure, true, 'cleanup failure is reported');
+    // Because isInstallingUpdate was properly reset to false, fatal app.exit(1) is invoked as expected
+    assert.deepEqual(app.exitCodes, [1], 'subsequent shutdown correctly exits with 1 instead of being poisoned');
+  }
+
+  // --- AutoUpdater error event resets isInstallingUpdate so subsequent shutdown is not poisoned ---
+  {
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    let isInstallingUpdate = false;
+
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => { throw new Error('Cleanup failed during later shutdown'); },
+      setQuitting: () => {},
+      destroyWindow: () => {},
+      isInstallingUpdate: () => isInstallingUpdate,
+    });
+
+    // Simulate update in-flight then autoUpdater error
+    isInstallingUpdate = true;
+    // autoUpdater.on('error') triggers reset
+    isInstallingUpdate = false;
+
+    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+    app.emit('will-quit', willQuit);
+    await assert.rejects(entrypoints.runCleanup());
+    await delay(0);
+
+    assert.deepEqual(app.exitCodes, [1], 'shutdown failure is not masked by prior updater error');
   }
 }
 

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -18,6 +18,7 @@ import {
   trackHttpRequestWork,
   waitForHttpShutdownWork,
 } from '../main/shutdown';
+import { createAutoUpdaterErrorHandler, createRestartAndInstallHandler, type UpdateShutdownState } from '../main/updater-shutdown';
 import { startStandaloneServers } from '../main/standalone-startup';
 
 const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-shutdown-lifecycle-'));
@@ -929,6 +930,36 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     await delay(0);
   }
 
+  // --- A concurrent normal quit does not preempt the updater handoff ---
+  {
+    const app = new AppDouble();
+    const process = new ProcessDouble();
+    let releaseCleanup: (() => void) | null = null;
+    const cleanupHeld = new Promise<void>((resolve) => { releaseCleanup = resolve; });
+    let isInstallingUpdate = true;
+
+    const entrypoints = createShutdownEntrypoints({
+      app,
+      process,
+      cleanup: async () => { await cleanupHeld; },
+      setQuitting: () => {},
+      destroyWindow: () => {},
+      isInstallingUpdate: () => isInstallingUpdate,
+    });
+
+    const cleanupPromise = entrypoints.runCleanup();
+    const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
+    app.emit('will-quit', willQuit);
+    assert.equal(willQuit.prevented, true, 'concurrent quit waits for in-flight cleanup');
+
+    releaseCleanup?.();
+    await cleanupPromise;
+    await delay(0);
+
+    assert.equal(app.quitCount, 0, 'normal quit does not preempt quitAndInstall after cleanup');
+    isInstallingUpdate = false;
+  }
+
   // --- Timeout during pre-install cleanup: rejection settles and allows updater quit ---
   {
     const app = new AppDouble();
@@ -1032,13 +1063,38 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     assert.deepEqual(app.exitCodes, [1], 'app.exit(1) was called on concurrent quit rejection when not updating');
   }
 
-  // --- Failed quitAndInstall resets isInstallingUpdate to avoid poisoning future shutdown ---
+  // --- Failed quitAndInstall resets updater shutdown state ---
   {
     const app = new AppDouble();
     const process = new ProcessDouble();
     let isInstallingUpdate = false;
-    let reportedFailure = false;
+    let isQuitting = false;
+    const updateState: UpdateShutdownState = {
+      setInstallingUpdate: (value) => { isInstallingUpdate = value; },
+      setQuitting: (value) => { isQuitting = value; },
+    };
+    const installError = new Error('Squirrel failed to spawn installer');
+    let installSawActiveState = false;
+    const handler = createRestartAndInstallHandler({
+      isInstallReady: () => true,
+      authorize: () => ({ ok: true }),
+      runCleanup: async () => {},
+      quitAndInstall: () => {
+        installSawActiveState = isInstallingUpdate && isQuitting;
+        throw installError;
+      },
+      updateState,
+      warn: () => {},
+      error: () => {},
+    });
 
+    const result = await handler({}, '1234');
+    assert.deepEqual(result, { success: false, error: installError.message });
+    assert.equal(installSawActiveState, true, 'quitAndInstall runs while updater shutdown state is active');
+    assert.equal(isInstallingUpdate, false, 'quitAndInstall failure resets installing state');
+    assert.equal(isQuitting, false, 'quitAndInstall failure resets quitting state');
+
+    let reportedFailure = false;
     const entrypoints = createShutdownEntrypoints({
       app,
       process,
@@ -1066,15 +1122,26 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     await delay(0);
 
     assert.equal(reportedFailure, true, 'cleanup failure is reported');
-    // Because isInstallingUpdate was properly reset to false, fatal app.exit(1) is invoked as expected
-    assert.deepEqual(app.exitCodes, [1], 'subsequent shutdown correctly exits with 1 instead of being poisoned');
+    assert.deepEqual(app.exitCodes, [1], 'subsequent shutdown exits after install failure reset');
   }
 
-  // --- AutoUpdater error event resets isInstallingUpdate so subsequent shutdown is not poisoned ---
+  // --- AutoUpdater errors reset updater shutdown state ---
   {
     const app = new AppDouble();
     const process = new ProcessDouble();
-    let isInstallingUpdate = false;
+    let isInstallingUpdate = true;
+    let isQuitting = true;
+    const updateState: UpdateShutdownState = {
+      setInstallingUpdate: (value) => { isInstallingUpdate = value; },
+      setQuitting: (value) => { isQuitting = value; },
+    };
+    let errorHandled = false;
+    const handleError = createAutoUpdaterErrorHandler(updateState, () => { errorHandled = true; });
+    handleError(new Error('Updater failed during install'));
+
+    assert.equal(errorHandled, true, 'updater error callback runs');
+    assert.equal(isInstallingUpdate, false, 'updater error resets installing state');
+    assert.equal(isQuitting, false, 'updater error resets quitting state');
 
     const entrypoints = createShutdownEntrypoints({
       app,
@@ -1084,11 +1151,6 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
       destroyWindow: () => {},
       isInstallingUpdate: () => isInstallingUpdate,
     });
-
-    // Simulate update in-flight then autoUpdater error
-    isInstallingUpdate = true;
-    // autoUpdater.on('error') triggers reset
-    isInstallingUpdate = false;
 
     const willQuit = { prevented: false, preventDefault: () => { willQuit.prevented = true; } };
     app.emit('will-quit', willQuit);


### PR DESCRIPTION
## Intent

fix(updater): prevent asynchronous autoUpdater error callbacks from prematurely clearing active install state during restart-and-install cleanup, ensuring updater-driven quit and relaunch proceeds uninterrupted.

## What Changed

- Run shutdown cleanup before `autoUpdater.quitAndInstall()` and make quit, signal, timeout, and failure paths aware of active update installation.
- Isolate updater shutdown/error handling so late callbacks preserve staged install state, with reset handling when installation fails.
- Add shutdown lifecycle regression coverage for ordering and updater races, and bump the app version to `3.3.1-beta.5`.

## Risk Assessment

✅ Low: The updater handoff and shutdown changes preserve cleanup ordering and guard concurrent failure paths without a substantiated remaining defect.

## Testing

After fixing missing project-local dependencies and build output, the focused lifecycle regression passed. Independent compiled-handler evidence confirmed updater errors do not clear active install state, cleanup precedes installation, and installer quit/relaunch is not blocked. Generated artifacts were removed and the worktree is clean; no full suite or lint/static-analysis commands were run.

<details>
<summary>Evidence: Shutdown lifecycle regression</summary>

<code>Targeted shutdown lifecycle test completed with `Shutdown lifecycle tests passed.`</code>

```text
phase coordinator
[Shutdown] failed listener failed: Error: startup failed
    at testCoordinatorOrderingAndIdempotency (~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/tests/shutdown-lifecycle.test.ts:119:26)
    at async ~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/tests/shutdown-lifecycle.test.ts:1250:3
[Shutdown] listener failed: Error: listener did not drain
    at Object.run (~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/tests/shutdown-lifecycle.test.ts:138:53)
    at ~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/main/shutdown.ts:334:61
    at async withShutdownTimeout (~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/main/shutdown.ts:141:12)
    at async runShutdownSteps (~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/main/shutdown.ts:335:7)
    at async waitForActual (node:assert:646:5)
    at async strict.rejects (node:assert:769:25)
    at async testDatabaseCloseRequiresSuccessfulDrains (~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/tests/shutdown-lifecycle.test.ts:133:3)
    at async ~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/tests/shutdown-lifecycle.test.ts:1251:3
[Shutdown] Google Drive failed: Error: Drive ownership did not settle
    at testTimedOutCleanupUsesFatalBarrier (~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/tests/shutdown-lifecycle.test.ts:149:33)
    at ~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/tests/shutdown-lifecycle.test.ts:1252:9 {
  code: 'ERR_SHUTDOWN_TIMEOUT'
}
phase resources
phase entrypoints
phase owned servers
[Server] HTTP/WebSocket server stopped
[KDS Server] HTTP/WebSocket server stopped
[Server App] HTTP server stopped
[DB] Opening database at: /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-shutdown-lifecycle-sc2sT8/flo.db
[DB] Schema: v0 → v75
[DB] Triggering auto-backup before migrating v0 → v75...
[DB] Auto-backup before migrating v0 → v75 created at /var/folders/y_/1ltcxtwj0zd_w1dg9jv4jl580000gn/T/flo-shutdown-lifecycle-sc2sT8/backups/flo-backup-2026-08-29T19-46-34-703Z-pre-v0-to-v75.db
[DB] Applying migration v1: initial_schema
[DB] Install defaults loaded; first-run setup pending
[DB] Migration v1 complete
[DB] Applying migration v2: hash_plaintext_pins
[DB] Migration v2 complete
[DB] Applying migration v3: cloud_identity_and_outbox
[DB] Migration v3 complete
[DB] Applying migration v4: add_notes_limits_settings
[DB] Migration v4 complete
[DB] Applying migration v5: add_print_logs_table
[DB] Migration v5 complete
[DB] Applying migration v6: add_loyalty_settings
[DB] Migration v6 complete
[DB] Applying migration v7: add_discount_settings
[DB] Migration v7 complete
[DB] Applying migration v8: add_loyalty_index
[DB] Migration v8 complete
[DB] Applying migration v9: add_sequences_table
[DB] Migration v9 complete
[DB] Applying migration v10: fix_sequences_composite_key
[DB] Migration v10 complete
[DB] Applying migration v11: first_run_setup_uses_welcome_form
[DB] Migration v11 complete
[DB] Applying migration v12: fix_table_integer_ids
[DB] Migration v12 complete
[DB] Applying migration v13: fix_null_table_ids
[DB] Migration v13 complete
[DB] Applying migration v14: simplify_loyalty_settings
[DB] Migration v14 complete
[DB] Applying migration v15: add_instagram_handle_setting
[DB] Migration v15 complete
[DB] Applying migration v16: add_terms_accepted_at_to_users
[DB] Migration v16 complete
[DB] Applying migration v17: add_held_orders_table
[DB] Migration v17 complete
[DB] Applying migration v18: fix_null_category_ids
[DB] Migration v18 complete
[DB] Applying migration v19: backfill_product_cb_percent_and_tags
[DB] Migration v19 complete
[DB] Applying migration v20: add_tables_is_active
[DB] Migration v20 complete
[DB] Applying migration v21: clear_legacy_loyalty_expiry
[DB] Migration v21 complete
[DB] Applying migration v22: add_customers_phone_digits
[DB] Migration v22 complete
[DB] Applying migration v23: normalize_customer_phones
[MIGRATION v23] normalized: 0, unparseable: 0
[MIGRATION v23] merged 0 duplicate customer(s)
[MIGRATION v23] verification: 0 customers, 0 still non-E.164
[DB] Migration v23 complete
[DB] Applying migration v24: normalize_customer_phones_retry
[MIGRATION v24] normalized: 0, unparseable: 0
[DB] Migration v24 complete
[DB] Applying migration v25: add_order_item_addons_table
[MIGRATION v25] backfilled addons for 0 order items (0 unparseable, skipped)
[DB] Migration v25 complete
[DB] Applying migration v26: add_kds_default_view
[DB] Migration v26 complete
[DB] Applying migration v27: add_station_printer_link_and_user_stations
[DB] Migration v27 complete
[DB] Applying migration v28: seed_telemetry_settings
[DB] Migration v28 complete
[DB] Applying migration v29: whatsapp_messaging
[DB] Migration v29 complete
[DB] Applying migration v30: drop_order_items_addons_json_column
[MIGRATION v30] backfilled 0 order_item(s) still missing a normalized addons snapshot
[MIGRATION v30] Dropped order_items.addons — order_item_addons is now the only place selected addons live.
[DB] Migration v30 complete
[DB] Applying migration v31: add_customers_tag_counts_column
[DB] Migration v31 complete
[DB] Applying migration v32: add_kds_and_kot_printing_toggles
[DB] Migration v32 complete
[DB] Applying migration v33: add_addon_groups_allow_multiple_quantities
[DB] Migration v33 complete
[DB] Applying migration v34: add_order_items_voided_at
[DB] Migration v34 complete
[DB] Applying migration v35: add_tax_pack_configuration_tables
[DB] Migration v35 complete
[DB] Applying migration v36: add_product_and_addon_tax_categories
[DB] Migration v36 complete
[DB] Applying migration v37: add_transaction_tax_snapshots_and_charge_categories
[DB] Migration v37 complete
[DB] Applying migration v38: register_bundled_tax_pack_versions
[DB] Migration v38 complete
[DB] Applying migration v39: add_users_tokens_valid_after
[DB] Migration v39 complete
[DB] Applying migration v40: v2_cloud_defaults_and_tax_toggle
[DB] Migration v40 complete
[DB] Applying migration v41: support_ticket_outbox
[DB] Migration v41 complete
[DB] Applying migration v42: add_global_cashback_percent
[DB] Migration v42 complete
[DB] Applying migration v43: telemetry_default_on_for_new_installs
[DB] Migration v43 complete
[DB] Applying migration v44: store_diagnostics_outbox
[DB] Migration v44 complete
[DB] Applying migration v45: add_performance_indexes_and_normalize_timestamps
[DB] Migration v45 complete
[DB] Applying migration v46: normalize_cloud_enabled_flags_to_01
[DB] Migration v46 complete
[DB] Applying migration v47: store_diagnostics_enabled_by_default
[DB] Migration v47 complete
[DB] Applying migration v48: deactivate_reusable_demo_credentials
[DB] Migration v48 complete
[DB] Applying migration v49: add_payment_idempotency_records
[DB] Migration v49 complete
[DB] Applying migration v50: add_order_idempotency_records
[DB] Migration v50 complete
[DB] Applying migration v51: enforce_global_payment_transaction_refs
[DB] Migration v51 complete
[DB] Applying migration v52: restore_method_scoped_transaction_refs
[DB] Migration v52 complete
[DB] Applying migration v53: scope_idempotency_records_to_user
[DB] Migration v53 complete
[DB] Applying migration v54: repair_retry_ownership_and_payment_reference_history
[DB] Migration v54 complete
[DB] Applying migration v55: durable_token_revocations
[DB] Migration v55 complete
[DB] Applying migration v56: persist_station_assignment_scope
[DB] Migration v56 complete
[DB] Applying migration v57: rename_gstin_to_generic_tax_registration_number
[DB] Migration v57 complete
[DB] Applying migration v58: configurable_manual_payment_methods
[DB] Migration v58 complete
[DB] Applying migration v59: split_checks_by_item_quantity
[DB] Migration v59 complete
[DB] Applying migration v60: seed_split_checks_disabled_setting
[DB] Migration v60 complete
[DB] Applying migration v61: seed_server_app_enabled_setting
[DB] Migration v61 complete
[DB] Applying migration v62: normalize_cloud_last_error
[DB] Migration v62 complete
[DB] Applying migration v63: seed_printer_trim_decimals_setting
[DB] Migration v63 complete
[DB] Applying migration v64: drop_unused_printer_usb_device_path
[DB] Migration v64 complete
[DB] Applying migration v65: seed_bill_content_visibility_settings
[DB] Migration v65 complete
[DB] Applying migration v66: seed_bill_template_settings
[DB] Migration v66 complete
[DB] Applying migration v67: persist_order_item_inventory_deductions
[DB] Migration v67 complete
[DB] Applying migration v68: add_invoice_numbering_settings
[DB] Migration v68 complete
[DB] Applying migration v69: installed_plugin_print_templates
[DB] Migration v69 complete
[DB] Applying migration v70: rename_waiter_role_to_server
[DB] Migration v70 complete
[DB] Applying migration v71: repair_durable_token_revocations
[DB] Migration v71 complete
[DB] Applying migration v72: merchant_print_templates
[DB] Migration v72 complete
[DB] Applying migration v73: normalize_merchant_template_payloads
[MIGRATION v73] normalized 0 merchant template payload(s); 0 already canonical or left untouched
[DB] Migration v73 complete
[DB] Applying migration v74: add_country_packs_disclaimer_ack
[DB] Migration v74 complete
[DB] Applying migration v75: add_printer_cash_drawer_pulse
[DB] Migration v75 complete
[DB] integrity_check: ok
[DB] foreign_key_check: clean
[Server] Frontend build not found. Run `npm run build:frontend` first.
[Server] HTTP server running on http://localhost:54025
[KDS] WebSocket server setup complete
[Server] KDS WebSocket running on ws://localhost:54025/kds
[KDS Server] Static build not found. Run `npm run build:frontend` first.
[KDS Server] HTTP server running on http://localhost:54026
[KDS] WebSocket server setup complete
[KDS Server] WebSocket running on ws://localhost:54026/kds
[Server App] Static build not found. Run `npm run build:frontend` first.
[Server App] HTTP server running on http://localhost:54021
[Auth] Generated new JWT secret for this install
[Server] HTTP/WebSocket server stopped
[KDS Server] HTTP/WebSocket server stopped
[Server App] HTTP server stopped
[DB] Database closed
phase update install ordering
[Shutdown] timed out service failed: Error: Cleanup step timed out
    at testQuitAndInstallCleanupOrdering (~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/tests/shutdown-lifecycle.test.ts:1055:35)
    at async ~/.no-mistakes/worktrees/de2296f2e6f8/01M17F3K3KPKNGAQFJA4YYRP30/tests/shutdown-lifecycle.test.ts:1271:3 {
  code: 'ERR_SHUTDOWN_TIMEOUT'
}
Shutdown lifecycle tests passed.
```
</details>
<details>
<summary>Evidence: Updater handoff behavior</summary>

<code>Async updater error preserved active flags; cleanup completed before `quitAndInstall`; simulated `will-quit` was not prevented; no normal exit occurred.</code>

```text
{
  "trace": [
    "cleanup:start",
    "updater:error-reported",
    "flags:during-error installing=true quitting=true",
    "cleanup:end",
    "autoUpdater:quitAndInstall",
    "window:destroy"
  ],
  "result": {
    "success": true
  },
  "updaterPhase": "check",
  "reportedStatus": {
    "status": "check-failed",
    "reason": "download-failed",
    "error": "background updater error"
  },
  "cleanupFinished": true,
  "flags": {
    "installing": true,
    "quitting": true
  },
  "installWillQuitPrevented": false,
  "appQuitCount": 0,
  "appExitCodes": []
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5dae26b7d06a533a78ee1d5d202c41bad63319d9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `main/index.ts` - branch carries 2 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (3 file(s)) into the PR:
- d7531d3 chore(release): bump version to 3.3.1-beta.5
- 4535bbf fix(updater): run cleanup before quitAndInstall to prevent relaunch failure

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
1 warning still open:

- ⚠️ `main/index.ts` - branch carries 2 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (3 file(s)) into the PR:
- d7531d3 chore(release): bump version to 3.3.1-beta.5
- 4535bbf fix(updater): run cleanup before quitAndInstall to prevent relaunch failure

Push main to origin, or rebase your branch onto origin/main, before gating.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `tests/shutdown-lifecycle.test.ts:1137` - This regression test never invokes an autoUpdater error callback; it only asserts preinitialized booleans and then calls resetUpdateShutdownState. The prior buggy callback would also pass, so the required state-preservation behavior is unprotected. Exercise the actual callback/handler and assert state after the error is delivered.

🔧 Fix: Cover updater error callback state preservation; tsc unavailable
3 warnings still open:

- ⚠️ `main/shutdown.ts:457` - The update guard is applied only to the Electron quit path. The SIGTERM/SIGINT cleanup callbacks still call process.exit unconditionally; if a signal starts cleanup before the updater request, the shared cleanup settles and exits before the handler reaches quitAndInstall, so the update cannot relaunch.
- ⚠️ `tests/shutdown-lifecycle.test.ts:889` - This regression test manually runs cleanup and emits will-quit but never invokes createRestartAndInstallHandler. Reverting the production handler to call quitAndInstall before cleanup would still pass. Exercise the actual handler with held cleanup and assert installation occurs only after cleanup settles.
- ⚠️ `tests/shutdown-lifecycle.test.ts:1133` - The test invokes only a forwarding helper with a test-owned callback; it never registers or emits the actual autoUpdater listener from main/index.ts. A future resetUpdateShutdownState inside that production callback would therefore still pass. Test the real listener or extract a factory for that callback with injected observable state.

🔧 Fix: Guard updater races and cover production callbacks; tsc unavailable
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm ci`
- `npm run build`
- `node tests/run-electron-node-test.cjs tests/shutdown-lifecycle.test.ts`
- <code>Compiled-runtime smoke check with asynchronous updater error during held cleanup and simulated installer `will-quit`</code>
- <code>`git status --short --branch` after removing generated `dist/` and `node_modules/`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
