### PR TITLE
feat(pos): add touchscreen-first controls

### DIFF
--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import api from '@/lib/api';
 import { useAuthStore } from '@/store/auth';
 import { useCartStore } from '@/store/cart';
@@ -87,6 +87,7 @@ export default function POSPage() {
   const [search, setSearch] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [mobileCartOpen, setMobileCartOpen] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
 
   // Modal state
   const [showTablePicker, setShowTablePicker] = useState(false);
@@ -272,6 +273,26 @@ export default function POSPage() {
       toast.error(t('kotPrintFailed'));
     }
   };
+
+  useEffect(() => {
+    const syncFullscreen = () => setFullscreen(document.fullscreenElement != null);
+    syncFullscreen();
+    document.addEventListener('fullscreenchange', syncFullscreen);
+    return () => document.removeEventListener('fullscreenchange', syncFullscreen);
+  }, []);
+
+  const toggleFullscreen = useCallback(async () => {
+    if (typeof document === 'undefined') return;
+    try {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      } else {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch {
+      toast.error(t('fullscreenUnavailable'));
+    }
+  }, [t]);
 
   const fetchLatestBill = async (billId: number): Promise<Bill> => {
     const { data } = await api.get(`/bills/${billId}`);
@@ -959,7 +980,12 @@ export default function POSPage() {
           )}
         </div>
       )}
-      <PosTopbar tables={tables} onShowTablePicker={() => setShowTablePicker(true)} />
+      <PosTopbar
+        tables={tables}
+        onShowTablePicker={() => setShowTablePicker(true)}
+        fullscreen={fullscreen}
+        onToggleFullscreen={toggleFullscreen}
+      />
 
       {/* Main content area */}
       <div className="flex flex-1 min-h-0 overflow-hidden p-4 gap-4">
