### PR TITLE
fix(pos): sync topbar with native window state

### DIFF
--- a/docs/title-bar-phase1.md
+++ b/docs/title-bar-phase1.md
@@ -38,13 +38,17 @@ Phase 2 adds a defensive runtime decision so no platform can end up hidden-with-
 5. Fallback `close` routes through `BrowserWindow.close()`, firing the same `close` event as the native caption button, so close-to-tray behavior in `main/index.ts` is identical in both modes.
 6. Renderer readiness is per-document: main begins a fresh readiness epoch and clears the prior document nonce on window creation and before each full-document `did-start-navigation` (manual reloads included), rejecting stale-epoch or stale-nonce reports and arming a fresh fail-safe per epoch, so a reload that fails to re-mount the root chrome re-evaluates readiness instead of inheriting a stale ready flag while the caption controls are gone.
 
-Contract coverage lives in `tests/titlebar-window-options.test.ts` (mode resolution matrix, fallback window options, window-action verb validation), `tests/window-readiness.test.ts` (epoch and nonce binding, stale-report rejection, reload invalidation, fail-safe firing and cancellation), and `tests/electron-api-contract.test.ts` (preload surface includes `windowAction` and document-bound `windowReady`).
+Contract coverage lives in `tests/titlebar-window-options.test.ts` (mode resolution matrix, fallback window options, window-action verb validation), `tests/window-readiness.test.ts` (epoch and nonce binding, stale-report rejection, reload invalidation, fail-safe firing and cancellation), and `tests/electron-api-contract.test.ts` (preload surface includes `windowAction`, `getWindowState`, `onWindowStateChanged`, and document-bound `windowReady`).
 
 ### Platform matrix follow-up (completed in #462)
 
 Cross-platform verification is recorded in [`docs/title-bar-platform-matrix.md`](title-bar-platform-matrix.md). The Windows assertion workflow runs on a hosted desktop runner; the packaged Linux AppImage is verified under Xvfb on the captain-approved Debian GNOME machine, with assertion/log evidence and a supplementary XWD capture. macOS fullscreen/traffic-light and browser/LAN/sidebar rows are recorded separately in that matrix.
 
-The renderer `ElectronAPI` declaration stays in parity with the preload surface, including settings, KDS, printer, and daily-summary methods plus the narrow `windowAction` control and `windowReady` readiness methods. The `titleBarMode` capability remains part of the `get-status` payload rather than a separate renderer gate. The KDS window, print receipt/local popup windows, native dialogs, and browser/LAN layouts remain on their existing paths. Context isolation and disabled Node integration are unchanged; the preload API is extended only by the two narrow readiness/control methods described above.
+The renderer `ElectronAPI` declaration stays in parity with the preload surface, including settings, KDS, printer, and daily-summary methods plus the narrow `windowAction`, `getWindowState`, `onWindowStateChanged`, and `windowReady` methods. The `titleBarMode` capability remains part of the `get-status` payload rather than a separate renderer gate. The KDS window, print receipt/local popup windows, native dialogs, and browser/LAN layouts remain on their existing paths. Context isolation and disabled Node integration are unchanged; the preload API is extended only by these narrow window-state, readiness, and control methods.
+
+## POS topbar window-state synchronization
+
+In the Electron app, the POS topbar's fullscreen toggle controls the native POS `BrowserWindow`: it maximizes a restored window, restores a maximized window, and exits native fullscreen before restoring the window. The topbar initializes from `getWindowState` and listens to `onWindowStateChanged`, so native maximize/fullscreen changes keep its label and icon synchronized. Browser/LAN clients retain the existing document Fullscreen API path.
 
 ## Explicit exclusions
 

--- a/docs/title-bar-platform-matrix.md
+++ b/docs/title-bar-platform-matrix.md
@@ -14,7 +14,7 @@ This record uses assertion and log evidence first. The Linux XWD capture is supp
 | [`tests/platform-titlebar-runtime-probe.cjs`](../tests/platform-titlebar-runtime-probe.cjs) | Cross-platform Electron mode resolution, window option shape, 40 DIP overlay configuration, fallback gating, and window-action validation. |
 | [`tests/titlebar-window-options.test.ts`](../tests/titlebar-window-options.test.ts) | Main-window option and fallback decision contract. |
 | [`tests/window-readiness.test.ts`](../tests/window-readiness.test.ts) | Epoch/nonce-bound renderer readiness and fail-safe contract. |
