### PR TITLE
chore(release): bump version to 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- Bumps `package.json` version to 3.5.1 for the next stable release.
- Bundles the fixes merged since 3.5.0: postcss-selector-parser DoS (#583), service worker page-prefetch network-error (#585), and browserslist DoS/prototype-pollution (#586).

## Test plan
- [x] Follows the same single-file version-bump convention as the 3.5.0 release commit (`ce26a9d`).
- CI will build/verify/publish the 3.5.1 GitHub release automatically once the `3.5.1` tag is pushed after this merges (per `docs/release-process.md`).