### PR TITLE
fix(ci): keep store submissions manual and preserve snap evidence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,6 +406,7 @@ jobs:
         # A missing credential is a release failure, not a skipped channel:
         # if this job runs, Snap publishing was requested.
         env:
+          GH_TOKEN: ${{ github.token }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: |
           if [ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]; then
@@ -779,66 +780,6 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         env:
           GH_TOKEN: ${{ github.token }}
-
-      - name: Setup Microsoft Store Developer CLI
-        # Tag-only: workflow_dispatch can run this job against arbitrary
-        # branch code, so it must never be allowed to reach Partner Center.
-        # Pinned to v1.4 by commit SHA rather than the mutable v1.1 tag
-        # (matches this repo's pinning convention for third-party actions).
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && needs.create-release.outputs.channel == 'stable'
-        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
-
-      - name: Publish Windows AppX packages to Microsoft Store
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && needs.create-release.outputs.channel == 'stable'
-        shell: pwsh
-        env:
-          AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
-          AZURE_AD_APPLICATION_CLIENT_ID: ${{ secrets.AZURE_AD_APPLICATION_CLIENT_ID }}
-          AZURE_AD_APPLICATION_SECRET: ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
-          SELLER_ID: ${{ secrets.SELLER_ID }}
-          MICROSOFT_STORE_PRODUCT_ID: ${{ vars.MICROSOFT_STORE_PRODUCT_ID }}
-          # Optional: set MSSTORE_NO_COMMIT=true (repo/environment variable)
-          # to leave a submission as a draft, or MSSTORE_FLIGHT_ID to submit
-          # to a Partner Center flight instead of production, for a
-          # dry-run validation. Remove both once validated.
-          MSSTORE_FLIGHT_ID: ${{ vars.MSSTORE_FLIGHT_ID }}
-          MSSTORE_NO_COMMIT: ${{ vars.MSSTORE_NO_COMMIT }}
-        run: |
-          # msstore is a native CLI, not a PowerShell cmdlet — a failing call
-          # doesn't throw a terminating error or fail the step on its own, so
-          # without an explicit $LASTEXITCODE check this step reports success
-          # even when the Store submission itself failed.
-          $ErrorActionPreference = 'Stop'
-
-          $missing = @()
-          foreach ($name in @("AZURE_AD_TENANT_ID", "AZURE_AD_APPLICATION_CLIENT_ID", "AZURE_AD_APPLICATION_SECRET", "SELLER_ID", "MICROSOFT_STORE_PRODUCT_ID")) {
-            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
-              $missing += $name
-            }
-          }
-          if ($missing.Count -gt 0) {
-            Write-Error "Missing Microsoft Store configuration: $($missing -join ', ')"
-            exit 1
-          }
-          msstore reconfigure `
-            --tenantId "$env:AZURE_AD_TENANT_ID" `
-            --sellerId "$env:SELLER_ID" `
-            --clientId "$env:AZURE_AD_APPLICATION_CLIENT_ID" `
-            --clientSecret "$env:AZURE_AD_APPLICATION_SECRET"
-          if ($LASTEXITCODE -ne 0) { throw "msstore reconfigure failed with exit code $LASTEXITCODE." }
-
-          # The Store CLI accepts the app/project path and discovers the package
-          # candidates from the release directory for Electron projects; appId
-          # keeps CI non-interactive.
-          $publishArgs = @("${{ github.workspace }}\release", '--appId', "$env:MICROSOFT_STORE_PRODUCT_ID")
-          if (-not [string]::IsNullOrWhiteSpace($env:MSSTORE_FLIGHT_ID)) {
-            $publishArgs += @('--flightId', $env:MSSTORE_FLIGHT_ID)
-          }
-          if ($env:MSSTORE_NO_COMMIT -eq 'true') {
-            $publishArgs += '--noCommit'
-          }
-          msstore publish @publishArgs
-          if ($LASTEXITCODE -ne 0) { throw "Microsoft Store publish failed with exit code $LASTEXITCODE." }
 
   verify-release:
     name: Verify uploaded draft release

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,8 +2,11 @@
 
 FloCafe desktop releases use one electron-builder pipeline and GitHub Releases for
 NSIS/Windows, macOS DMG+ZIP, and Linux AppImage/deb/rpm/Snap artifacts. Microsoft