@@ -987,7 +1013,7 @@ export default function POSPage() {
       {/* Mobile: Floating Cart Button + Bottom Sheet — outside flex container */}
       <Drawer open={mobileCartOpen} onOpenChange={setMobileCartOpen}>
         <DrawerTrigger asChild>
-          <button className="fixed bottom-5 end-5 z-40 w-14 h-14 bg-brand text-white rounded-full shadow-lg flex items-center justify-center hover:bg-brand-hover transition-colors md:hidden">
+          <button className="touch-target fixed bottom-5 end-5 z-40 w-14 h-14 bg-brand text-white rounded-full shadow-lg hover:bg-brand-hover active:bg-brand-hover transition-colors md:hidden" aria-label={t('cart')}>
             <ShoppingCart size={22} />
             {itemCount > 0 && (
               <span className="absolute -top-0.5 -end-0.5 bg-red-500 text-white text-xs w-5 h-5 rounded-full flex items-center justify-center font-bold">
@@ -1066,7 +1092,7 @@ export default function POSPage() {
           <div className="bg-card rounded-2xl p-5 w-full max-w-sm">
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-bold">{t('selectCustomer')}</h3>
-              <button onClick={() => setShowCustomerPrompt(false)} className="text-gray-400 hover:text-muted-foreground">
+              <button onClick={() => setShowCustomerPrompt(false)} className="touch-target rounded-full text-gray-400 hover:text-muted-foreground active:bg-muted" aria-label={t('close')}>
                 <X size={20} />
               </button>
             </div>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -51,6 +51,15 @@ body {
   font-family: var(--font-sans);
 }
 
+.touch-target {
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+}
+
 /* Desktop title bar: native-overlay mode supplies the caption buttons through
  * Electron; html-fallback mode mounts equivalent controls in the renderer.
  * The safe-area env values exclude native buttons and update on geometrychange;

--- a/frontend/src/components/pos/AddonModal.tsx
+++ b/frontend/src/components/pos/AddonModal.tsx
@@ -111,13 +111,13 @@ export default function AddonModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-card rounded-2xl w-full max-w-md max-h-[85vh] flex flex-col">
+      <div className="bg-card rounded-2xl w-full max-w-lg max-h-[92vh] flex flex-col">
         <div className="flex justify-between items-center p-5 border-b border-border">
           <div>
             <h2 className="text-lg font-bold text-foreground">{product.name}</h2>
             <p className="text-brand font-semibold">{fmt(Number(product.price))}</p>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-muted-foreground">
+          <button onClick={onClose} className="touch-target rounded-full text-gray-400 hover:text-muted-foreground active:bg-muted" aria-label={t('close')}>
             <X size={20} />
           </button>
         </div>
@@ -161,7 +161,7 @@ export default function AddonModal({
                       return (
                         <div
                           key={addon.id}
-                          className={`w-full flex items-center justify-between px-3 py-2.5 rounded-lg border text-sm transition-colors ${
+                          className={`w-full min-h-14 flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg border text-sm transition-colors ${
                             isSel
                               ? 'border-brand bg-brand-light text-brand'
                               : 'border-border hover:border-gray-300 dark:hover:border-border dark:border-border'
@@ -179,15 +179,15 @@ export default function AddonModal({
                                 <button
                                   type="button"
                                   onClick={() => updateAddonQuantity(group, addon, -1)}
-                                  className="w-6 h-6 rounded flex items-center justify-center text-brand hover:bg-brand-light"
+                                  className="touch-target rounded flex items-center justify-center text-brand hover:bg-brand-light active:bg-brand-light"
                                 >
                                   <Minus size={14} />
                                 </button>
-                                <span className="text-xs font-bold w-4 text-center text-brand">{addonQty}</span>
+                                <span className="text-sm font-bold w-5 text-center text-brand tabular-nums">{addonQty}</span>
                                 <button
                                   type="button"
                                   onClick={() => updateAddonQuantity(group, addon, 1)}
-                                  className="w-6 h-6 rounded flex items-center justify-center text-brand hover:bg-brand-light"
+                                  className="touch-target rounded flex items-center justify-center text-brand hover:bg-brand-light active:bg-brand-light"
                                 >
                                   <Plus size={14} />
                                 </button>
@@ -196,7 +196,7 @@ export default function AddonModal({
                               <button
                                 type="button"
                                 onClick={() => updateAddonQuantity(group, addon, 1)}
-                                className="w-6 h-6 rounded-full bg-muted flex items-center justify-center text-muted-foreground hover:bg-muted"
+                                className="touch-target rounded-full bg-muted flex items-center justify-center text-muted-foreground hover:bg-muted active:bg-muted"
                               >
                                 <Plus size={14} />
                               </button>
@@ -209,7 +209,7 @@ export default function AddonModal({
                     return (
                       <div
                         key={addon.id}
-                        className={`w-full flex items-center justify-between px-3 py-2.5 rounded-lg border text-sm transition-colors ${
+                        className={`w-full min-h-14 flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg border text-sm transition-colors ${
                           isSel
                             ? 'border-brand bg-brand-light text-brand'
                             : 'border-border hover:border-gray-300 dark:hover:border-border dark:border-border'
@@ -227,15 +227,15 @@ export default function AddonModal({
                               <button
                                 type="button"
                                 onClick={() => toggleAddonCheckbox(group, addon)}
-                                className="w-6 h-6 rounded flex items-center justify-center text-brand hover:bg-brand-light"
+                                className="touch-target rounded flex items-center justify-center text-brand hover:bg-brand-light active:bg-brand-light"
                               >
                                 <Minus size={14} />
                               </button>
-                              <span className="text-xs font-bold w-4 text-center text-brand">1</span>
+                              <span className="text-sm font-bold w-5 text-center text-brand tabular-nums">1</span>
                               <button
                                 type="button"
                                 disabled
-                                className="w-6 h-6 rounded flex items-center justify-center text-gray-300 cursor-not-allowed opacity-50"
+                                className="touch-target rounded flex items-center justify-center text-gray-300 cursor-not-allowed opacity-50"
                               >
                                 <Plus size={14} />
                               </button>
@@ -244,7 +244,7 @@ export default function AddonModal({
                             <button
                               type="button"
                               onClick={() => toggleAddonCheckbox(group, addon)}
-                              className="w-6 h-6 rounded-full bg-muted flex items-center justify-center text-muted-foreground hover:bg-muted"
+                              className="touch-target rounded-full bg-muted flex items-center justify-center text-muted-foreground hover:bg-muted active:bg-muted"
                             >
                               <Plus size={14} />
                             </button>
@@ -275,7 +275,7 @@ export default function AddonModal({
               onChange={(e) => setInstructions(e.target.value.slice(0, 100))}
               placeholder={t('specialInstructionsPlaceholder')}
               maxLength={100}
-              className="w-full px-3 py-2 text-sm border border-border rounded-lg outline-none focus:ring-2 focus:ring-brand"
+              className="w-full min-h-11 px-3 py-2 text-sm border border-border rounded-lg outline-none focus:ring-2 focus:ring-brand"
             />
             <p className="text-xs text-gray-400 text-end mt-0.5">{instructions.length}/100</p>
           </div>
@@ -285,16 +285,32 @@ export default function AddonModal({
           <div className="flex items-center justify-center gap-4 mb-4">
             <button
               onClick={() => setQuantity(Math.max(1, quantity - 1))}
-              className="w-8 h-8 rounded-full bg-muted flex items-center justify-center hover:bg-muted"
+              className="touch-target rounded-full bg-muted flex items-center justify-center hover:bg-muted active:bg-muted"
+              aria-label={t('remove')}
             >
-              <Minus size={16} />
+              <Minus size={18} />
             </button>
-            <span className="text-lg font-bold w-8 text-center">{quantity}</span>
+            <div className="grid grid-cols-3 gap-2">
+              {[1, 2, 3].map((quickQty) => (
+                <button
+                  key={quickQty}
+                  type="button"
+                  onClick={() => setQuantity(quickQty)}
+                  className={`touch-target rounded-lg border px-3 text-sm font-bold tabular-nums ${
+                    quantity === quickQty ? 'border-brand bg-brand text-white' : 'border-border bg-card text-foreground'
+                  }`}
+                >
+                  {quickQty}
+                </button>
+              ))}
+            </div>
+            <span className="text-lg font-bold w-10 text-center tabular-nums">{quantity}</span>
             <button
               onClick={() => setQuantity(quantity + 1)}
-              className="w-8 h-8 rounded-full bg-muted flex items-center justify-center hover:bg-muted"
+              className="touch-target rounded-full bg-muted flex items-center justify-center hover:bg-muted active:bg-muted"
+              aria-label={t('addItems')}
             >
-              <Plus size={16} />
+              <Plus size={18} />
             </button>
           </div>
           <Button onClick={handleAdd} disabled={!isValid} className="w-full" size="lg">

--- a/frontend/src/components/pos/CartPanel.tsx
+++ b/frontend/src/components/pos/CartPanel.tsx
@@ -82,7 +82,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
                 <button
                   key={type}
                   onClick={() => cart.setOrderType(type)}
-                  className={`flex-1 flex items-center justify-center gap-1 py-2 rounded-md text-xs font-medium transition-colors ${
+                  className={`touch-target flex-1 gap-1 px-2 rounded-md text-xs font-medium transition-colors ${
                     cart.orderType === type
                       ? 'bg-card text-brand shadow-sm'
                       : 'text-muted-foreground hover:text-foreground'
@@ -99,9 +99,9 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
           <div className="flex items-center justify-between rounded-lg border border-border bg-card px-3 py-2">
             <div className="flex items-center gap-2 text-sm text-muted-foreground"><Users size={15} /><span>{t('pax')}</span></div>
             <div className="flex items-center gap-2">
-              <button type="button" aria-label={t('decreasePax')} onClick={() => cart.setGuestCount(Math.max(1, cart.guestCount - 1))} className="size-7 rounded-full bg-muted flex items-center justify-center"><Minus size={13} /></button>
-              <input aria-label={t('pax')} type="number" min="1" max="99" value={cart.guestCount} onChange={(e) => cart.setGuestCount(Math.min(99, Math.max(1, Number(e.target.value) || 1)))} className="w-10 text-center text-sm font-semibold border-0 outline-none bg-transparent" />
-              <button type="button" aria-label={t('increasePax')} onClick={() => cart.setGuestCount(Math.min(99, cart.guestCount + 1))} className="size-7 rounded-full bg-muted flex items-center justify-center"><Plus size={13} /></button>
+              <button type="button" aria-label={t('decreasePax')} onClick={() => cart.setGuestCount(Math.max(1, cart.guestCount - 1))} className="touch-target rounded-full bg-muted"><Minus size={15} /></button>
+              <input aria-label={t('pax')} inputMode="numeric" type="number" min="1" max="99" value={cart.guestCount} onChange={(e) => cart.setGuestCount(Math.min(99, Math.max(1, Number(e.target.value) || 1)))} className="w-12 text-center text-base font-semibold border-0 outline-none bg-transparent" />
+              <button type="button" aria-label={t('increasePax')} onClick={() => cart.setGuestCount(Math.min(99, cart.guestCount + 1))} className="touch-target rounded-full bg-muted"><Plus size={15} /></button>
             </div>
           </div>
         )}
@@ -115,7 +115,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
               value={cart.deliveryAddress}
               onChange={(e) => cart.setDeliveryAddress(e.target.value)}
               placeholder={t('deliveryAddress')}
-              className="flex-1 px-3 py-1.5 text-sm border border-border bg-card rounded-lg focus:ring-2 focus:ring-brand focus:border-brand outline-none"
+              className="flex-1 min-h-11 px-3 py-2 text-sm border border-border bg-card rounded-lg focus:ring-2 focus:ring-brand focus:border-brand outline-none"
             />
           </div>
         )}
@@ -149,9 +149,10 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
               <div key={item.id} className="flex items-start gap-3">
                 <button
                   onClick={() => cart.removeItem(item.id)}
-                  className="w-6 h-6 rounded-full text-gray-300 hover:text-red-500 hover:bg-red-50 flex items-center justify-center transition-colors mt-0.5 shrink-0"
+                  className="touch-target -ms-2 -mt-2 rounded-full text-gray-300 hover:text-red-500 hover:bg-red-50 active:bg-red-50 transition-colors shrink-0"
+                  aria-label={t('remove')}
                 >
-                  <Trash2 size={13} />
+                  <Trash2 size={16} />
                 </button>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-start justify-between gap-2">
@@ -161,7 +162,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
                     {onEditItem && (
                       <button
                         onClick={() => onEditItem(item)}
-                        className="shrink-0 flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 hover:bg-amber-200 text-xs font-medium transition-colors"
+                        className="touch-target shrink-0 gap-1 rounded-full bg-amber-100 px-3 text-amber-700 hover:bg-amber-200 active:bg-amber-200 text-xs font-medium transition-colors"
                       >
                         <SquarePen size={12} />
                         {tCommon('edit')}
@@ -187,16 +188,18 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
                 <div className="flex items-center gap-1.5 shrink-0">
                   <button
                     onClick={() => cart.updateQuantity(item.id, item.quantity - 1)}
-                    className="w-7 h-7 rounded-full bg-muted flex items-center justify-center hover:bg-muted/70 transition-colors"
+                    className="touch-target rounded-full bg-muted hover:bg-muted/70 active:bg-muted/70 transition-colors"
+                    aria-label={t('remove')}
                   >
-                    <Minus size={14} />
+                    <Minus size={16} />
                   </button>
-                  <span className="text-sm font-medium w-5 text-center">{item.quantity}</span>
+                  <span className="text-base font-semibold w-6 text-center tabular-nums">{item.quantity}</span>
                   <button
                     onClick={() => cart.updateQuantity(item.id, item.quantity + 1)}
-                    className="w-7 h-7 rounded-full bg-muted flex items-center justify-center hover:bg-muted/70 transition-colors"
+                    className="touch-target rounded-full bg-muted hover:bg-muted/70 active:bg-muted/70 transition-colors"
+                    aria-label={t('addItems')}
                   >
-                    <Plus size={14} />
+                    <Plus size={16} />
                   </button>
                 </div>
               </div>
@@ -216,7 +219,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
               placeholder={t('orderNotesPlaceholder')}
               rows={2}
               maxLength={200}
-              className="w-full px-3 py-2 text-sm border border-border bg-card rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-brand/30 focus:border-brand"
+              className="w-full min-h-20 px-3 py-2 text-sm border border-border bg-card rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-brand/30 focus:border-brand"
             />
             <p className="text-xs text-gray-400 text-end mt-0.5">{cart.orderNotes.length}/200</p>
           </div>

--- a/frontend/src/components/pos/CreateCustomerModal.tsx
+++ b/frontend/src/components/pos/CreateCustomerModal.tsx
@@ -72,7 +72,7 @@ export default function CreateCustomerModal({ initialSearch = '', onClose, onCre
       <div className="bg-card rounded-2xl w-full max-w-sm p-5 shadow-xl">
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-bold text-foreground">{t('addCustomer')}</h3>
-          <button onClick={onClose} disabled={saving} className="text-gray-400 hover:text-muted-foreground">
+          <button onClick={onClose} disabled={saving} className="touch-target rounded-full text-gray-400 hover:text-muted-foreground active:bg-muted disabled:opacity-50" aria-label={t('close')}>
             <X size={20} />
           </button>
         </div>

--- a/frontend/src/components/pos/CustomerSearch.tsx
+++ b/frontend/src/components/pos/CustomerSearch.tsx
@@ -203,7 +203,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
   const handleClear = () => cart.setCustomer(null);
 
   // ── Shared input classes ───────────────────────────────────────────────────
-  const baseInput = 'px-3 border border-border rounded-lg focus:ring-2 focus:ring-brand focus:border-brand outline-none text-sm';
+  const baseInput = 'min-h-11 px-3 border border-border rounded-lg focus:ring-2 focus:ring-brand focus:border-brand outline-none text-sm';
 
   // ── Customer already selected ──────────────────────────────────────────────
   if (customer) {
@@ -212,15 +212,15 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
     if (variant === 'topbar') {
       return (
         <>
-          <div className="h-10 flex items-center gap-2 px-3 bg-brand-light rounded-lg min-w-0 w-full">
+          <div className="min-h-11 flex items-center gap-2 px-3 bg-brand-light rounded-lg min-w-0 w-full">
             <button
               onClick={() => setEditingCustomer(true)}
               title={t('editCustomer')}
-              className="flex-1 min-w-0 flex items-center gap-x-2 flex-wrap text-start group"
+              className="touch-target flex-1 min-w-0 justify-start gap-x-2 flex-wrap text-start"
             >
-              <span className="font-semibold text-brand text-sm truncate group-hover:underline">{customer.name}</span>
+              <span className="font-semibold text-brand text-sm truncate">{customer.name}</span>
               <span className="text-brand/70 text-xs shrink-0"><Ltr>{customer.phone}</Ltr></span>
-              <Pencil size={11} className="text-brand/50 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+              <Pencil size={14} className="text-brand/60 shrink-0" />
               {!!loyaltyPoints && loyaltyPoints > 0 && (
                 <span className="flex items-center gap-0.5 text-xs font-medium text-brand bg-card/70 rounded-full px-1.5 py-0.5 shrink-0">
                   <Gift size={11} />
@@ -229,8 +229,8 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
               )}
               {hasTags && <TagBadges counts={customer.tag_counts!} />}
             </button>
-            <button onClick={handleClear} className="text-brand hover:text-brand-hover shrink-0 ms-auto">
-              <X size={14} />
+            <button onClick={handleClear} className="touch-target rounded-full text-brand hover:text-brand-hover active:bg-card/60 shrink-0 ms-auto" aria-label={t('remove')}>
+              <X size={16} />
             </button>
           </div>
           {editingCustomer && (
@@ -247,13 +247,13 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
     return (
       <div className="space-y-1">
         <div className="flex items-center justify-between px-3 py-2 bg-brand-light rounded-lg text-sm">
-          <button onClick={() => setEditingCustomer(true)} className="flex-1 min-w-0 flex items-center gap-2 text-start group">
-            <span className="font-medium text-brand truncate group-hover:underline">{customer.name}</span>
+          <button onClick={() => setEditingCustomer(true)} className="touch-target flex-1 min-w-0 justify-start gap-2 text-start">
+            <span className="font-medium text-brand truncate">{customer.name}</span>
             {customer.phone && <span className="text-xs text-muted-foreground"><Ltr>{customer.phone}</Ltr></span>}
-            <Pencil size={11} className="text-brand/50 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+            <Pencil size={14} className="text-brand/60 shrink-0" />
           </button>
-          <button onClick={handleClear} className="text-brand hover:text-brand-hover ms-2 shrink-0">
-            <X size={14} />
+          <button onClick={handleClear} className="touch-target rounded-full text-brand hover:text-brand-hover active:bg-card/60 ms-2 shrink-0" aria-label={t('remove')}>
+            <X size={16} />
           </button>
         </div>
         {!!loyaltyPoints && loyaltyPoints > 0 && (
@@ -312,7 +312,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
           {matched && (
             <button
               onClick={handleSelectMatched}
-              className="h-10 shrink-0 px-3 bg-brand text-white text-xs rounded-lg hover:bg-brand-hover whitespace-nowrap"
+              className="touch-target shrink-0 px-3 bg-brand text-white text-xs rounded-lg hover:bg-brand-hover active:bg-brand-hover whitespace-nowrap"
             >
               {t('select')}
             </button>
@@ -321,7 +321,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
             <button
               onClick={handleCreate}
               disabled={creating}
-              className="h-10 shrink-0 px-3 bg-brand text-white text-xs rounded-lg hover:bg-brand-hover disabled:opacity-50 whitespace-nowrap"
+              className="touch-target shrink-0 px-3 bg-brand text-white text-xs rounded-lg hover:bg-brand-hover active:bg-brand-hover disabled:opacity-50 whitespace-nowrap"
             >
               {creating ? t('loadingEllipsis') : tCommon('add')}
             </button>
@@ -383,7 +383,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
               {matched.tag_counts && <TagBadges counts={matched.tag_counts} />}
               <button
                 onClick={handleSelectMatched}
-                className="w-full py-1.5 bg-brand text-white text-sm rounded-lg hover:bg-brand-hover"
+                className="touch-target w-full bg-brand text-white text-sm rounded-lg hover:bg-brand-hover active:bg-brand-hover"
               >
                 {t('selectName', { name: matched.name })}
               </button>
@@ -395,7 +395,7 @@ export default function CustomerSearch({ onSelected, variant = 'default' }: Prop
                 <button
                   onClick={handleCreate}
                   disabled={creating}
-                  className="w-full py-1.5 bg-brand text-white text-sm rounded-lg hover:bg-brand-hover disabled:opacity-50"
+                  className="touch-target w-full bg-brand text-white text-sm rounded-lg hover:bg-brand-hover active:bg-brand-hover disabled:opacity-50"
                 >
                   {creating ? t('creating') : t('addName', { name: name.trim() })}
                 </button>

--- a/frontend/src/components/pos/EditCustomerModal.tsx
+++ b/frontend/src/components/pos/EditCustomerModal.tsx
@@ -60,7 +60,7 @@ export default function EditCustomerModal({ customer, onClose, onSaved }: Props)
       <div className="bg-card rounded-2xl w-full max-w-sm p-5">
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-bold text-foreground">{t('editCustomer')}</h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-muted-foreground">
+          <button onClick={onClose} className="touch-target rounded-full text-gray-400 hover:text-muted-foreground active:bg-muted" aria-label={t('close')}>
             <X size={20} />
           </button>
         </div>
@@ -71,7 +71,7 @@ export default function EditCustomerModal({ customer, onClose, onSaved }: Props)
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full px-3 py-2 text-sm border border-border rounded-lg focus:ring-2 focus:ring-brand focus:border-brand outline-none"
+              className="w-full min-h-11 px-3 py-2 text-sm border border-border rounded-lg focus:ring-2 focus:ring-brand focus:border-brand outline-none"
               autoFocus
             />
           </div>
@@ -83,7 +83,7 @@ export default function EditCustomerModal({ customer, onClose, onSaved }: Props)
               value={phone}
               onChange={(e) => setPhone(e.target.value)}
               placeholder={dialCode}
-              className="w-full px-3 py-2 text-sm border border-border rounded-lg focus:ring-2 focus:ring-brand focus:border-brand outline-none"
+              className="w-full min-h-11 px-3 py-2 text-sm border border-border rounded-lg focus:ring-2 focus:ring-brand focus:border-brand outline-none"
               dir="ltr"
             />
           </div>

--- a/frontend/src/components/pos/PaymentModal.tsx
+++ b/frontend/src/components/pos/PaymentModal.tsx
@@ -18,6 +18,7 @@ import { useCurrencyUnitAdapter } from '@/hooks/useCurrencyUnitAdapter';
 import { useWhatsAppReady } from '@/hooks/useWhatsAppReady';
 import { sendBillViaFlo, shareBillViaWhatsApp } from '@/lib/whatsapp-share';
 import { useAuthStore } from '@/store/auth';
+import TouchNumberPad from '@/components/pos/TouchNumberPad';
 import {
   defaultDiscountTypeForMode,
   isDiscountTypeAllowed,
@@ -39,6 +40,8 @@ interface Payment {
   payment_method_id?: number;
   amount: string;
 }
+
+type AmountTarget = { kind: 'payment'; index: number } | { kind: 'wallet' } | { kind: 'discount' } | null;
 
 // Loyalty points are 1:1 with currency units. Must match LOYALTY_REDEMPTION_RATE in main/routes/bills.ts.
 const LOYALTY_REDEMPTION_RATE = 1;
@@ -109,6 +112,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
   const [discountPin, setDiscountPin] = useState('');
   const [applyingDiscount, setApplyingDiscount] = useState(false);
   const [loyaltySettings, setLoyaltySettings] = useState<{ loyalty_enabled: boolean } | null>(null);
+  const [amountTarget, setAmountTarget] = useState<AmountTarget>(null);
 
   // Sync state with active bill discount on load or update. Read directly during render
   // (React's recommended pattern for "adjusting state when a prop changes") instead of an
@@ -190,7 +194,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
 
   const updatePaymentAmount = (idx: number, value: string) => {
     setPaymentsTouched(true);
-    setPayments(payments.map((payment, index) => index === idx ? { ...payment, amount: value } : payment));
+    setPayments((current) => current.map((payment, index) => index === idx ? { ...payment, amount: value } : payment));
   };
 
   const allocateRemainingTo = (idx: number) => {
@@ -200,6 +204,54 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
     setPaymentsTouched(true);
     setPayments(payments.map((payment, index) => index === idx ? { ...payment, amount: dueDisplay > 0 ? String(dueDisplay) : '' } : payment));
   };
+
+  const activeAmountValue = amountTarget?.kind === 'payment'
+    ? payments[amountTarget.index]?.amount || ''
+    : amountTarget?.kind === 'wallet'
+      ? walletAmount
+      : amountTarget?.kind === 'discount'
+        ? discountValue
+        : '';
+
+  const updateActiveAmount = (value: string) => {
+    if (!amountTarget) return;
+    if (amountTarget.kind === 'payment') {
+      updatePaymentAmount(amountTarget.index, value);
+      return;
+    }
+    if (amountTarget.kind === 'wallet') {
+      const maxWalletCurrencyStored = Math.floor((walletBalance || 0) / LOYALTY_REDEMPTION_RATE);
+      const maxDisplay = toDisplayUnit(Math.min(maxWalletCurrencyStored, remaining));
+      const clamped = parseFloat(value) > maxDisplay ? String(maxDisplay) : value;
+      setWalletAmount(clamped);
+      setPaymentsTouched(true);
+      return;
+    }
+    setDiscountValue(value);
+  };
+
+  const activeAmountMax = amountTarget?.kind === 'discount'
+    ? discountType === 'percentage' ? 100 : toDisplayUnit(Number(bill.subtotal))
+    : amountTarget?.kind === 'wallet'
+      ? toDisplayUnit(Math.min(Math.floor((walletBalance || 0) / LOYALTY_REDEMPTION_RATE), remaining))
+      : undefined;
+
+  const activeAmountQuickValues = (() => {
+    if (amountTarget?.kind === 'payment') {
+      const allocatedElsewhere = payments.reduce((sum, payment, index) => (
+        index === amountTarget.index ? sum : sum + toStoredUnit(parseFloat(payment.amount) || 0)
+      ), walletAmt);
+      const dueDisplay = toDisplayUnit(Math.max(0, remaining - allocatedElsewhere));
+      return dueDisplay > 0 ? [{ label: t('exactAmount'), value: String(dueDisplay) }] : [];
+    }
+    if (amountTarget?.kind === 'wallet') {
+      const allocatedElsewhere = payments.reduce((sum, payment) => sum + toStoredUnit(parseFloat(payment.amount) || 0), 0);
+      const maxWalletStored = Math.floor((walletBalance || 0) / LOYALTY_REDEMPTION_RATE);
+      const dueDisplay = toDisplayUnit(Math.min(maxWalletStored, Math.max(0, remaining - allocatedElsewhere)));
+      return dueDisplay > 0 ? [{ label: t('exactAmount'), value: String(dueDisplay) }] : [];
+    }
+    return [];
+  })();
 
   const hasCash = payments.some((p) => p.method === 'cash' && (parseFloat(p.amount) || 0) > 0);
 
@@ -390,7 +442,8 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
           </div>
           <button
             onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center rounded-full bg-muted hover:bg-muted text-muted-foreground transition-colors"
+            className="touch-target rounded-full bg-muted hover:bg-muted active:bg-muted text-muted-foreground transition-colors"
+            aria-label={t('close')}
           >
             <X size={16} />
           </button>
@@ -472,7 +525,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
 
           {/* Discount */}
           {!bill.split_group_id && <div className="rounded-xl border border-border overflow-hidden">
-            <button type="button" onClick={() => setShowDiscount((open) => !open)} className="w-full flex items-center justify-between gap-3 px-3 py-2.5 bg-muted text-start">
+            <button type="button" onClick={() => setShowDiscount((open) => !open)} className="touch-target w-full justify-between gap-3 px-3 bg-muted text-start">
               <span className="text-sm font-medium text-foreground">
                 {Number(bill.discount_amount) > 0
                   ? `${t('discount')}: -${currencyFmt(Number(bill.discount_amount))}`
@@ -487,7 +540,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   {isDiscountTypeAllowed(discountMode, 'percentage') && (
                     <button
                       onClick={() => { setDiscountType('percentage'); }}
-                      className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors ${discountType === 'percentage' ? 'bg-purple-600 text-white' : 'bg-card text-muted-foreground hover:bg-muted'}`}
+                      className={`touch-target flex-1 gap-1.5 text-sm font-medium transition-colors ${discountType === 'percentage' ? 'bg-purple-600 text-white' : 'bg-card text-muted-foreground hover:bg-muted'}`}
                     >
                       <Percent size={14} />
                       {t('percentage')}
@@ -496,7 +549,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   {isDiscountTypeAllowed(discountMode, 'amount') && (
                     <button
                       onClick={() => { setDiscountType('amount'); }}
-                      className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors ${discountType === 'amount' ? 'bg-purple-600 text-white' : 'bg-card text-muted-foreground hover:bg-muted'}`}
+                      className={`touch-target flex-1 gap-1.5 text-sm font-medium transition-colors ${discountType === 'amount' ? 'bg-purple-600 text-white' : 'bg-card text-muted-foreground hover:bg-muted'}`}
                     >
                       {t('flatAmount')}
                     </button>
@@ -509,12 +562,14 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   <input
                     type="number"
                     value={discountValue}
+                    onFocus={() => setAmountTarget({ kind: 'discount' })}
                     onChange={(e) => setDiscountValue(e.target.value)}
                     placeholder={discountType === 'percentage' ? '0' : '0.00'}
                     min="0"
                     max={discountType === 'percentage' ? 100 : toDisplayUnit(Number(bill.subtotal))}
                     step={discountType === 'percentage' ? 1 : inputCurrencyStep}
-                    className="w-full ps-8 pe-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
+                    inputMode={discountType === 'percentage' ? 'numeric' : 'decimal'}
+                    className="w-full min-h-11 ps-8 pe-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
                   />
                 </div>
                 <input
@@ -522,7 +577,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   value={discountReason}
                   onChange={(e) => setDiscountReason(e.target.value)}
                   placeholder={t('discountReasonPlaceholder')}
-                  className="w-full px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
+                  className="w-full min-h-11 px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
                 />
                 {discountRequiresApproval && parseFloat(discountValue) > 0 && (
                   <input
@@ -531,11 +586,10 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                     onChange={(e) => setDiscountPin(e.target.value)}
                     placeholder={t('managerPin')}
                     maxLength={6}
-                    className="w-full px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
+                    className="w-full min-h-11 px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
                   />
                 )}
                 <Button
-                  size="sm"
                   onClick={() => handleApplyDiscount()}
                   disabled={applyingDiscount || discountValue === '' || isNaN(parseFloat(discountValue))}
                   className="w-full bg-purple-600 hover:bg-purple-700 text-white"
@@ -545,7 +599,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                     : Number(bill.discount_amount) > 0 ? t('updateDiscount') : t('applyDiscount')}
                 </Button>
                 {Number(bill.discount_amount) > 0 && (
-                  <Button variant="outline" size="sm" className="w-full" onClick={async () => {
+                  <Button variant="outline" className="w-full" onClick={async () => {
                     if (await confirm(t('removeDiscountConfirm'), { destructive: true, confirmLabel: t('remove') })) void handleApplyDiscount(0);
                   }}>
                     {t('remove')}
@@ -562,8 +616,8 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
               const label = builtIn ? t(BUILT_IN_PAYMENT_KEYS[builtIn.key]) : custom?.name || tCommon('unknown');
               const Icon = builtIn?.icon;
               const active = (parseFloat(payment.amount) || 0) > 0;
-              return <div key={payment.payment_method_id === undefined ? payment.method : `custom:${payment.payment_method_id}`} className="flex h-11">
-                <button type="button" title={label} onClick={() => allocateRemainingTo(idx)} className={`w-36 shrink-0 rounded-s-xl border px-3 flex items-center gap-2 text-sm font-semibold transition-colors ${active ? 'bg-brand text-white border-brand' : 'bg-muted text-foreground border-border hover:border-brand hover:text-brand'}`}>
+              return <div key={payment.payment_method_id === undefined ? payment.method : `custom:${payment.payment_method_id}`} className="flex min-h-12">
+                <button type="button" title={label} onClick={() => { setAmountTarget({ kind: 'payment', index: idx }); allocateRemainingTo(idx); }} className={`touch-target w-36 shrink-0 justify-start rounded-s-xl border px-3 gap-2 text-sm font-semibold transition-colors ${active ? 'bg-brand text-white border-brand' : 'bg-muted text-foreground border-border hover:border-brand hover:text-brand'}`}>
                   {Icon && <Icon size={15} />}
                   <span className="truncate">{label}</span>
                 </button>
@@ -572,9 +626,11 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   <input
                     type="number"
                     value={payment.amount}
+                    onFocus={() => setAmountTarget({ kind: 'payment', index: idx })}
                     onChange={(e) => updatePaymentAmount(idx, e.target.value)}
                     placeholder="0.00"
-                    className="min-w-0 flex-1 px-2 py-2 text-end text-sm font-semibold outline-none rounded-e-xl"
+                    inputMode="decimal"
+                    className="min-w-0 flex-1 px-2 py-2 text-end text-base font-semibold outline-none rounded-e-xl"
                     step={inputCurrencyStep}
                     min="0"
                   />
@@ -616,14 +672,15 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
           {/* Loyalty Wallet Section */}
           {loyaltySettings?.loyalty_enabled && effectiveCustomerId && walletBalance !== null && (
             <div className="space-y-1">
-              <div className="flex h-11">
+              <div className="flex min-h-12">
                 <button type="button" disabled={walletBalance <= 0} onClick={() => {
                   const allocatedElsewhere = payments.reduce((sum, payment) => sum + toStoredUnit(parseFloat(payment.amount) || 0), 0);
                   const maxWalletStored = Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE);
                   const dueStored = Math.min(maxWalletStored, Math.max(0, remaining - allocatedElsewhere));
                   const dueDisplay = toDisplayUnit(dueStored);
                   setWalletAmount(dueDisplay > 0 ? String(dueDisplay) : '');
-                }} className={`w-36 shrink-0 rounded-s-xl border px-3 flex items-center gap-2 text-sm font-semibold ${walletAmt > 0 ? 'bg-purple-600 text-white border-purple-600' : 'bg-purple-50 text-purple-800 border-purple-200 disabled:bg-muted disabled:text-gray-400 disabled:border-border'}`}>
+                  setAmountTarget({ kind: 'wallet' });
+                }} className={`touch-target w-36 shrink-0 justify-start rounded-s-xl border px-3 gap-2 text-sm font-semibold ${walletAmt > 0 ? 'bg-purple-600 text-white border-purple-600' : 'bg-purple-50 text-purple-800 border-purple-200 disabled:bg-muted disabled:text-gray-400 disabled:border-border'}`}>
                   <Wallet size={15} /><span className="truncate">{t('loyaltyWallet')}</span>
                 </button>
                 <div className="flex flex-1 items-center border border-s-0 border-purple-200 rounded-e-xl bg-card focus-within:ring-2 focus-within:ring-purple-400">
@@ -631,6 +688,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                   <input
                     type="number"
                     value={walletAmount}
+                    onFocus={() => setAmountTarget({ kind: 'wallet' })}
                     onChange={(e) => {
                       const v = e.target.value;
                       const maxWalletCurrencyStored = Math.floor(walletBalance / (LOYALTY_REDEMPTION_RATE));
@@ -640,7 +698,8 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                     }}
                     placeholder="0.00"
                     disabled={walletBalance <= 0}
-                    className="min-w-0 flex-1 px-2 py-2 text-end text-sm font-semibold outline-none rounded-e-xl disabled:bg-muted"
+                    inputMode="decimal"
+                    className="min-w-0 flex-1 px-2 py-2 text-end text-base font-semibold outline-none rounded-e-xl disabled:bg-muted"
                     step={inputCurrencyStep}
                     min="0"
                     max={toDisplayUnit(Math.min(Math.floor(walletBalance / (LOYALTY_REDEMPTION_RATE)), remaining))}
@@ -649,6 +708,18 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
               </div>
               <p className="px-1 text-[11px] text-gray-400 text-end">{walletBalance > 0 ? t('pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE)) }) : t('noBalance')}</p>
             </div>
+          )}
+          {amountTarget && (
+            <TouchNumberPad
+              value={activeAmountValue}
+              onChange={updateActiveAmount}
+              ariaLabel={t('numericKeypad')}
+              clearLabel={t('clearAmount')}
+              backspaceLabel={t('backspaceAmount')}
+              allowDecimal={amountTarget.kind !== 'discount' || discountType === 'amount'}
+              max={activeAmountMax}
+              quickValues={activeAmountQuickValues}
+            />
           )}
         </div>
 

--- a/frontend/src/components/pos/PosTopbar.tsx
+++ b/frontend/src/components/pos/PosTopbar.tsx
@@ -5,16 +5,18 @@ import CustomerSearch from './CustomerSearch';
 import { useCartStore } from '@/store/cart';
 import { useAuthStore } from '@/store/auth';
 import { usePosSettingsStore } from '@/store/pos-settings';
-import { LayoutGrid } from 'lucide-react';
+import { LayoutGrid, Maximize2, Minimize2 } from 'lucide-react';
 import type { Table } from '@/lib/types';
 import { useTranslations } from 'use-intl';
 
 interface Props {
   tables: Table[];
   onShowTablePicker: () => void;
+  fullscreen: boolean;
+  onToggleFullscreen: () => void;
 }
 
-export default function PosTopbar({ tables, onShowTablePicker }: Props) {
+export default function PosTopbar({ tables, onShowTablePicker, fullscreen, onToggleFullscreen }: Props) {
   const cart = useCartStore();
   const { currentTenant } = useAuthStore();
   const tablesRequired = usePosSettingsStore((s) => s.tablesRequired);
@@ -32,7 +34,7 @@ export default function PosTopbar({ tables, onShowTablePicker }: Props) {
       {showTableBtn && (
         <button
           onClick={onShowTablePicker}
-          className={`h-10 shrink-0 flex items-center gap-1.5 px-3 text-sm rounded-lg border font-medium transition-colors whitespace-nowrap ${
+          className={`touch-target shrink-0 gap-1.5 px-3 text-sm rounded-lg border font-medium transition-colors whitespace-nowrap ${
             cart.tableId
               ? 'bg-orange-500 text-white border-orange-500 hover:bg-orange-600'
               : 'bg-amber-50 border-amber-400 text-amber-700 hover:bg-amber-100'
@@ -48,6 +50,15 @@ export default function PosTopbar({ tables, onShowTablePicker }: Props) {
       <div className="shrink-0">
         <PrinterStatus />
       </div>
+      <button
+        type="button"
+        onClick={onToggleFullscreen}
+        className="touch-target shrink-0 rounded-lg border border-border bg-card px-3 text-muted-foreground transition-colors hover:bg-muted active:bg-muted"
+        title={fullscreen ? t('exitFullscreen') : t('enterFullscreen')}
+        aria-label={fullscreen ? t('exitFullscreen') : t('enterFullscreen')}
+      >
+        {fullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/pos/PrepaidCheckoutModal.tsx
+++ b/frontend/src/components/pos/PrepaidCheckoutModal.tsx
@@ -13,6 +13,7 @@ import { PAYMENT_METHODS, type CustomPaymentMethod } from '@/lib/payment-methods
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useFormatNumber } from '@/hooks/useFormatNumber';
 import { useCurrencyUnitAdapter } from '@/hooks/useCurrencyUnitAdapter';
+import TouchNumberPad from '@/components/pos/TouchNumberPad';
 import {
   defaultDiscountTypeForMode,
   isDiscountTypeAllowed,
@@ -71,6 +72,8 @@ interface Payment {
   amount: string;
 }
 
+type AmountTarget = { kind: 'payment'; index: number } | { kind: 'wallet' } | { kind: 'discount' } | null;
+
 export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
   const cart = useCartStore();
   const customer = cart.customer;
@@ -95,6 +98,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
   const [discountMode, setDiscountMode] = useState<DiscountMode>('percentage');
   const [discountRequiresApproval, setDiscountRequiresApproval] = useState(false);
   const [discountPin, setDiscountPin] = useState('');
+  const [amountTarget, setAmountTarget] = useState<AmountTarget>(null);
 
   const previewDiscount = useMemo(() => {
     const rawValue = Number.parseFloat(discountValue);
@@ -213,7 +217,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
 
   const updatePaymentAmount = (idx: number, value: string) => {
     setPaymentsTouched(true);
-    setPayments(payments.map((payment, index) => index === idx ? { ...payment, amount: value } : payment));
+    setPayments((current) => current.map((payment, index) => index === idx ? { ...payment, amount: value } : payment));
   };
 
   const allocateRemainingTo = (idx: number) => {
@@ -228,6 +232,55 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
   const change = hasCash && totalPayment > remaining + 0.009
     ? parseFloat((totalPayment - remaining).toFixed(2))
     : 0;
+
+  const activeAmountValue = amountTarget?.kind === 'payment'
+    ? payments[amountTarget.index]?.amount || ''
+    : amountTarget?.kind === 'wallet'
+      ? walletAmount
+      : amountTarget?.kind === 'discount'
+        ? discountValue
+        : '';
+
+  const updateActiveAmount = (value: string) => {
+    if (!amountTarget) return;
+    if (amountTarget.kind === 'payment') {
+      updatePaymentAmount(amountTarget.index, value);
+      return;
+    }
+    if (amountTarget.kind === 'wallet') {
+      const maxWalletCurrencyStored = Math.floor((walletBalance || 0) / LOYALTY_REDEMPTION_RATE);
+      const maxDisplay = toDisplayUnit(Math.min(maxWalletCurrencyStored, remaining));
+      const clamped = parseFloat(value) > maxDisplay ? String(maxDisplay) : value;
+      setWalletAmount(clamped);
+      setPaymentsTouched(true);
+      return;
+    }
+    setDiscountValue(value);
+    setPaymentsTouched(false);
+  };
+
+  const activeAmountMax = amountTarget?.kind === 'discount'
+    ? discountType === 'percentage' ? 100 : preview ? toDisplayUnit(preview.subtotal) : undefined
+    : amountTarget?.kind === 'wallet'
+      ? toDisplayUnit(Math.min(Math.floor((walletBalance || 0) / LOYALTY_REDEMPTION_RATE), remaining))
+      : undefined;
+
+  const activeAmountQuickValues = (() => {
+    if (amountTarget?.kind === 'payment') {
+      const allocatedElsewhere = payments.reduce((sum, payment, index) => (
+        index === amountTarget.index ? sum : sum + toStoredUnit(parseFloat(payment.amount) || 0)
+      ), walletAmt);
+      const dueDisplay = toDisplayUnit(Math.max(0, remaining - allocatedElsewhere));
+      return dueDisplay > 0 ? [{ label: t('exactAmount'), value: String(dueDisplay) }] : [];
+    }
+    if (amountTarget?.kind === 'wallet') {
+      const allocatedElsewhere = payments.reduce((sum, payment) => sum + toStoredUnit(parseFloat(payment.amount) || 0), 0);
+      const maxWalletStored = Math.floor((walletBalance || 0) / LOYALTY_REDEMPTION_RATE);
+      const dueDisplay = toDisplayUnit(Math.min(maxWalletStored, Math.max(0, remaining - allocatedElsewhere)));
+      return dueDisplay > 0 ? [{ label: t('exactAmount'), value: String(dueDisplay) }] : [];
+    }
+    return [];
+  })();
 
   const handleConfirm = () => {
     if (!preview) return;
@@ -306,7 +359,8 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
           </div>
           <button
             onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center rounded-full bg-muted hover:bg-muted text-muted-foreground transition-colors"
+            className="touch-target rounded-full bg-muted hover:bg-muted active:bg-muted text-muted-foreground transition-colors"
+            aria-label={t('close')}
           >
             <X size={16} />
           </button>
@@ -387,7 +441,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
 
           {/* Discount */}
           <div className="rounded-xl border border-border overflow-hidden">
-            <button type="button" onClick={() => setDiscountOpen((open) => !open)} className="w-full flex items-center justify-between gap-3 px-3 py-2.5 bg-muted text-start">
+            <button type="button" onClick={() => setDiscountOpen((open) => !open)} className="touch-target w-full justify-between gap-3 px-3 bg-muted text-start">
               <span className="text-sm font-medium text-foreground">
                 {preview?.discountAmount ? `${t('discount')}: -${currencyFmt(preview.discountAmount)}` : t('applyDiscount')}
               </span>
@@ -400,7 +454,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   {isDiscountTypeAllowed(discountMode, 'percentage') && (
                     <button
                       onClick={() => setDiscountType('percentage')}
-                      className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors ${discountType === 'percentage' ? 'bg-purple-600 text-white' : 'bg-card text-muted-foreground hover:bg-muted'}`}
+                      className={`touch-target flex-1 gap-1.5 text-sm font-medium transition-colors ${discountType === 'percentage' ? 'bg-purple-600 text-white' : 'bg-card text-muted-foreground hover:bg-muted'}`}
                     >
                       <Percent size={14} />
                       {t('percentage')}
@@ -409,7 +463,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   {isDiscountTypeAllowed(discountMode, 'amount') && (
                     <button
                       onClick={() => setDiscountType('amount')}
-                      className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors ${discountType === 'amount' ? 'bg-purple-600 text-white' : 'bg-card text-muted-foreground hover:bg-muted'}`}
+                      className={`touch-target flex-1 gap-1.5 text-sm font-medium transition-colors ${discountType === 'amount' ? 'bg-purple-600 text-white' : 'bg-card text-muted-foreground hover:bg-muted'}`}
                     >
                       {t('flatAmount')}
                     </button>
@@ -422,12 +476,14 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   <input
                     type="number"
                     value={discountValue}
+                    onFocus={() => setAmountTarget({ kind: 'discount' })}
                     onChange={(e) => setDiscountValue(e.target.value)}
                     placeholder={discountType === 'percentage' ? '0' : '0.00'}
                     min="0"
                     max={discountType === 'percentage' ? 100 : (preview ? toDisplayUnit(preview.subtotal) : undefined)}
                     step={discountType === 'percentage' ? 1 : inputCurrencyStep}
-                    className="w-full ps-8 pe-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
+                    inputMode={discountType === 'percentage' ? 'numeric' : 'decimal'}
+                    className="w-full min-h-11 ps-8 pe-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
                   />
                 </div>
                 <input
@@ -435,7 +491,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   value={discountReason}
                   onChange={(e) => setDiscountReason(e.target.value)}
                   placeholder={t('discountReasonPlaceholder')}
-                  className="w-full px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
+                  className="w-full min-h-11 px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
                 />
                 {discountRequiresApproval && parseFloat(discountValue) > 0 && (
                   <input
@@ -444,7 +500,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                     onChange={(e) => setDiscountPin(e.target.value)}
                     placeholder={t('managerPin')}
                     maxLength={6}
-                    className="w-full px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
+                    className="w-full min-h-11 px-3 py-2 text-sm border border-purple-200 rounded-lg outline-none focus:ring-2 focus:ring-purple-400 bg-card"
                   />
                 )}
                 {discountValue && (
@@ -469,8 +525,8 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
               const label = builtIn ? t(BUILT_IN_PAYMENT_KEYS[builtIn.key]) : custom?.name || tCommon('unknown');
               const Icon = builtIn?.icon;
               const active = (parseFloat(payment.amount) || 0) > 0;
-              return <div key={payment.payment_method_id === undefined ? payment.method : `custom:${payment.payment_method_id}`} className="flex h-11">
-                <button type="button" title={label} onClick={() => allocateRemainingTo(idx)} className={`w-36 shrink-0 rounded-s-xl border px-3 flex items-center gap-2 text-sm font-semibold transition-colors ${active ? 'bg-brand text-white border-brand' : 'bg-muted text-foreground border-border hover:border-brand hover:text-brand'}`}>
+              return <div key={payment.payment_method_id === undefined ? payment.method : `custom:${payment.payment_method_id}`} className="flex min-h-12">
+                <button type="button" title={label} onClick={() => { setAmountTarget({ kind: 'payment', index: idx }); allocateRemainingTo(idx); }} className={`touch-target w-36 shrink-0 justify-start rounded-s-xl border px-3 gap-2 text-sm font-semibold transition-colors ${active ? 'bg-brand text-white border-brand' : 'bg-muted text-foreground border-border hover:border-brand hover:text-brand'}`}>
                   {Icon && <Icon size={15} />}
                   <span className="truncate">{label}</span>
                 </button>
@@ -479,9 +535,11 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   <input
                     type="number"
                     value={payment.amount}
+                    onFocus={() => setAmountTarget({ kind: 'payment', index: idx })}
                     onChange={(e) => updatePaymentAmount(idx, e.target.value)}
                     placeholder="0.00"
-                    className="min-w-0 flex-1 px-2 py-2 text-end text-sm font-semibold outline-none rounded-e-xl"
+                    inputMode="decimal"
+                    className="min-w-0 flex-1 px-2 py-2 text-end text-base font-semibold outline-none rounded-e-xl"
                     step={inputCurrencyStep}
                     min="0"
                   />
@@ -523,14 +581,15 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
           {/* Loyalty Wallet Section */}
           {loyaltySettings?.loyalty_enabled && customer && walletBalance !== null && (
             <div className="space-y-1">
-              <div className="flex h-11">
+              <div className="flex min-h-12">
                 <button type="button" disabled={walletBalance <= 0} onClick={() => {
                   const allocatedElsewhere = payments.reduce((sum, payment) => sum + toStoredUnit(parseFloat(payment.amount) || 0), 0);
                   const maxWalletStored = Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE);
                   const dueStored = Math.min(maxWalletStored, Math.max(0, remaining - allocatedElsewhere));
                   const dueDisplay = toDisplayUnit(dueStored);
                   setWalletAmount(dueDisplay > 0 ? String(dueDisplay) : '');
-                }} className={`w-36 shrink-0 rounded-s-xl border px-3 flex items-center gap-2 text-sm font-semibold ${walletAmt > 0 ? 'bg-purple-600 text-white border-purple-600' : 'bg-purple-50 text-purple-800 border-purple-200 disabled:bg-muted disabled:text-gray-400 disabled:border-border'}`}>
+                  setAmountTarget({ kind: 'wallet' });
+                }} className={`touch-target w-36 shrink-0 justify-start rounded-s-xl border px-3 gap-2 text-sm font-semibold ${walletAmt > 0 ? 'bg-purple-600 text-white border-purple-600' : 'bg-purple-50 text-purple-800 border-purple-200 disabled:bg-muted disabled:text-gray-400 disabled:border-border'}`}>
                   <Wallet size={15} /><span className="truncate">{t('loyaltyWallet')}</span>
                 </button>
                 <div className="flex flex-1 items-center border border-s-0 border-purple-200 rounded-e-xl bg-card focus-within:ring-2 focus-within:ring-purple-400">
@@ -538,6 +597,7 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                   <input
                     type="number"
                     value={walletAmount}
+                    onFocus={() => setAmountTarget({ kind: 'wallet' })}
                     onChange={(e) => {
                       const v = e.target.value;
                       const maxWalletCurrencyStored = Math.floor(walletBalance / (LOYALTY_REDEMPTION_RATE));
@@ -547,7 +607,8 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
                     }}
                     placeholder="0.00"
                     disabled={walletBalance <= 0}
-                    className="min-w-0 flex-1 px-2 py-2 text-end text-sm font-semibold outline-none rounded-e-xl disabled:bg-muted"
+                    inputMode="decimal"
+                    className="min-w-0 flex-1 px-2 py-2 text-end text-base font-semibold outline-none rounded-e-xl disabled:bg-muted"
                     step={inputCurrencyStep}
                     min="0"
                     max={toDisplayUnit(Math.min(Math.floor(walletBalance / (LOYALTY_REDEMPTION_RATE)), remaining))}
@@ -556,6 +617,18 @@ export default function PrepaidCheckoutModal({ onClose, onConfirm }: Props) {
               </div>
               <p className="px-1 text-[11px] text-gray-400 text-end">{walletBalance > 0 ? t('pointsApproxValue', { count: fmtNum(walletBalance), value: currencyFmt(Math.floor(walletBalance / LOYALTY_REDEMPTION_RATE)) }) : t('noBalance')}</p>
             </div>
+          )}
+          {amountTarget && (
+            <TouchNumberPad
+              value={activeAmountValue}
+              onChange={updateActiveAmount}
+              ariaLabel={t('numericKeypad')}
+              clearLabel={t('clearAmount')}
+              backspaceLabel={t('backspaceAmount')}
+              allowDecimal={amountTarget.kind !== 'discount' || discountType === 'amount'}
+              max={activeAmountMax}
+              quickValues={activeAmountQuickValues}
+            />
           )}
         </div>
 

--- a/frontend/src/components/pos/ProductGrid.tsx
+++ b/frontend/src/components/pos/ProductGrid.tsx
@@ -142,11 +142,12 @@ export default function ProductGrid({
             
 
             return (
-              <div
+              <button
                 key={product.id}
                 data-testid="pos-product-card"
+                type="button"
                 onClick={() => onProductClick(product)}
-                className="bg-card rounded-xl p-2.5 border border-border hover:border-brand/40 hover:shadow-md transition-all text-start relative group cursor-pointer overflow-hidden"
+                className="min-h-36 bg-card rounded-xl p-2.5 border border-border hover:border-brand/40 active:border-brand active:bg-muted/40 hover:shadow-md transition-all text-start relative cursor-pointer overflow-hidden touch-manipulation focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
               >
                 {!!product.track_inventory && (
                   <>
@@ -209,21 +210,18 @@ export default function ProductGrid({
                       <TagBadge tag={product.tags[0]} />
                     )}
                     {product.addon_groups && product.addon_groups.length > 0 && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onProductClick(product);
-                        }}
-                        className="text-gray-400 hover:text-gray-600 transition-colors"
+                      <span
+                        className="touch-target -me-2 -my-2 rounded-lg text-gray-400"
                         title={t('customisable')}
+                        aria-label={t('customisable')}
                       >
-                        <SlidersHorizontal size={12} />
-                      </button>
+                        <SlidersHorizontal size={16} />
+                      </span>
                     )}
                   </div>
                 </div>
 
-              </div>
+              </button>
             );
           })}
         </div>

--- a/frontend/src/components/pos/TableCheckoutModal.tsx
+++ b/frontend/src/components/pos/TableCheckoutModal.tsx
@@ -155,7 +155,7 @@ export default function TableCheckoutModal({
             </div>
             <p className="text-sm text-muted-foreground">{t('orderNumber', { number: order.order_number })}</p>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-muted-foreground">
+          <button onClick={onClose} className="touch-target rounded-full text-gray-400 hover:text-muted-foreground active:bg-muted" aria-label={t('close')}>
             <X size={20} />
           </button>
         </div>

--- a/frontend/src/components/pos/TablePickerModal.tsx
+++ b/frontend/src/components/pos/TablePickerModal.tsx
@@ -55,7 +55,7 @@ export default function TablePickerModal({
       <div className="bg-card rounded-2xl p-6 w-full max-w-lg max-h-[80vh] overflow-y-auto">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-bold">{t('selectTable')}</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-muted-foreground">
+          <button onClick={onClose} className="touch-target rounded-full text-gray-400 hover:text-muted-foreground active:bg-muted" aria-label={t('close')}>
             <X size={20} />
           </button>
         </div>
@@ -72,7 +72,7 @@ export default function TablePickerModal({
                 key={table.id}
                 onClick={() => !isDisabled && handleClick(table)}
                 disabled={isDisabled}
-                className={`p-4 rounded-xl border-2 text-center transition-colors relative ${
+                className={`min-h-28 p-4 rounded-xl border-2 text-center transition-colors relative ${
                   isSelected
                     ? 'border-brand bg-brand-light'
                     : isHeld
@@ -110,7 +110,7 @@ export default function TablePickerModal({
           <div className="flex gap-3 mt-4 pt-4 border-t border-border">
             <button
               onClick={() => onHoldTable(selectedTableId)}
-              className="flex-1 px-4 py-3 rounded-xl border-2 border-border text-foreground font-medium hover:bg-muted transition-colors"
+              className="touch-target flex-1 px-4 rounded-xl border-2 border-border text-foreground font-medium hover:bg-muted active:bg-muted transition-colors"
             >
               {t('holdTable')}
             </button>
@@ -119,7 +119,7 @@ export default function TablePickerModal({
                 onPlaceOrder();
                 onClose();
               }}
-              className="flex-1 px-4 py-3 rounded-xl bg-brand text-white font-medium hover:bg-brand/90 transition-colors"
+              className="touch-target flex-1 px-4 rounded-xl bg-brand text-white font-medium hover:bg-brand/90 active:bg-brand/90 transition-colors"
             >
               {t('placeOrderButton')}
             </button>

--- a/frontend/src/components/pos/TouchNumberPad.tsx
+++ b/frontend/src/components/pos/TouchNumberPad.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { Delete, RotateCcw } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface QuickValue {
+  label: string;
+  value: string;
+}
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+  clearLabel: string;
+  backspaceLabel: string;
+  allowDecimal?: boolean;
+  max?: number;
+  quickValues?: QuickValue[];
+  className?: string;
+}
+
+function clampValue(value: string, max?: number) {
+  if (max == null || value === '' || value === '.') return value;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return value;
+  return numeric > max ? String(max) : value;
+}
+
+function appendDigit(value: string, digit: string, allowDecimal: boolean, max?: number) {
+  if (digit === '.') {
+    if (!allowDecimal || value.includes('.')) return value;
+    return value === '' ? '0.' : `${value}.`;
+  }
+  const next = value === '0' ? digit : `${value}${digit}`;
+  return clampValue(next, max);
+}
+
+export default function TouchNumberPad({
+  value,
+  onChange,
+  ariaLabel,
+  clearLabel,
+  backspaceLabel,
+  allowDecimal = true,
+  max,
+  quickValues = [],
+  className,
+}: Props) {
+  const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', allowDecimal ? '.' : '', '0'];
+
+  return (
+    <div className={cn('rounded-xl border border-border bg-muted/40 p-2', className)} aria-label={ariaLabel}>
+      {quickValues.length > 0 && (
+        <div className="mb-2 grid grid-cols-2 gap-2">
+          {quickValues.map((quick) => (
+            <button
+              key={`${quick.label}-${quick.value}`}
+              type="button"
+              onClick={() => onChange(clampValue(quick.value, max))}
+              className="touch-target rounded-lg border border-border bg-card px-3 text-sm font-semibold text-foreground transition-colors active:bg-muted"
+            >
+              {quick.label}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="grid grid-cols-3 gap-2">
+        {keys.map((key, index) => key ? (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onChange(appendDigit(value, key, allowDecimal, max))}
+            className="touch-target rounded-lg border border-border bg-card text-lg font-bold tabular-nums text-foreground transition-colors active:bg-muted"
+          >
+            {key}
+          </button>
+        ) : (
+          <span key={`blank-${index}`} aria-hidden="true" />
+        ))}
+        <button
+          type="button"
+          onClick={() => onChange(value.slice(0, -1))}
+          className="touch-target rounded-lg border border-border bg-card text-muted-foreground transition-colors active:bg-muted"
+          aria-label={backspaceLabel}
+          title={backspaceLabel}
+        >
+          <Delete size={18} />
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          className="touch-target col-span-2 gap-2 rounded-lg border border-border bg-card text-sm font-semibold text-muted-foreground transition-colors active:bg-muted"
+        >
+          <RotateCcw size={16} />
+          {clearLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/i18n/messages/en.json
+++ b/frontend/src/lib/i18n/messages/en.json
@@ -658,7 +658,14 @@
     "totalDue": "Total Due",
     "unpaid": "Unpaid",
     "updateDiscount": "Update Discount",
-    "walletMaxAmount": "Wallet amount exceeds available balance. Max: {max}"
+    "walletMaxAmount": "Wallet amount exceeds available balance. Max: {max}",
+    "clearAmount": "Clear amount",
+    "enterFullscreen": "Enter full-screen POS",
+    "exactAmount": "Exact due",
+    "exitFullscreen": "Exit full-screen POS",
+    "fullscreenUnavailable": "Full-screen mode is unavailable",
+    "backspaceAmount": "Backspace amount",
+    "numericKeypad": "Numeric keypad"
   },
   "printTest": {
     "amt": "Amt",

--- a/frontend/src/lib/i18n/messages/es.json
+++ b/frontend/src/lib/i18n/messages/es.json
@@ -658,7 +658,14 @@
     "totalDue": "Total a pagar",
     "unpaid": "No pagado",
     "updateDiscount": "Actualizar descuento",
-    "walletMaxAmount": "El saldo de la billetera supera el disponible. Máximo: {max}"
+    "walletMaxAmount": "El saldo de la billetera supera el disponible. Máximo: {max}",
+    "clearAmount": "Borrar importe",
+    "enterFullscreen": "Entrar al POS en pantalla completa",
+    "exactAmount": "Importe exacto",
+    "exitFullscreen": "Salir del POS en pantalla completa",
+    "fullscreenUnavailable": "El modo de pantalla completa no está disponible",
+    "backspaceAmount": "Borrar último dígito",
+    "numericKeypad": "Teclado numérico"
   },
   "printTest": {
     "amt": "Total",

--- a/frontend/src/lib/i18n/messages/fa.json
+++ b/frontend/src/lib/i18n/messages/fa.json
@@ -658,7 +658,14 @@
     "totalDue": "کل قابل پرداخت",
     "unpaid": "پرداخت‌نشده",
     "updateDiscount": "به‌روزرسانی تخفیف",
-    "walletMaxAmount": "مبلغ کیف از مانده در دسترس بیشتر است. بیشینه: {max}"
+    "walletMaxAmount": "مبلغ کیف از مانده در دسترس بیشتر است. بیشینه: {max}",
+    "clearAmount": "پاک کردن مبلغ",
+    "enterFullscreen": "ورود به صندوق تمام‌صفحه",
+    "exactAmount": "مبلغ دقیق",
+    "exitFullscreen": "خروج از صندوق تمام‌صفحه",
+    "fullscreenUnavailable": "حالت تمام‌صفحه در دسترس نیست",
+    "backspaceAmount": "حذف رقم آخر",
+    "numericKeypad": "صفحه‌کلید عددی"
   },
   "printTest": {
     "amt": "مبلغ",

--- a/frontend/src/lib/i18n/messages/fr.json
+++ b/frontend/src/lib/i18n/messages/fr.json
@@ -658,7 +658,14 @@
     "totalDue": "Total dû",
     "unpaid": "Impayé",
     "updateDiscount": "Mettre à jour la remise",
-    "walletMaxAmount": "Le montant du portefeuille dépasse le solde disponible. Maximum : {max}"
+    "walletMaxAmount": "Le montant du portefeuille dépasse le solde disponible. Maximum : {max}",
+    "clearAmount": "Effacer le montant",
+    "enterFullscreen": "Passer le POS en plein écran",
+    "exactAmount": "Montant exact",
+    "exitFullscreen": "Quitter le POS en plein écran",
+    "fullscreenUnavailable": "Le mode plein écran n'est pas disponible",
+    "backspaceAmount": "Effacer le dernier chiffre",
+    "numericKeypad": "Pavé numérique"
   },
   "printTest": {
     "amt": "Montant",

--- a/frontend/src/lib/i18n/messages/pt.json
+++ b/frontend/src/lib/i18n/messages/pt.json
@@ -658,7 +658,14 @@
     "totalDue": "Total a Pagar",
     "unpaid": "Não Pago",
     "updateDiscount": "Atualizar Desconto",
-    "walletMaxAmount": "O valor da carteira excede o saldo disponível. Máx.: {max}"
+    "walletMaxAmount": "O valor da carteira excede o saldo disponível. Máx.: {max}",
+    "clearAmount": "Limpar valor",
+    "enterFullscreen": "Abrir PDV em tela cheia",
+    "exactAmount": "Valor exato",
+    "exitFullscreen": "Sair do PDV em tela cheia",
+    "fullscreenUnavailable": "O modo de tela cheia não está disponível",
+    "backspaceAmount": "Apagar último dígito",
+    "numericKeypad": "Teclado numérico"
   },
   "printTest": {
     "amt": "Total",


### PR DESCRIPTION
## Summary

- enlarge POS controls and interaction targets for touch monitors
- add reusable numeric keypads to payment and prepaid checkout flows
- add fullscreen POS mode and remove remaining hover-only POS actions
- localize the new touchscreen controls across all supported languages

Closes #368

## Verification

- `npm test`
- `npm run lint`
- `npm run build:frontend`
- `npm run i18n:check`
- `git diff --check`