### PR TITLE
chore: pre-release cleanup — restore Settings nav, add country/currency docs, new language READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,82 @@
+# FloCafe
+
+**Kostenloses, quelloffenes und offline-orientiertes Kassensystem für Cafés, Restaurants und kleine Küchen.**
+
+[English](README.md) | [Español](README.es.md) | [Português](README.pt.md) | [Français](README.fr.md) | [Türkçe](README.tr.md) | [Filipino](README.fil.md) | **Deutsch**
+
+FloCafe läuft direkt auf dem Computer des Betriebs. Bestellungen, Kunden, Belege und Sicherungen werden in einer lokalen SQLite-Datenbank gespeichert. Dadurch können Kassenbetrieb und Küchenanzeigen auch ohne Internetverbindung weiterarbeiten. Für den grundlegenden Kassenbetrieb ist kein gehostetes oder cloudbasiertes Konto erforderlich. Optionale Integrationen wie Google-Drive-Sicherungen, der Versand von Belegen über WhatsApp und cloudbasierte Berichte können bei Bedarf aktiviert werden.
+
+## FloCafe herunterladen
+
+Laden Sie das neueste Installationsprogramm von [GitHub Releases](https://github.com/FreeOpenSourcePOS/FloCafe/releases) herunter oder installieren Sie FloCafe über den App-Store Ihrer Plattform.
+
+Die Releases enthalten Windows-Installationsprogramme, macOS-DMGs sowie AppImage-, `.deb`-, `.rpm`- und Snap-Pakete für Linux. Informationen zu Linux-Paketen, Updates, FUSE, Druckberechtigungen und dem Verhalten der Systemleiste finden Sie im [Linux-Installations- und Supportleitfaden](docs/linux.md).
+
+### Systemanforderungen
+
+| Anforderung | Minimum |
+| --- | --- |
+| Betriebssystem | Windows 10+, macOS 12+ oder eine aktuelle unterstützte Linux-Distribution |
+| Arbeitsspeicher | 4 GB RAM |
+| Speicherplatz | 500 MB frei, zusätzlich Platz für lokale Sicherungen |
+
+Node.js wird nur zur Entwicklung von FloCafe benötigt, nicht zum Ausführen einer paketierten Version.
+
+## Highlights
+
+- **Bestellabläufe:** Bestellungen an der Kasse, im Restaurant, zum Mitnehmen und zur Lieferung mit Tischverwaltung und zurückgehaltenen Bestellungen.
+- **Optionen und Preise:** Artikeloptionen, Zusatzgruppen, Rabatte und Kunden-Treuepunkte.
+- **Belegdruck:** ESC/POS-Thermodruck über USB, lokales TCP-Netzwerk und Druckwarteschlangen des Betriebssystems, mit WebUSB in kompatiblen Browsern.
+- **Küchenbetrieb:** Eigenständiger Küchenbildschirm-Server (KDS) und kategoriebasierte Weiterleitung an Küchenstationen.
+- **Katalogverwaltung:** Produktbilder, Barcode-Scan sowie CSV-Import und -Export von Menüs.
+- **Verwaltung:** Mitarbeiterkonten mit Rollen, Verkaufsanalysen und Prüfprotokolle.
+- **Datenschutz:** Lokale SQLite-Datenbank, automatische Sicherungen vor Migrationen, manuelle Wiederherstellung und optionale Google-Drive-Sicherung.
+
+## Offline-orientiertes Design
+
+Der grundlegende Kassenbetrieb und lokale Daten funktionieren offline. Auftragserfassung, Abrechnung, KDS-Koordination und Belegdruck sind nicht von Internet oder externen Cloud-Diensten abhängig.
+
+- Die SQLite-Datenbank und lokale Sicherungen liegen im Benutzerdatenverzeichnis, getrennt von den installierten Programmbinärdateien.
+- FloCafe erstellt vor Schema-Migrationen automatisch eine Sicherung mit Zeitstempel.
+- Optionale Netzwerkfunktionen kommunizieren nur, wenn sie vom Betriebsinhaber ausdrücklich konfiguriert und aktiviert wurden.
+
+## Sprachen und regionale Unterstützung
+
+FloCafe bietet Benutzeroberflächen auf Englisch, Spanisch, brasilianischem Portugiesisch, Persisch (Farsi), Türkisch, Filipino und Deutsch. Persisch unterstützt RTL; Türkisch, Filipino und Deutsch werden von links nach rechts geschrieben. Die UI-Sprache ist unabhängig von Land und regionalen Einstellungen des Geschäfts. Steuerberechnungsregeln sind ein getrenntes Thema.
+
+FloCafe enthält Profile für 131 Länder und 109 Währungen. Jedes Profil legt Währung, Region und Standardzeitzone fest; der Betriebsinhaber kann die Zeitzone während der Einrichtung oder später in den Einstellungen ändern.
+
+## Steuerunterstützung
+
+FloCafe enthält eine allgemeine Berechnungs-Engine sowie signierte und versionierte regionale Steuerpakete. Manuelle Steuerregeln und Steuersätze können ebenfalls lokal konfiguriert werden.
+
+> **Hinweis:** FloCafe ist Software und keine Rechts- oder Steuerberatung. Steuerpakete und Konfigurationswerkzeuge bescheinigen allein keine Einhaltung lokaler Vorschriften.
+
+## Entwicklung
+
+Für die Entwicklung von FloCafe benötigen Sie Node.js 22 oder höher:
+
+```sh
+git clone https://github.com/FreeOpenSourcePOS/FloCafe.git
+cd FloCafe
+npm install
+npm run dev
+```
+
+`npm run dev` erstellt Frontend und Backend und startet anschließend Electron.
+
+Weitere Informationen zu Entwicklungsabläufen, Programmierrichtlinien und Tests finden Sie in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Hilfe und Dokumentation
+
+- [Dokumentationsindex](docs/README.md)
+- [Druckerleitfaden](docs/printers.md)
+- [Linux-Einrichtung und Support](docs/linux.md)
+- [Internationalisierung und Übersetzungen](docs/i18n.md)
+- [Einrichtung der Google-Drive-Sicherung](docs/google-drive-setup.md)
+- [GitHub Issues](https://github.com/FreeOpenSourcePOS/FloCafe/issues)
+- [GitHub Discussions](https://github.com/FreeOpenSourcePOS/FloCafe/discussions)
+
+## Lizenz
+
+FloCafe ist Open-Source-Software unter der [MIT-Lizenz](LICENSE).

--- a/README.de.md
+++ b/README.de.md
@@ -42,7 +42,7 @@ Der grundlegende Kassenbetrieb und lokale Daten funktionieren offline. Auftragse
 
 ## Sprachen und regionale Unterstützung
 
-FloCafe bietet Benutzeroberflächen auf Englisch, Spanisch, brasilianischem Portugiesisch, Persisch (Farsi), Türkisch, Filipino und Deutsch. Persisch unterstützt RTL; Türkisch, Filipino und Deutsch werden von links nach rechts geschrieben. Die UI-Sprache ist unabhängig von Land und regionalen Einstellungen des Geschäfts. Steuerberechnungsregeln sind ein getrenntes Thema.
+FloCafe bietet Benutzeroberflächen auf Englisch, Spanisch, brasilianischem Portugiesisch, Französisch, Persisch (Farsi), Türkisch, Filipino und Deutsch. Persisch unterstützt RTL; Türkisch, Filipino und Deutsch werden von links nach rechts geschrieben. Die UI-Sprache ist unabhängig von Land und regionalen Einstellungen des Geschäfts. Steuerberechnungsregeln sind ein getrenntes Thema.
 
 FloCafe enthält Profile für 131 Länder und 109 Währungen. Jedes Profil legt Währung, Region und Standardzeitzone fest; der Betriebsinhaber kann die Zeitzone während der Einrichtung oder später in den Einstellungen ändern.
 

--- a/README.es.md
+++ b/README.es.md
@@ -2,7 +2,7 @@
 
 **Punto de venta gratuito, de código abierto y diseñado para funcionar sin conexión para cafeterías, restaurantes y pequeñas cocinas.**
 
-[English](README.md) | **Español** | [Português](README.pt.md) | [Français](README.fr.md)
+[English](README.md) | **Español** | [Português](README.pt.md) | [Français](README.fr.md) | [Türkçe](README.tr.md) | [Filipino](README.fil.md) | [Deutsch](README.de.md)
 
 FloCafe funciona directamente en el ordenador del negocio. Los pedidos, clientes, recibos y copias de seguridad se guardan en una base de datos SQLite local, por lo que el servicio de mostrador y las pantallas de cocina pueden seguir funcionando sin conexión a Internet. No se necesita una cuenta alojada ni en la nube para las funciones principales del TPV. Las integraciones opcionales, como las copias de seguridad en Google Drive, el envío de facturas por WhatsApp y los informes conectados a la nube, pueden activarse cuando sea necesario.
 
@@ -46,7 +46,7 @@ Las funciones principales del TPV y los datos locales funcionan sin conexión. L
 
 ## Idiomas y soporte regional
 
-FloCafe incluye traducciones de la interfaz en inglés, español, portugués brasileño, francés, persa (farsi), turco, filipino y alemán, con soporte RTL para persa. El idioma de la interfaz es independiente del país de la tienda y de la configuración regional. Las reglas de cálculo de impuestos son un aspecto separado.
+FloCafe incluye traducciones de la interfaz en inglés, español, portugués brasileño y persa (farsi), con soporte RTL. El idioma de la interfaz es independiente del país de la tienda y de la configuración regional. Las reglas de cálculo de impuestos son un aspecto separado.
 
 FloCafe incluye perfiles para 131 países y 109 monedas. Cada perfil establece una moneda, configuración regional y zona horaria predeterminadas; el propietario puede cambiar la zona horaria durante la configuración o más adelante en Ajustes.
 

--- a/README.fil.md
+++ b/README.fil.md
@@ -1,0 +1,82 @@
+# FloCafe
+
+**Libre, open-source, at offline-first na point of sale para sa mga café, restaurant, at maliliit na kusina.**
+
+[English](README.md) | [Español](README.es.md) | [Português](README.pt.md) | [Français](README.fr.md) | [Türkçe](README.tr.md) | **Filipino** | [Deutsch](README.de.md)
+
+Direktang tumatakbo ang FloCafe sa computer ng negosyo. Naka-save ang mga order, customer, resibo, at backup sa lokal na SQLite database, kaya patuloy na gagana ang counter service at kitchen display kahit walang koneksyon sa Internet. Hindi kailangan ng hosted o cloud account para sa pangunahing operasyon ng POS. Maaaring paganahin kapag kailangan ang mga opsyonal na integration gaya ng Google Drive backup, pagpapadala ng bill sa WhatsApp, at cloud-connected reporting.
+
+## Kunin ang FloCafe
+
+I-download ang pinakabagong installer mula sa [GitHub Releases](https://github.com/FreeOpenSourcePOS/FloCafe/releases), o i-install ito mula sa app store ng iyong platform.
+
+May Windows installer, macOS DMG, at AppImage, `.deb`, `.rpm`, at Snap package para sa Linux ang mga release. Para sa mga detalye tungkol sa Linux package, update, FUSE, printing permission, at system tray, tingnan ang [Linux installation and support guide](docs/linux.md).
+
+### Mga kinakailangan ng system
+
+| Kinakailangan | Minimum |
+| --- | --- |
+| Operating system | Windows 10+, macOS 12+, o kasalukuyang suportadong Linux distribution |
+| Memory | 4 GB RAM |
+| Storage | 500 MB na libre, dagdag pa para sa lokal na backup |
+
+Kailangan lamang ang Node.js para sa pag-develop ng FloCafe, hindi para patakbuhin ang naka-package na bersyon.
+
+## Mga tampok
+
+- **Mga workflow ng order:** Counter, dine-in, takeaway, at delivery order na may table management at held orders.
+- **Mga modifier at presyo:** Item modifier, addon group, discount, at customer loyalty point.
+- **Pagpi-print ng resibo:** ESC/POS thermal printing sa USB, lokal na TCP network, at operating-system print queue, kasama ang WebUSB sa mga suportadong browser.
+- **Mga operasyon sa kusina:** Standalone Kitchen Display System (KDS) server at category-based kitchen station routing.
+- **Pamamahala ng catalog:** Product image, barcode scanning, at CSV menu import/export.
+- **Administration:** Staff account na may role, sales analytics, at audit log.
+- **Proteksyon ng data:** Lokal na SQLite database, awtomatikong backup bago ang migration, manual restore, at opsyonal na Google Drive backup.
+
+## Offline-first
+
+Gumagana offline ang pangunahing POS operation at lokal na data. Hindi nakadepende sa Internet o external cloud service ang order entry, billing, KDS coordination, at receipt printing.
+
+- Nasa user-data directory ang SQLite database at lokal na backup, hiwalay sa naka-install na application binary.
+- Awtomatikong gumagawa ang FloCafe ng timestamped backup bago magpatakbo ng schema migration.
+- Nakikipag-ugnayan lamang ang opsyonal na network feature kapag tahasang na-configure at na-enable ng may-ari ng negosyo.
+
+## Mga wika at regional support
+
+May UI translation ang FloCafe para sa English, Spanish, Brazilian Portuguese, Persian (Farsi), Filipino, Turkish, at German. Filipino ay left-to-right at hindi nangangailangan ng RTL layout. Hiwalay ang UI language sa country at regional setting ng store, at hiwalay din ang tax calculation rules.
+
+May profile ang FloCafe para sa 131 bansa at 109 currency. Tinutukoy ng bawat profile ang default currency, locale, at timezone; maaaring baguhin ng may-ari ang timezone sa setup o sa Settings.
+
+## Tax support
+
+May generic calculation engine at signed, versioned regional tax pack ang FloCafe. Maaari ring mag-configure ng manual tax rule at rate nang lokal.
+
+> **Paalala:** Software ang FloCafe, hindi legal o tax advice. Hindi awtomatikong nagpapatunay ng pagsunod sa lokal na regulasyon ang tax pack at configuration tool.
+
+## Development
+
+Kailangan ang Node.js 22 o mas bago para sa development:
+
+```sh
+git clone https://github.com/FreeOpenSourcePOS/FloCafe.git
+cd FloCafe
+npm install
+npm run dev
+```
+
+Binubuo ng `npm run dev` ang frontend at backend, pagkatapos ay sinisimulan ang Electron.
+
+Tingnan ang [CONTRIBUTING.md](CONTRIBUTING.md) para sa development workflow, coding standard, at testing procedure.
+
+## Tulong at dokumentasyon
+
+- [Documentation index](docs/README.md)
+- [Printer guide](docs/printers.md)
+- [Linux setup and support](docs/linux.md)
+- [Internationalization and translations](docs/i18n.md)
+- [Google Drive backup setup](docs/google-drive-setup.md)
+- [GitHub Issues](https://github.com/FreeOpenSourcePOS/FloCafe/issues)
+- [GitHub Discussions](https://github.com/FreeOpenSourcePOS/FloCafe/discussions)
+
+## Lisensya
+
+Ang FloCafe ay open-source software sa ilalim ng [MIT License](LICENSE).

--- a/README.fil.md
+++ b/README.fil.md
@@ -42,7 +42,7 @@ Gumagana offline ang pangunahing POS operation at lokal na data. Hindi nakadepen
 
 ## Mga wika at regional support
 
-May UI translation ang FloCafe para sa English, Spanish, Brazilian Portuguese, Persian (Farsi), Filipino, Turkish, at German. Filipino ay left-to-right at hindi nangangailangan ng RTL layout. Hiwalay ang UI language sa country at regional setting ng store, at hiwalay din ang tax calculation rules.
+May UI translation ang FloCafe para sa English, Spanish, Brazilian Portuguese, French, Persian (Farsi), Filipino, Turkish, at German. Filipino ay left-to-right at hindi nangangailangan ng RTL layout. Hiwalay ang UI language sa country at regional setting ng store, at hiwalay din ang tax calculation rules.
 
 May profile ang FloCafe para sa 131 bansa at 109 currency. Tinutukoy ng bawat profile ang default currency, locale, at timezone; maaaring baguhin ng may-ari ang timezone sa setup o sa Settings.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -46,7 +46,7 @@ Les fonctions principales du point de vente et les données locales fonctionnent
 
 ## Langues et support régional
 
-FloCafe propose des traductions de l’interface en anglais, espagnol, portugais brésilien, français, persan (farsi), turc, filipino et allemand, avec prise en charge RTL pour le persan. La langue de l’interface est indépendante du pays et des paramètres régionaux du magasin. Les règles de calcul des taxes constituent un domaine séparé.
+FloCafe propose des traductions de l’interface en anglais, espagnol, portugais brésilien et persan (farsi), avec prise en charge RTL. La langue de l’interface est indépendante du pays et des paramètres régionaux du magasin. Les règles de calcul des taxes constituent un domaine séparé.
 
 FloCafe inclut des profils pour 131 pays et 109 devises. Chaque profil définit une devise, une région et un fuseau horaire par défaut ; le propriétaire peut modifier le fuseau horaire lors de la configuration ou plus tard dans les paramètres.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,7 +2,7 @@
 
 **Point de vente gratuit, open source et conçu pour fonctionner hors ligne pour les cafés, restaurants et petites cuisines.**
 
-[English](README.md) | [Español](README.es.md) | [Português](README.pt.md) | **Français**
+[English](README.md) | [Español](README.es.md) | [Português](README.pt.md) | **Français** | [Türkçe](README.tr.md) | [Filipino](README.fil.md) | [Deutsch](README.de.md)
 
 FloCafe fonctionne directement sur l’ordinateur de l’établissement. Les commandes, les clients, les reçus et les sauvegardes sont stockés dans une base de données SQLite locale. Le service au comptoir et les écrans de cuisine peuvent donc continuer à fonctionner sans connexion Internet. Aucun compte hébergé ou cloud n’est nécessaire pour l’utilisation principale du point de vente. Des intégrations optionnelles, comme les sauvegardes Google Drive, l’envoi de factures par WhatsApp et les rapports connectés au cloud, peuvent être activées si nécessaire.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>FloCafe</h1>
-  <p><a href="README.es.md">Español</a> · <a href="README.pt.md">Português</a> · <a href="README.fr.md">Français</a></p>
+  <p><a href="README.es.md">Español</a> · <a href="README.pt.md">Português</a> · <a href="README.fr.md">Français</a> · <a href="README.tr.md">Türkçe</a> · <a href="README.fil.md">Filipino</a> · <a href="README.de.md">Deutsch</a></p>
   <p><strong>Free, open-source, offline-first point of sale for cafés, restaurants, and small kitchens.</strong></p>
   <p>
     <a href="https://flopos.com">Website</a> ·

--- a/README.pt.md
+++ b/README.pt.md
@@ -2,7 +2,7 @@
 
 **Ponto de venda gratuito, de código aberto e desenvolvido para funcionar offline em cafés, restaurantes e pequenas cozinhas.**
 
-[English](README.md) | [Español](README.es.md) | **Português** | [Français](README.fr.md)
+[English](README.md) | [Español](README.es.md) | **Português** | [Français](README.fr.md) | [Türkçe](README.tr.md) | [Filipino](README.fil.md) | [Deutsch](README.de.md)
 
 O FloCafe funciona diretamente no computador do estabelecimento. Pedidos, clientes, recibos e backups são armazenados em um banco de dados SQLite local, permitindo que o atendimento no balcão e as telas da cozinha continuem funcionando sem conexão com a Internet. Nenhuma conta hospedada ou na nuvem é necessária para a operação principal do PDV. Integrações opcionais, como backup no Google Drive, envio de contas pelo WhatsApp e relatórios conectados à nuvem, podem ser ativadas quando necessário.
 
@@ -46,7 +46,7 @@ A operação principal do PDV e os dados locais funcionam offline. A criação d
 
 ## Idiomas e suporte regional
 
-O FloCafe inclui traduções da interface em inglês, espanhol, português brasileiro, francês, persa (farsi), turco, filipino e alemão, incluindo suporte RTL para persa. O idioma da interface é independente do país e das configurações regionais da loja. As regras de cálculo de impostos são uma área separada.
+O FloCafe inclui traduções da interface em inglês, espanhol, português brasileiro e persa (farsi), incluindo suporte RTL. O idioma da interface é independente do país e das configurações regionais da loja. As regras de cálculo de impostos são uma área separada.
 
 O FloCafe inclui perfis para 131 países e 109 moedas. Cada perfil define moeda, localidade e fuso horário padrão; o proprietário pode alterar o fuso durante a configuração ou depois em Configurações.
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,0 +1,86 @@
+# FloCafe
+
+**Kafeler, restoranlar ve küçük mutfaklar için ücretsiz, açık kaynaklı ve çevrimdışı çalışmaya öncelik veren satış noktası uygulaması.**
+
+[English](README.md) | [Español](README.es.md) | [Português](README.pt.md) | [Français](README.fr.md) | **Türkçe** | [Filipino](README.fil.md) | [Deutsch](README.de.md)
+
+FloCafe doğrudan işletmenin kendi bilgisayarında çalışır. Siparişler, müşteriler, fişler ve yedekler yerel bir SQLite veritabanında saklanır. Böylece internet bağlantısı olmadan da kasa hizmeti ve mutfak ekranları çalışmaya devam eder. Temel satış noktası işlemleri için barındırılan veya bulut tabanlı bir hesap gerekmez. Google Drive yedekleme, WhatsApp ile fiş gönderme ve bulut bağlantılı raporlama gibi isteğe bağlı entegrasyonlar gerektiğinde etkinleştirilebilir.
+
+## FloCafe’yi edinin
+
+En yeni yükleyiciyi [GitHub Releases](https://github.com/FreeOpenSourcePOS/FloCafe/releases) sayfasından indirin veya platformunuzun uygulama mağazasından yükleyin.
+
+Sürümlerde Windows yükleyicileri, macOS DMG dosyaları ve Linux için AppImage, `.deb`, `.rpm` ve Snap paketleri bulunur. Linux paketleri, güncellemeler, FUSE, yazdırma izinleri ve sistem tepsisi davranışı hakkında bilgi için [Linux kurulum ve destek kılavuzuna](docs/linux.md) bakın.
+
+### Sistem gereksinimleri
+
+| Gereksinim | Minimum |
+| --- | --- |
+| İşletim sistemi | Windows 10+, macOS 12+ veya güncel desteklenen bir Linux dağıtımı |
+| Bellek | 4 GB RAM |
+| Depolama | 500 MB boş alan ve yerel yedekler için ek alan |
+
+Node.js yalnızca FloCafe geliştirmek için gereklidir; paketlenmiş sürümü çalıştırmak için gerekmez.
+
+## Öne çıkan özellikler
+
+- **Sipariş akışları:** Masa yönetimi ve bekletilen siparişlerle birlikte kasada, masada, paket ve teslimat siparişleri.
+- **Değiştiriciler ve fiyatlandırma:** Ürün değiştiricileri, ek ürün grupları, indirimler ve müşteri sadakat puanları.
+- **Fiş yazdırma:** USB, yerel TCP ağı ve işletim sistemi yazdırma kuyrukları üzerinden ESC/POS termal yazdırma; uyumlu tarayıcılarda WebUSB desteği.
+- **Mutfak işlemleri:** Bağımsız Mutfak Ekranı (KDS) sunucusu ve kategoriye göre mutfak istasyonu yönlendirmesi.
+- **Katalog yönetimi:** Ürün görselleri, barkod tarama ve CSV menü içe/dışa aktarma.
+- **Yönetim:** Personel rolleri, satış analizleri ve denetim kayıtları.
+- **Veri koruması:** Yerel SQLite veritabanı, geçişlerden önce otomatik yedekler, manuel geri yükleme araçları ve isteğe bağlı Google Drive yedekleme.
+
+## Proje durumu
+
+FloCafe aktif olarak geliştirilmektedir ve gerçek kurulumlarda kullanılmaktadır. Müşteri verileri ve yükseltme güvenliği açık veritabanı geçişleri ve kurtarma mekanizmalarıyla dikkatle korunur.
+
+## Çevrimdışı çalışacak şekilde tasarlandı
+
+Temel satış noktası işlemleri ve yerel veriler çevrimdışı çalışır. Sipariş girişi, faturalandırma, KDS koordinasyonu ve fiş yazdırma internet bağlantısına veya harici bulut hizmetlerine bağlı değildir.
+
+- SQLite veritabanı ve yerel yedekler, kurulu uygulama ikili dosyalarından ayrı olarak kullanıcı veri dizininde saklanır.
+- FloCafe şema geçişlerini çalıştırmadan önce tarih ve saat içeren otomatik bir yedek oluşturur.
+- İsteğe bağlı ağ özellikleri yalnızca işletme sahibi tarafından açıkça yapılandırılıp etkinleştirildiğinde iletişim kurar.
+
+## Diller ve bölgesel destek
+
+FloCafe arayüzü İngilizce, İspanyolca, Brezilya Portekizcesi, Farsça, Türkçe, Filipince ve Almanca dillerinde kullanılabilir. Farsça RTL desteği içerir; Türkçe, Filipince ve Almanca soldan sağa yazılır. Arayüz dili, mağazanın ülke ve bölgesel ayarlarından bağımsızdır. Vergi hesaplama kuralları ayrı bir konudur.
+
+FloCafe 131 ülke ve 109 para birimi için profiller içerir. Her profil varsayılan para birimi, yerel ayar ve saat dilini belirler; işletme sahibi saat dilini kurulum sırasında veya daha sonra Ayarlar bölümünden değiştirebilir.
+
+## Vergi desteği
+
+FloCafe genel bir hesaplama motoru ve imzalı, sürümlenmiş bölgesel vergi paketleri içerir. Manuel vergi kuralları ve oranları da yerel olarak yapılandırılabilir.
+
+> **Uyarı:** FloCafe yazılımdır; hukuki veya vergisel danışmanlık değildir. Vergi paketleri ve yapılandırma araçları tek başına yerel mevzuata uyumluluğu belgelemez.
+
+## Geliştirme
+
+FloCafe geliştirmek için Node.js 22 veya üzeri gerekir:
+
+```sh
+git clone https://github.com/FreeOpenSourcePOS/FloCafe.git
+cd FloCafe
+npm install
+npm run dev
+```
+
+`npm run dev`, frontend ve backend’i derler ve ardından Electron’u başlatır.
+
+Geliştirme akışları, kod standartları ve test prosedürleri için [CONTRIBUTING.md](CONTRIBUTING.md) dosyasına bakın.
+
+## Yardım ve belgeler
+
+- [Belge dizini](docs/README.md)
+- [Yazıcı kılavuzu](docs/printers.md)
+- [Linux kurulumu ve desteği](docs/linux.md)
+- [Uluslararasılaştırma ve çeviriler](docs/i18n.md)
+- [Google Drive yedekleme kurulumu](docs/google-drive-setup.md)
+- [GitHub Issues](https://github.com/FreeOpenSourcePOS/FloCafe/issues)
+- [GitHub Discussions](https://github.com/FreeOpenSourcePOS/FloCafe/discussions)
+
+## Lisans
+
+FloCafe, [MIT lisansı](LICENSE) ile lisanslanmış açık kaynaklı bir yazılımdır.

--- a/README.tr.md
+++ b/README.tr.md
@@ -46,7 +46,7 @@ Temel satış noktası işlemleri ve yerel veriler çevrimdışı çalışır. S
 
 ## Diller ve bölgesel destek
 
-FloCafe arayüzü İngilizce, İspanyolca, Brezilya Portekizcesi, Farsça, Türkçe, Filipince ve Almanca dillerinde kullanılabilir. Farsça RTL desteği içerir; Türkçe, Filipince ve Almanca soldan sağa yazılır. Arayüz dili, mağazanın ülke ve bölgesel ayarlarından bağımsızdır. Vergi hesaplama kuralları ayrı bir konudur.
+FloCafe arayüzü İngilizce, İspanyolca, Brezilya Portekizcesi, Fransızca, Farsça, Türkçe, Filipince ve Almanca dillerinde kullanılabilir. Farsça RTL desteği içerir; Türkçe, Filipince ve Almanca soldan sağa yazılır. Arayüz dili, mağazanın ülke ve bölgesel ayarlarından bağımsızdır. Vergi hesaplama kuralları ayrı bir konudur.
 
 FloCafe 131 ülke ve 109 para birimi için profiller içerir. Her profil varsayılan para birimi, yerel ayar ve saat dilini belirler; işletme sahibi saat dilini kurulum sırasında veya daha sonra Ayarlar bölümünden değiştirebilir.
 

--- a/frontend/e2e/settings-kds-navigation.spec.ts
+++ b/frontend/e2e/settings-kds-navigation.spec.ts
@@ -7,8 +7,7 @@ test('KDS sidebar link selects the KDS tab after switching Settings tabs', async
   await page.getByLabel('Password').fill('E2ePass123!');
   await page.getByRole('button', { name: 'Sign In' }).click();
 
-  await page.getByRole('button', { name: /manager@flo.local|Manager|User/i }).click();
-  await page.getByRole('menuitem', { name: 'Settings' }).click();
+  await page.getByRole('link', { name: 'Settings', exact: true }).click();
   await expect(page).toHaveURL(/\/settings\/?$/);
 
   await page.getByRole('link', { name: 'KDS', exact: true }).click();

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -75,6 +75,7 @@ const ALL_NAV_ITEMS: NavItem[] = [
   { href: '/settings?tab=kds', labelKey: 'kds', icon: ChefHat, roles: ROLE_ACCESS.ownerManager, businessTypes: ['restaurant'] },
   { href: '/customers', labelKey: 'customers', icon: Users, roles: ROLE_ACCESS.ownerManager, businessTypes: null },
   { href: '/staff', labelKey: 'staff', icon: UserCog, roles: ROLE_ACCESS.ownerManager, businessTypes: null },
+  { href: '/settings', labelKey: 'settings', icon: Settings, roles: ROLE_ACCESS.ownerManager, businessTypes: null },
 ];
 
 export default function AppSidebar() {
@@ -236,22 +237,6 @@ export default function AppSidebar() {
                 align={isMobile ? "end" : "start"}
                 className="w-56 rounded-lg"
               >
-                {hasRole(role, ROLE_ACCESS.ownerManager) && (
-                  <DropdownMenuItem asChild className="cursor-pointer">
-                    <Link href="/settings" onClick={closeMobile} className="flex items-center gap-2">
-                      <span className="relative flex size-4 items-center justify-center">
-                        <Settings className="size-4 shrink-0" />
-                        {emailNeedsAttention && (
-                          <span
-                            aria-label="Email verification required"
-                            className="absolute -end-1 -top-1 size-2 rounded-full bg-red-500 ring-2 ring-sidebar"
-                          />
-                        )}
-                      </span>
-                      <span>{t('settings')}</span>
-                    </Link>
-                  </DropdownMenuItem>
-                )}
                 <DropdownMenuItem asChild className="cursor-pointer">
                   <Link href="/support" onClick={closeMobile} className="flex items-center gap-2">
                     <LifeBuoy className="size-4 shrink-0" />


### PR DESCRIPTION
## Summary
- Restore `Settings` to the main sidebar navigation (was moved into the profile dropdown only by #524, dropped from the sidebar entirely)
- Add supported country/currency table to README.md (cherry-picked from `codex/readme-country-currency-support`)
- Add translated `README.de.md`, `README.fil.md`, `README.tr.md` and cross-links (cherry-picked from `docs/readme-new-language-links`)

## Test plan
- [x] `npm run lint` — 0 errors, only pre-existing warnings
- [ ] CI status checks (required by branch protection)