### PR TITLE
chore(release): bump version to 3.3.1-beta.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,8 +399,8 @@ jobs:
       - name: Publish snap to the matching Snap Store channel
         # Both matrix entries publish their snap, each tagged with its arch.
         # Snap Store keeps multiple per-arch revisions under one snap name.
-        # Stable/beta map to stable/beta respectively; this keeps a
-        # prerelease out of the stable package-manager channel.
+        # Release channel → store channel: stable→stable, beta→edge (#468);
+        # this keeps a prerelease out of the stable package-manager channel.
         # The credentials check is at runtime, not in `if:` — GitHub Actions
         # rejects `secrets` in `if:` expressions (unrecognized named-value).
         # A missing credential is a release failure, not a skipped channel:
@@ -415,19 +415,24 @@ jobs:
           SNAP_NAME="flocafe"
           SNAP=$(find release -maxdepth 1 -type f -name '*.snap' -print -quit)
           [ -n "$SNAP" ] || { echo "::error::No .snap produced by electron-builder for ${{ matrix.arch }}"; exit 1; }
-          SNAP_CHANNEL="${{ needs.create-release.outputs.channel }}"
+          # #468: the SNAPCRAFT_STORE_CREDENTIALS macaroon is restricted to
+          # the stable and edge channels, so a beta release publishes to
+          # `edge` (opt-in channel) instead of the beta channel; the evidence
+          # marker records the real store channel.
+          case "${{ needs.create-release.outputs.channel }}" in
+            stable) SNAP_CHANNEL="stable" ;;
+            beta) SNAP_CHANNEL="edge" ;;
+            *) echo "::error::Unexpected release channel '${{ needs.create-release.outputs.channel }}'"; exit 1 ;;
+          esac
           snapcraft register "$SNAP_NAME" || echo "::warning::register skipped/failed; continuing"
-          # #468: the current SNAPCRAFT_STORE_CREDENTIALS macaroon was exported
-          # with channel restrictions (stable, edge) and cannot release to
-          # beta (`invalid-channel-permission`). The GitHub release still gets
-          # the full .snap artifact set; failing the whole release build for a
-          # Store-side credential scope would block every other platform's
-          # updater feed. Degrade exactly this error to a loud warning until
-          # the credentials are re-exported with beta enabled.
+          # Degrade exactly a credential-scope denial to a loud warning (#468):
+          # the GitHub release still gets the full .snap artifact set; failing
+          # the whole release build for a Store-side credential scope would
+          # block every other platform's updater feed.
           if ! UPLOAD_OUT=$(snapcraft upload "$SNAP" --release="$SNAP_CHANNEL" 2>&1); then
             printf '%s\n' "$UPLOAD_OUT"
-            if [ "$SNAP_CHANNEL" = "beta" ] && printf '%s' "$UPLOAD_OUT" | grep -q "invalid-channel-permission"; then
-              echo "::warning::Snap Store credentials do not permit the '$SNAP_CHANNEL' channel (macaroon restriction). The .snap remains attached to this GitHub release; re-export SNAPCRAFT_STORE_CREDENTIALS with the beta channel enabled to restore Store publishing (#468)."
+            if printf '%s' "$UPLOAD_OUT" | grep -q "invalid-channel-permission"; then
+              echo "::warning::Snap Store credentials do not permit the '$SNAP_CHANNEL' channel (macaroon restriction). The .snap remains attached to this GitHub release; re-export SNAPCRAFT_STORE_CREDENTIALS with that channel enabled to restore Store publishing (#468)."
               exit 0
             fi
             echo "::error::snapcraft upload failed"

--- a/docs/release-evidence-index.md
+++ b/docs/release-evidence-index.md
@@ -18,8 +18,9 @@ logs.
 - Stable Snap publication: one sanitized marker per architecture, required by
   draft verification in `scripts/verify-release-assets.cjs` and rechecked by
   `scripts/release-gate/verify-stable-promotion.cjs` before promotion.
-- Beta Snap Store permission denial: explicitly degraded/NOT-RUN; beta draft
-  verification does not treat missing permission-denied markers as a pass.
+- Beta Snap publication: one sanitized marker per architecture recording the
+  real store channel (`edge`, #468); beta draft verification does not require
+  these markers and a permission denial is degraded to a warning, not a pass.
 
 ## Explicit external/manual boundaries
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -3,14 +3,13 @@
 FloCafe desktop releases use one electron-builder pipeline and GitHub Releases for
 NSIS/Windows, macOS DMG+ZIP, and Linux AppImage/deb/rpm/Snap artifacts. Microsoft
 Store (AppX) and Mac App Store (MAS) packages are submitted to their stores and
-are not consumed by `electron-updater`. Snap Store uploads target the stable or
-beta channel matching the release when the configured macaroon permits that
-channel; a beta upload denied with `invalid-channel-permission` is downgraded
-to a warning and the GitHub release remains publishable until credentials are
-re-exported. Stable draft verification requires both per-architecture Snap
-publication markers; the beta permission-denied path is explicitly degraded as
-NOT-RUN and does not claim a Snap Store pass. Snap installations are updated
-by snapd rather than `electron-updater`.
+are not consumed by `electron-updater`. Snap Store uploads map the release
+channel to a channel the configured macaroon permits (#468): stable releases
+publish to the `stable` channel and beta releases publish to the `edge`
+(opt-in) channel; an upload denied with `invalid-channel-permission` is
+downgraded to a warning and the GitHub release remains publishable. Stable
+draft verification requires both per-architecture Snap publication markers.
+Snap installations are updated by snapd rather than `electron-updater`.
 
 Nightly releases are explicitly rejected (#503): beta is the only prerelease
 distribution channel, and no nightly publish path exists anywhere in the
@@ -152,8 +151,9 @@ directly to GitHub `Latest`.
    candidate manifest and permanent sanitized summary, then publishes it as a
    **prerelease** with `make_latest=false`. A propagation check confirms every
    bound asset is downloadable and Stable Latest is unchanged. Snap Store
-   packages go to the snap `beta` channel when credentials permit it; a
-   channel-permission warning does not block GitHub release publication.
+   packages go to the `stable` or `edge` snap channel (release channel →
+   store channel mapping, #468); a channel-permission warning does not block
+   GitHub release publication.
 5. Run **Actions > Release candidate confidence gate** with the exact published
    beta tag, commit, candidate-manifest asset ID/SHA-256, Stable Latest tag, and
    the exact stable `from_version` installed as N by the runtime matrix.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.3.1-beta.6",
+  "version": "3.3.1-beta.7",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
chore(release): bump version to 3.3.1-beta.7

Also map Snap Store publishing to channels the macaroon permits (#468):
stable→stable, beta→edge — beta uploads targeting the beta channel always
failed with invalid-channel-permission, so beta snaps never reached the
Snap Store. Docs updated to match.