### PR TITLE
fix: print order type and appended items on KOT

### DIFF
--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -258,7 +258,7 @@ export default function POSPage() {
     if (!autoPrintKot) return;
 
     try {
-      const printWarnings = await printKot(order);
+      const printWarnings = await printKot(order, order.items ? { items: order.items } : undefined);
       showPrintWarningsToast(printWarnings);
     } catch (err) {
       console.error('[POS] KOT print failed:', err);
@@ -475,7 +475,10 @@ export default function POSPage() {
           { headers: { 'Idempotency-Key': itemAttempt.idempotencyKey } },
         );
         toast.success(t('itemsAddedToOrder', { number: pendingOrder.order_number }));
-        orderForKot = data.order as Order;
+        const updatedOrder = data.order as Order;
+        const existingItemIds = new Set((pendingOrder.items || []).map((item) => Number(item.id)));
+        const appendedItems = (updatedOrder.items || []).filter((item) => !existingItemIds.has(Number(item.id)));
+        orderForKot = appendedItems.length > 0 ? { ...updatedOrder, items: appendedItems } : updatedOrder;
         if (!clearAppendAttempt(storage, itemAttempt)) throw new Error('Unable to clear append retry state');
         addItemsAttemptRef.current = null;
         setPendingOrder(null);
@@ -844,7 +847,7 @@ export default function POSPage() {
         orderNumber: order.order_number,
       });
       addItemsAttemptRef.current = itemAttempt;
-      await api.post(`/orders/${order.id}/items`, {
+      const { data } = await api.post(`/orders/${order.id}/items`, {
         items,
         special_instructions: specialInstructions,
       }, { headers: { 'Idempotency-Key': itemAttempt.idempotencyKey } });
@@ -853,6 +856,10 @@ export default function POSPage() {
       if (!clearAppendAttempt(storage, itemAttempt)) throw new Error('Unable to clear append retry state');
       addItemsAttemptRef.current = null;
       toast.success(t('itemsAddedToOrder', { number: order.order_number }));
+      const updatedOrder = data.order as Order;
+      const existingItemIds = new Set((order.items || []).map((item) => Number(item.id)));
+      const appendedItems = (updatedOrder.items || []).filter((item) => !existingItemIds.has(Number(item.id)));
+      await printKotIfEnabled(appendedItems.length > 0 ? { ...updatedOrder, items: appendedItems } : updatedOrder);
       cart.clearCart();
       setCheckoutTable(null);
       refreshTables();

--- a/frontend/src/hooks/usePrinter.ts
+++ b/frontend/src/hooks/usePrinter.ts
@@ -19,7 +19,7 @@ import { buildKotBytes, type KotOptions } from '@/lib/printer/kot-encoder';
 import { makeBillTemplateFallbackWarning, type PrintWarning } from '@/lib/printer/warnings';
 import api from '@/lib/api';
 import toast from 'react-hot-toast';
-import type { Bill, Tenant, Order } from '@/lib/types';
+import type { Bill, Tenant, Order, OrderItem } from '@/lib/types';
 
 export type { PrintWarning } from '@/lib/printer/warnings';
 
@@ -56,7 +56,7 @@ interface PrinterState {
   disconnect: () => Promise<void>;
   printBill: (bill: Bill, tenant: ReceiptTenant, opts?: ReceiptOptions) => Promise<PrintWarning[]>;
   printTaxBill: (bill: Bill, tenant: ReceiptTenant, opts?: TaxBillOptions) => Promise<PrintWarning[]>;
-  printKot: (order: Order, opts?: KotOptions) => Promise<PrintWarning[]>;
+  printKot: (order: Order, opts?: KotOptions & { items?: OrderItem[] }) => Promise<PrintWarning[]>;
   setPrintMode: (mode: PrintModeType) => void;
   setPaperWidth: (width: PaperWidth) => void;
   setPrintMethod: (method: PrintMode) => void;
@@ -314,7 +314,7 @@ export const usePrinterStore = create<PrinterState>()(
           const hw = get().hardwarePrinter;
           if (hw && get().printMethod === 'escpos') {
             try {
-              const response = await api.post<{ warnings?: PrintWarning[] }>('/printers/print-kot', { orderId: order.id, useUnicode: printerUseUnicode, arabicShaping: printerArabicShaping });
+              const response = await api.post<{ warnings?: PrintWarning[] }>('/printers/print-kot', { orderId: order.id, items: opts?.items, useUnicode: printerUseUnicode, arabicShaping: printerArabicShaping });
               return response.data.warnings || [];
             } catch (err: unknown) {
               const e = err as { response?: { data?: { error?: string } }; message?: string };
@@ -329,7 +329,11 @@ export const usePrinterStore = create<PrinterState>()(
           if (get().printMethod === 'escpos' && printerService.isConnected) {
             const { paperWidth } = get();
             const warnings: PrintWarning[] = [];
-            const bytes = buildKotBytes(order, { ...opts, paperWidth, arabicShaping: printerArabicShaping }, warnings);
+            const bytes = buildKotBytes(
+              opts?.items ? { ...order, items: opts.items } : order,
+              { ...opts, paperWidth, arabicShaping: printerArabicShaping },
+              warnings,
+            );
             set({ lastPrintedBytes: bytes });
             await printerService.print(bytes);
             return warnings;

--- a/main/printers/document-kot.ts
+++ b/main/printers/document-kot.ts
@@ -50,6 +50,7 @@ export function buildKotPrintData(order: any, items: any[], stationName: string)
       orderNumber: String(order?.order_number ?? ''),
       createdAt: String(order?.created_at ?? ''),
       tableName: String(order?.table?.name ?? ''),
+      orderType: formatKotOrderType(order?.type),
     },
     items: ticketItems.map((item: any) => ({
       productName: String(item?.product_name ?? ''),
@@ -113,6 +114,10 @@ function formatTableLabel(label: SemanticLabel, tableName: string): string {
   return labelOf(label).replace('{name}', tableName);
 }
 
+function formatKotOrderType(type: unknown): string {
+  return String(type ?? '').replace(/_/g, ' ').trim().toUpperCase();
+}
+
 function kotHeaderLines(header: KotHeaderBlock, options: KotDocumentRenderOptions): string[] {
   const cols = options.columns;
   const lines: string[] = [];
@@ -127,6 +132,9 @@ function kotHeaderLines(header: KotHeaderBlock, options: KotDocumentRenderOption
   lines.push(truncateShapedLine('Order: ' + header.orderNumber.text, cols, options.arabicShaping));
   if (header.table) {
     lines.push(truncateShapedLine(formatTableLabel(header.table.label, header.table.name.text), cols, options.arabicShaping));
+  }
+  if (header.orderType) {
+    lines.push(truncateShapedLine(labelOf(header.orderType.label) + ': ' + header.orderType.value.text, cols, options.arabicShaping));
   }
   lines.push(labelOf(header.timeLabel) + ': ' + parseDbTimestamp(header.timestamp.text).toLocaleTimeString((options.locale ?? 'en-US') + '-u-nu-latn', tzOptions));
   return lines;

--- a/main/routes/printers.ts
+++ b/main/routes/printers.ts
@@ -603,13 +603,15 @@ router.post('/print-kot', requireRole(...ROLE_ACCESS.ownerManagerCashier), async
       }
     }
 
-    // An explicit stationName/items override (not used by the current frontend,
-    // but kept for any external caller) always prints a single ticket, as before.
-    // Otherwise, auto-route items to their configured kitchen stations.
+    // A stationName override prints one ticket. Item overrides without an
+    // explicit station are still routed, which lets running-order append
+    // tickets contain only the newly added rows while preserving station
+    // routing.
     let success = true;
     const warnings: NonNullable<Awaited<ReturnType<typeof printKOTDetailed>>['warnings']> = [];
     let failure: Awaited<ReturnType<typeof printKOTDetailed>> | null = null;
-    if (stationName || items) {
+    const kotSourceItems = Array.isArray(items) ? items : orderItems;
+    if (stationName) {
       const kotItems = items || orderItems;
       const station = stationName || 'Kitchen';
       const result = await printKOTDetailed(order, kotItems, station, useUnicode, undefined, getHttpRequestSignal(req), arabicShapingOverride, kotLanguage);
@@ -617,7 +619,7 @@ router.post('/print-kot', requireRole(...ROLE_ACCESS.ownerManagerCashier), async
       failure = result.ok ? null : result;
       warnings.push(...(result.warnings || []));
     } else {
-      const groups = routeItemsToStations(db, orderItems).filter((g) => g.items.length > 0);
+      const groups = routeItemsToStations(db, kotSourceItems).filter((g) => g.items.length > 0);
       for (const group of groups) {
         const result = await printKOTDetailed(order, group.items, group.stationName, useUnicode, group.printer || undefined, getHttpRequestSignal(req), arabicShapingOverride, kotLanguage);
         success = success && result.ok;

--- a/shared/print/document.ts
+++ b/shared/print/document.ts
@@ -662,11 +662,12 @@ export interface KotItemSnapshot {
   readonly specialInstructions: string;
 }
 
-/** The order behind the ticket (order number, canonical timestamp, table). */
+/** The order behind the ticket (order number, canonical timestamp, table, type). */
 export interface KotOrderSnapshot {
   readonly orderNumber: string;
   readonly createdAt: string;
   readonly tableName: string;
+  readonly orderType: string;
 }
 
 /**
@@ -679,7 +680,7 @@ export interface KotPrintData {
   readonly items: readonly KotItemSnapshot[];
 }
 
-/** Ticket header: banner, station, order number, table, time. */
+/** Ticket header: banner, station, order number, table, type, time. */
 export interface KotHeaderBlock {
   readonly kind: 'kot-header';
   readonly direction: TextDirection;
@@ -694,6 +695,7 @@ export interface KotHeaderBlock {
   readonly orderNumber: DirectionalText;
   /** Table reference with its (uninterpolated) label concept. */
   readonly table: { readonly label: SemanticLabel; readonly name: DirectionalText } | null;
+  readonly orderType: { readonly label: SemanticLabel; readonly value: DirectionalText } | null;
   readonly timeLabel: SemanticLabel;
   /** Canonical stored timestamp; presentation formatting is a renderer duty. */
   readonly timestamp: DirectionalText;
@@ -746,6 +748,12 @@ export function buildKotDocument(printData: KotPrintData, printContext: PrintCon
       ? Object.freeze({
         label: resolveSemanticLabel(labels, 'pos.tableLabel'),
         name: directionalText(printData.order.tableName, base),
+      })
+      : null,
+    orderType: typeof printData.order?.orderType === 'string' && printData.order.orderType.length > 0
+      ? Object.freeze({
+        label: resolveSemanticLabel(labels, 'print.kot.type'),
+        value: directionalText(printData.order.orderType, base),
       })
       : null,
     timeLabel: resolveSemanticLabel(labels, 'print.time'),

--- a/tests/print-document.test.ts
+++ b/tests/print-document.test.ts
@@ -343,6 +343,7 @@ console.log('\n▶ KOT document builder (#443)');
       orderNumber: 'ORD-PARITY-001',
       createdAt: '2026-08-21 18:42:00',
       tableName: '4',
+      orderType: 'DINE IN',
     },
     items: [
       {
@@ -376,8 +377,10 @@ console.log('\n▶ KOT document builder (#443)');
   assert.equal(header.orderNumber.direction, 'ltr', 'order number is an LTR island under rtl base');
   assert.equal(header.table?.label.conceptId, 'pos.tableLabel');
   assert.equal(header.table?.name.text, '4');
+  assert.equal(header.orderType?.label.conceptId, 'print.kot.type');
+  assert.equal(header.orderType?.value.text, 'DINE IN');
   assert.equal(header.timestamp.text, '2026-08-21 18:42:00');
-  ok('KOT header carries banner/station/order/table/time semantics');
+  ok('KOT header carries banner/station/order/table/type/time semantics');
 
   const noTable = buildKotDocument(
     { ...kotData, order: { ...kotData.order, tableName: '' } },

--- a/tests/print-labels.test.ts
+++ b/tests/print-labels.test.ts
@@ -47,6 +47,7 @@ function assert(label: string, cond: boolean, detail?: string) {
 function buildOrder(): any {
   return {
     order_number: 'ORD-LABELS-001',
+    type: 'dine_in',
     created_at: '2026-08-21 18:42:00',
     table: { name: '7' },
     items: [{
@@ -151,9 +152,11 @@ function run(): void {
     const order = { ...buildOrder(), table: { name: '3' } };
     const text = escPosToText(formatKOT(order, order.items, 'Grill', 48));
     assert('default KOT banner stays English', text.includes('KITCHEN ORDER TICKET'));
+    assert('default KOT type label stays English', text.includes('Type: DINE IN'));
     const faText = escPosToText(formatKOT(order, order.items, 'Grill', 48, false, 'full', 'en-US', undefined, [], true, 'fa'));
     assert('fa KOT banner translated', faText.includes('برگ سفارش آشپزخانه'));
     assert('fa KOT station label translated', faText.includes('ایستگاه:'));
+    assert('fa KOT type label translated', faText.includes('نوع: DINE IN'));
     assert('fa KOT time label translated', faText.includes('ساعت:'));
   }
 

--- a/tests/print-parity.test.ts
+++ b/tests/print-parity.test.ts
@@ -462,6 +462,7 @@ function run(): void {
     created_at: order.created_at,
     table: { name: '4' },
   };
+  const typedKotOrder = { ...kotOrder, type: 'dine_in' };
 
   section('PrintDocument vs legacy classic');
   for (const cols of [32, 42, 48]) {
@@ -531,6 +532,8 @@ function run(): void {
     warn(kotText.includes('** Less sugar **'), `${label}: instruction lines rendered`);
     if (cols >= 42) warn(!kotText.includes(PERSIAN_ITEM), `${label}: unsupported-script item skipped with warning only`);
   }
+  const typedKotText = escPosToText(formatKOT(typedKotOrder, order.items, 'Main Kitchen', 42, false, 'full', 'en-US', { timeZone: 'Asia/Kolkata' }, [], false, 'en'));
+  warn(typedKotText.includes('Type: DINE IN'), 'kot-document/order-type: order type rendered when present');
 
   // ------------------------------------------------------------------
   // 5. Receipt/KOT language routing (#443): fa/es/fr tenants get localized

--- a/tests/printer.test.ts
+++ b/tests/printer.test.ts
@@ -206,6 +206,7 @@ function visibleRawPrinterLines(data: Uint8Array): string[] {
 
 const fixtureOrder = {
   order_number: 'ORD-20260421-0001',
+  type: 'dine_in',
   created_at: new Date('2026-04-21T10:30:00Z').toISOString(),
   table: { name: 'T3' },
   items: [
@@ -759,6 +760,7 @@ console.log('\n✅ Test 6: KOT (Kitchen Order Ticket)');
   assert('renders station name', text.includes('Main Kitchen'));
   assert('renders order number', text.includes('ORD-20260421-0001'));
   assert('renders table number', text.includes('T3'));
+  assert('renders order type', text.includes('Type: DINE IN'));
   assert('renders each item with qty prefix', text.includes('2x  Cheeseburger'));
   assert('renders addon "Extra Cheese"', text.includes('+ Extra Cheese'));
   assert('renders addon "Bacon"', text.includes('+ Bacon'));


### PR DESCRIPTION
## Summary
- print order type on backend KOT tickets
- print KOT for newly appended running-order items
- route explicit KOT item subsets through kitchen stations

Fixes #573 for the KOT printing scope. The WhatsApp offer-sending item in the issue is a separate feature request.

## Verification
- node tests/run-electron-node-test.cjs tests/print-document.test.ts
- node tests/run-electron-node-test.cjs tests/printer.test.ts
- node tests/run-electron-node-test.cjs tests/print-labels.test.ts
- node tests/run-electron-node-test.cjs tests/print-parity.test.ts
- npm run build
- npm run lint (existing warnings only)
- npm run build:frontend
- git diff --check