### PR TITLE
fix(print): preserve receipt financial parity and add-on quantities

### DIFF
--- a/docs/printing-architecture.md
+++ b/docs/printing-architecture.md
@@ -136,8 +136,8 @@ Receipt block vocabulary v1 ([`shared/print/document.ts`](../shared/print/docume
 | `business-header` | name, address, phone (+label), instagram, conditional tax-ID line |
 | `document-meta` | invoice title (tax vs plain), number, canonical timestamp, optional table |
 | `customer` | customer name/phone with their labels |
-| `item-table` | header labels, item rows (quantity, unit price, amount, addons, special instructions) |
-| `totals` | subtotal, discount, flat tax/service/delivery, grand total, loyalty points lines |
+| `item-table` | header labels, item rows (quantity, unit price, amount, add-ons with quantity and extended amount, special instructions) |
+| `totals` | subtotal, discount, flat tax, optional frontend service charge, delivery/packaging charges, grand total, loyalty points lines |
 | `tax-breakdown` | per-component lines when the merchant shows the breakdown |
 | `payments` | captured payment lines (known methods resolve through concept ids, unknown stay literal) |
 | `message` | reprint banner, footer note, thank-you |
@@ -148,9 +148,10 @@ Kitchen tickets use a separate smaller vocabulary, `KotDocument` v1
 Invariants every consumer may rely on:
 
 - **Financial totals are not recomputed.** Builders copy persisted financial
-  amounts verbatim from the `PrintData` snapshots; they apply presence/show
-  decisions and the display-only tax-component reconciliation documented
-  above (`buildBillDocument` doc comment, asserted in
+  amounts verbatim from the `PrintData` snapshots; normalizers materialize
+  add-on display amounts as `price × add-on quantity × item quantity`, while
+  builders apply presence/show decisions and the display-only tax-component
+  reconciliation documented above (`buildBillDocument` doc comment, asserted in
   [`tests/print-document.test.ts`](../tests/print-document.test.ts) and
   byte-compared against the frozen pre-migration oracle in
   [`tests/print-parity.test.ts`](../tests/print-parity.test.ts)).

--- a/frontend/src/lib/printer/print-document.ts
+++ b/frontend/src/lib/printer/print-document.ts
@@ -192,6 +192,7 @@ export function buildBillPrintData(bill: Bill, opts: BillBusinessOptions = {}): 
       total: Number(bill?.total) || 0,
       serviceCharge: Number(bill?.service_charge) || 0,
       deliveryCharge: Number(bill?.delivery_charge) || 0,
+      packagingCharge: Number(bill?.packaging_charge) || 0,
       taxComponents: resolveTaxComponents(bill),
       payments: parsePaymentDetails(bill?.payment_details),
       pointsEarned: Number(bill?.points_earned) || 0,

--- a/frontend/src/lib/printer/print-document.ts
+++ b/frontend/src/lib/printer/print-document.ts
@@ -173,8 +173,9 @@ export function buildBillPrintData(bill: Bill, opts: BillBusinessOptions = {}): 
         quantity: Number(item?.quantity) || 0,
         unitPrice: Number(item?.unit_price) || 0,
         total: Number(item?.total) || 0,
-        addons: (item?.addons ?? []).map((addon) => {
-          const addonQty = ('quantity' in addon && typeof addon.quantity === 'number' && addon.quantity) || 1;
+        addons: (Array.isArray(item?.addons) ? item.addons : []).map((addon) => {
+          const addonQty = (addon !== null && typeof addon === 'object' && 'quantity' in addon
+            && typeof addon.quantity === 'number' && addon.quantity) || 1;
           return {
             name: String(addon?.name ?? ''),
             price: (Number(addon?.price) || 0) * addonQty * (Number(item?.quantity) || 0),

--- a/frontend/src/lib/printer/receipt-encoder.ts
+++ b/frontend/src/lib/printer/receipt-encoder.ts
@@ -540,6 +540,9 @@ export function buildClassicReceiptBytes(
     if (totals.deliveryCharge) {
       safePrinterText(enc, padRow(labelOf(totals.deliveryCharge.label), formatAmount(totals.deliveryCharge.amount, currency, locale, opts.trimDecimals === true), cols), warnings, false, arabicShaping).newline();
     }
+    if (totals.packagingCharge) {
+      safePrinterText(enc, padRow(labelOf(totals.packagingCharge.label), formatAmount(totals.packagingCharge.amount, currency, locale, opts.trimDecimals === true), cols), warnings, false, arabicShaping).newline();
+    }
 
     enc.rule({ style: 'double' });
     enc.bold(true);
@@ -719,6 +722,9 @@ export function buildCompactReceiptBytes(
   }
   if (totals?.deliveryCharge) {
     safePrinterText(enc, padRow(labelOf(totals.deliveryCharge.label), formatAmount(totals.deliveryCharge.amount, currency, locale, trim), cols), warnings, false, arabicShaping).newline();
+  }
+  if (totals?.packagingCharge) {
+    safePrinterText(enc, padRow(labelOf(totals.packagingCharge.label), formatAmount(totals.packagingCharge.amount, currency, locale, trim), cols), warnings, false, arabicShaping).newline();
   }
   if (breakdown && breakdown.lines.length > 0) {
     for (const line of breakdown.lines) {

--- a/frontend/src/lib/printer/web-print.ts
+++ b/frontend/src/lib/printer/web-print.ts
@@ -306,6 +306,7 @@ export function generateBillHtml(
     rate: printLabelResolver('receipt.rate', lang),
     totalTax: surfaceLabel(totals?.tax?.label, 'pos.tax', 'receipt.totalTax', lang),
     deliveryCharge: surfaceLabel(totals?.deliveryCharge?.label, 'pos.delivery', 'receipt.deliveryCharge', lang),
+    packagingCharge: documentLabel(totals?.packagingCharge?.label, 'pos.packaging', lang),
     grandTotal: surfaceLabel(totals?.grandTotal?.label, 'print.grandTotal', 'receipt.grandTotal', lang),
     taxDetails: printLabelResolver('receipt.taxDetails', lang),
     paymentsHeader: printLabelResolver('receipt.payments', lang),
@@ -414,6 +415,7 @@ export function generateBillHtml(
       ${totals.tax ? `<tr><td>${escapeHtml(L.totalTax)}</td><td class="text-end num">${fmtAmount(totals.tax.amount)}</td></tr>` : ''}
       ${totals.serviceCharge ? `<tr><td>${escapeHtml(totals.serviceCharge.label.primary)}</td><td class="text-end num">${fmtAmount(totals.serviceCharge.amount)}</td></tr>` : ''}
       ${totals.deliveryCharge ? `<tr><td>${escapeHtml(L.deliveryCharge)}</td><td class="text-end num">${fmtAmount(totals.deliveryCharge.amount)}</td></tr>` : ''}
+      ${totals.packagingCharge ? `<tr><td>${escapeHtml(L.packagingCharge)}</td><td class="text-end num">${fmtAmount(totals.packagingCharge.amount)}</td></tr>` : ''}
       <tr class="total-row"><td><strong>${escapeHtml(L.grandTotal)}</strong></td><td class="text-end num"><strong>${fmtAmount(totals.grandTotal.amount)}</strong></td></tr>
       ` : ''}
     </table>

--- a/main/print/print-labels.generated.ts
+++ b/main/print/print-labels.generated.ts
@@ -51,6 +51,7 @@ export type PrintConceptId =
   | 'pos.discount'
   | 'pos.tax'
   | 'pos.delivery'
+  | 'pos.packaging'
   | 'receipt.totalTax'
   | 'receipt.serviceCharge'
   | 'receipt.taxDetails'
@@ -133,6 +134,7 @@ const PRINT_LABELS: Record<PrintLabelLanguage, PrintLabelTable> = {
     'pos.discount': "Discount",
     'pos.tax': "Tax",
     'pos.delivery': "Delivery",
+    'pos.packaging': "Packaging",
     'receipt.totalTax': "Total Tax",
     'receipt.serviceCharge': "Service Charge",
     'receipt.taxDetails': "Tax Details",
@@ -198,6 +200,7 @@ const PRINT_LABELS: Record<PrintLabelLanguage, PrintLabelTable> = {
     'pos.discount': "تخفیف",
     'pos.tax': "مالیات",
     'pos.delivery': "رسانش",
+    'pos.packaging': "بسته‌بندی",
     'receipt.totalTax': "مالیات کل",
     'receipt.serviceCharge': "کارمزد خدمات",
     'receipt.taxDetails': "جزئیات مالیات",
@@ -263,6 +266,7 @@ const PRINT_LABELS: Record<PrintLabelLanguage, PrintLabelTable> = {
     'pos.discount': "Descuento",
     'pos.tax': "IVA",
     'pos.delivery': "Delivery",
+    'pos.packaging': "Envase",
     'receipt.totalTax': "Impuesto total",
     'receipt.serviceCharge': "Cargo por servicio",
     'receipt.taxDetails': "Detalle de impuestos",
@@ -328,6 +332,7 @@ const PRINT_LABELS: Record<PrintLabelLanguage, PrintLabelTable> = {
     'pos.discount': "Remise",
     'pos.tax': "Taxe",
     'pos.delivery': "Livraison",
+    'pos.packaging': "Emballage",
     'receipt.totalTax': "Total des taxes",
     'receipt.serviceCharge': "Frais de service",
     'receipt.taxDetails': "Détails des taxes",
@@ -393,6 +398,7 @@ const PRINT_LABELS: Record<PrintLabelLanguage, PrintLabelTable> = {
     'pos.discount': "Desconto",
     'pos.tax': "Imposto",
     'pos.delivery': "Entrega",
+    'pos.packaging': "Embalagem",
     'receipt.totalTax': "Imposto total",
     'receipt.serviceCharge': "Taxa de serviço",
     'receipt.taxDetails': "Detalhes de impostos",
@@ -458,6 +464,7 @@ const PRINT_LABELS: Record<PrintLabelLanguage, PrintLabelTable> = {
     'pos.discount': "İndirim",
     'pos.tax': "Vergi",
     'pos.delivery': "Teslimat",
+    'pos.packaging': "Paketleme",
     'receipt.totalTax': "Toplam Vergi",
     'receipt.serviceCharge': "Servis Ücreti",
     'receipt.taxDetails': "Vergi Detayları",
@@ -523,6 +530,7 @@ const PRINT_LABELS: Record<PrintLabelLanguage, PrintLabelTable> = {
     'pos.discount': "Discount",
     'pos.tax': "Buwis",
     'pos.delivery': "Delivery",
+    'pos.packaging': "Packaging",
     'receipt.totalTax': "Kabuuang Buwis",
     'receipt.serviceCharge': "Service Charge",
     'receipt.taxDetails': "Mga Detalye ng Buwis",
@@ -588,6 +596,7 @@ const PRINT_LABELS: Record<PrintLabelLanguage, PrintLabelTable> = {
     'pos.discount': "Rabatt",
     'pos.tax': "Steuer",
     'pos.delivery': "Lieferung",
+    'pos.packaging': "Verpackung",
     'receipt.totalTax': "Gesamtsteuer",
     'receipt.serviceCharge': "Servicegebühr",
     'receipt.taxDetails': "Steuerdetails",

--- a/main/printers/document-classic.ts
+++ b/main/printers/document-classic.ts
@@ -140,6 +140,9 @@ export function buildBillPrintData(order: any, bill: any, business: any, isRepri
       discountAmount: Number(bill?.discount_amount) || 0,
       taxAmount: Number(bill?.tax_amount) || 0,
       total: Number(bill?.total) || 0,
+      // Backend bills persist delivery and packaging charges. Service charges
+      // are currently an order/tax-engine concept with no persisted bill source,
+      // so keep the normalized backend boundary explicit until one exists.
       deliveryCharge: Number(bill?.delivery_charge) || 0,
       packagingCharge: Number(bill?.packaging_charge) || 0,
       taxComponents: resolveTaxComponents({ ...bill, items }),

--- a/main/printers/document-classic.ts
+++ b/main/printers/document-classic.ts
@@ -123,7 +123,8 @@ export function buildBillPrintData(order: any, bill: any, business: any, isRepri
         unitPrice: Number(item?.unit_price ?? item?.price ?? 0) || 0,
         total: Number(item?.total) || 0,
         addons: (Array.isArray(item?.addons) ? item.addons : []).map((addon: any) => {
-          const addonQuantity = ('quantity' in addon && typeof addon.quantity === 'number' && addon.quantity) || 1;
+          const addonQuantity = (addon !== null && typeof addon === 'object' && 'quantity' in addon
+            && typeof addon.quantity === 'number' && addon.quantity) || 1;
           return {
             name: String(addon?.name ?? ''),
             price: (Number(addon?.price) || 0) * addonQuantity * (Number(item?.quantity) || 0),

--- a/main/printers/document-classic.ts
+++ b/main/printers/document-classic.ts
@@ -304,8 +304,17 @@ export function renderBillDocumentToClassicLines(
     return segment;
   };
 
-  const renderGrandTotal = (block: TotalsBlock): void => {
-    segmentOf('totals').main.push(...financialRows(labelOf(block.grandTotal.label), formatCurrency(block.grandTotal.amount, prefix, options.locale, trimDecimals), cols, options.language).map((line) => `{BOLD}${line}{/BOLD}`));
+  const renderGrandTotal = (block: TotalsBlock, target = segmentOf('totals')): void => {
+    target.main.push(...financialRows(labelOf(block.grandTotal.label), formatCurrency(block.grandTotal.amount, prefix, options.locale, trimDecimals), cols, options.language).map((line) => `{BOLD}${line}{/BOLD}`));
+  };
+
+  const renderCharges = (block: TotalsBlock, target: BlockSegments): void => {
+    if (block.deliveryCharge) {
+      target.main.push(...financialRows(labelOf(block.deliveryCharge.label), formatCurrency(block.deliveryCharge.amount, prefix, options.locale, trimDecimals), cols, options.language));
+    }
+    if (block.packagingCharge) {
+      target.main.push(...financialRows(labelOf(block.packagingCharge.label), formatCurrency(block.packagingCharge.amount, prefix, options.locale, trimDecimals), cols, options.language));
+    }
   };
 
   for (const block of blocks) {
@@ -396,7 +405,9 @@ export function renderBillDocumentToClassicLines(
           && totalsIndex >= 0
           && breakdownIndex > totalsIndex
         ) {
-          renderGrandTotal(blocks[totalsIndex] as TotalsBlock);
+          const totalsBlock = blocks[totalsIndex] as TotalsBlock;
+          renderCharges(totalsBlock, segment);
+          renderGrandTotal(totalsBlock, segment);
         }
         break;
       }
@@ -417,11 +428,8 @@ export function renderBillDocumentToClassicLines(
         if (!hasBreakdownLines && block.tax) {
           segment.main.push(...financialRows(labelOf(block.tax.label), formatCurrency(block.tax.amount, prefix, options.locale, trimDecimals), cols, options.language));
         }
-        if (block.deliveryCharge) {
-          segment.main.push(...financialRows(labelOf(block.deliveryCharge.label), formatCurrency(block.deliveryCharge.amount, prefix, options.locale, trimDecimals), cols, options.language));
-        }
-        if (block.packagingCharge) {
-          segment.main.push(...financialRows(labelOf(block.packagingCharge.label), formatCurrency(block.packagingCharge.amount, prefix, options.locale, trimDecimals), cols, options.language));
+        if (!hasBreakdownLines || breakdownIndex < totalsIndex) {
+          renderCharges(block, segment);
         }
         if (!hasBreakdownLines) {
           renderGrandTotal(block);

--- a/main/printers/document-classic.ts
+++ b/main/printers/document-classic.ts
@@ -122,10 +122,14 @@ export function buildBillPrintData(order: any, bill: any, business: any, isRepri
         quantity: Number(item?.quantity) || 0,
         unitPrice: Number(item?.unit_price ?? item?.price ?? 0) || 0,
         total: Number(item?.total) || 0,
-        addons: (Array.isArray(item?.addons) ? item.addons : []).map((addon: any) => ({
-          name: String(addon?.name ?? ''),
-          price: Number(addon?.price) || 0,
-        })),
+        addons: (Array.isArray(item?.addons) ? item.addons : []).map((addon: any) => {
+          const addonQuantity = ('quantity' in addon && typeof addon.quantity === 'number' && addon.quantity) || 1;
+          return {
+            name: String(addon?.name ?? ''),
+            price: (Number(addon?.price) || 0) * addonQuantity * (Number(item?.quantity) || 0),
+            quantity: addonQuantity,
+          };
+        }),
         specialInstructions: String(item?.special_instructions ?? ''),
       })),
     },
@@ -135,6 +139,8 @@ export function buildBillPrintData(order: any, bill: any, business: any, isRepri
       discountAmount: Number(bill?.discount_amount) || 0,
       taxAmount: Number(bill?.tax_amount) || 0,
       total: Number(bill?.total) || 0,
+      deliveryCharge: Number(bill?.delivery_charge) || 0,
+      packagingCharge: Number(bill?.packaging_charge) || 0,
       taxComponents: resolveTaxComponents({ ...bill, items }),
       payments: parsePaymentDetails(bill?.payment_details),
       pointsEarned: Number(business?.points_earned) || 0,
@@ -404,10 +410,16 @@ export function renderBillDocumentToClassicLines(
           (candidate) => candidate.kind === 'tax-breakdown'
             && (candidate as TaxBreakdownBlock).lines.length > 0,
         );
+        if (!hasBreakdownLines && block.tax) {
+          segment.main.push(...financialRows(labelOf(block.tax.label), formatCurrency(block.tax.amount, prefix, options.locale, trimDecimals), cols, options.language));
+        }
+        if (block.deliveryCharge) {
+          segment.main.push(...financialRows(labelOf(block.deliveryCharge.label), formatCurrency(block.deliveryCharge.amount, prefix, options.locale, trimDecimals), cols, options.language));
+        }
+        if (block.packagingCharge) {
+          segment.main.push(...financialRows(labelOf(block.packagingCharge.label), formatCurrency(block.packagingCharge.amount, prefix, options.locale, trimDecimals), cols, options.language));
+        }
         if (!hasBreakdownLines) {
-          if (block.tax) {
-            segment.main.push(...financialRows(labelOf(block.tax.label), formatCurrency(block.tax.amount, prefix, options.locale, trimDecimals), cols, options.language));
-          }
           renderGrandTotal(block);
         } else if (breakdownIndex < totalsIndex) {
           renderGrandTotal(block);

--- a/main/printers/document-compact.ts
+++ b/main/printers/document-compact.ts
@@ -199,6 +199,12 @@ export function renderBillDocumentToCompactLines(
     } else if (totals.tax) {
       lines.push(...financialRows(labelOf(totals.tax.label), formatCurrency(totals.tax.amount, prefix, options.locale, trimDecimals), cols, options.language));
     }
+    if (totals.deliveryCharge) {
+      lines.push(...financialRows(labelOf(totals.deliveryCharge.label), formatCurrency(totals.deliveryCharge.amount, prefix, options.locale, trimDecimals), cols, options.language));
+    }
+    if (totals.packagingCharge) {
+      lines.push(...financialRows(labelOf(totals.packagingCharge.label), formatCurrency(totals.packagingCharge.amount, prefix, options.locale, trimDecimals), cols, options.language));
+    }
     lines.push(...financialRows(labelOf(totals.grandTotal.label), formatCurrency(totals.grandTotal.amount, prefix, options.locale, trimDecimals), cols, options.language).map((line) => `{BOLD}${line}{/BOLD}`));
   }
 

--- a/scripts/generate-print-labels.cjs
+++ b/scripts/generate-print-labels.cjs
@@ -97,6 +97,7 @@ const BORROWED_KEYS = [
   'pos.discount',
   'pos.tax',
   'pos.delivery',
+  'pos.packaging',
   'receipt.totalTax',
   'receipt.serviceCharge',
   'receipt.taxDetails',

--- a/shared/print/document.ts
+++ b/shared/print/document.ts
@@ -148,6 +148,8 @@ export interface BillSnapshot {
   readonly serviceCharge?: number;
   /** Flat delivery charge, when the bill carries one (frontend bills). */
   readonly deliveryCharge?: number;
+  /** Flat packaging charge, when the bill carries one. */
+  readonly packagingCharge?: number;
   readonly taxComponents: readonly TaxComponentSnapshot[];
   readonly payments: readonly PaymentSnapshot[];
   readonly pointsEarned: number;
@@ -343,6 +345,8 @@ export interface TotalsBlock {
   readonly serviceCharge: { readonly label: SemanticLabel; readonly amount: number } | null;
   /** Flat delivery-charge line, present when the snapshot carries a nonzero charge. */
   readonly deliveryCharge: { readonly label: SemanticLabel; readonly amount: number } | null;
+  /** Flat packaging-charge line, present when the snapshot carries a nonzero charge. */
+  readonly packagingCharge: { readonly label: SemanticLabel; readonly amount: number } | null;
   readonly grandTotal: { readonly label: SemanticLabel; readonly amount: number };
   readonly pointsRedeemed: { readonly label: SemanticLabel; readonly points: number } | null;
   readonly pointsEarned: { readonly label: SemanticLabel; readonly points: number } | null;
@@ -608,6 +612,12 @@ export function buildBillDocument(printData: PrintData, printContext: PrintConte
       ? Object.freeze({
         label: resolveSemanticLabel(labels, 'pos.delivery'),
         amount: toFiniteNumber(bill.deliveryCharge),
+      })
+      : null,
+    packagingCharge: toFiniteNumber(bill.packagingCharge) !== 0
+      ? Object.freeze({
+        label: resolveSemanticLabel(labels, 'pos.packaging'),
+        amount: toFiniteNumber(bill.packagingCharge),
       })
       : null,
     grandTotal: Object.freeze({

--- a/shared/print/document.ts
+++ b/shared/print/document.ts
@@ -93,7 +93,7 @@ export function directionalText(text: string, base: TextDirection): DirectionalT
 // Snapshots (PrintData) — normalized authoritative values, no live rows
 // ---------------------------------------------------------------------------
 
-/** One addon line under an item row. Price is printed truth (0 = unpriced). */
+/** One add-on line; price is the extended printed amount (0 = unpriced). */
 export interface ItemAddonSnapshot {
   readonly name: string;
   readonly price: number;
@@ -278,7 +278,7 @@ export interface CustomerBlock {
   readonly phoneLabel: SemanticLabel;
 }
 
-/** One addon under an item row. `price === 0` means unpriced extra. */
+/** One add-on under an item row; price is its extended printed amount. */
 export interface ItemAddonValue {
   readonly name: DirectionalText;
   readonly price: number;

--- a/tests/helpers/legacy-thermal-oracle.ts
+++ b/tests/helpers/legacy-thermal-oracle.ts
@@ -6,13 +6,13 @@
  * `main/printers/thermal.ts`, captured before the backend migrated to the
  * PrintDocument model. Nothing in `main/` imports this module; it exists so
  * tests/print-parity.test.ts can enforce byte-equivalence between the
- * document-driven production renderers and today's printed output at every
- * supported width (32/42/48 columns).
+ * document-driven production renderers and the expected printed output at
+ * every supported width (32/42/48 columns).
  *
- * Do NOT modernize, fix, or extend these bodies. If a parity assertion
- * fails, the document-driven renderer regressed; change that side, not this
- * oracle. When an output change is INTENTIONAL, update the oracle together
- * with the harness expectations in a reviewed commit citing the decision.
+ * The receipt oracle preserves the legacy layout, but its add-on amount is
+ * materialized from the authoritative financial semantics
+ * (`price × addonQty × itemQty`) so parity tests do not preserve the
+ * confirmed undercharged output. Do not make unrelated changes here.
  */
 
 import { parseDbTimestamp } from '../../main/db';
@@ -41,6 +41,19 @@ import { printLabel } from '../../main/print/print-labels.generated';
 
 function parseAddons(addons: any): any[] {
   return Array.isArray(addons) ? addons : [];
+}
+
+function withExtendedAddonAmounts(order: any): any {
+  return {
+    ...order,
+    items: Array.isArray(order?.items) ? order.items.map((item: any) => ({
+      ...item,
+      addons: parseAddons(item.addons).map((addon: any) => ({
+        ...addon,
+        price: (Number(addon?.price) || 0) * (Number(addon?.quantity) || 1) * (Number(item?.quantity) || 0),
+      })),
+    })) : order?.items,
+  };
 }
 
 function itemHeaderLegacy(lang: string, nameLen: number, amtLen: number): string {
@@ -75,7 +88,7 @@ export function formatClassicReceiptLegacy(order: any, bill: any, biz: any, cols
   const prefix = resolveCurrencyPrefix(biz.currency_symbol || '₹', useUnicode);
   const trimDecimals = biz.trim_decimals === true;
   const locale = getCountryByCode(biz.country)?.locale ?? 'en-US';
-  const amtLen = itemAmountWidth(order, prefix, locale, trimDecimals, cols);
+  const amtLen = itemAmountWidth(withExtendedAddonAmounts(order), prefix, locale, trimDecimals, cols);
   const itemNameLen = itemNameWidth(cols, amtLen);
   const taxComponents = resolveTaxComponents({ ...bill, items: order.items });
   const hasTax = Number(bill.tax_amount) !== 0
@@ -107,7 +120,10 @@ export function formatClassicReceiptLegacy(order: any, bill: any, biz: any, cols
 
       const addons = parseAddons(item.addons);
       for (const addon of addons) {
-        lines.push(...addonRows(addon, itemNameLen, amtLen, cols, prefix, locale, trimDecimals));
+        lines.push(...addonRows({
+          ...addon,
+          price: (Number(addon?.price) || 0) * (Number(addon?.quantity) || 1) * (Number(item?.quantity) || 0),
+        }, itemNameLen, amtLen, cols, prefix, locale, trimDecimals));
       }
       if (item.special_instructions) {
         lines.push('  ' + printLabel(lang, 'print.note') + ': ' + truncate(item.special_instructions, cols - 8));
@@ -136,6 +152,15 @@ export function formatClassicReceiptLegacy(order: any, bill: any, biz: any, cols
     }
   } else if (Number(bill.tax_amount) !== 0) {
     lines.push(...financialRows(printLabel(lang, 'pos.tax'), formatCurrency(bill.tax_amount, prefix, locale, trimDecimals), cols));
+  }
+  if ((Number(bill.service_charge) || 0) !== 0) {
+    lines.push(...financialRows(printLabel(lang, 'receipt.serviceCharge'), formatCurrency(bill.service_charge, prefix, locale, trimDecimals), cols));
+  }
+  if (Number(bill.delivery_charge) !== 0) {
+    lines.push(...financialRows(printLabel(lang, 'pos.delivery'), formatCurrency(bill.delivery_charge, prefix, locale, trimDecimals), cols));
+  }
+  if (Number(bill.packaging_charge) !== 0) {
+    lines.push(...financialRows(printLabel(lang, 'pos.packaging'), formatCurrency(bill.packaging_charge, prefix, locale, trimDecimals), cols));
   }
   lines.push(...financialRows(printLabel(lang, 'print.grandTotal'), formatCurrency(bill.total, prefix, locale, trimDecimals), cols).map((line: string) => `{BOLD}${line}{/BOLD}`));
 
@@ -203,7 +228,7 @@ export function formatCompactReceiptLegacy(order: any, bill: any, biz: any, cols
   const prefix = resolveCurrencyPrefix(biz.currency_symbol || '₹', useUnicode);
   const trimDecimals = biz.trim_decimals === true;
   const locale = getCountryByCode(biz.country)?.locale ?? 'en-US';
-  const amtLen = itemAmountWidth(order, prefix, locale, trimDecimals, cols);
+  const amtLen = itemAmountWidth(withExtendedAddonAmounts(order), prefix, locale, trimDecimals, cols);
   const itemNameLen = itemNameWidth(cols, amtLen);
   const taxIdLabel = getCountryByCode(biz.country)?.taxIdLabel || 'Tax ID';
   const taxComponents = resolveTaxComponents({ ...bill, items: order.items });
@@ -231,7 +256,10 @@ export function formatCompactReceiptLegacy(order: any, bill: any, biz: any, cols
 
       const addons = parseAddons(item.addons);
       for (const addon of addons) {
-        lines.push(...addonRows(addon, itemNameLen, amtLen, cols, prefix, locale, trimDecimals));
+        lines.push(...addonRows({
+          ...addon,
+          price: (Number(addon?.price) || 0) * (Number(addon?.quantity) || 1) * (Number(item?.quantity) || 0),
+        }, itemNameLen, amtLen, cols, prefix, locale, trimDecimals));
       }
       if (item.special_instructions) {
         lines.push('  ' + printLabel(lang, 'print.note') + ': ' + truncate(item.special_instructions, cols - 8));
@@ -253,6 +281,15 @@ export function formatCompactReceiptLegacy(order: any, bill: any, biz: any, cols
     }
   } else if (Number(bill.tax_amount) !== 0) {
     lines.push(...financialRows(printLabel(lang, 'pos.tax'), formatCurrency(bill.tax_amount, prefix, locale, trimDecimals), cols));
+  }
+  if ((Number(bill.service_charge) || 0) !== 0) {
+    lines.push(...financialRows(printLabel(lang, 'receipt.serviceCharge'), formatCurrency(bill.service_charge, prefix, locale, trimDecimals), cols));
+  }
+  if (Number(bill.delivery_charge) !== 0) {
+    lines.push(...financialRows(printLabel(lang, 'pos.delivery'), formatCurrency(bill.delivery_charge, prefix, locale, trimDecimals), cols));
+  }
+  if (Number(bill.packaging_charge) !== 0) {
+    lines.push(...financialRows(printLabel(lang, 'pos.packaging'), formatCurrency(bill.packaging_charge, prefix, locale, trimDecimals), cols));
   }
   lines.push(...financialRows(printLabel(lang, 'print.grandTotal'), formatCurrency(bill.total, prefix, locale, trimDecimals), cols).map((line: string) => `{BOLD}${line}{/BOLD}`));
 

--- a/tests/print-document.test.ts
+++ b/tests/print-document.test.ts
@@ -399,6 +399,30 @@ console.log('\n▶ Add-on quantity and charge financial parity');
         `${renderer} renders packaging charge`);
     }
   }
+
+  const malformedOrder = {
+    order_number: 'ORD-ADDON-MALFORMED',
+    created_at: '2026-08-21 18:42:00',
+    items: [{
+      product_name: 'Tea',
+      quantity: 2,
+      unit_price: 10,
+      total: 20,
+      addons: [null, 'legacy-addon', { name: 'Safe extra', price: 4, quantity: 2 }],
+    }],
+  };
+  const malformedData = buildBillPrintData(malformedOrder, {
+    bill_number: 'INV-ADDON-MALFORMED',
+    subtotal: 20,
+    discount_amount: 0,
+    tax_amount: 0,
+    total: 20,
+  }, { country: 'IN', currency_symbol: '₹' }, false);
+  assert.equal(malformedData.order.items[0].addons[0].price, 0);
+  assert.equal(malformedData.order.items[0].addons[1].price, 0);
+  assert.equal(malformedData.order.items[0].addons[2].price, 16,
+    'object add-on quantity still uses the extended amount after malformed entries');
+  ok('malformed add-on entries do not break normalization');
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/print-document.test.ts
+++ b/tests/print-document.test.ts
@@ -29,7 +29,9 @@ import {
   buildBillPrintContext,
   buildBillPrintData,
   detectPrintLanguageDirection,
+  renderBillDocumentToClassicLines,
 } from '../main/printers/document-classic';
+import { renderBillDocumentToCompactLines } from '../main/printers/document-compact';
 import { buildParityFixtures } from './print-parity.test';
 
 // ---------------------------------------------------------------------------
@@ -134,7 +136,10 @@ console.log('\n▶ Block construction (fixture bill)');
   const totals = blockOf(document, 'totals');
   assert.equal(totals.subtotal.amount, 1220);
   assert.equal(totals.discount?.amount, 120);
-  assert.equal(totals.grandTotal.amount, 1100);
+  assert.equal(totals.serviceCharge, null, 'backend fixture does not invent a service-charge bill field');
+  assert.equal(totals.deliveryCharge?.amount, 8);
+  assert.equal(totals.packagingCharge?.amount, 9);
+  assert.equal(totals.grandTotal.amount, 1117);
   assert.equal(totals.tax, null, 'no flat tax line when tax amount is zero');
   assert.equal(blockOf(document, 'tax-breakdown').lines.length, 0, 'no breakdown lines when merchant hides them');
   const payments = blockOf(document, 'payments');
@@ -201,7 +206,7 @@ console.log('\n▶ Printed truth is never recomputed');
   const totals = blockOf(odd, 'totals');
   assert.equal(totals.subtotal.amount, 1220.456);
   assert.equal(totals.grandTotal.amount, 999999.99);
-  assert.equal(blockOf(odd, 'payments').lines[1].amount, 500);
+  assert.equal(blockOf(odd, 'payments').lines[1].amount, 517);
   ok('amounts pass through verbatim');
 }
 
@@ -304,7 +309,7 @@ console.log('\n▶ Backend PrintData normalization (main layer)');
   const { order, bill, business } = buildParityFixtures();
   const rawBill = { ...bill, payment_details: JSON.stringify(bill.payment_details) };
   const printData = buildBillPrintData(order, rawBill, business, false);
-  assert.deepEqual(printData.bill.payments, [{ method: 'cash', amount: 600 }, { method: 'card', amount: 500 }]);
+  assert.deepEqual(printData.bill.payments, [{ method: 'cash', amount: 600 }, { method: 'card', amount: 517 }]);
   assert.equal(printData.bill.pointsEarned, 0);
   assert.equal(printData.business.showTaxId, 'force', 'fixture show_tax_id true maps to force');
   const unsetFlags = buildBillPrintData(order, rawBill, { ...business, show_tax_id: undefined }, false);
@@ -324,6 +329,76 @@ console.log('\n▶ Backend PrintData normalization (main layer)');
   assert.equal(context.trimDecimals, false);
   assert.equal(context.baseDirection, 'ltr');
   ok('print context derived from business snapshot');
+}
+
+console.log('\n▶ Add-on quantity and charge financial parity');
+{
+  const cases = [
+    { itemQuantity: 1, addonQuantity: 1, addonPrice: 5, expected: 5 },
+    { itemQuantity: 2, addonQuantity: 3, addonPrice: 5, expected: 30 },
+    { itemQuantity: 3, addonQuantity: 2, addonPrice: 7.5, expected: 45 },
+  ];
+
+  for (const testCase of cases) {
+    const order = {
+      order_number: 'ORD-ADDON-PARITY',
+      created_at: '2026-08-21 18:42:00',
+      items: [{
+        product_name: 'Tea',
+        quantity: testCase.itemQuantity,
+        unit_price: 10,
+        total: 20,
+        addons: [
+          { name: 'Extra shot', price: testCase.addonPrice, quantity: testCase.addonQuantity },
+          { name: 'Vanilla syrup', price: 2, quantity: 2 },
+        ],
+      }],
+    };
+    const bill = {
+      bill_number: 'INV-ADDON-PARITY',
+      subtotal: 50,
+      discount_amount: 0,
+      tax_amount: 0,
+      delivery_charge: 8,
+      packaging_charge: 9,
+      total: 67,
+    };
+    const business = { country: 'IN', currency_symbol: '₹' };
+    const printData = buildBillPrintData(order, bill, business, false);
+    assert.equal(printData.order.items[0].quantity, testCase.itemQuantity);
+    assert.equal(printData.order.items[0].addons[0].quantity, testCase.addonQuantity);
+    assert.equal(printData.order.items[0].addons[0].price, testCase.expected,
+      `addon extension ${testCase.itemQuantity}x item × ${testCase.addonQuantity}x addon`);
+    assert.equal(printData.order.items[0].addons[1].price, testCase.itemQuantity * 2 * 2,
+      'multiple add-ons retain independent extensions');
+    assert.equal(printData.bill.serviceCharge, undefined, 'backend normalization does not invent service-charge storage');
+    assert.equal(printData.bill.deliveryCharge, 8);
+    assert.equal(printData.bill.packagingCharge, 9);
+
+    const context = buildBillPrintContext({ columns: 48, language: 'en', business });
+    const document = buildBillDocument(printData, context);
+    const options = {
+      columns: 48,
+      language: 'en',
+      locale: context.locale,
+      currencySymbol: '₹',
+      trimDecimals: false,
+      useUnicode: true,
+      arabicShaping: false,
+      cutMode: 'full' as const,
+    };
+    for (const [renderer, lines] of [
+      ['classic', renderBillDocumentToClassicLines(document, options)],
+      ['compact', renderBillDocumentToCompactLines(document, options)],
+    ] as const) {
+      assert(lines.some((line) => line.includes('Extra shot') && line.includes(`₹${testCase.expected.toFixed(2)}`)),
+        `${renderer} renders extended add-on amount`);
+      assert(lines.some((line) => line.includes('Delivery') && line.includes('₹8.00')),
+        `${renderer} renders delivery charge`);
+      assert(lines.some((line) => line.includes('Packaging') && line.includes('₹9.00')),
+        `${renderer} renders packaging charge`);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/print-document.test.ts
+++ b/tests/print-document.test.ts
@@ -185,6 +185,40 @@ console.log('\n▶ Show-flag and tax-presence decisions');
   const breakdownBlock = blockOf(breakdown, 'tax-breakdown');
   assert.deepEqual(breakdownBlock.lines.map((line) => line.label.primary), ['GST', 'VAT'], 'zero-amount components filtered');
   assert.equal(blockOf(breakdown, 'totals').tax, null, 'flat tax line suppressed when breakdown shown');
+
+  const chargedBreakdown = buildBillDocument(
+    makePrintData({
+      bill: {
+        taxAmount: 90,
+        taxComponents: [{ title: 'GST', rate: 5, amount: 90 }],
+        deliveryCharge: 8,
+        packagingCharge: 9,
+      },
+      business: { showTaxBreakdown: true },
+    }),
+    makeContext(),
+  );
+  const chargedOptions = {
+    columns: 48,
+    language: 'en',
+    locale: 'en-IN',
+    currencySymbol: '₹',
+    trimDecimals: false,
+    useUnicode: true,
+    arabicShaping: false,
+    cutMode: 'full' as const,
+  };
+  for (const [renderer, lines] of [
+    ['classic', renderBillDocumentToClassicLines(chargedBreakdown, chargedOptions)],
+    ['compact', renderBillDocumentToCompactLines(chargedBreakdown, chargedOptions)],
+  ] as const) {
+    const taxIndex = lines.findIndex((line) => line.includes('GST'));
+    const deliveryIndex = lines.findIndex((line) => line.includes('pos.delivery[en]'));
+    const packagingIndex = lines.findIndex((line) => line.includes('pos.packaging[en]'));
+    const totalIndex = lines.findIndex((line) => line.includes('print.grandTotal[en]'));
+    assert(taxIndex >= 0 && taxIndex < deliveryIndex && deliveryIndex < packagingIndex && packagingIndex < totalIndex,
+      `${renderer} places tax breakdown before charges and grand total`);
+  }
   ok('tax breakdown vs flat tax line decision');
 
   const noBreakdown = buildBillDocument(

--- a/tests/print-parity.test.ts
+++ b/tests/print-parity.test.ts
@@ -436,6 +436,29 @@ function run(): void {
     }
     warn(browserHtml.includes('Extra shot') && browserHtml.includes('×3'), 'browser: addon quantity remains visible');
     warn(browserHtml.includes('Delivery Charge') && browserHtml.includes('Packaging'), 'browser: delivery and packaging charges render');
+
+    let malformedPrintSucceeded = true;
+    for (const addons of [
+      [null, 'legacy-addon', { name: 'Safe extra', price: 4, quantity: 2 }],
+      'legacy-addon',
+      { legacy: true },
+    ]) {
+      const malformedBill = {
+        ...quantityBill,
+        order: {
+          ...quantityOrder,
+          items: [{ ...quantityOrder.items[0], addons }],
+        },
+      };
+      try {
+        fe.receiptEncoder.buildClassicReceiptBytes(malformedBill as any, { ...tenant, business_name: 'Flo Parity Cafe' } as any, { paperWidth: 80 }, []);
+        fe.receiptEncoder.buildCompactReceiptBytes(malformedBill as any, { ...tenant, business_name: 'Flo Parity Cafe' } as any, { paperWidth: 80 }, []);
+        fe.webPrint.generateBillHtml(malformedBill as any, { ...tenant, business_name: 'Flo Parity Cafe' } as any, { paperSize: 'thermal80' });
+      } catch {
+        malformedPrintSucceeded = false;
+      }
+    }
+    warn(malformedPrintSucceeded, 'frontend: malformed add-on containers and entries do not crash printing');
   }
 
   // ------------------------------------------------------------------

--- a/tests/print-parity.test.ts
+++ b/tests/print-parity.test.ts
@@ -142,12 +142,12 @@ export function buildParityFixtures() {
     subtotal: 1220,
     discount_amount: 120,
     tax_amount: 0,
-    service_charge: 0,
-    delivery_charge: 0,
-    total: 1100,
+    delivery_charge: 8,
+    packaging_charge: 9,
+    total: 1117,
     payment_details: [
       { method: 'cash', amount: 600 },
-      { method: 'card', amount: 500 },
+      { method: 'card', amount: 517 },
     ],
   };
   // Frontend renderers navigate bill.order for items/table/customer.
@@ -300,7 +300,7 @@ function run(): void {
   const baseExpect = {
     items: [LATIN_ITEM, LONG_NAME_STEM],
     discount: 120,
-    total: 1100,
+    total: 1117,
     payments: ['Cash', 'Card'],
     businessName: 'Flo Parity Cafe',
     truncationMarker: true,
@@ -383,6 +383,62 @@ function run(): void {
   }
 
   // ------------------------------------------------------------------
+  // 2b. Financial parity — backend normalization must match the proven
+  // frontend add-on extension (`price × addonQty × itemQty`) and retain
+  // existing charge totals.
+  // ------------------------------------------------------------------
+  section('Add-on quantity and charge parity');
+  {
+    const quantityOrder = {
+      order_number: 'ORD-FINANCIAL-PARITY',
+      created_at: '2026-08-21 18:42:00',
+      items: [{
+        product_name: 'Tea',
+        quantity: 2,
+        unit_price: 10,
+        total: 20,
+        addons: [
+          { name: 'Extra shot', price: 5, quantity: 3 },
+          { name: 'Vanilla syrup', price: 2, quantity: 2 },
+        ],
+      }],
+    };
+    const quantityBill = {
+      bill_number: 'INV-FINANCIAL-PARITY',
+      subtotal: 50,
+      discount_amount: 0,
+      tax_amount: 0,
+      delivery_charge: 8,
+      packaging_charge: 9,
+      total: 67,
+      payment_details: [{ method: 'cash', amount: 67 }],
+      order: quantityOrder,
+    };
+    const quantityBusiness = { ...business, name: 'Flo Parity Cafe' };
+    const backendOutputs = ['classic', 'compact'].map((template) => escPosToText(
+      formatReceipt(quantityOrder, quantityBill, quantityBusiness, template, 48, true, false, 'full', []),
+    ));
+    const frontendText = new TextDecoder().decode(
+      fe.receiptEncoder.buildClassicReceiptBytes(quantityBill as any, { ...tenant, business_name: 'Flo Parity Cafe' } as any, { paperWidth: 80, useUnicode: true }, []),
+    );
+    const browserHtml = fe.webPrint.generateBillHtml(
+      quantityBill as any,
+      { ...tenant, business_name: 'Flo Parity Cafe' } as any,
+      { paperSize: 'thermal80', businessName: 'Flo Parity Cafe' },
+    );
+
+    for (const [renderer, text] of [['backend/classic', backendOutputs[0]], ['backend/compact', backendOutputs[1]], ['frontend/webusb/classic', frontendText]] as const) {
+      const addonRow = contentRows(text).find((row) => /Extra shot/.test(row));
+      warn(addonRow != null && digitsOf(addonRow).includes('3000'), `${renderer}: addon 5 × 3 × 2 renders 30.00`);
+      const secondAddonRow = contentRows(text).find((row) => /Vanilla syrup/.test(row));
+      warn(secondAddonRow != null && digitsOf(secondAddonRow).includes('800'), `${renderer}: second addon extension renders 8.00`);
+      warn(text.includes('8.00') && text.includes('9.00'), `${renderer}: delivery and packaging charges render`);
+    }
+    warn(browserHtml.includes('Extra shot') && browserHtml.includes('×3'), 'browser: addon quantity remains visible');
+    warn(browserHtml.includes('Delivery Charge') && browserHtml.includes('Packaging'), 'browser: delivery and packaging charges render');
+  }
+
+  // ------------------------------------------------------------------
   // 3. Browser HTML — full Unicode path (Persian MUST be present here)
   // ------------------------------------------------------------------
   for (const paperSize of ['thermal58', 'thermal80'] as const) {
@@ -436,6 +492,7 @@ function run(): void {
       ['receipt.amount', 'Amount'],
       ['pos.subtotal', 'Subtotal'],
       ['pos.discount', 'Discount'],
+      ['pos.packaging', 'Packaging'],
       ['receipt.grandTotal', 'Grand Total'],
       ['receipt.payments', 'Payments'],
       ['pos.methodCash', 'Cash'],


### PR DESCRIPTION
## Intent

Address reviewer feedback for receipt-printing financial parity and add-on quantity handling. Preserve item and add-on quantities, render extended add-on amounts as price × add-on quantity × item quantity across classic and compact backend receipts, preserve existing persisted charge totals, and add focused regression and parity tests. Keep the work isolated on fm/flocafe-print-financial-parity-r1 from latest origin/main (at least 24f5e0d2); exclude printer capability, character handling, timezone, KOT, WebUSB, raster, localization setup, and unrelated refactors. Backend bill storage has delivery_charge and packaging_charge but no service_charge; do not invent backend service-charge storage. Keep frontend shared service-charge support unchanged. Malformed persisted add-on entries must not crash normalization, while valid add-on quantity financial behavior remains unchanged. Do not merge.

## What Changed

- Preserve item and add-on quantities, calculating extended add-on amounts as price × add-on quantity × item quantity across receipt renderers.
- Render persisted delivery and packaging charges in classic, compact, thermal, and browser receipts without introducing backend service-charge storage.
- Add focused regression and cross-renderer parity coverage, including malformed add-on normalization cases.

## Risk Assessment

✅ Low: The change is bounded to receipt normalization and rendering, and no remaining source-verifiable material issue was substantiated.

## Testing

Focused print-document and parity tests passed. Direct receipt output demonstrated extended add-on amounts, preserved delivery/packaging charges, tax-before-charge ordering, malformed frontend add-on tolerance, and frontend service-charge rendering. Evidence was saved outside the worktree; no full suite, lint, or static analysis was run.

<details>
<summary>Evidence: Receipt financial parity transcript</summary>

```text
--- backend classic ---
[Printer] formatReceipt - template: classic
[Printer] formatReceipt - order: ORD-EVIDENCE bill: INV-EVIDENCE
[Printer] formatReceipt - items count: 1 cols: 48
Evidence Cafe
  + Extra shot                           Rs30.00
  + Vanilla syrup                         Rs8.00
GST @5%                                  Rs90.00
Delivery                                  Rs8.00
Packaging                                 Rs9.00
TOTAL                                    Rs67.00
--- backend compact ---
[Printer] formatReceipt - template: compact
[Printer] formatReceipt - order: ORD-EVIDENCE bill: INV-EVIDENCE
[Printer] formatReceipt - items count: 1 cols: 48
Evidence Cafe
  + Extra shot                           Rs30.00
  + Vanilla syrup                         Rs8.00
GST @5%                                  Rs90.00
Delivery                                  Rs8.00
Packaging                                 Rs9.00
TOTAL                                    Rs67.00
--- frontend webusb classic ---
           @.ME!tEvidence Cafe!E
+ Extra shot x3                         ?30.00
+ Vanilla syrup x2                       ?8.00
Delivery                                   ?8.00
Packaging                                  ?9.00
ETOTAL                                     ?67.00E
--- frontend browser html totals/items ---
Tea + Extra shot ×3, + Vanilla syrup ×2 2 ₹10.00 ₹20.00
GST @5% ₹90.00
Service Charge ₹4.00
Delivery Charge ₹8.00
Packaging ₹9.00
Grand Total ₹67.00
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"aa7bb2b53ea0763c729709c6b39ed862237d2070","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `frontend/src/lib/printer/print-document.ts:177` - The required criterion says “Malformed persisted add-on entries must not crash normalization,” but the changed frontend normalizer evaluates `(&#39;quantity&#39; in addon ...)` at this line. A persisted `addons: [null]` throws a TypeError, while a non-array add-on container fails at `.map`; browser/WebUSB receipt generation then aborts. The new malformed-input test exercises only the backend normalizer. Guard the frontend add-on container and entries consistently with the backend fix.
- ⚠️ `main/printers/document-compact.ts:202` - For a taxable bill with non-zero delivery or packaging charges and `showTaxBreakdown=true`, these rows are added to `totals.main`, which canonical assembly emits before the tax-breakdown block. The backend output becomes Subtotal → Delivery/Packaging → tax components → Grand Total, while the updated legacy oracle emits tax components → Delivery/Packaging → Grand Total. This breaks the stated parity contract for classic and compact receipts; choose and align the intended user-visible ordering.

🔧 Fix: Guard malformed add-ons and restore tax-charge receipt ordering
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:print-document`
- `npm run test:print-parity`
- `Direct backend classic and compact receipt rendering`
- `Direct frontend WebUSB and browser HTML rendering`
- `Final worktree status and target diff inspection`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
