### PR TITLE
fix(frontend): treat page-route prefetches as pages in service worker offline fallback

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'flo-v18';
+const CACHE_NAME = 'flo-v19';
 const PRECACHE_URLS = [
   '/dashboard',
   '/pos',
@@ -28,16 +28,44 @@ self.addEventListener('activate', (event) => {
   );
 });
 
+// Cache keys are precached without a trailing slash (see PRECACHE_URLS), but
+// requests for the same route can arrive with one — e.g. Next.js's <Link>
+// prefetch of "/dashboard/" when trailingSlash is enabled for the desktop
+// build. Normalizing avoids a spurious cache miss on an otherwise-cached page.
+function normalizedUrlString(url) {
+  const parsed = new URL(url);
+  if (parsed.pathname.length > 1 && parsed.pathname.endsWith('/')) {
+    parsed.pathname = parsed.pathname.slice(0, -1);
+  }
+  return parsed.toString();
+}
+
 function matchCached(request) {
-  return caches.match(request).catch(() => null);
+  return caches.match(request)
+    .then((match) => match || caches.match(normalizedUrlString(
+      typeof request === 'string' ? request : request.url
+    )))
+    .catch(() => null);
+}
+
+// A route prefetch (e.g. <Link> hovering/entering the viewport) fetches a
+// page path the same way a real subresource would, but with request.mode
+// other than "navigate". Treat it like a navigation for fallback purposes —
+// it targets one of our own pages, not a script/image/font — so it gets a
+// real HTTP response instead of a network-error Response.
+function isPageRequest(request) {
+  if (request.mode === 'navigate') return true;
+  const lastSegment = new URL(request.url).pathname.split('/').pop() || '';
+  return !lastSegment.includes('.');
 }
 
 function offlineResponse(request) {
-  // Navigation needs a real HTTP response so Electron shows a useful offline
-  // state instead of a service-worker promise-conversion error. Subresources
-  // use a network-error Response, which preserves normal failed-resource
+  // Navigation (and page prefetches) need a real HTTP response so Electron
+  // shows a useful offline state instead of a service-worker
+  // promise-conversion error. True subresources (scripts, images, fonts) use
+  // a network-error Response, which preserves normal failed-resource
   // semantics without inventing a body or caching a failure.
-  if (request.mode === 'navigate') {
+  if (isPageRequest(request)) {
     return new Response('Offline', { status: 503, statusText: 'Offline' });
   }
   return typeof Response.error === 'function'
@@ -84,7 +112,7 @@ self.addEventListener('fetch', (event) => {
       })
       .catch(() => matchCached(event.request)
         .then((cached) => cached || (
-          event.request.mode === 'navigate' ? matchCached('/dashboard') : null
+          isPageRequest(event.request) ? matchCached('/dashboard') : null
         ))
         .then((cached) => cached || offlineResponse(event.request))
       )

--- a/tests/service-worker.test.cjs
+++ b/tests/service-worker.test.cjs
@@ -133,6 +133,45 @@ async function run() {
   );
   assert.equal(uncachedSubresource.type, 'error');
 
+  const shellPrefetchCaches = new TestCaches();
+  await shellPrefetchCaches.cache.put(
+    '/dashboard',
+    new Response('<html>cached shell</html>', { status: 200 }),
+  );
+  const shellPrefetchWorker = loadFetchHandler(
+    shellPrefetchCaches,
+    async () => { throw new TypeError('Failed to fetch'); },
+  );
+  const prefetchResponse = await dispatch(shellPrefetchWorker.fetch, {
+    method: 'GET',
+    url: 'http://localhost:3001/dashboard/',
+    mode: 'cors',
+  });
+  assert.ok(prefetchResponse instanceof Response, 'route prefetch failure resolves a valid Response');
+  assert.notEqual(
+    prefetchResponse.type,
+    'error',
+    'a <Link> prefetch of a page (non-navigate mode) must not resolve a network-error Response',
+  );
+  assert.equal(await prefetchResponse.text(), '<html>cached shell</html>');
+
+  const uncachedPrefetchWorker = loadFetchHandler(
+    new TestCaches(),
+    async () => { throw new TypeError('Failed to fetch'); },
+  );
+  const uncachedPrefetchResponse = await dispatch(uncachedPrefetchWorker.fetch, {
+    method: 'GET',
+    url: 'http://localhost:3001/dashboard/',
+    mode: 'cors',
+  });
+  assert.ok(
+    uncachedPrefetchResponse instanceof Response,
+    'uncached route prefetch failure still resolves a valid Response',
+  );
+  assert.notEqual(uncachedPrefetchResponse.type, 'error');
+  assert.equal(uncachedPrefetchResponse.status, 503);
+  assert.equal(await uncachedPrefetchResponse.text(), 'Offline');
+
   const startupNavigation = await dispatch(failureWorker.fetch, {
     method: 'GET',
     url: 'http://localhost:3001/dashboard/',


### PR DESCRIPTION
## Summary
- Fixes: `The FetchEvent for "http://localhost:3001/dashboard/" resulted in a network error response: the promise was resolved with an error response object.`
- Root cause: Next.js's sidebar `<Link href="/dashboard">` prefetches that route as a background subresource fetch (`request.mode` other than `"navigate"`). When the local backend at `:3001` is briefly unreachable, the service worker's catch handler fell through to `Response.error()` — behavior intended for true subresources (scripts/images), not full page-route prefetches — which Chrome reports as the network-error message above.
- Added `isPageRequest()` in `frontend/public/sw.js` to route page-path prefetches through the same offline-shell fallback as real navigations, instead of returning a network-error `Response`.
- Normalized trailing-slash handling in cache lookups so `/dashboard` and `/dashboard/` resolve to the same cached entry.
- Bumped `CACHE_NAME` to `flo-v19` so existing installs pick up the new logic.

## Test plan
- [x] `node tests/service-worker.test.cjs` — added two regression cases (prefetch with cached shell, prefetch with no cache) alongside existing navigation/subresource/staleness coverage; all pass.
- [x] `npm run lint` — 0 errors (pre-existing unrelated warnings only).