### PR TITLE
test: stabilize native Electron harness and Windows theme test assertions

### DIFF
--- a/frontend/e2e/desktop/native-harness.ts
+++ b/frontend/e2e/desktop/native-harness.ts
@@ -390,6 +390,16 @@ export async function createNativeElectronHarness(): Promise<NativeElectronHarne
         throw new Error(`Native E2E expected a stable auth route, got ${nextPage.url()}`);
       }
       if (currentPath === '/auth/login') {
+        const hasPersistedSession = await nextPage.evaluate(() => Boolean(localStorage.getItem('token'))).catch(() => false);
+        if (hasPersistedSession) {
+          await nextPage.waitForFunction(() => {
+            const path = window.location.pathname.replace(/\/+$/, '') || '/';
+            return path === '/pos' || !localStorage.getItem('token');
+          }, { timeout: 30_000 }).catch(() => {});
+          currentPath = new URL(nextPage.url()).pathname.replace(/\/+$/, '') || '/';
+        }
+      }
+      if (currentPath === '/auth/login') {
         await nextPage.locator('#email').fill(env.FLO_E2E_OWNER_EMAIL);
         await nextPage.locator('#password').fill(env.FLO_E2E_OWNER_PASSWORD);
         await nextPage.locator('button[type="submit"]').click();

--- a/tests/theme-fouc-script.test.ts
+++ b/tests/theme-fouc-script.test.ts
@@ -33,6 +33,8 @@ const ROOT = path.join(__dirname, '..');
 const LAYOUT_PATH = path.join(ROOT, 'frontend/src/app/layout.tsx');
 const THEME_SYNC_PATH = path.join(ROOT, 'frontend/src/components/layout/ThemeSync.tsx');
 
+const readSource = (filePath: string): string => fs.readFileSync(filePath, 'utf8').replace(/\r\n?/g, '\n');
+
 // ---------------------------------------------------------------------------
 // Script extraction — tolerant, loud-fail-on-shape-change.
 // ---------------------------------------------------------------------------
@@ -188,7 +190,7 @@ function runScript(script: string, g: HarnessGlobals): RunResult {
 // Matrix tests.
 // ---------------------------------------------------------------------------
 
-const layoutSrc = fs.readFileSync(LAYOUT_PATH, 'utf8');
+const layoutSrc = readSource(LAYOUT_PATH);
 const script = extractFoucScript(layoutSrc);
 
 const cases: Array<{
@@ -289,7 +291,7 @@ console.log(`ok   FOUC script body is try/catch wrapped (${script.length} chars)
 // The behavioral path is exercised by Wave 3 e2e; these are coarse tripwires.
 // ---------------------------------------------------------------------------
 
-const themeSyncSrc = fs.readFileSync(THEME_SYNC_PATH, 'utf8');
+const themeSyncSrc = readSource(THEME_SYNC_PATH);
 assert.ok(
   /useState\s*\(\s*false\s*\)/.test(themeSyncSrc),
   'ThemeSync must guard apply behind a hydrated flag (F1 fix)',
@@ -350,7 +352,7 @@ console.log(`\nFOUC matrix: ${passed} passed, ${failed} failed`);
 // ---------------------------------------------------------------------------
 
 const STORE_PATH = path.join(ROOT, 'frontend/src/store/theme.ts');
-const storeSrc = fs.readFileSync(STORE_PATH, 'utf8');
+const storeSrc = readSource(STORE_PATH);
 assert.ok(
   /userSelected/.test(storeSrc),
   'theme store must declare userSelected state (PR review P1-1)',
@@ -387,10 +389,7 @@ console.log('ok   ThemeSync gates every boot setMode on userHasChosen() (PR revi
 
 // Settings saveThemeMode must call markUserSelected BEFORE the optimistic
 // setThemeMode — a one-line placement that's the whole point of the guard.
-const settingsSrc = fs.readFileSync(
-  path.join(ROOT, 'frontend/src/app/(dashboard)/settings/page.tsx'),
-  'utf8',
-);
+const settingsSrc = readSource(path.join(ROOT, 'frontend/src/app/(dashboard)/settings/page.tsx'));
 const saveBody = (settingsSrc.match(/saveThemeMode = async[\s\S]*?\n\s{2}\};/) ?? [''])[0];
 assert.ok(
   saveBody.includes('markUserSelectedTheme()') || saveBody.includes('markUserSelected()'),
@@ -662,10 +661,7 @@ assert.ok(
 
 // --- auth-changed dispatch + listener ---
 
-const authSrc = fs.readFileSync(
-  path.join(ROOT, 'frontend/src/store/auth.ts'),
-  'utf8',
-);
+const authSrc = readSource(path.join(ROOT, 'frontend/src/store/auth.ts'));
 // 2a. The persistSession helper must dispatch the event after the
 // token is persisted.
 assert.ok(


### PR DESCRIPTION
## Intent

Prepare and publish a patch PR against main for the CI failures affecting FloCafe: verify whether the failures associated with commits 29a8c4a012388c4887392342526301c2620af98b, 48970c2e4a16edf73c9193ffda447485593e9725, and d2af77bd6bd74a7704425100a1d972442e980ac2 are caused by those changes, fix the actual Windows cross-platform test portability failure and the post-merge native Electron runtime-recovery failure, preserve unrelated work, and watch the patch PR CI.

## What Changed

- Added a `readSource` helper in `tests/theme-fouc-script.test.ts` to normalize CRLF line endings to LF when reading source files for test assertions.
- Updated `frontend/e2e/desktop/native-harness.ts` to wait for auto-navigation to `/pos` if a persisted session token is present in `localStorage` before attempting login.

## Risk Assessment

✅ Low: The changes cleanly and minimally resolve Windows CRLF line-ending test failures and stabilize Electron session recovery in the native E2E test harness without introducing regressions.

## Testing

Targeted test suite verified Windows line ending normalization in theme-fouc-script, unit/integration recovery invariants, and native Electron runtime recovery and theme persistence e2e specs with full passing status and captured screenshot evidence.

- Evidence: Recovered window after renderer destroyed (local file: <code>~/.no-mistakes/evidence/01M1C47NQEE72242EJBH2514CN/recovered-window-after-renderer-destroyed.png</code>)
- Evidence: Recovered window after terminal runtime loss (local file: <code>~/.no-mistakes/evidence/01M1C47NQEE72242EJBH2514CN/recovered-window-after-terminal-runtime-loss.png</code>)
- Evidence: Dark mode toggle verification in native Electron (local file: <code>~/.no-mistakes/evidence/01M1C47NQEE72242EJBH2514CN/03-theme-dark-toggle.png</code>)
- Evidence: System mode sync verification in native Electron (local file: <code>~/.no-mistakes/evidence/01M1C47NQEE72242EJBH2514CN/04-theme-system-mode.png</code>)
- Evidence: Theme persistence after relaunch in native Electron (local file: <code>~/.no-mistakes/evidence/01M1C47NQEE72242EJBH2514CN/05-theme-persistence-after-relaunch.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"03210762ea46ce683618dce9e4061fc177eec5da","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:theme-fouc-script`
- `npm run test:theme-mode-settings`
- `npm run test:runtime-recovery`
- `npm run test:phase2`
- `npx playwright test --config=playwright.electron.config.ts e2e/desktop/runtime-recovery.electron.spec.ts`
- `npx playwright test --config=playwright.electron.config.ts e2e/desktop/theme.electron.spec.ts`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
