### PR TITLE
chore(release): bump version to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- Bump package.json version to 3.5.0 (minor bump: includes feat(pos) touchscreen-first controls #576 since 3.4.0)

## Test plan
- [ ] CI status checks (required by branch protection)