### PR TITLE
fix(deps): bump postcss-selector-parser to patch DoS via AST recursion

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9605,9 +9605,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "ip-address": "^10.4.0",
     "undici": "^7.29.0",
     "postcss": "8.5.26",
+    "postcss-selector-parser": "^7.1.3",
     "sharp": "$sharp",
     "@hono/node-server": "^2.0.12",
     "hono": "^4.12.34"


### PR DESCRIPTION
## Summary
- Fixes [Dependabot alert #34](https://github.com/FreeOpenSourcePOS/FloCafe/security/dependabot/34) (GHSA-w9m9-85wc-3x92 / CVE-2026-9358): `postcss-selector-parser` < 7.1.3 has a DoS via uncontrolled AST recursion.
- The package is a transitive dev dependency pulled in by `shadcn` (frontend tooling only, not shipped runtime code).
- Pinned via the existing `overrides` block in `frontend/package.json` (consistent with how other transitive deps like `undici` and `fast-uri` are already pinned there), bumping the resolved version from 7.1.1 to 7.1.5.

## Test plan
- [x] `npm ls postcss-selector-parser` confirms resolved version is 7.1.5
- [x] `npm run lint` passes (only pre-existing unrelated warnings)