-| [`tests/electron-api-contract.test.ts`](../tests/electron-api-contract.test.ts) | Preload `windowAction` and `windowReady` contract. |
+| [`tests/electron-api-contract.test.ts`](../tests/electron-api-contract.test.ts) | Preload `windowAction`, `getWindowState`, `onWindowStateChanged`, and `windowReady` contract. |
 | [`frontend/e2e/title-bar-platform.spec.ts`](../frontend/e2e/title-bar-platform.spec.ts) | Browser/LAN multi-viewport and #504 sidebar regression checks. |
 | [`frontend/e2e/desktop/title-bar.electron.spec.ts`](../frontend/e2e/desktop/title-bar.electron.spec.ts) | Dedicated native Electron readiness, authenticated dashboard, and window-boundary checks. |
 | [`frontend/e2e/layout-integrity.spec.ts`](../frontend/e2e/layout-integrity.spec.ts) | Existing browser/LAN geometry and zero-title-bar checks. |

--- a/frontend/e2e/desktop/title-bar.electron.spec.ts
+++ b/frontend/e2e/desktop/title-bar.electron.spec.ts
@@ -69,6 +69,75 @@ test('real preload, renderer, and main boundaries reach an authenticated dashboa
   expect(runtime.readiness).toEqual({ success: true });
 });
 
