### PR TITLE
docs: add translated README files

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -46,7 +46,7 @@ Las funciones principales del TPV y los datos locales funcionan sin conexión. L
 
 ## Idiomas y soporte regional
 
-FloCafe incluye traducciones de la interfaz en inglés, español, portugués brasileño y persa (farsi), con soporte RTL. El idioma de la interfaz es independiente del país de la tienda y de la configuración regional. Las reglas de cálculo de impuestos son un aspecto separado.
+FloCafe incluye traducciones de la interfaz en inglés, español, portugués brasileño, francés, persa (farsi), turco, filipino y alemán, con soporte RTL para persa. El idioma de la interfaz es independiente del país de la tienda y de la configuración regional. Las reglas de cálculo de impuestos son un aspecto separado.
 
 FloCafe incluye perfiles para 131 países y 109 monedas. Cada perfil establece una moneda, configuración regional y zona horaria predeterminadas; el propietario puede cambiar la zona horaria durante la configuración o más adelante en Ajustes.
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,86 @@
+# FloCafe
+
+**Punto de venta gratuito, de código abierto y diseñado para funcionar sin conexión para cafeterías, restaurantes y pequeñas cocinas.**
+
+[English](README.md) | **Español** | [Português](README.pt.md) | [Français](README.fr.md)
+
+FloCafe funciona directamente en el ordenador del negocio. Los pedidos, clientes, recibos y copias de seguridad se guardan en una base de datos SQLite local, por lo que el servicio de mostrador y las pantallas de cocina pueden seguir funcionando sin conexión a Internet. No se necesita una cuenta alojada ni en la nube para las funciones principales del TPV. Las integraciones opcionales, como las copias de seguridad en Google Drive, el envío de facturas por WhatsApp y los informes conectados a la nube, pueden activarse cuando sea necesario.
+
+## Obtener FloCafe
+
+Descarga el instalador más reciente desde [GitHub Releases](https://github.com/FreeOpenSourcePOS/FloCafe/releases), o instala FloCafe desde la tienda de aplicaciones de tu plataforma.
+
+Las versiones incluyen instaladores para Windows, DMG para macOS y paquetes AppImage, `.deb`, `.rpm` y Snap para Linux. Consulta la [guía de instalación y soporte de Linux](docs/linux.md) para obtener información específica sobre paquetes, actualizaciones, FUSE, permisos de impresión y la bandeja del sistema.
+
+### Requisitos del sistema
+
+| Requisito | Mínimo |
+| --- | --- |
+| Sistema operativo | Windows 10+, macOS 12+ o una distribución Linux compatible actual |
+| Memoria | 4 GB de RAM |
+| Almacenamiento | 500 MB libres, además del espacio para copias de seguridad locales |
+
+Node.js solo es necesario para desarrollar FloCafe, no para ejecutar una versión empaquetada.
+
+## Funciones principales
+
+- **Flujos de pedidos:** pedidos de mostrador, mesa, para llevar y entrega, con gestión de mesas y pedidos retenidos.
+- **Modificadores y precios:** modificadores de artículos, grupos de complementos, descuentos y puntos de fidelidad.
+- **Impresión de recibos:** impresión térmica ESC/POS por USB, red local TCP y colas de impresión del sistema operativo, con WebUSB en navegadores compatibles.
+- **Operaciones de cocina:** servidor independiente de pantalla de cocina (KDS) y asignación de estaciones por categoría.
+- **Gestión del catálogo:** imágenes de productos, lectura de códigos de barras e importación/exportación CSV del menú.
+- **Administración:** cuentas de personal con roles, análisis de ventas y registros de auditoría.
+- **Protección de datos:** base de datos SQLite local, copias automáticas antes de migraciones, restauración manual y copias opcionales en Google Drive.
+
+## Estado del proyecto
+
+FloCafe está en desarrollo activo y ya se utiliza en instalaciones reales. La seguridad de los datos de clientes y las actualizaciones se trata con cuidado mediante migraciones explícitas y mecanismos de recuperación.
+
+## Diseñado para funcionar sin conexión
+
+Las funciones principales del TPV y los datos locales funcionan sin conexión. La creación de pedidos, la facturación, la coordinación con KDS y la impresión de recibos no dependen de Internet ni de servicios externos en la nube.
+
+- La base de datos SQLite y las copias locales se guardan en el directorio de datos del usuario, separado de los binarios instalados.
+- FloCafe crea automáticamente una copia de seguridad con fecha y hora antes de ejecutar migraciones del esquema.
+- Las funciones opcionales de red solo se comunican cuando el propietario del negocio las configura y activa explícitamente.
+
+## Idiomas y soporte regional
+
+FloCafe incluye traducciones de la interfaz en inglés, español, portugués brasileño y persa (farsi), con soporte RTL. El idioma de la interfaz es independiente del país de la tienda y de la configuración regional. Las reglas de cálculo de impuestos son un aspecto separado.
+
+FloCafe incluye perfiles para 131 países y 109 monedas. Cada perfil establece una moneda, configuración regional y zona horaria predeterminadas; el propietario puede cambiar la zona horaria durante la configuración o más adelante en Ajustes.
+
+## Soporte fiscal
+
+FloCafe incluye un motor de cálculo genérico y paquetes fiscales regionales firmados y versionados. También permite configurar reglas y tipos impositivos manuales localmente.
+
+> **Aviso:** FloCafe es software, no asesoramiento legal ni fiscal. Los paquetes fiscales y las herramientas de configuración no certifican por sí mismos el cumplimiento de las normativas locales.
+
+## Desarrollo
+
+Para desarrollar FloCafe necesitas Node.js 22 o posterior:
+
+```sh
+git clone https://github.com/FreeOpenSourcePOS/FloCafe.git
+cd FloCafe
+npm install
+npm run dev
+```
+
+`npm run dev` compila el frontend y el backend y después inicia Electron.
+
+Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para conocer los flujos de desarrollo, las normas de código y los procedimientos de pruebas.
+
+## Ayuda y documentación
+
+- [Índice de documentación](docs/README.md)
+- [Guía de impresoras](docs/printers.md)
+- [Configuración y soporte de Linux](docs/linux.md)
+- [Internacionalización y traducciones](docs/i18n.md)
+- [Configuración de copias en Google Drive](docs/google-drive-setup.md)
+- [GitHub Issues](https://github.com/FreeOpenSourcePOS/FloCafe/issues)
+- [GitHub Discussions](https://github.com/FreeOpenSourcePOS/FloCafe/discussions)
+
+## Licencia
+
+FloCafe es software de código abierto bajo la [licencia MIT](LICENSE).

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,86 @@
+# FloCafe
+
+**Point de vente gratuit, open source et conçu pour fonctionner hors ligne pour les cafés, restaurants et petites cuisines.**
+
+[English](README.md) | [Español](README.es.md) | [Português](README.pt.md) | **Français**
+
+FloCafe fonctionne directement sur l’ordinateur de l’établissement. Les commandes, les clients, les reçus et les sauvegardes sont stockés dans une base de données SQLite locale. Le service au comptoir et les écrans de cuisine peuvent donc continuer à fonctionner sans connexion Internet. Aucun compte hébergé ou cloud n’est nécessaire pour l’utilisation principale du point de vente. Des intégrations optionnelles, comme les sauvegardes Google Drive, l’envoi de factures par WhatsApp et les rapports connectés au cloud, peuvent être activées si nécessaire.
+
+## Obtenir FloCafe
+
+Téléchargez le dernier installateur depuis [GitHub Releases](https://github.com/FreeOpenSourcePOS/FloCafe/releases), ou installez FloCafe depuis la boutique d’applications de votre plateforme.
+
+Les versions comprennent des installateurs Windows, des DMG macOS ainsi que des paquets AppImage, `.deb`, `.rpm` et Snap pour Linux. Consultez le [guide d’installation et d’assistance Linux](docs/linux.md) pour les informations concernant les paquets, les mises à jour, FUSE, les permissions d’impression et la barre d’état système.
+
+### Configuration requise
+
+| Exigence | Minimum |
+| --- | --- |
+| Système d’exploitation | Windows 10+, macOS 12+ ou une distribution Linux actuelle prise en charge |
+| Mémoire | 4 Go de RAM |
+| Stockage | 500 Mo libres, plus l’espace nécessaire aux sauvegardes locales |
+
+Node.js est uniquement nécessaire pour développer FloCafe, pas pour exécuter une version empaquetée.
+
+## Points forts
+
+- **Flux de commandes :** commandes au comptoir, sur place, à emporter et en livraison, avec gestion des tables et des commandes mises en attente.
+- **Modificateurs et tarifs :** modificateurs d’articles, groupes d’options, remises et points de fidélité.
+- **Impression des reçus :** impression thermique ESC/POS par USB, réseau local TCP et files d’impression du système, avec WebUSB dans les navigateurs compatibles.
+- **Opérations en cuisine :** serveur autonome d’écran de cuisine (KDS) et routage des stations par catégorie.
+- **Gestion du catalogue :** images des produits, lecture des codes-barres et import/export CSV du menu.
+- **Administration :** comptes du personnel avec rôles, analyses des ventes et journaux d’audit.
+- **Protection des données :** base SQLite locale, sauvegardes automatiques avant migration, outils de restauration manuelle et sauvegarde Google Drive optionnelle.
+
+## État du projet
+
+FloCafe est activement développé et déjà utilisé dans des déploiements réels. Les données clients et la sécurité des mises à niveau sont protégées avec des migrations explicites et des mécanismes de récupération.
+
+## Conçu pour fonctionner hors ligne
+
+Les fonctions principales du point de vente et les données locales fonctionnent hors ligne. La saisie des commandes, la facturation, la coordination KDS et l’impression des reçus ne dépendent pas d’Internet ni de services cloud externes.
+
+- La base SQLite et les sauvegardes locales se trouvent dans le répertoire de données de l’utilisateur, séparé des binaires installés.
+- FloCafe crée automatiquement une sauvegarde horodatée avant d’exécuter les migrations du schéma.
+- Les fonctions réseau optionnelles ne communiquent que lorsqu’elles sont explicitement configurées et activées par le propriétaire de l’établissement.
+
+## Langues et support régional
+
+FloCafe propose des traductions de l’interface en anglais, espagnol, portugais brésilien et persan (farsi), avec prise en charge RTL. La langue de l’interface est indépendante du pays et des paramètres régionaux du magasin. Les règles de calcul des taxes constituent un domaine séparé.
+
+FloCafe inclut des profils pour 131 pays et 109 devises. Chaque profil définit une devise, une région et un fuseau horaire par défaut ; le propriétaire peut modifier le fuseau horaire lors de la configuration ou plus tard dans les paramètres.
+
+## Gestion des taxes
+
+FloCafe comprend un moteur de calcul générique ainsi que des packs fiscaux régionaux signés et versionnés. Il permet également de configurer localement des règles et taux de taxe manuels.
+
+> **Avertissement :** FloCafe est un logiciel, et non un conseil juridique ou fiscal. Les packs fiscaux et les outils de configuration ne certifient pas à eux seuls la conformité aux réglementations locales.
+
+## Développement
+
+Le développement de FloCafe nécessite Node.js 22 ou une version ultérieure :
+
+```sh
+git clone https://github.com/FreeOpenSourcePOS/FloCafe.git
+cd FloCafe
+npm install
+npm run dev
+```
+
+`npm run dev` compile le frontend et le backend, puis lance Electron.
+
+Consultez [CONTRIBUTING.md](CONTRIBUTING.md) pour les procédures de développement, les conventions de code et les tests.
+
+## Aide et documentation
+
+- [Index de la documentation](docs/README.md)
+- [Guide des imprimantes](docs/printers.md)
+- [Configuration et assistance Linux](docs/linux.md)
+- [Internationalisation et traductions](docs/i18n.md)
+- [Configuration des sauvegardes Google Drive](docs/google-drive-setup.md)
+- [GitHub Issues](https://github.com/FreeOpenSourcePOS/FloCafe/issues)
+- [GitHub Discussions](https://github.com/FreeOpenSourcePOS/FloCafe/discussions)
+
+## Licence
+
+FloCafe est un logiciel open source distribué sous [licence MIT](LICENSE).

--- a/README.fr.md
+++ b/README.fr.md
@@ -46,7 +46,7 @@ Les fonctions principales du point de vente et les données locales fonctionnent
 
 ## Langues et support régional
 
-FloCafe propose des traductions de l’interface en anglais, espagnol, portugais brésilien et persan (farsi), avec prise en charge RTL. La langue de l’interface est indépendante du pays et des paramètres régionaux du magasin. Les règles de calcul des taxes constituent un domaine séparé.
+FloCafe propose des traductions de l’interface en anglais, espagnol, portugais brésilien, français, persan (farsi), turc, filipino et allemand, avec prise en charge RTL pour le persan. La langue de l’interface est indépendante du pays et des paramètres régionaux du magasin. Les règles de calcul des taxes constituent un domaine séparé.
 
 FloCafe inclut des profils pour 131 pays et 109 devises. Chaque profil définit une devise, une région et un fuseau horaire par défaut ; le propriétaire peut modifier le fuseau horaire lors de la configuration ou plus tard dans les paramètres.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <div align="center">
   <h1>FloCafe</h1>
+  <p><a href="README.es.md">Español</a> · <a href="README.pt.md">Português</a> · <a href="README.fr.md">Français</a></p>
   <p><strong>Free, open-source, offline-first point of sale for cafés, restaurants, and small kitchens.</strong></p>
   <p>
     <a href="https://flopos.com">Website</a> ·

--- a/README.pt.md
+++ b/README.pt.md
@@ -46,7 +46,7 @@ A operação principal do PDV e os dados locais funcionam offline. A criação d
 
 ## Idiomas e suporte regional
 
-O FloCafe inclui traduções da interface em inglês, espanhol, português brasileiro e persa (farsi), incluindo suporte RTL. O idioma da interface é independente do país e das configurações regionais da loja. As regras de cálculo de impostos são uma área separada.
+O FloCafe inclui traduções da interface em inglês, espanhol, português brasileiro, francês, persa (farsi), turco, filipino e alemão, incluindo suporte RTL para persa. O idioma da interface é independente do país e das configurações regionais da loja. As regras de cálculo de impostos são uma área separada.
 
 O FloCafe inclui perfis para 131 países e 109 moedas. Cada perfil define moeda, localidade e fuso horário padrão; o proprietário pode alterar o fuso durante a configuração ou depois em Configurações.
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,0 +1,86 @@
+# FloCafe
+
+**Ponto de venda gratuito, de código aberto e desenvolvido para funcionar offline em cafés, restaurantes e pequenas cozinhas.**
+
+[English](README.md) | [Español](README.es.md) | **Português** | [Français](README.fr.md)
+
+O FloCafe funciona diretamente no computador do estabelecimento. Pedidos, clientes, recibos e backups são armazenados em um banco de dados SQLite local, permitindo que o atendimento no balcão e as telas da cozinha continuem funcionando sem conexão com a Internet. Nenhuma conta hospedada ou na nuvem é necessária para a operação principal do PDV. Integrações opcionais, como backup no Google Drive, envio de contas pelo WhatsApp e relatórios conectados à nuvem, podem ser ativadas quando necessário.
+
+## Obter o FloCafe
+
+Baixe o instalador mais recente em [GitHub Releases](https://github.com/FreeOpenSourcePOS/FloCafe/releases) ou instale-o pela loja de aplicativos da sua plataforma.
+
+As versões incluem instaladores para Windows, DMGs para macOS e pacotes AppImage, `.deb`, `.rpm` e Snap para Linux. Consulte o [guia de instalação e suporte do Linux](docs/linux.md) para informações sobre pacotes, atualizações, FUSE, permissões de impressão e comportamento da bandeja do sistema.
+
+### Requisitos do sistema
+
+| Requisito | Mínimo |
+| --- | --- |
+| Sistema operacional | Windows 10+, macOS 12+ ou uma distribuição Linux atual compatível |
+| Memória | 4 GB de RAM |
+| Armazenamento | 500 MB livres, além do espaço para backups locais |
+
+Node.js é necessário apenas para desenvolver o FloCafe, não para executar uma versão empacotada.
+
+## Destaques
+
+- **Fluxos de pedidos:** pedidos no balcão, no salão, para viagem e entrega, com gerenciamento de mesas e pedidos suspensos.
+- **Modificadores e preços:** modificadores de itens, grupos de adicionais, descontos e pontos de fidelidade.
+- **Impressão de recibos:** impressão térmica ESC/POS por USB, rede local TCP e filas de impressão do sistema operacional, com WebUSB em navegadores compatíveis.
+- **Operações de cozinha:** servidor independente de tela de cozinha (KDS) e roteamento de estações por categoria.
+- **Gerenciamento do catálogo:** imagens de produtos, leitura de códigos de barras e importação/exportação CSV do cardápio.
+- **Administração:** contas de funcionários com funções, análise de vendas e registros de auditoria.
+- **Proteção de dados:** banco de dados SQLite local, backups automáticos antes das migrações, restauração manual e backup opcional no Google Drive.
+
+## Status do projeto
+
+O FloCafe está em desenvolvimento ativo e já é usado em instalações reais. Os dados dos clientes e a segurança das atualizações são tratados com cuidado por meio de migrações explícitas e mecanismos de recuperação.
+
+## Offline por design
+
+A operação principal do PDV e os dados locais funcionam offline. A criação de pedidos, o faturamento, a coordenação com o KDS e a impressão de recibos não dependem da Internet nem de serviços externos na nuvem.
+
+- O banco SQLite e os backups locais ficam no diretório de dados do usuário, separado dos binários instalados.
+- O FloCafe cria automaticamente um backup com data e hora antes de executar migrações do esquema.
+- Recursos opcionais de rede só se comunicam quando configurados e ativados explicitamente pelo proprietário do estabelecimento.
+
+## Idiomas e suporte regional
+
+O FloCafe inclui traduções da interface em inglês, espanhol, português brasileiro e persa (farsi), incluindo suporte RTL. O idioma da interface é independente do país e das configurações regionais da loja. As regras de cálculo de impostos são uma área separada.
+
+O FloCafe inclui perfis para 131 países e 109 moedas. Cada perfil define moeda, localidade e fuso horário padrão; o proprietário pode alterar o fuso durante a configuração ou depois em Configurações.
+
+## Suporte fiscal
+
+O FloCafe inclui um mecanismo genérico de cálculo e pacotes fiscais regionais assinados e versionados. Também permite configurar regras e alíquotas fiscais manualmente de forma local.
+
+> **Aviso:** FloCafe é software, não aconselhamento jurídico ou fiscal. Pacotes fiscais e ferramentas de configuração não certificam, por si só, conformidade com as normas locais.
+
+## Desenvolvimento
+
+Para desenvolver o FloCafe, é necessário Node.js 22 ou posterior:
+
+```sh
+git clone https://github.com/FreeOpenSourcePOS/FloCafe.git
+cd FloCafe
+npm install
+npm run dev
+```
+
+`npm run dev` compila o frontend e o backend e depois inicia o Electron.
+
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para os fluxos de desenvolvimento, padrões de código e procedimentos de testes.
+
+## Ajuda e documentação
+
+- [Índice da documentação](docs/README.md)
+- [Guia de impressoras](docs/printers.md)
+- [Configuração e suporte do Linux](docs/linux.md)
+- [Internacionalização e traduções](docs/i18n.md)
+- [Configuração de backup no Google Drive](docs/google-drive-setup.md)
+- [GitHub Issues](https://github.com/FreeOpenSourcePOS/FloCafe/issues)
+- [GitHub Discussions](https://github.com/FreeOpenSourcePOS/FloCafe/discussions)
+
+## Licença
+
+FloCafe é um software de código aberto sob a [licença MIT](LICENSE).


### PR DESCRIPTION
## Summary

- Add Spanish, Portuguese, and French README translations at the repository root.
- Add language links to the main README and each translation.
- Keep the translated documentation aligned with the current installation, offline-first, regional support, development, and licensing guidance.

## Verification

- `git diff --check`
- Confirmed the README and documentation links target existing files.
- Confirmed the branch is based directly on `main`.
