### PR TITLE
fix(main): clear runtime relaunch marker after recovery and guard activation during shutdown

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -50,6 +50,7 @@ import { setupWindowLoadRetry } from './window-load-retry';
 import { registerUsbDevicePermissions } from './usb-device-permissions';
 import { probeBackendHealth } from './backend-health';
 import {
+  createRelaunchAttemptGuard,
   createRelaunchGate,
   decideRuntimeActivationAction,
   hasRelaunchAttemptFlag,
@@ -465,6 +466,11 @@ function hasAlreadyAttemptedRuntimeRelaunch(): boolean {
   return hasRelaunchAttemptFlag(process.argv, RUNTIME_RELAUNCH_ATTEMPT_FLAG);
 }
 
+// Gates repeat relaunches across process restarts (see hasAlreadyAttemptedRuntimeRelaunch
+// above), but only until this process's runtime first recovers — see
+// createRelaunchAttemptGuard for why an outright process-lifetime check is wrong.
+const relaunchAttemptGuard = createRelaunchAttemptGuard(hasAlreadyAttemptedRuntimeRelaunch());
+
 function performAppRelaunch(): void {
   if (process.defaultApp || !app.isPackaged) {
     const relaunchArgs = process.argv.slice(1).map((arg) => (arg === '.' ? process.cwd() : arg));
@@ -497,7 +503,7 @@ function requestRuntimeRelaunch(reason: string): void {
   log.error(`[Lifecycle] Runtime recovery relaunch requested: ${reason}`);
   if (process.env.FLO_E2E_PID_FILE) console.log('[Native E2E] runtime relaunch requested');
 
-  const alreadyAttempted = hasAlreadyAttemptedRuntimeRelaunch();
+  const alreadyAttempted = relaunchAttemptGuard.hasExhaustedAttempt();
 
   const finishRelaunch = (): void => {
     try {
@@ -761,6 +767,9 @@ async function handleMainWindowActivation(): Promise<void> {
       kds: getKdsPort(),
       serverApp: getServerAppPort(),
     });
+    // Shutdown or update installation may have started while the probe was
+    // in flight — a stale failure must not request a relaunch mid-shutdown.
+    if (isQuitting || isShutdownRequested()) return;
     if (!reallyHealthy) {
       requestRuntimeRelaunchOnce('activation-health-probe-failed');
       return;
@@ -1232,6 +1241,7 @@ async function initialize(): Promise<void> {
     });
 
     runtimeState = 'ready';
+    relaunchAttemptGuard.markRuntimeRecovered();
     log.info('[Lifecycle] Runtime is ready');
     ipcMain.handle('set-theme-effective', (event, isDark: unknown) => {
       // gh-513 F8: validate the sender — the ipc.ts handle() wrapper applies

--- a/main/runtime-recovery.ts
+++ b/main/runtime-recovery.ts
@@ -54,3 +54,23 @@ export function createRelaunchGate(onRelaunch: (reason: string) => void): (reaso
 export function hasRelaunchAttemptFlag(argv: readonly string[], attemptFlag: string): boolean {
   return argv.includes(attemptFlag);
 }
+
+/**
+ * Bounds hasRelaunchAttemptFlag() to the window between process start and the
+ * runtime's first successful recovery, rather than the whole process
+ * lifetime. Without this, a process that carries the attempt marker (because
+ * it is itself the result of a relaunch) would treat every later relaunch
+ * request as a second failed attempt forever — even hours after that relaunch
+ * succeeded and the runtime ran healthy — and show the manual-restart dialog
+ * instead of trying to recover from a new, unrelated failure.
+ */
+export function createRelaunchAttemptGuard(processCarriesAttemptFlag: boolean): {
+  hasExhaustedAttempt: () => boolean;
+  markRuntimeRecovered: () => void;
+} {
+  let recovered = false;
+  return {
+    hasExhaustedAttempt: () => processCarriesAttemptFlag && !recovered,
+    markRuntimeRecovered: () => { recovered = true; },
+  };
+}

--- a/tests/backend-health.test.ts
+++ b/tests/backend-health.test.ts
@@ -33,6 +33,25 @@ function startHealthyServer(): Promise<{ port: number; close: () => Promise<void
   });
 }
 
+// Returns a port the OS just handed out and then released, instead of
+// guessing one via arithmetic offsets from a live port (which is not
+// guaranteed to be closed and can collide with something else listening).
+// Nothing else can claim it between the close() below and the probe running
+// immediately after, which is deterministic enough for a test.
+function getDeterministicallyClosedPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = http.createServer();
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      probe.close((err) => {
+        if (err) reject(err);
+        else resolve(port);
+      });
+    });
+  });
+}
+
 async function run(): Promise<void> {
   console.log('[Step 1] All three services healthy...');
   const main = await startHealthyServer();
@@ -46,23 +65,49 @@ async function run(): Promise<void> {
     await Promise.all([main.close(), kds.close(), serverApp.close()]);
   }
 
-  console.log('\n[Step 2] One service silently dead (port closed, connection refused)...');
-  const main2 = await startHealthyServer();
-  const kds2 = await startHealthyServer();
-  // Simulates the exact reported bug: a server that has died but whose
-  // isServerRunning()-style reference would still be non-null. Using a
-  // closed port here reproduces the same "nobody answers" behavior a dead
-  // listener produces, without needing a real process crash.
-  const deadPort = kds2.port + 10_000 > 65535 ? kds2.port - 100 : kds2.port + 10_000;
-  try {
-    const healthy = await probeBackendHealth({ server: main2.port, kds: deadPort, serverApp: main2.port }, 500);
-    assert.equal(healthy, false, 'probeBackendHealth reports unhealthy when any one endpoint is unreachable');
-    console.log('  ✓ Reports unhealthy when one of the three services does not answer.');
-  } finally {
-    await Promise.all([main2.close(), kds2.close()]);
+  console.log('\n[Step 2] KDS silently dead (port closed, connection refused)...');
+  {
+    const main2 = await startHealthyServer();
+    const serverApp2 = await startHealthyServer();
+    // Simulates the exact reported bug: a server that has died but whose
+    // isServerRunning()-style reference would still be non-null. A port the
+    // OS just freed reproduces the same "nobody answers" behavior a dead
+    // listener produces, without needing a real process crash.
+    const deadKdsPort = await getDeterministicallyClosedPort();
+    try {
+      const healthy = await probeBackendHealth(
+        { server: main2.port, kds: deadKdsPort, serverApp: serverApp2.port },
+        500,
+      );
+      assert.equal(healthy, false, 'probeBackendHealth reports unhealthy when the KDS endpoint is unreachable');
+      console.log('  ✓ Reports unhealthy when the KDS endpoint does not answer.');
+    } finally {
+      await Promise.all([main2.close(), serverApp2.close()]);
+    }
   }
 
-  console.log('\n[Step 3] Non-ok HTTP response counts as unhealthy...');
+  console.log('\n[Step 3] Server App silently dead (port closed, connection refused)...');
+  {
+    const main3 = await startHealthyServer();
+    const kds3 = await startHealthyServer();
+    // Independently exercises the third endpoint — Step 2 only ever proved
+    // the KDS check works; a bug that always treated serverApp as healthy
+    // would previously slip through since serverApp reused an already-healthy
+    // port in this test rather than one known to be dead.
+    const deadServerAppPort = await getDeterministicallyClosedPort();
+    try {
+      const healthy = await probeBackendHealth(
+        { server: main3.port, kds: kds3.port, serverApp: deadServerAppPort },
+        500,
+      );
+      assert.equal(healthy, false, 'probeBackendHealth reports unhealthy when the Server App endpoint is unreachable');
+      console.log('  ✓ Reports unhealthy when the Server App endpoint does not answer.');
+    } finally {
+      await Promise.all([main3.close(), kds3.close()]);
+    }
+  }
+
+  console.log('\n[Step 4] Non-ok HTTP response counts as unhealthy...');
   const server3 = http.createServer((_req, res) => { res.writeHead(503); res.end(); });
   await new Promise<void>((resolve) => server3.listen(0, '127.0.0.1', () => resolve()));
   const address3 = server3.address();
@@ -75,7 +120,7 @@ async function run(): Promise<void> {
     await new Promise<void>((resolve) => server3.close(() => resolve()));
   }
 
-  console.log('\n✅ ALL BACKEND HEALTH PROBE CHECKS PASSED (3/3)');
+  console.log('\n✅ ALL BACKEND HEALTH PROBE CHECKS PASSED (4/4)');
 }
 
 run().catch((err) => {

--- a/tests/runtime-recovery.test.ts
+++ b/tests/runtime-recovery.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict';
 import {
+  createRelaunchAttemptGuard,
   createRelaunchGate,
   decideRuntimeActivationAction,
   hasRelaunchAttemptFlag,
@@ -102,5 +103,34 @@ assert.equal(
   false,
   'an empty argv is treated as a first launch',
 );
+
+// createRelaunchAttemptGuard: a successful recovery must not permanently
+// disable a later, independent relaunch attempt (issue #568 #1) — the marker
+// carried in process.argv should only count against the process until this
+// process's own runtime first recovers.
+{
+  // A first launch (no marker) never counts as an exhausted attempt.
+  const freshLaunch = createRelaunchAttemptGuard(false);
+  assert.equal(freshLaunch.hasExhaustedAttempt(), false);
+  freshLaunch.markRuntimeRecovered();
+  assert.equal(freshLaunch.hasExhaustedAttempt(), false);
+}
+{
+  // A relaunched process that fails again before ever recovering is exhausted.
+  const failedRelaunch = createRelaunchAttemptGuard(true);
+  assert.equal(failedRelaunch.hasExhaustedAttempt(), true, 'a relaunched process is exhausted until it recovers');
+}
+{
+  // A relaunched process that recovers, then later hits an unrelated failure,
+  // gets a fresh attempt instead of being treated as already exhausted.
+  const recoveredRelaunch = createRelaunchAttemptGuard(true);
+  assert.equal(recoveredRelaunch.hasExhaustedAttempt(), true);
+  recoveredRelaunch.markRuntimeRecovered();
+  assert.equal(
+    recoveredRelaunch.hasExhaustedAttempt(),
+    false,
+    'a later, independent failure is not blocked by a marker from a relaunch that already succeeded',
+  );
+}
 
 console.log('Runtime recovery tests passed');


### PR DESCRIPTION
## Summary

Follow-up to #567, addressing the three issues from the read-only audit in #568:

- The relaunch-attempt marker no longer blocks a later, independent recovery attempt after a successful relaunch — `createRelaunchAttemptGuard` now bounds the marker to the window between process start and the runtime's first successful recovery (cleared once `runtimeState` reaches `'ready'`), instead of the whole process lifetime.
- `handleMainWindowActivation` now rechecks `isQuitting`/`isShutdownRequested()` immediately after its health probe resolves, so a stale probe failure can no longer request a relaunch once shutdown or update installation has begun.
- The backend-health test now derives dead ports deterministically (bind to `0`, read the assigned port, close) instead of guessing via arithmetic offset, and independently exercises the KDS and Server App failure paths instead of reusing an already-healthy port for one of them.

## Test plan

- [x] `npm run build`
- [x] `npm run lint` (no new warnings/errors)
- [x] `npx ts-node --transpile-only -P tests/tsconfig.json tests/runtime-recovery.test.ts`
- [x] `npx ts-node --transpile-only -P tests/tsconfig.json tests/backend-health.test.ts`
- [x] `npm test` (full suite, exit code 0)

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)