+test('POS topbar fullscreen toggle stays synchronized with native window state', async () => {
+  test.skip(process.platform === 'linux', 'Linux CI uses Xvfb without a window manager, so native maximize state is not observable');
+  await harness.authenticateDashboard();
+
+  const readNativeWindowState = async () => harness.app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows().find((candidate) => {
+      try { return new URL(candidate.webContents.getURL()).pathname.replace(/\/+$/, '') === '/pos'; } catch { return false; }
+    });
+    if (!window) return null;
+    return { isMaximized: window.isMaximized(), isFullScreen: window.isFullScreen() };
+  });
+  const topbarToggle = harness.page.getByRole('button', { name: /full-screen POS/i });
+
+  await harness.app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows().find((candidate) => {
+      try { return new URL(candidate.webContents.getURL()).pathname.replace(/\/+$/, '') === '/pos'; } catch { return false; }
+    });
+    if (!window) throw new Error('POS BrowserWindow not found');
+    if (window.isFullScreen()) window.setFullScreen(false);
+    if (window.isMaximized()) window.unmaximize();
+  });
+  await expect.poll(readNativeWindowState).toEqual({ isMaximized: false, isFullScreen: false });
+  await expect(topbarToggle).toHaveAttribute('aria-label', 'Enter full-screen POS');
+
+  if (process.env.FLO_E2E_EVIDENCE_DIR) {
+    await harness.page.screenshot({
+      path: `${process.env.FLO_E2E_EVIDENCE_DIR}/06-pos-topbar-restored.png`,
+    });
+  }
+
+  await topbarToggle.click();
+  await expect.poll(readNativeWindowState).toMatchObject({ isMaximized: true, isFullScreen: false });
+  await expect(topbarToggle).toHaveAttribute('aria-label', 'Exit full-screen POS');
+  if (process.env.FLO_E2E_EVIDENCE_DIR) {
+    await harness.page.screenshot({
+      path: `${process.env.FLO_E2E_EVIDENCE_DIR}/07-pos-topbar-maximized.png`,
+    });
+  }
+
+  await harness.app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows().find((candidate) => {
+      try { return new URL(candidate.webContents.getURL()).pathname.replace(/\/+$/, '') === '/pos'; } catch { return false; }
+    });
+    if (!window) throw new Error('POS BrowserWindow not found');
+    window.unmaximize();
+  });
+  await expect.poll(readNativeWindowState).toMatchObject({ isMaximized: false, isFullScreen: false });
+  await expect(topbarToggle).toHaveAttribute('aria-label', 'Enter full-screen POS');
+
+  await harness.app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows().find((candidate) => {
+      try { return new URL(candidate.webContents.getURL()).pathname.replace(/\/+$/, '') === '/pos'; } catch { return false; }
+    });
+    if (!window) throw new Error('POS BrowserWindow not found');
+    window.setFullScreen(true);
+  });
+  await expect.poll(readNativeWindowState).toMatchObject({ isMaximized: false, isFullScreen: true });
+  await expect(topbarToggle).toHaveAttribute('aria-label', 'Exit full-screen POS');
+  if (process.env.FLO_E2E_EVIDENCE_DIR) {
+    await harness.page.screenshot({
+      path: `${process.env.FLO_E2E_EVIDENCE_DIR}/08-pos-topbar-native-fullscreen.png`,
+    });
+  }
+
+  await topbarToggle.click();
+  await expect.poll(readNativeWindowState).toMatchObject({ isFullScreen: false });
+  await expect(topbarToggle).toHaveAttribute('aria-label', 'Enter full-screen POS');
+});
+
 test('native window lifecycle is observable through the Electron boundary', async () => {
   test.skip(!['darwin', 'win32', 'linux'].includes(process.platform), 'FloCafe native window lifecycle is unsupported on this platform');
   test.skip(process.platform === 'linux', 'Linux CI uses Xvfb without a window manager, so native minimize/restore is not observable');

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -275,6 +275,26 @@ export default function POSPage() {
   };
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    if (window.electronAPI?.getWindowState) {
+      window.electronAPI
+        .getWindowState()
+        .then((state) => {
+          if (state && typeof state === 'object' && 'isMaximized' in state) {
+            setFullscreen(Boolean(state.isMaximized || state.isFullScreen));
+          }
+        })
+        .catch(() => {});
+
+      if (window.electronAPI.onWindowStateChanged) {
+        return window.electronAPI.onWindowStateChanged((state) => {
+          setFullscreen(Boolean(state?.isMaximized || state?.isFullScreen));
+        });
+      }
+      return;
+    }
+
     const syncFullscreen = () => setFullscreen(document.fullscreenElement != null);
     syncFullscreen();
     document.addEventListener('fullscreenchange', syncFullscreen);
@@ -282,6 +302,17 @@ export default function POSPage() {
   }, []);
 
   const toggleFullscreen = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+
+    if (window.electronAPI?.windowAction) {
+      try {
+        await window.electronAPI.windowAction('toggle-maximize');
+      } catch {
+        toast.error(t('fullscreenUnavailable'));
+      }
+      return;
+    }
+
     if (typeof document === 'undefined') return;
     try {
       if (document.fullscreenElement) {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -7,9 +7,10 @@ export interface ElectronAPI {
   // Menu
   onMenuAction: (callback: (action: string) => void) => (() => void);
 
-  // Window controls (HTML title-bar fallback; only invoked when getStatus()
-  // reports titleBarMode 'html-fallback')
+  // Window controls
   windowAction: (action: WindowControlAction) => Promise<ElectronActionResult | ElectronIpcError>;
+  getWindowState?: () => Promise<{ isMaximized: boolean; isFullScreen: boolean }>;
+  onWindowStateChanged?: (callback: (state: { isMaximized: boolean; isFullScreen: boolean }) => void) => () => void;
 
   // Database
   backupDatabase: (pin?: string) => Promise<{ success: boolean; path?: string; error?: string }>;

--- a/main/index.ts
+++ b/main/index.ts
@@ -680,6 +680,23 @@ function createWindow(): void {
     usbDevicePermissionsRegistered = true;
   }
 
+  const sendWindowState = () => {
+    if (!createdWindow || createdWindow.isDestroyed()) return;
+    try {
+      createdWindow.webContents.send('window-state-changed', {
+        isMaximized: createdWindow.isMaximized(),
+        isFullScreen: createdWindow.isFullScreen(),
+      });
+    } catch {
+      // Ignored if webContents destroyed
+    }
+  };
+
+  createdWindow.on('maximize', sendWindowState);
+  createdWindow.on('unmaximize', sendWindowState);
+  createdWindow.on('enter-full-screen', sendWindowState);
+  createdWindow.on('leave-full-screen', sendWindowState);
+
   mainWindow.on('close', (event) => {
     if (!isQuitting) {
       event.preventDefault();

--- a/main/ipc.ts
+++ b/main/ipc.ts
@@ -320,6 +320,15 @@ export function registerIpcHandlers(
     return applyWindowControlAction(win, action);
   });
 
+  handle('get-window-state', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return { isMaximized: false, isFullScreen: false };
+    return {
+      isMaximized: win.isMaximized(),
+      isFullScreen: win.isFullScreen(),
+    };
+  });
+
   handle('window-ready', (event, payload: unknown) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win || win.isDestroyed()) return { error: 'Window unavailable' };

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -33,6 +33,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // controls. Only ever called when main reports titleBarMode 'html-fallback'.
   windowAction: (action: string) => ipcRenderer.invoke('window-action', action),
 
+  getWindowState: () => ipcRenderer.invoke('get-window-state'),
+  onWindowStateChanged: (callback: (state: { isMaximized: boolean; isFullScreen: boolean }) => void) => {
+    const handler = (_event: unknown, state: { isMaximized: boolean; isFullScreen: boolean }) => callback(state);
+    ipcRenderer.on('window-state-changed', handler);
+    return () => { ipcRenderer.removeListener('window-state-changed', handler); };
+  },
+
   getPrinters: () => ipcRenderer.invoke('get-printers'),
   savePrinter: (printer: unknown) => ipcRenderer.invoke('save-printer', printer),
 

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -30,7 +30,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   windowReady: (payload: { epoch: number }) => ipcRenderer.invoke('window-ready', { ...payload, documentNonce }),
 
   // Narrow window-control surface for the renderer title bar's HTML fallback
-  // controls. Only ever called when main reports titleBarMode 'html-fallback'.
+  // controls and the POS topbar's native window-state toggle.
   windowAction: (action: string) => ipcRenderer.invoke('window-action', action),
 
   getWindowState: () => ipcRenderer.invoke('get-window-state'),

--- a/main/window-options.ts
+++ b/main/window-options.ts
@@ -93,7 +93,10 @@ export function createMainWindow(
 export type WindowControlTarget = Pick<
   BrowserWindow,
   'isDestroyed' | 'minimize' | 'isMaximized' | 'maximize' | 'unmaximize' | 'close'
->;
+> & {
+  isFullScreen?: () => boolean;
+  setFullScreen?: (flag: boolean) => void;
+};
 
 /**
  * Applies one validated window-control action. 'close' intentionally goes
@@ -112,8 +115,17 @@ export function applyWindowControlAction(
       win.minimize();
       break;
     case 'toggle-maximize':
-      if (win.isMaximized()) win.unmaximize();
-      else win.maximize();
+      if (typeof win.isFullScreen === 'function' && win.isFullScreen()) {
+        if (typeof win.setFullScreen === 'function') {
+          win.setFullScreen(false);
+        } else {
+          win.unmaximize();
+        }
+      } else if (win.isMaximized()) {
+        win.unmaximize();
+      } else {
+        win.maximize();
+      }
       break;
     case 'close':
       win.close();

--- a/tests/electron-api-contract.test.ts
+++ b/tests/electron-api-contract.test.ts
@@ -56,7 +56,7 @@ async function run(): Promise<void> {
     'backupDatabase', 'checkForUpdates', 'dbApplySafeFixes', 'dbHealthCheck',
     'dbInitialize', 'getAppInfo', 'getBetaChannel', 'getDailySummary', 'getKdsInfo',
     'getMasterPinStatus', 'getPrinters', 'getSettings', 'getStatus', 'getUpdateStatus',
-    'onMenuAction', 'onUpdateStatus', 'openKdsWindow', 'platform', 'restartAndInstall',
+    'getWindowState', 'onMenuAction', 'onUpdateStatus', 'onWindowStateChanged', 'openKdsWindow', 'platform', 'restartAndInstall',
     'restoreBackup', 'savePrinter', 'setBetaChannel', 'setSetting', 'setThemeEffective',
     'windowAction', 'windowReady',
   ].sort());
@@ -76,6 +76,7 @@ async function run(): Promise<void> {
   await call('setBetaChannel', true);
   await call('windowReady', { epoch: 1 });
   await call('windowAction', 'minimize');
+  await call('getWindowState');
 
   const receivedStatuses: unknown[] = [];
   const unsubscribe = (exposedApi!['onUpdateStatus'] as (callback: (status: unknown) => void) => () => void)(
@@ -90,6 +91,16 @@ async function run(): Promise<void> {
   unsubscribe();
   assert.equal(eventHandlers.has('update-status'), false);
 
+  const receivedWindowStates: unknown[] = [];
+  const unsubscribeWindowState = (exposedApi!['onWindowStateChanged'] as (callback: (state: unknown) => void) => () => void)(
+    (state) => receivedWindowStates.push(state),
+  );
+  const windowStatePayload = { isMaximized: true, isFullScreen: false };
+  eventHandlers.get('window-state-changed')?.({}, windowStatePayload);
+  assert.deepEqual(receivedWindowStates, [windowStatePayload]);
+  unsubscribeWindowState();
+  assert.equal(eventHandlers.has('window-state-changed'), false);
+
   assert.deepEqual(calls, [
     { channel: 'get-settings', args: [] },
     { channel: 'set-setting', args: ['business_name', 'Flo Cafe'] },
@@ -102,6 +113,7 @@ async function run(): Promise<void> {
     { channel: 'updates:set-beta-channel', args: [true] },
     { channel: 'window-ready', args: [{ epoch: 1, documentNonce }] },
     { channel: 'window-action', args: ['minimize'] },
+    { channel: 'get-window-state', args: [] },
   ]);
 
   console.log('Electron preload methods expose the expected narrow IPC channels.');

--- a/tests/titlebar-window-options.test.ts
+++ b/tests/titlebar-window-options.test.ts
@@ -132,11 +132,14 @@ assert.equal(linuxFallbackMainWindow.options.webPreferences.contextIsolation, tr
 class FakeWindow {
   calls: string[] = [];
   maximized = false;
+  fullscreen = false;
   isDestroyed() { return false; }
   minimize() { this.calls.push('minimize'); }
   isMaximized() { return this.maximized; }
   maximize() { this.maximized = true; this.calls.push('maximize'); }
   unmaximize() { this.maximized = false; this.calls.push('unmaximize'); }
+  isFullScreen() { return this.fullscreen; }
+  setFullScreen(val: boolean) { this.fullscreen = val; this.calls.push(`fullscreen:${val}`); }
   close() { this.calls.push('close'); }
 }
 
@@ -146,8 +149,11 @@ assert.deepEqual(applyWindowControlAction(win as any, 'toggle-maximize'), { succ
 assert.equal(win.maximized, true, 'toggle-maximize maximizes a restored window');
 assert.deepEqual(applyWindowControlAction(win as any, 'toggle-maximize'), { success: true });
 assert.equal(win.maximized, false, 'toggle-maximize restores a maximized window');
+win.fullscreen = true;
+assert.deepEqual(applyWindowControlAction(win as any, 'toggle-maximize'), { success: true });
+assert.equal(win.fullscreen, false, 'toggle-maximize exits fullscreen if window is fullscreen');
 assert.deepEqual(applyWindowControlAction(win as any, 'close'), { success: true });
-assert.deepEqual(win.calls, ['minimize', 'maximize', 'unmaximize', 'close']);
+assert.deepEqual(win.calls, ['minimize', 'maximize', 'unmaximize', 'fullscreen:false', 'close']);
 
 for (const bad of ['destroy', '', 'minimize ', 'MAXIMIZE', undefined, null, 42]) {
   assert.deepEqual(
@@ -156,7 +162,7 @@ for (const bad of ['destroy', '', 'minimize ', 'MAXIMIZE', undefined, null, 42])
     `action ${String(bad)} must be rejected`,
   );
 }
-assert.deepEqual(win.calls, ['minimize', 'maximize', 'unmaximize', 'close'], 'rejected actions must not touch the window');
+assert.deepEqual(win.calls, ['minimize', 'maximize', 'unmaximize', 'fullscreen:false', 'close'], 'rejected actions must not touch the window');
 const printPopup = localWindowOpenHandler({ url: 'about:blank' });
 assert.equal(printPopup?.action, 'allow');
 assert.deepEqual(printPopup?.overrideBrowserWindowOptions, {


### PR DESCRIPTION
## Intent

Sync POS topbar maximize/fullscreen toggle with native Electron window state

## What Changed

- Wired the Electron POS topbar toggle to native maximize/fullscreen state, including initialization and live synchronization when the window changes externally.
- Added narrow `getWindowState` and `window-state-changed` preload/IPC APIs; native toggling maximizes, restores, or exits fullscreen as appropriate while browser/LAN clients retain the document Fullscreen API.
- Added Electron E2E and contract coverage, plus updated title-bar documentation and platform evidence references.

## Risk Assessment

✅ Low: The change is narrowly scoped and the native/browser state transitions are coherently bridged without a substantiated source defect.

## Testing

After restoring dependencies, targeted contracts, builds, the 15/15 native window-state probe, and the real Electron POS topbar e2e all passed. The e2e verified restored, maximized, externally unmaximized, native fullscreen, and fullscreen exit states, captured three screenshots, and left only the intentional focused test change in the worktree.

<details>
<summary>Evidence: Native window-state probe</summary>

`SUMMARY | 15/15 checks passed`

```text
INFO | environment | platform=darwin electron=43.4.1
PASS | mode-resolution: real environment decision matches contract | resolved=native-overlay (platform=darwin, electronMajor=43, overlayApiPresent=false)
PASS | mode-resolution: missing overlay API fails closed to html-fallback on Windows/Linux | overlayApiPresent=false -> html-fallback on win32/linux
PASS | mode-resolution: macOS resolves to native-overlay even without overlay API | platform=darwin -> native-overlay
PASS | mode-resolution: pre-33 Electron fails closed to html-fallback | electron 32.x -> html-fallback
PASS | mode-resolution: unknown platform fails closed to html-fallback | platform=sunos -> html-fallback
PASS | fallback-options: html-fallback builds without titleBarOverlay | titleBarOverlay present=false
PASS | fallback-options: titleBarStyle stays hidden/hiddenInset in fallback | titleBarStyle=hiddenInset
PASS | window-creation: main window created with resolved mode | mode=native-overlay
PASS | overlay-config: real macOS BrowserWindow receives hiddenInset and centered traffic lights | titleBarStyle=hiddenInset trafficLightPosition={"x":16,"y":14}
PASS | window-action: unsupported verbs are rejected | action='explode' rejected
PASS | window-action: minimize via IPC verb works | isMinimized()=true after minimize
PASS | window-action: toggle-maximize via IPC verb maximizes | isMaximized()=true
PASS | window-action: toggle-maximize restores | isMaximized()=false after second toggle
PASS | fullscreen: enters native fullscreen | isFullScreen()=true
PASS | fullscreen: exits native fullscreen cleanly | isFullScreen()=false
SUMMARY | 15/15 checks passed
```
</details>
<details>
<summary>Evidence: POS topbar Electron e2e</summary>

```text
1 passed
```
</details>

- Evidence: Restored POS (local file: <code>~/.no-mistakes/evidence/01M1FGDPGA1NDBYM0SMNRTP4AC/06-pos-topbar-restored.png</code>)
- Evidence: Maximized POS (local file: <code>~/.no-mistakes/evidence/01M1FGDPGA1NDBYM0SMNRTP4AC/07-pos-topbar-maximized.png</code>)
- Evidence: Native fullscreen POS (local file: <code>~/.no-mistakes/evidence/01M1FGDPGA1NDBYM0SMNRTP4AC/08-pos-topbar-native-fullscreen.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e46b515c4b1f534736ecb8d2b1d4e23effe0228f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm ci`
- `npm run test:titlebar-window-options`
- `npm run test:electron-api-contract`
- `npm run build && npm run build:frontend`
- `npx electron tests/platform-titlebar-runtime-probe.cjs --fullscreen-check`
- `npx playwright test desktop/title-bar.electron.spec.ts --config=playwright.electron.config.ts --project=electron-desktop --grep "POS topbar fullscreen toggle"`
- `git diff --check`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
