### PR TITLE
feat: add quick theme toggle to sidebar, fix theme_mode 404

### DIFF
--- a/frontend/e2e/title-bar-platform.spec.ts
+++ b/frontend/e2e/title-bar-platform.spec.ts
@@ -162,8 +162,9 @@ test('sidebar renders profile dropup trigger and supports drag rail resizing', a
   await page.locator('button[type="submit"]').click();
   await page.waitForURL(/\/pos/, { timeout: 20000 });
 
-  // Sidebar footer profile button renders
-  const profileButton = page.locator('[data-sidebar="footer"] button[data-sidebar="menu-button"]');
+  // Sidebar footer profile dropup trigger renders (the footer also has a
+  // quick theme-toggle button, so scope to the dropdown trigger specifically).
+  const profileButton = page.locator('[data-sidebar="footer"] button[data-sidebar="menu-button"][data-slot="dropdown-menu-trigger"]');
   await expect(profileButton).toBeVisible();
 
   // Rail has cursor-col-resize

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -18,6 +18,9 @@ import {
   MessageCircle,
   LifeBuoy,
   ChevronUp,
+  Sun,
+  Moon,
+  Monitor,
   type LucideIcon,
 } from 'lucide-react';
 import { useTranslations, type AppConfig } from 'use-intl';
@@ -26,6 +29,7 @@ import { usePosSettingsStore } from '@/store/pos-settings';
 import { getLandingPage } from '@/components/layout/AuthGuard';
 import api from '@/lib/api';
 import { useConfirm } from '@/hooks/use-confirm';
+import { useThemeModeToggle } from '@/hooks/useThemeModeToggle';
 import { ROLE_ACCESS, hasRole, type Role } from '@shared/role-permissions';
 import {
   DropdownMenu,
@@ -83,6 +87,15 @@ export default function AppSidebar() {
   const { confirm, ConfirmDialog } = useConfirm();
   const [emailNeedsAttention, setEmailNeedsAttention] = useState(false);
   const closeMobile = () => { if (isMobile) setOpenMobile(false); };
+  const tSettings = useTranslations('settings');
+  const { mode: themeMode, cycle: cycleThemeMode } = useThemeModeToggle();
+  const themeModeIcon = themeMode === 'light' ? Sun : themeMode === 'dark' ? Moon : Monitor;
+  const themeModeLabel = themeMode === 'light'
+    ? tSettings('themeLight')
+    : themeMode === 'dark'
+      ? tSettings('themeDark')
+      : tSettings('themeSystem');
+  const ThemeModeIcon = themeModeIcon;
 
   const role = currentTenant?.role || 'cashier';
   const businessType = currentTenant?.business_type || 'restaurant';
@@ -192,6 +205,18 @@ export default function AppSidebar() {
 
       <SidebarFooter>
         <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              onClick={cycleThemeMode}
+              tooltip={`${tSettings('themeTitle')}: ${themeModeLabel}`}
+            >
+              <ThemeModeIcon className="size-4 shrink-0" />
+              <span>{tSettings('themeTitle')}</span>
+              <span className="ms-auto text-xs text-muted-foreground group-data-[collapsible=icon]:hidden">
+                {themeModeLabel}
+              </span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
           <SidebarMenuItem>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/frontend/src/hooks/useThemeModeToggle.ts
+++ b/frontend/src/hooks/useThemeModeToggle.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslations } from 'use-intl';
+import { useThemeMode, type ThemeMode } from '@/store/theme';
+import api from '@/lib/api';
+
+const CYCLE: readonly ThemeMode[] = ['light', 'dark', 'system'];
+
+/**
+ * Quick theme-mode control for chrome (e.g. the sidebar): optimistically
+ * flips the shared store and persists it, rolling back on a failed save.
+ * Settings > Appearance owns its own hydration/race handling independently;
+ * this hook only ever writes, so the two never contend over the same state.
+ */
+export function useThemeModeToggle() {
+  const t = useTranslations('settings');
+  const mode = useThemeMode((s) => s.mode);
+  const setMode = useThemeMode((s) => s.setMode);
+  const markUserSelected = useThemeMode((s) => s.markUserSelected);
+  const [saving, setSaving] = useState(false);
+  const savingRef = useRef(false);
+
+  const save = async (next: ThemeMode) => {
+    if (savingRef.current || next === mode) return;
+    const previous = mode;
+    savingRef.current = true;
+    setSaving(true);
+    markUserSelected();
+    setMode(next);
+    try {
+      await api.put('/settings/theme_mode', { value: next });
+    } catch {
+      setMode(previous);
+      toast.error(t('saveFailed'));
+    } finally {
+      savingRef.current = false;
+      setSaving(false);
+    }
+  };
+
+  const cycle = () => {
+    const next = CYCLE[(CYCLE.indexOf(mode) + 1) % CYCLE.length];
+    void save(next);
+  };
+
+  return { mode, saving, save, cycle };
+}

--- a/main/routes/settings.ts
+++ b/main/routes/settings.ts
@@ -85,6 +85,10 @@ const OPTIONAL_SETTING_DEFAULTS: Record<string, string> = {
   currency_display: 'rial',
   number_digits: 'locale',
   calendar: 'locale',
+  // No row until the user first changes it; 'system' is the renderer's own
+  // default (frontend/src/store/theme.ts), so a GET before that point should
+  // return it rather than 404.
+  theme_mode: 'system',
 };
 
 function maskSetting(key: string, value: string): string {

--- a/tests/theme-mode-settings.test.ts
+++ b/tests/theme-mode-settings.test.ts
@@ -169,8 +169,16 @@ async function main() {
       });
     });
 
+    // ── HTTP wildcard GET — default before any row exists ───────────────
+    console.log('0. GET /api/settings/theme_mode with no row yet → HTTP 200 "system" (not 404)');
+    {
+      const res = await httpRequest(baseUrl, '/api/settings/theme_mode');
+      assert.equal(res.status, 200, 'returns 200 even with no persisted row');
+      assert.equal(res.data?.setting?.value, 'system', 'defaults to "system"');
+    }
+
     // ── HTTP wildcard PUT — negative path ──────────────────────────────
-    console.log('1. PUT /api/settings/theme_mode with bogus value → HTTP 400');
+    console.log('\n1. PUT /api/settings/theme_mode with bogus value → HTTP 400');
     {
       const res = await httpRequest(baseUrl, '/api/settings/theme_mode', {
         method: 'PUT',


### PR DESCRIPTION
## Summary
- Add a Light/Dark/System theme toggle to the sidebar footer, so users can switch theme without opening Settings. Cycles Light → Dark → System, shows current mode as icon + label (icon-only with tooltip when the sidebar is collapsed).
- Fix `GET /api/settings/theme_mode` returning 404 on fresh installs — `theme_mode` had no row until first written and no entry in `OPTIONAL_SETTING_DEFAULTS`, so it 404'd instead of returning the renderer's own `'system'` default (same pattern already used for `currency_display`, `number_digits`, etc).

## Test plan
- [x] `npm run test:theme-mode-settings` — added a regression test asserting `GET` returns 200 `"system"` before any row exists; all 7 assertions pass.
- [x] `npx tsc --noEmit` (backend) and `cd frontend && npx tsc --noEmit` — no errors.
- [x] `npm run lint` — no new warnings/errors introduced.
- [x] Manually verified in a live, isolated instance of the app: toggle cycles System → Light → Dark → System, re-themes instantly, PUT persists (200 OK), GET no longer 404s, and renders correctly both expanded and icon-collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)