### PR TITLE
fix(kds): route category-scoped stations for dine-in orders too

### DIFF
--- a/main/kds-server.ts
+++ b/main/kds-server.ts
@@ -310,9 +310,9 @@ export function startKdsServer(): Promise<void> {
         if (stationIds.length > 0) {
           const stationPlaceholders = stationIds.map(() => '?').join(',');
           const categoryRoute = stationRoutingCategoryIds.length > 0
-            ? ` OR EXISTS (SELECT 1 FROM order_items routed_oi JOIN products routed_p ON routed_p.id = routed_oi.product_id WHERE routed_oi.order_id = o.id AND o.table_id IS NULL AND routed_p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))`
+            ? ` OR EXISTS (SELECT 1 FROM order_items routed_oi JOIN products routed_p ON routed_p.id = routed_oi.product_id WHERE routed_oi.order_id = o.id AND t.kitchen_station_id IS NULL AND routed_p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))`
             : '';
-          query += ` AND (EXISTS (SELECT 1 FROM tables assigned_table WHERE assigned_table.id = o.table_id AND assigned_table.kitchen_station_id IN (${stationPlaceholders}))${categoryRoute}${stationScope.hasUnrestrictedStation ? ' OR o.table_id IS NULL' : ''})`;
+          query += ` AND (EXISTS (SELECT 1 FROM tables assigned_table WHERE assigned_table.id = o.table_id AND assigned_table.kitchen_station_id IN (${stationPlaceholders}))${categoryRoute}${stationScope.hasUnrestrictedStation ? ' OR t.kitchen_station_id IS NULL' : ''})`;
           orderParams.push(...stationIds, ...stationRoutingCategoryIds);
         }
         query += ' ORDER BY o.created_at ASC';

--- a/main/routes/kds.ts
+++ b/main/routes/kds.ts
@@ -109,16 +109,16 @@ router.get('/orders', requireKdsEnabled, (req: Request, res: Response) => {
     if (userStationIds.length > 0) {
       const stationPlaceholders = userStationIds.map(() => '?').join(',');
       const categoryRoute = stationRoutingCategoryIds.length > 0
-        ? ` OR EXISTS (SELECT 1 FROM order_items routed_oi JOIN products routed_p ON routed_p.id = routed_oi.product_id WHERE routed_oi.order_id = o.id AND o.table_id IS NULL AND routed_p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))`
+        ? ` OR EXISTS (SELECT 1 FROM order_items routed_oi JOIN products routed_p ON routed_p.id = routed_oi.product_id WHERE routed_oi.order_id = o.id AND t.kitchen_station_id IS NULL AND routed_p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))`
         : '';
-      query += ` AND (t.kitchen_station_id IN (${stationPlaceholders})${categoryRoute}${requestedScope.hasUnrestrictedStation ? ' OR o.table_id IS NULL' : ''})`;
+      query += ` AND (t.kitchen_station_id IN (${stationPlaceholders})${categoryRoute}${requestedScope.hasUnrestrictedStation ? ' OR t.kitchen_station_id IS NULL' : ''})`;
       params.push(...userStationIds, ...stationRoutingCategoryIds);
     }
     if (stationId) {
       const categoryRoute = requestedRoutingCategoryIds.length > 0
-        ? ` OR EXISTS (SELECT 1 FROM order_items requested_oi JOIN products requested_p ON requested_p.id = requested_oi.product_id WHERE requested_oi.order_id = o.id AND o.table_id IS NULL AND requested_p.category_id IN (${requestedRoutingCategoryIds.map(() => '?').join(',')}))`
+        ? ` OR EXISTS (SELECT 1 FROM order_items requested_oi JOIN products requested_p ON requested_p.id = requested_oi.product_id WHERE requested_oi.order_id = o.id AND t.kitchen_station_id IS NULL AND requested_p.category_id IN (${requestedRoutingCategoryIds.map(() => '?').join(',')}))`
         : '';
-      query += ` AND (t.kitchen_station_id = ?${categoryRoute}${requestedScope.hasUnrestrictedStation ? ' OR o.table_id IS NULL' : ''})`;
+      query += ` AND (t.kitchen_station_id = ?${categoryRoute}${requestedScope.hasUnrestrictedStation ? ' OR t.kitchen_station_id IS NULL' : ''})`;
       params.push(stationId, ...requestedRoutingCategoryIds);
     }
 
@@ -318,9 +318,9 @@ router.get('/display', requireKdsEnabled, (req: Request, res: Response) => {
 
     const params: any[] = [voidedCutoff];
     const categoryRoute = stationItemCategoryIds === null
-      ? ' OR o.table_id IS NULL'
+      ? ' OR t.kitchen_station_id IS NULL'
       : stationItemCategoryIds.length > 0
-        ? ` OR EXISTS (SELECT 1 FROM products routed_p WHERE o.table_id IS NULL AND routed_p.id = oi.product_id AND routed_p.category_id IN (${stationItemCategoryIds.map(() => '?').join(',')}))`
+        ? ` OR EXISTS (SELECT 1 FROM products routed_p WHERE t.kitchen_station_id IS NULL AND routed_p.id = oi.product_id AND routed_p.category_id IN (${stationItemCategoryIds.map(() => '?').join(',')}))`
         : '';
     itemsQuery += ` AND (t.kitchen_station_id = ?${categoryRoute})`;
     params.push(stationId, ...(stationItemCategoryIds || []));

--- a/main/routes/kitchen.ts
+++ b/main/routes/kitchen.ts
@@ -53,8 +53,8 @@ router.get('/orders', (req: Request, res: Response) => {
 
     const stationFilter = stationIds.length > 0
       ? ` AND (EXISTS (SELECT 1 FROM tables assigned_table WHERE assigned_table.id = o.table_id AND assigned_table.kitchen_station_id IN (${stationIds.map(() => '?').join(',')}))
-          ${stationRoutingCategoryIds.length > 0 ? `OR EXISTS (SELECT 1 FROM order_items routed_oi JOIN products routed_p ON routed_p.id = routed_oi.product_id WHERE routed_oi.order_id = o.id AND o.table_id IS NULL AND routed_p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))` : ''}
-          ${stationScope.hasUnrestrictedStation ? 'OR o.table_id IS NULL' : ''})`
+          ${stationRoutingCategoryIds.length > 0 ? `OR EXISTS (SELECT 1 FROM order_items routed_oi JOIN products routed_p ON routed_p.id = routed_oi.product_id WHERE routed_oi.order_id = o.id AND t.kitchen_station_id IS NULL AND routed_p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))` : ''}
+          ${stationScope.hasUnrestrictedStation ? 'OR t.kitchen_station_id IS NULL' : ''})`
       : '';
     const orders = db.prepare(`
       SELECT o.*, t.kitchen_station_id

--- a/main/services/kds.ts
+++ b/main/services/kds.ts
@@ -498,9 +498,9 @@ function sendActiveOrders(ws: WebSocket, categoryIds: string[], stationIds: stri
   if (stationIds.length > 0) {
     const stationPlaceholders = stationIds.map(() => '?').join(',');
     const categoryRoute = stationRoutingCategoryIds.length > 0
-      ? ` OR EXISTS (SELECT 1 FROM order_items routed_oi JOIN products routed_p ON routed_p.id = routed_oi.product_id WHERE routed_oi.order_id = o.id AND o.table_id IS NULL AND routed_p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))`
+      ? ` OR EXISTS (SELECT 1 FROM order_items routed_oi JOIN products routed_p ON routed_p.id = routed_oi.product_id WHERE routed_oi.order_id = o.id AND t.kitchen_station_id IS NULL AND routed_p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))`
       : '';
-    query += ` AND (t.kitchen_station_id IN (${stationPlaceholders})${categoryRoute}${stationScope.hasUnrestrictedStation ? ' OR o.table_id IS NULL' : ''})`;
+    query += ` AND (t.kitchen_station_id IN (${stationPlaceholders})${categoryRoute}${stationScope.hasUnrestrictedStation ? ' OR t.kitchen_station_id IS NULL' : ''})`;
     orderParams.push(...stationIds, ...stationRoutingCategoryIds);
   }
   query += ' ORDER BY o.created_at ASC';
@@ -590,10 +590,10 @@ function sendActiveOrders(ws: WebSocket, categoryIds: string[], stationIds: stri
       }
     }
     if (stationRoutingCategoryIds.length > 0) {
-      stationRoutes.push(`(o.table_id IS NULL AND p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))`);
+      stationRoutes.push(`(t.kitchen_station_id IS NULL AND p.category_id IN (${stationRoutingCategoryIds.map(() => '?').join(',')}))`);
       countParams.push(...stationRoutingCategoryIds);
     }
-    if (stationScope.hasUnrestrictedStation) stationRoutes.push('o.table_id IS NULL');
+    if (stationScope.hasUnrestrictedStation) stationRoutes.push('t.kitchen_station_id IS NULL');
     countsQuery += ` AND (${stationRoutes.length > 0 ? stationRoutes.join(' OR ') : '0'})`;
   }
   if (categoryIds.length > 0) {

--- a/tests/kds-contract.test.ts
+++ b/tests/kds-contract.test.ts
@@ -164,6 +164,56 @@ async function main() {
     const storedPairing = db.prepare('SELECT id FROM kds_pairing_tokens WHERE token = ?').get(pairingCreate.body.pairingToken.token) as { id: string };
     assertEqual(pairingCreate.body.pairingToken.id, storedPairing.id, 'pairing response returns stored identifier');
 
+    // Regression for the reported bug: a dine-in order (table has no
+    // kitchen_station_id of its own — there's no settings UI to set one)
+    // whose items are split across two category-scoped stations used to
+    // match neither station's routing clause and vanish from both screens.
+    db.prepare(`INSERT INTO tables (id, number, created_at, updated_at)
+      VALUES ('kds-split-table', '7', ?, ?)`).run(now(), now());
+    db.prepare(`INSERT INTO orders (order_number, table_id, type, status, subtotal, total, created_at, updated_at)
+      VALUES ('KDS-SPLIT-001', 'kds-split-table', 'dine_in', 'pending', 22, 22, ?, ?)`).run(now(), now());
+    const splitOrderId = (db.prepare("SELECT id FROM orders WHERE order_number = 'KDS-SPLIT-001'").get() as any).id;
+    db.prepare(`INSERT INTO order_items (order_id, product_id, product_name, unit_price, quantity, subtotal, tax_amount, total, status, created_at, updated_at)
+      VALUES (?, 'kds-contract-product', 'Contract food', 10, 1, 10, 0, 10, 'pending', ?, ?)`).run(splitOrderId, now(), now());
+    db.prepare(`INSERT INTO order_items (order_id, product_id, product_name, unit_price, quantity, subtotal, tax_amount, total, status, created_at, updated_at)
+      VALUES (?, 'kds-contract-bar-product', 'Contract bar', 12, 1, 12, 0, 12, 'pending', ?, ?)`).run(splitOrderId, now(), now());
+
+    db.prepare(`INSERT INTO kitchen_stations (id, name, category_ids, is_active, created_at, updated_at)
+      VALUES ('kds-split-counter-station', 'Split Counter Station', ?, 1, ?, ?)`).run(JSON.stringify(['kds-contract-bar']), now(), now());
+    const splitKitchenChefId = 'kds-split-kitchen-chef';
+    db.prepare(`INSERT INTO users (id, name, email, password, role, is_active, created_at, updated_at)
+      VALUES (?, 'Split Kitchen Chef', ?, ?, 'chef', 1, ?, ?)`).run(
+      splitKitchenChefId, 'kds-split-kitchen@flo.local', bcrypt.hashSync('testpass123', 10), now(), now(),
+    );
+    db.prepare('INSERT INTO station_users (user_id, station_id, created_at) VALUES (?, ?, ?)').run(splitKitchenChefId, 'kds-contract-station', now());
+    const splitKitchenAuth = { Authorization: `Bearer ${jwt.sign({ userId: splitKitchenChefId, role: 'chef' }, getJWTSecret(), { expiresIn: '1h' })}` };
+
+    const splitCounterChefId = 'kds-split-counter-chef';
+    db.prepare(`INSERT INTO users (id, name, email, password, role, is_active, created_at, updated_at)
+      VALUES (?, 'Split Counter Chef', ?, ?, 'chef', 1, ?, ?)`).run(
+      splitCounterChefId, 'kds-split-counter@flo.local', bcrypt.hashSync('testpass123', 10), now(), now(),
+    );
+    db.prepare('INSERT INTO station_users (user_id, station_id, created_at) VALUES (?, ?, ?)').run(splitCounterChefId, 'kds-split-counter-station', now());
+    const splitCounterAuth = { Authorization: `Bearer ${jwt.sign({ userId: splitCounterChefId, role: 'chef' }, getJWTSecret(), { expiresIn: '1h' })}` };
+
+    const kitchenSplitOrders = await request(app).get('/api/kds/orders').set(splitKitchenAuth);
+    assertEqual(kitchenSplitOrders.status, 200, 'kitchen-station chef can access embedded KDS orders for a dine-in split order');
+    const kitchenSplitOrder = kitchenSplitOrders.body.orders.find((entry: any) => entry.id === splitOrderId);
+    assertEqual(kitchenSplitOrder?.items?.length, 1, 'kitchen-station chef sees only the food item on a dine-in order with category-split stations');
+
+    const counterSplitOrders = await request(app).get('/api/kds/orders').set(splitCounterAuth);
+    assertEqual(counterSplitOrders.status, 200, 'counter-station chef can access embedded KDS orders for a dine-in split order');
+    const counterSplitOrder = counterSplitOrders.body.orders.find((entry: any) => entry.id === splitOrderId);
+    assertEqual(counterSplitOrder?.items?.length, 1, 'counter-station chef sees only the drink item on a dine-in order with category-split stations');
+
+    const kitchenSplitDisplay = await request(app).get('/api/kds/display?station_id=kds-contract-station').set(splitKitchenAuth);
+    assertEqual(kitchenSplitDisplay.status, 200, 'kitchen-station display request succeeds for a dine-in split order');
+    assertEqual(kitchenSplitDisplay.body.orders.some((entry: any) => entry.order_id === splitOrderId), true, 'kitchen station display shows the dine-in split order food item');
+
+    const counterSplitDisplay = await request(app).get('/api/kds/display?station_id=kds-split-counter-station').set(splitCounterAuth);
+    assertEqual(counterSplitDisplay.status, 200, 'counter-station display request succeeds for a dine-in split order');
+    assertEqual(counterSplitDisplay.body.orders.some((entry: any) => entry.order_id === splitOrderId), true, 'counter station display shows the dine-in split order drink item');
+
     db.exec('PRAGMA foreign_keys = OFF');
     db.prepare('UPDATE order_items SET order_id = ? WHERE id = ?').run('missing-order', barItemId);
     db.exec('PRAGMA foreign_keys = ON');


### PR DESCRIPTION
## Summary
- Category-based KDS station routing (Settings → Kitchen Stations, assigning categories like Food/Drinks to different stations/users) only matched orders with no table (`o.table_id IS NULL`). Any dine-in order fell through every routing branch once category-scoped stations were configured, so it disappeared from **every** KDS screen — exactly the support report in #577.
- The per-item filter (`isKdsStationItemAllowed` in `main/db.ts`) already only cared whether the *table* had its own `kitchen_station_id`, not whether the order had a table at all — so the SQL pre-filters were stricter than the actual authorization logic they were supposed to mirror.
- Updated the SQL pre-filters in `main/services/kds.ts`, `main/routes/kds.ts`, `main/routes/kitchen.ts`, and `main/kds-server.ts` to gate on `t.kitchen_station_id IS NULL` instead of `o.table_id IS NULL`, matching `isKdsStationItemAllowed`'s semantics. Behavior is unchanged for tables that already have an explicit `kitchen_station_id` (verified by the existing `kds-contract.test.ts` cases for that scenario).
- Added a regression test in `tests/kds-contract.test.ts` reproducing the exact reported setup: a dine-in order on a table with no explicit station, split across a food-scoped station/user and a drinks-scoped station/user. Confirmed it fails without the fix (`got undefined` / `got false`) and passes with it.

Fixes FreeOpenSourcePOS/FloCafe#577

## Test plan
- [x] `npm run build` — clean compile
- [x] `npm run lint` — no new errors (pre-existing warnings only)
- [x] `bash tests/run-test.sh npm run test:kds-contract` — all pass, including the new regression cases and the existing "does not duplicate table-assigned orders" cases
- [x] `bash tests/run-test.sh npm run test:kds-integration` / `test:kds-frontend-conflict` / `test:kds-window-hardening` / `test:issue-133-kds-kot-toggles` / `test:rtl-kds-server-whatsapp` / `test:kitchen-addons` / `test:order-item-addons` — all pass
- [x] `npm test` (full suite) — exit code 0, no failures
- [x] Confirmed new test fails on pre-fix code via `git stash` and passes after restoring the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)