-Store (AppX) and Mac App Store (MAS) packages are submitted to their stores and
-are not consumed by `electron-updater`. Snap Store uploads map the release
+Store (AppX) and Mac App Store (MAS) packages are submitted through
+explicit/manual workflows and are not consumed by `electron-updater`. The tag
+release uploads AppX packages as GitHub release assets but does not submit to
+Microsoft Store, and MAS uses its separate manual workflow. Snap Store uploads
+map the release
 channel to a channel the configured macaroon permits (#468): stable releases
 publish to the `stable` channel and beta releases publish to the `edge`
 (opt-in) channel; an upload denied with `invalid-channel-permission` is
@@ -89,10 +92,10 @@ or newer stable release without database rollbacks.
 3. Each self-updating platform job asserts that its local updater manifest
    and representative installer exist before upload. Platform jobs upload
    installers, update manifests, blockmaps, and required store packages to the
-   draft release. Microsoft Store AppX submission runs only for stable tag
-   pushes. Beta AppX packages remain outside the Store submission
-   path because their four-part MSIX versions would otherwise collide with
-   stable and with later prereleases.
+   draft release. Microsoft Store and Mac App Store submission are not part of
+   the automatic tag release. Beta AppX packages remain outside the Store
+   submission path because their four-part MSIX versions would otherwise
+   collide with stable and with later prereleases.
 4. `scripts/verify-release-assets.cjs` fetches the draft release metadata, then
    downloads manifests and every referenced asset back through the GitHub API.
    It parses each manifest as YAML, requires every referenced asset to resolve

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -262,6 +262,7 @@ function run() {
   assertShellStep(linuxJob, 'Prepend AppStream release entry');
   const snapPublish = findStep(linuxJob, 'Publish snap to the matching Snap Store channel');
   assertShellStep(linuxJob, 'Publish snap to the matching Snap Store channel');
+  assert.equal(snapPublish.env.GH_TOKEN, '${{ github.token }}', 'Snap evidence upload must have GitHub API credentials');
   assert.deepEqual(linuxJob.strategy.matrix.include.map((entry: any) => entry.runner), ['ubuntu-24.04', 'ubuntu-24.04-arm']);
   assert.equal(snapPublish.if, undefined, 'Snap publication must run for both architectures');
 
@@ -274,13 +275,9 @@ function run() {
   assertShellStep(winJob, 'Build Windows');
   assertShellStep(winJob, 'Verify Windows release assets');
   assertShellStep(winJob, 'Upload Windows assets to GitHub release');
-  const storeSetup = findStep(winJob, 'Setup Microsoft Store Developer CLI');
-  const storePublish = findStep(winJob, 'Publish Windows AppX packages to Microsoft Store');
-  assertShellStep(winJob, 'Publish Windows AppX packages to Microsoft Store');
-  assert.equal(storeSetup.uses, 'microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0');
-  assert.equal(storeSetup.if, "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && needs.create-release.outputs.channel == 'stable'");
-  assert.equal(storePublish.if, storeSetup.if);
-  assert.equal(storePublish.env.RELEASE_CHANNEL, undefined);
+  const windowsStepNames = new Set((winJob.steps || []).map((step: any) => step.name));
+  assert.equal(windowsStepNames.has('Setup Microsoft Store Developer CLI'), false, 'Microsoft Store setup must remain manual');
+  assert.equal(windowsStepNames.has('Publish Windows AppX packages to Microsoft Store'), false, 'Microsoft Store submission must not run automatically');
 
   const verifyJob = jobs['verify-release'];
   const verifierDependencies = findStep(verifyJob, 'Install verifier dependencies');


### PR DESCRIPTION
## Summary

- provide `GH_TOKEN` to the Snap publication step so per-architecture evidence uploads can complete after a successful Snap Store publish
- keep Windows AppX artifacts in the GitHub release while removing automatic Microsoft Store submission
- retain the existing manual Mac App Store workflow
- update release workflow contract coverage and release-process documentation

## Root causes addressed

The 3.4.0 release built and uploaded the platform artifacts successfully. Both Linux jobs published Snap revision 74 to the stable channel, then failed because the evidence upload helper had no GitHub token. The Windows job failed only when `msstore reconfigure` attempted Partner Center authentication. Store submissions are now manual, while Snap publication remains required.

## Validation

`npm run test:release-config`
