### PR TITLE
feat: make service charges server-authoritative

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -339,7 +339,7 @@ Create new order.
 
 **Headers:** `Authorization: Bearer <token>`
 
-Order item `addons` reference catalog add-ons by `id`. Each add-on must be active and linked to the product's add-on group. Add-on name and price are resolved from the catalog (client-supplied names and prices are ignored). Quantity defaults to `1` when omitted and must be a positive integer.
+Order item `addons` reference catalog add-ons by `id`. Each add-on must be active and linked to the product's add-on group. Add-on name and price are resolved from the catalog (client-supplied names and prices are ignored). Quantity defaults to `1` when omitted and must be a positive integer. `service_charge` is an optional explicit non-negative per-order amount validated and persisted by the server; omitted/null means `0`. Settings' service-charge category selects tax treatment only - it does not define an amount or rate, and no automatic service charge is applied.
 
 **Request:**
 ```json
@@ -347,6 +347,7 @@ Order item `addons` reference catalog add-ons by `id`. Each add-on must be activ
   "type": "dine_in",
   "table_id": "table-1",
   "customer_id": "cust-1",
+  "service_charge": 0,
   "items": [
     {
       "product_id": "prod-1",

--- a/docs/printing-architecture.md
+++ b/docs/printing-architecture.md
@@ -137,7 +137,7 @@ Receipt block vocabulary v1 ([`shared/print/document.ts`](../shared/print/docume
 | `document-meta` | invoice title (tax vs plain), number, canonical timestamp, optional table |
 | `customer` | customer name/phone with their labels |
 | `item-table` | header labels, item rows (quantity, unit price, amount, add-ons with quantity and extended amount, special instructions) |
-| `totals` | subtotal, discount, flat tax, optional frontend service charge, delivery/packaging charges, grand total, loyalty points lines |
+| `totals` | subtotal, discount, flat tax, optional server-persisted service charge, delivery/packaging charges, grand total, loyalty points lines |
 | `tax-breakdown` | per-component lines when the merchant shows the breakdown |
 | `payments` | captured payment lines (known methods resolve through concept ids, unknown stay literal) |
 | `message` | reprint banner, footer note, thank-you |

--- a/frontend/src/components/orders/OrderHistoryGrid.tsx
+++ b/frontend/src/components/orders/OrderHistoryGrid.tsx
@@ -29,7 +29,7 @@ const MOCK_HISTORY: HistoryOrder[] = [
   {
     id: 981, order_number: 'A-0981', table_id: 'tbl-04', customer_id: null,
     type: 'dine_in', status: 'completed', subtotal: 890, tax_amount: 44.5,
-    discount_amount: 0, delivery_charge: 0, total: 934.5, guest_count: 3,
+    discount_amount: 0, delivery_charge: 0, service_charge: 0, total: 934.5, guest_count: 3,
     special_instructions: null, created_by: 1, created_at: hoursAgo(2),
     table: { id: 'tbl-04', name: '4', capacity: 4, status: 'occupied', kitchen_station_id: null, floor: null, section: null, is_active: true },
     items: [
@@ -47,7 +47,7 @@ const MOCK_HISTORY: HistoryOrder[] = [
   {
     id: 976, order_number: 'A-0976', table_id: null, customer_id: null,
     type: 'takeaway', status: 'cancelled', subtotal: 480, tax_amount: 24,
-    discount_amount: 0, delivery_charge: 0, total: 504, guest_count: null,
+    discount_amount: 0, delivery_charge: 0, service_charge: 0, total: 504, guest_count: null,
     special_instructions: null, created_by: 1, created_at: hoursAgo(5),
     items: [
       { id: 4, order_id: 976, product_id: '4', product_name: 'Chicken Biryani', product_sku: null, unit_price: 280, quantity: 1, subtotal: 280, tax_amount: 14, total: 294, addons: null, special_instructions: null, status: 'cancelled' },
@@ -64,7 +64,7 @@ const MOCK_HISTORY: HistoryOrder[] = [
   {
     id: 970, order_number: 'A-0970', table_id: 'tbl-09', customer_id: null,
     type: 'dine_in', status: 'completed', subtotal: 1240, tax_amount: 62,
-    discount_amount: 100, delivery_charge: 0, total: 1202, guest_count: 5,
+    discount_amount: 100, delivery_charge: 0, service_charge: 0, total: 1202, guest_count: 5,
     special_instructions: null, created_by: 1, created_at: hoursAgo(9),
     table: { id: 'tbl-09', name: '9', capacity: 6, status: 'occupied', kitchen_station_id: null, floor: null, section: null, is_active: true },
     items: [
@@ -84,7 +84,7 @@ const MOCK_HISTORY: HistoryOrder[] = [
   {
     id: 964, order_number: 'A-0964', table_id: null, customer_id: null,
     type: 'delivery', status: 'completed', subtotal: 360, tax_amount: 18,
-    discount_amount: 0, delivery_charge: 40, total: 418, guest_count: null,
+    discount_amount: 0, delivery_charge: 40, service_charge: 0, total: 418, guest_count: null,
     special_instructions: null, created_by: 1, created_at: hoursAgo(26),
     items: [
       { id: 12, order_id: 964, product_id: '12', product_name: 'Veg Hakka Noodles', product_sku: null, unit_price: 200, quantity: 1, subtotal: 200, tax_amount: 10, total: 210, addons: null, special_instructions: null, status: 'served' },

--- a/frontend/src/components/pos/PaymentModal.tsx
+++ b/frontend/src/components/pos/PaymentModal.tsx
@@ -64,6 +64,7 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
   const locale = useLocale();
   const tCommon = useTranslations('common');
   const tOrders = useTranslations('orders');
+  const tReceipt = useTranslations('receipt');
   const tWhatsappSend = useTranslations('whatsapp.send');
 
   // sendBillViaFlo (shared with OrdersPage) takes a translator callback;
@@ -493,6 +494,12 @@ export default function PaymentModal({ bill, onClose, onPaid, onBillUpdate }: Pr
                 <div className="flex justify-between text-slate-300">
                   <span>{t('packaging')}</span>
                   <span>{currencyFmt(Number(bill.packaging_charge))}</span>
+                </div>
+              )}
+              {Number(bill.service_charge) > 0 && (
+                <div className="flex justify-between text-slate-300">
+                  <span>{tReceipt('serviceCharge')}</span>
+                  <span>{currencyFmt(Number(bill.service_charge))}</span>
                 </div>
               )}
               {Number(bill.round_off) !== 0 && (

--- a/frontend/src/lib/printer/test-data.ts
+++ b/frontend/src/lib/printer/test-data.ts
@@ -127,6 +127,7 @@ export function createTestOrder(overrides?: Partial<Order>): Order {
     tax_amount: 53,
     discount_amount: 0,
     delivery_charge: 0,
+    service_charge: 0,
     total: 583,
     guest_count: 3,
     special_instructions: 'Birthday celebration',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -157,6 +157,8 @@ export interface Order {
   discount_amount: number;
   delivery_charge: number;
   packaging_charge?: number;
+  /** Server-validated explicit per-order amount; Settings only configures tax treatment. */
+  service_charge: number;
   round_off?: number;
   tax_breakdown?: { title: string; rate: number; amount: number }[] | null;
   tax_snapshot?: TaxSnapshot[] | TaxSnapshot | null;

--- a/main/db.ts
+++ b/main/db.ts
@@ -4163,6 +4163,20 @@ export const MIGRATIONS: { version: number; name: string; up: () => void }[] = [
       }
     },
   },
+  {
+    version: 79,
+    name: 'add_service_charge_amounts',
+    up: () => {
+      const orderColumns = getColumns(db, 'orders');
+      if (!orderColumns.includes('service_charge')) {
+        db.exec(`ALTER TABLE orders ADD COLUMN service_charge REAL DEFAULT 0`);
+      }
+      const billColumns = getColumns(db, 'bills');
+      if (!billColumns.includes('service_charge')) {
+        db.exec(`ALTER TABLE bills ADD COLUMN service_charge REAL DEFAULT 0`);
+      }
+    },
+  },
 ];
 
 function syncBackupBeforeMigration(fromVersion: number, toVersion: number): void {
@@ -4468,6 +4482,7 @@ function createSchema(): void {
       special_instructions TEXT,
       packaging_charge REAL DEFAULT 0,
       delivery_charge REAL DEFAULT 0,
+      service_charge REAL DEFAULT 0,
       status TEXT DEFAULT 'pending',
       subtotal REAL DEFAULT 0,
       tax_amount REAL DEFAULT 0,
@@ -4534,6 +4549,7 @@ function createSchema(): void {
       discount_reason TEXT,
       delivery_charge REAL DEFAULT 0,
       packaging_charge REAL DEFAULT 0,
+      service_charge REAL DEFAULT 0,
       round_off REAL DEFAULT 0,
       total REAL DEFAULT 0,
       paid_amount REAL DEFAULT 0,

--- a/main/printers/document-classic.ts
+++ b/main/printers/document-classic.ts
@@ -140,9 +140,9 @@ export function buildBillPrintData(order: any, bill: any, business: any, isRepri
       discountAmount: Number(bill?.discount_amount) || 0,
       taxAmount: Number(bill?.tax_amount) || 0,
       total: Number(bill?.total) || 0,
-      // Backend bills persist delivery and packaging charges. Service charges
-      // are currently an order/tax-engine concept with no persisted bill source,
-      // so keep the normalized backend boundary explicit until one exists.
+      ...(Object.prototype.hasOwnProperty.call(bill || {}, 'service_charge')
+        ? { serviceCharge: Number(bill?.service_charge) || 0 }
+        : {}),
       deliveryCharge: Number(bill?.delivery_charge) || 0,
       packagingCharge: Number(bill?.packaging_charge) || 0,
       taxComponents: resolveTaxComponents({ ...bill, items }),

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -461,6 +461,7 @@ router.post('/generate', requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: 
         const orderDiscountAmt   = order.discount_amount || 0;
         const orderDelivery      = order.delivery_charge || 0;
         const orderPackaging     = order.packaging_charge|| 0;
+        const orderService       = order.service_charge  || 0;
         const orderTotal         = order.total           || 0;
 
         const pack = getActiveCountryPack(getSettingValue('country') || 'IN');
@@ -470,6 +471,7 @@ router.post('/generate', requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: 
           existingBill.payment_status !== 'paid' && (
             existingBill.discount_amount !== orderDiscountAmt ||
             existingBill.subtotal        !== orderSubtotal    ||
+            existingBill.service_charge  !== orderService     ||
             existingBill.total           !== roundedOrderTotal
           );
 
@@ -487,6 +489,7 @@ router.post('/generate', requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: 
                 discount_reason= ?,
                 delivery_charge= ?,
                 packaging_charge= ?,
+                service_charge = ?,
                 round_off      = ?,
                 total          = ?,
                 balance        = ?,
@@ -495,7 +498,7 @@ router.post('/generate', requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: 
           `).run(
             orderSubtotal, orderTaxAmount, order.tax_breakdown, order.tax_snapshot,
             orderDiscountAmt, order.discount_type, order.discount_value, order.discount_reason,
-            orderDelivery, orderPackaging, orderRoundOff,
+            orderDelivery, orderPackaging, orderService, orderRoundOff,
             roundedOrderTotal, newBalance, now(),
             existingBill.id
           );
@@ -514,18 +517,19 @@ router.post('/generate', requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: 
       const discountAmount = order.discount_amount || 0;
       const deliveryCharge = order.delivery_charge || 0;
       const packagingCharge = order.packaging_charge || 0;
+      const serviceCharge = order.service_charge || 0;
       const pack = getActiveCountryPack(getSettingValue('country') || 'IN');
       const { total, adjustment: roundOff } = applyPayableRounding(order.total || 0, pack);
 
       const runResult = db.prepare(`
         INSERT INTO bills (bill_number, order_id, customer_id, subtotal, tax_amount, tax_breakdown, tax_snapshot,
           discount_amount, discount_type, discount_value, discount_reason,
-          delivery_charge, packaging_charge, round_off, total, paid_amount, balance, payment_status, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'unpaid', ?, ?)
+          delivery_charge, packaging_charge, service_charge, round_off, total, paid_amount, balance, payment_status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'unpaid', ?, ?)
       `).run(
         billNumber, order_id, order.customer_id, subtotal, taxAmount, order.tax_breakdown, order.tax_snapshot,
         discountAmount, order.discount_type, order.discount_value, order.discount_reason,
-        deliveryCharge, packagingCharge, roundOff, total, 0, total, now(), now()
+        deliveryCharge, packagingCharge, serviceCharge, roundOff, total, 0, total, now(), now()
       );
 
       const newBill = parseRowJson(db.prepare('SELECT * FROM bills WHERE id = ?').get(runResult.lastInsertRowid));
@@ -864,6 +868,7 @@ function composeSplitTotals(
   const discountAmount = allocations.discount_amount ?? allocations.discountAmount;
   const deliveryCharge = allocations.delivery_charge ?? allocations.deliveryCharge;
   const packagingCharge = allocations.packaging_charge ?? allocations.packagingCharge;
+  const serviceCharge = allocations.service_charge ?? allocations.serviceCharge;
   const roundOff = allocations.round_off ?? allocations.roundOff;
   return allocations.subtotal.map((subtotal, index) => Number((
     subtotal
@@ -871,6 +876,7 @@ function composeSplitTotals(
     + exclusiveTaxMinors[index] / 100
     + deliveryCharge[index]
     + packagingCharge[index]
+    + serviceCharge[index]
     + roundOff[index]
   ).toFixed(2)));
 }
@@ -1014,6 +1020,7 @@ interface OrderBillSyncValues {
   discountAmount: number;
   deliveryCharge: number;
   packagingCharge: number;
+  serviceCharge: number;
   total: number;
 }
 
@@ -1320,14 +1327,14 @@ export function syncUnpaidBillsForOrder(
   if (!splitBills) {
     const update = db.prepare(`
       UPDATE bills SET subtotal = ?, total = ?, balance = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?,
-        discount_amount = ?, delivery_charge = ?, packaging_charge = ?, round_off = ?, updated_at = ?
+        discount_amount = ?, delivery_charge = ?, packaging_charge = ?, service_charge = ?, round_off = ?, updated_at = ?
       WHERE id = ?
     `);
     for (const bill of unpaidBills) {
       update.run(
         source.subtotal, billTotal, Math.max(0, billTotal - Number(bill.paid_amount || 0)), source.taxAmount,
         source.taxBreakdown, source.taxSnapshot, source.discountAmount, source.deliveryCharge,
-        source.packagingCharge, billRoundOff, now(), bill.id,
+        source.packagingCharge, source.serviceCharge, billRoundOff, now(), bill.id,
       );
     }
     return;
@@ -1351,6 +1358,7 @@ export function syncUnpaidBillsForOrder(
     discountAmount: Math.round(source.discountAmount * 100),
     deliveryCharge: Math.round(source.deliveryCharge * 100),
     packagingCharge: Math.round(source.packagingCharge * 100),
+    serviceCharge: Math.round(source.serviceCharge * 100),
     roundOff: Math.round(billRoundOff * 100),
     total: Math.round(billTotal * 100),
   };
@@ -1395,7 +1403,7 @@ export function syncUnpaidBillsForOrder(
   const snapshots = snapshotAllocation.snapshots;
   const update = db.prepare(`
     UPDATE bills SET subtotal = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?,
-      delivery_charge = ?, packaging_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ?
+      delivery_charge = ?, packaging_charge = ?, service_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ?
     WHERE id = ?
   `);
 
@@ -1404,7 +1412,7 @@ export function syncUnpaidBillsForOrder(
     const total = allocations.total[index];
     update.run(
       allocations.subtotal[index], allocations.taxAmount[index], breakdowns[index], snapshots[index],
-      allocations.discountAmount[index], allocations.deliveryCharge[index], allocations.packagingCharge[index],
+      allocations.discountAmount[index], allocations.deliveryCharge[index], allocations.packagingCharge[index], allocations.serviceCharge[index],
       allocations.roundOff[index], total, Math.max(0, total - Number(bill.paid_amount || 0)), now(), bill.id,
     );
   });
@@ -1463,7 +1471,7 @@ router.post('/:id/split-check', requireRole(...ROLE_ACCESS.ownerManagerCashier),
         check.items.reduce((sum: number, entry: { item: any; quantity: number }) => sum + Number(entry.item.total || entry.item.subtotal || 0) * entry.quantity / Number(entry.item.quantity), 0)
       );
 
-      const fields = ['subtotal', 'tax_amount', 'discount_amount', 'delivery_charge', 'packaging_charge', 'round_off', 'total'] as const;
+      const fields = ['subtotal', 'tax_amount', 'discount_amount', 'delivery_charge', 'packaging_charge', 'service_charge', 'round_off', 'total'] as const;
       const allocations: Record<string, number[]> = {};
       for (const field of fields) {
         const totalMinor = Math.round(Number(txnSource[field] || 0) * 100);
@@ -1534,12 +1542,12 @@ router.post('/:id/split-check', requireRole(...ROLE_ACCESS.ownerManagerCashier),
         const splitBk = resolvedTaxBreakdowns[index];
         const splitSnapshot = checkTaxSnapshots[index];
         if (index === 0) {
-          db.prepare(`UPDATE bills SET split_group_id = ?, split_label = ?, subtotal = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, delivery_charge = ?, packaging_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ? WHERE id = ?`)
-            .run(groupId, check.label, allocations.subtotal[index], allocations.tax_amount[index], splitBk, splitSnapshot, allocations.discount_amount[index], allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], now(), txnSource.id);
+          db.prepare(`UPDATE bills SET split_group_id = ?, split_label = ?, subtotal = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, delivery_charge = ?, packaging_charge = ?, service_charge = ?, round_off = ?, total = ?, balance = ?, updated_at = ? WHERE id = ?`)
+            .run(groupId, check.label, allocations.subtotal[index], allocations.tax_amount[index], splitBk, splitSnapshot, allocations.discount_amount[index], allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.service_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], now(), txnSource.id);
           billId = Number(txnSource.id);
         } else {
-          const inserted = db.prepare(`INSERT INTO bills (bill_number, order_id, customer_id, subtotal, tax_amount, tax_breakdown, tax_snapshot, discount_amount, discount_type, discount_value, discount_reason, delivery_charge, packaging_charge, round_off, total, paid_amount, balance, payment_status, split_group_id, split_label, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 'unpaid', ?, ?, ?, ?)`)
-            .run(generateBillNumber(), txnSource.order_id, txnSource.customer_id, allocations.subtotal[index], allocations.tax_amount[index], splitBk, splitSnapshot, allocations.discount_amount[index], txnSource.discount_type, txnSource.discount_value, txnSource.discount_reason, allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], groupId, check.label, now(), now());
+          const inserted = db.prepare(`INSERT INTO bills (bill_number, order_id, customer_id, subtotal, tax_amount, tax_breakdown, tax_snapshot, discount_amount, discount_type, discount_value, discount_reason, delivery_charge, packaging_charge, service_charge, round_off, total, paid_amount, balance, payment_status, split_group_id, split_label, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 'unpaid', ?, ?, ?, ?)`)
+            .run(generateBillNumber(), txnSource.order_id, txnSource.customer_id, allocations.subtotal[index], allocations.tax_amount[index], splitBk, splitSnapshot, allocations.discount_amount[index], txnSource.discount_type, txnSource.discount_value, txnSource.discount_reason, allocations.delivery_charge[index], allocations.packaging_charge[index], allocations.service_charge[index], allocations.round_off[index], allocations.total[index], allocations.total[index], groupId, check.label, now(), now());
           billId = Number(inserted.lastInsertRowid);
         }
         billIds.push(billId);

--- a/main/routes/index.ts
+++ b/main/routes/index.ts
@@ -487,10 +487,7 @@ export function registerRoutes(app: Express): void {
         const customer = currentOrder.customer_id
           ? db.prepare('SELECT * FROM customers WHERE id = ?').get(currentOrder.customer_id) as any
           : null;
-        const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, {
-          ...currentOrder,
-          service_charge: 0,
-        }, customer);
+        const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, currentOrder, customer);
         const taxRollup = combineItemAndChargeTaxes({
           itemTaxAmount: newTaxAmount,
           itemExclusiveTaxAmount: newExclusiveTax,
@@ -502,7 +499,7 @@ export function registerRoutes(app: Express): void {
 
         // BUG #5 FIX: Correct round-off formula; BUG #24 FIX: include delivery_charge (was missing, causing total mismatch with bill generation)
         const preRoundTotal = discountedSubtotal + taxRollup.exclusiveTaxAmount
-          + (currentOrder.delivery_charge || 0) + (currentOrder.packaging_charge || 0);
+          + (currentOrder.delivery_charge || 0) + (currentOrder.packaging_charge || 0) + (currentOrder.service_charge || 0);
         const roundOff = 0;
         const total = Number(preRoundTotal.toFixed(2));
 
@@ -535,6 +532,7 @@ export function registerRoutes(app: Express): void {
           discountAmount: newDiscountAmount,
           deliveryCharge: order.delivery_charge || 0,
           packagingCharge: order.packaging_charge || 0,
+          serviceCharge: order.service_charge || 0,
           total,
         }, tenantInfo.country);
 
@@ -673,10 +671,7 @@ export function registerRoutes(app: Express): void {
         const customer = currentOrder.customer_id
           ? db.prepare('SELECT * FROM customers WHERE id = ?').get(currentOrder.customer_id) as any
           : null;
-        const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, {
-          ...currentOrder,
-          service_charge: 0,
-        }, customer);
+        const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, currentOrder, customer);
         const taxRollup = combineItemAndChargeTaxes({
           itemTaxAmount: newTaxAmount,
           itemExclusiveTaxAmount: newExclusiveTax,
@@ -688,7 +683,7 @@ export function registerRoutes(app: Express): void {
 
         // BUG #5 FIX: Correct round-off formula; BUG #24 FIX: include delivery_charge (was missing, causing total mismatch with bill generation)
         const preRoundTotal = discountedSubtotal + taxRollup.exclusiveTaxAmount
-          + (currentOrder.delivery_charge || 0) + (currentOrder.packaging_charge || 0);
+          + (currentOrder.delivery_charge || 0) + (currentOrder.packaging_charge || 0) + (currentOrder.service_charge || 0);
         const roundOff = 0;
         const total = Number(preRoundTotal.toFixed(2));
 
@@ -704,6 +699,7 @@ export function registerRoutes(app: Express): void {
           discountAmount: newDiscountAmount,
           deliveryCharge: order.delivery_charge || 0,
           packagingCharge: order.packaging_charge || 0,
+          serviceCharge: order.service_charge || 0,
           total,
         }, tenantInfo.country);
 

--- a/main/routes/orders.ts
+++ b/main/routes/orders.ts
@@ -7,6 +7,7 @@ import {
   combineItemAndChargeTaxes,
   getActiveCountryPack,
   getConfiguredChargeTaxCategories,
+  normalizeChargeAmount,
 } from '../services/tax';
 import { applyPayableRounding } from '../services/tax-engine';
 import { notifyKdsUpdate, notifyOrderUpdated } from '../services/kds';
@@ -372,7 +373,10 @@ router.get('/:id', orderReadRateLimit, requireRole(...ROLE_ACCESS.sales), (req: 
 router.post('/', orderWriteRateLimit, requireRole(...ROLE_ACCESS.sales), (req: Request, res: Response) => {
   try {
     const body = req.body || {};
-    const { table_id, customer_id, type, guest_count, special_instructions, packaging_charge, delivery_charge, items, online_platform, external_order_id } = body;
+    const { table_id, customer_id, type, guest_count, special_instructions, packaging_charge, delivery_charge, service_charge, items, online_platform, external_order_id } = body;
+    // Settings supplies only service-charge tax treatment. The explicit amount
+    // is accepted once here, validated, and then carried by the order/bill;
+    // missing means zero until a product decision defines an automatic policy.
     const idempotencyKey = orderIdempotencyKey(req);
     const idempotencyUserId = String((req as any).user.userId);
     const requestHash = idempotencyKey
@@ -397,10 +401,15 @@ router.post('/', orderWriteRateLimit, requireRole(...ROLE_ACCESS.sales), (req: R
       return res.status(400).json({ error: 'guest_count must be a whole number between 1 and 99' });
     }
 
-    const pkgCharge = Number(packaging_charge || 0);
-    const delCharge = Number(delivery_charge || 0);
-    if (!Number.isFinite(pkgCharge) || pkgCharge < 0 || !Number.isFinite(delCharge) || delCharge < 0) {
-      return res.status(400).json({ error: 'Packaging and delivery charges must be non-negative numbers' });
+    let pkgCharge: number;
+    let delCharge: number;
+    let serviceCharge: number;
+    try {
+      pkgCharge = normalizeChargeAmount(packaging_charge, 'packaging');
+      delCharge = normalizeChargeAmount(delivery_charge, 'delivery');
+      serviceCharge = normalizeChargeAmount(service_charge, 'service_charge');
+    } catch (error: any) {
+      return res.status(error.statusCode || 400).json({ error: error.message });
     }
 
     if (online_platform !== undefined && online_platform !== null && typeof online_platform !== 'string') {
@@ -463,9 +472,9 @@ router.post('/', orderWriteRateLimit, requireRole(...ROLE_ACCESS.sales), (req: R
       };
       const chargeCategories = getConfiguredChargeTaxCategories(tenantInfo.country);
       const chargeContext = {
-        packaging_charge: packaging_charge || 0,
-        delivery_charge: delivery_charge || 0,
-        service_charge: 0,
+        packaging_charge: pkgCharge,
+        delivery_charge: delCharge,
+        service_charge: serviceCharge,
         packaging_tax_category_id: chargeCategories.packaging?.categoryId || null,
         delivery_tax_category_id: chargeCategories.delivery?.categoryId || null,
         service_charge_tax_category_id: chargeCategories.service_charge?.categoryId || null,
@@ -474,12 +483,13 @@ router.post('/', orderWriteRateLimit, requireRole(...ROLE_ACCESS.sales), (req: R
       const orderResult = db.prepare(`
         INSERT INTO orders (order_number, table_id, customer_id, user_id, type, guest_count, special_instructions,
           packaging_charge, delivery_charge, packaging_tax_category_id, delivery_tax_category_id,
-          service_charge_tax_category_id, online_platform, external_order_id, status, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+          service_charge, service_charge_tax_category_id, online_platform, external_order_id, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
       `).run(orderNumber, table_id || null, customer_id || null, authenticatedUserId, type, guest_count || null,
-        special_instructions || null, packaging_charge || 0, delivery_charge || 0,
+        special_instructions || null, pkgCharge, delCharge,
         chargeContext.packaging_tax_category_id, chargeContext.delivery_tax_category_id,
-        chargeContext.service_charge_tax_category_id, onlinePlatform || null, externalOrderId || null, now(), now());
+        serviceCharge, chargeContext.service_charge_tax_category_id,
+        onlinePlatform || null, externalOrderId || null, now(), now());
 
       const orderId = orderResult.lastInsertRowid;
 
@@ -577,7 +587,7 @@ router.post('/', orderWriteRateLimit, requireRole(...ROLE_ACCESS.sales), (req: R
         chargeTaxes,
       });
       const preRoundTotal = subtotal + taxRollup.exclusiveTaxAmount
-        + (delivery_charge || 0) + (packaging_charge || 0);
+        + delCharge + pkgCharge + serviceCharge;
       const total = Number(preRoundTotal.toFixed(2));
       const roundOff = 0;
 
@@ -819,10 +829,7 @@ router.post('/:id/items', orderWriteRateLimit, requireRole(...ROLE_ACCESS.sales)
         newExclusiveTax = Math.round(exclusiveTax * taxRatio * 100) / 100;
       }
 
-      const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, {
-        ...currentOrder,
-        service_charge: 0,
-      }, customer);
+      const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, currentOrder, customer);
       const taxRollup = combineItemAndChargeTaxes({
         itemTaxAmount: newTaxAmount,
         itemExclusiveTaxAmount: newExclusiveTax,
@@ -832,7 +839,7 @@ router.post('/:id/items', orderWriteRateLimit, requireRole(...ROLE_ACCESS.sales)
         chargeTaxes,
       });
       const preRoundTotal = discountedSubtotal + taxRollup.exclusiveTaxAmount
-        + (currentOrder.delivery_charge || 0) + (currentOrder.packaging_charge || 0);
+        + (currentOrder.delivery_charge || 0) + (currentOrder.packaging_charge || 0) + (currentOrder.service_charge || 0);
       const total = Number(preRoundTotal.toFixed(2));
       const roundOff = 0;
 
@@ -853,8 +860,8 @@ router.post('/:id/items', orderWriteRateLimit, requireRole(...ROLE_ACCESS.sales)
         const pack = getActiveCountryPack(tenantInfo.country);
         const { total: billTotal, adjustment: billRoundOff } = applyPayableRounding(total, pack);
         const newBillBalance = Math.max(0, billTotal - (existingBill.paid_amount || 0));
-        db.prepare(`UPDATE bills SET total = ?, balance = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, round_off = ?, updated_at = ? WHERE id = ?`)
-          .run(billTotal, newBillBalance, taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, newDiscountAmount, billRoundOff, now(), existingBill.id);
+        db.prepare(`UPDATE bills SET total = ?, balance = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, service_charge = ?, round_off = ?, updated_at = ? WHERE id = ?`)
+          .run(billTotal, newBillBalance, taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, newDiscountAmount, currentOrder.service_charge || 0, billRoundOff, now(), existingBill.id);
       }
 
       const updatedOrder = parseRowJson(db.prepare('SELECT * FROM orders WHERE id = ?').get(req.params.id)) as any;
@@ -1284,10 +1291,7 @@ router.patch('/:id/discount', orderWriteRateLimit, requireRole(...ROLE_ACCESS.ow
       }
 
       const discountedSubtotal = Math.max(0, currentOrder.subtotal - discountAmount);
-      const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, {
-        ...currentOrder,
-        service_charge: 0,
-      }, customer);
+      const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, currentOrder, customer);
       const taxRollup = combineItemAndChargeTaxes({
         itemTaxAmount: newTaxAmount,
         itemExclusiveTaxAmount: newExclusiveTax,
@@ -1297,7 +1301,7 @@ router.patch('/:id/discount', orderWriteRateLimit, requireRole(...ROLE_ACCESS.ow
         chargeTaxes,
       });
       const preRoundTotal = discountedSubtotal + taxRollup.exclusiveTaxAmount
-        + (currentOrder.packaging_charge || 0) + (currentOrder.delivery_charge || 0);
+        + (currentOrder.packaging_charge || 0) + (currentOrder.delivery_charge || 0) + (currentOrder.service_charge || 0);
       const newTotal = Number(preRoundTotal.toFixed(2));
       const roundOff = 0;
 
@@ -1321,14 +1325,14 @@ router.patch('/:id/discount', orderWriteRateLimit, requireRole(...ROLE_ACCESS.ow
         const newBillBalance = Math.max(0, billTotal - (existingBill.paid_amount || 0));
         db.prepare(`
           UPDATE bills SET discount_amount = ?, discount_type = ?, discount_value = ?,
-            discount_reason = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, total = ?, balance = ?, round_off = ?, updated_at = ?
+            discount_reason = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, total = ?, balance = ?, service_charge = ?, round_off = ?, updated_at = ?
           WHERE id = ?
         `).run(
           discountAmount,
           discount_value > 0 ? discount_type : null,
           discount_value > 0 ? discount_value : null,
           discount_value > 0 ? (discount_reason || null) : null,
-          taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, billTotal, newBillBalance, billRoundOff, now(), existingBill.id
+          taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, billTotal, newBillBalance, currentOrder.service_charge || 0, billRoundOff, now(), existingBill.id
         );
       }
 
@@ -1508,10 +1512,7 @@ router.patch('/:id/items/:itemId/discount', orderWriteRateLimit, requireRole(...
         newExclusiveOrderTax = Math.round(exclusiveOrderTax * taxRatio * 100) / 100;
       }
 
-      const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, {
-        ...order,
-        service_charge: 0,
-      }, customer);
+      const chargeTaxes = calculateConfiguredChargeTaxes(tenantInfo, order, customer);
       const taxRollup = combineItemAndChargeTaxes({
         itemTaxAmount: newOrderTax,
         itemExclusiveTaxAmount: newExclusiveOrderTax,
@@ -1521,7 +1522,7 @@ router.patch('/:id/items/:itemId/discount', orderWriteRateLimit, requireRole(...
         chargeTaxes,
       });
       const preRoundTotal = discountedSubtotal + taxRollup.exclusiveTaxAmount
-        + (order.packaging_charge || 0) + (order.delivery_charge || 0);
+        + (order.packaging_charge || 0) + (order.delivery_charge || 0) + (order.service_charge || 0);
       const orderTotal = Number(preRoundTotal.toFixed(2));
       const roundOff = 0;
 
@@ -1535,8 +1536,8 @@ router.patch('/:id/items/:itemId/discount', orderWriteRateLimit, requireRole(...
         const pack = getActiveCountryPack(tenantInfo.country);
         const { total: billTotal, adjustment: billRoundOff } = applyPayableRounding(orderTotal, pack);
         const newBillBalance = Math.max(0, billTotal - (existingBill.paid_amount || 0));
-        db.prepare(`UPDATE bills SET total = ?, balance = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, round_off = ?, updated_at = ? WHERE id = ?`)
-          .run(billTotal, newBillBalance, taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, newOrderDiscount, billRoundOff, now(), existingBill.id);
+        db.prepare(`UPDATE bills SET total = ?, balance = ?, tax_amount = ?, tax_breakdown = ?, tax_snapshot = ?, discount_amount = ?, service_charge = ?, round_off = ?, updated_at = ? WHERE id = ?`)
+          .run(billTotal, newBillBalance, taxRollup.taxAmount, JSON.stringify(taxRollup.breakdowns), taxRollup.snapshotJson, newOrderDiscount, order.service_charge || 0, billRoundOff, now(), existingBill.id);
       }
 
       return db.prepare('SELECT * FROM order_items WHERE id = ?').get(req.params.itemId) as any;

--- a/main/services/tax.ts
+++ b/main/services/tax.ts
@@ -342,20 +342,27 @@ export function getConfiguredChargeTaxCategories(
   }
 }
 
+export function normalizeChargeAmount(value: unknown, kind: ChargeTaxKind): number {
+  if (value === undefined || value === null || value === '') return 0;
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    throw Object.assign(new Error(`${kind} charge must be a non-negative finite amount`), { statusCode: 400 });
+  }
+  try {
+    const amount = new Decimal(value as Decimal.Value);
+    if (!amount.isFinite() || amount.isNegative()) {
+      throw new Error(`${kind} charge must be a non-negative finite amount`);
+    }
+    return amount.toNumber();
+  } catch (error: any) {
+    throw Object.assign(new Error(error.message || `${kind} charge is invalid`), { statusCode: 400 });
+  }
+}
+
 function chargeAmount(context: ChargeTaxContext, kind: ChargeTaxKind): Decimal {
   const amountKey: keyof ChargeTaxContext = kind === 'service_charge'
     ? 'service_charge'
     : `${kind}_charge`;
-  const raw = context[amountKey] ?? 0;
-  try {
-    const amount = new Decimal(raw as Decimal.Value);
-    if (!amount.isFinite() || amount.isNegative()) {
-      throw new Error(`${kind} charge must be a non-negative finite amount`);
-    }
-    return amount;
-  } catch (error: any) {
-    throw Object.assign(new Error(error.message || `${kind} charge is invalid`), { statusCode: 400 });
-  }
+  return new Decimal(normalizeChargeAmount(context[amountKey], kind));
 }
 
 function chargeCategoryId(context: ChargeTaxContext, kind: ChargeTaxKind): string | null {
@@ -792,13 +799,9 @@ export async function calculateTaxPreview(req: any, res: any): Promise<void> {
       }
     }
 
-    const normalizeCharge = (value: unknown): number => {
-      const parsed = Number(value);
-      return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-    };
-    const packaging = normalizeCharge(packaging_charge);
-    const delivery = normalizeCharge(delivery_charge);
-    const service = normalizeCharge(service_charge);
+    const packaging = normalizeChargeAmount(packaging_charge, 'packaging');
+    const delivery = normalizeChargeAmount(delivery_charge, 'delivery');
+    const service = normalizeChargeAmount(service_charge, 'service_charge');
 
     let discountAmount = new Decimal(0);
     if (discount_type !== undefined || discount_value !== undefined) {
@@ -883,6 +886,6 @@ export async function calculateTaxPreview(req: any, res: any): Promise<void> {
     });
   } catch (error: any) {
     console.error('[Tax] Preview error:', error);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(error.statusCode || 500).json({ error: error.statusCode ? error.message : "Internal server error" });
   }
 }

--- a/main/services/tax.ts
+++ b/main/services/tax.ts
@@ -352,7 +352,11 @@ export function normalizeChargeAmount(value: unknown, kind: ChargeTaxKind): numb
     if (!amount.isFinite() || amount.isNegative()) {
       throw new Error(`${kind} charge must be a non-negative finite amount`);
     }
-    return amount.toNumber();
+    const numericAmount = amount.toNumber();
+    if (!Number.isFinite(numericAmount)) {
+      throw new Error(`${kind} charge must be a non-negative finite amount`);
+    }
+    return numericAmount;
   } catch (error: any) {
     throw Object.assign(new Error(error.message || `${kind} charge is invalid`), { statusCode: 400 });
   }

--- a/shared/print/document.ts
+++ b/shared/print/document.ts
@@ -144,7 +144,7 @@ export interface BillSnapshot {
   readonly discountAmount: number;
   readonly taxAmount: number;
   readonly total: number;
-  /** Flat service charge, when the bill carries one (frontend bills). */
+  /** Flat service charge, when the server-persisted bill carries one. */
   readonly serviceCharge?: number;
   /** Flat delivery charge, when the bill carries one (frontend bills). */
   readonly deliveryCharge?: number;
@@ -341,7 +341,7 @@ export interface TotalsBlock {
   readonly discount: { readonly label: SemanticLabel; readonly amount: number } | null;
   /** Flat tax line, present only when no breakdown lines are emitted. */
   readonly tax: { readonly label: SemanticLabel; readonly amount: number } | null;
-  /** Flat service-charge line, present when the snapshot carries a nonzero charge. */
+  /** Flat service-charge line, present when the server snapshot carries a nonzero charge. */
   readonly serviceCharge: { readonly label: SemanticLabel; readonly amount: number } | null;
   /** Flat delivery-charge line, present when the snapshot carries a nonzero charge. */
   readonly deliveryCharge: { readonly label: SemanticLabel; readonly amount: number } | null;

--- a/tests/print-document.test.ts
+++ b/tests/print-document.test.ts
@@ -147,6 +147,15 @@ console.log('\n▶ Block construction (fixture bill)');
   assert.equal(payments.lines[0].label.conceptId, 'pos.methodCash');
   ok('totals/payments blocks copy printed truth verbatim');
 
+  const serviceDocument = buildBillDocument(
+    makePrintData({ bill: { serviceCharge: 12, total: 1129 } }),
+    makeContext(),
+  );
+  const serviceTotals = blockOf(serviceDocument, 'totals');
+  assert.equal(serviceTotals.serviceCharge?.amount, 12, 'server-persisted service charge is rendered once');
+  assert.equal(serviceTotals.grandTotal.amount, 1129, 'receipt uses the authoritative total alongside service charge');
+  ok('service charge is present on the shared receipt surface when persisted');
+
   assert.equal(blockOf(document, 'message').reprintBanner, null, 'no reprint banner on first print');
 }
 

--- a/tests/schema-health.test.ts
+++ b/tests/schema-health.test.ts
@@ -86,9 +86,10 @@ function main() {
       'packaging_tax_category_id',
       'delivery_tax_category_id',
       'service_charge_tax_category_id',
+      'service_charge',
     ],
     order_items: ['tax_snapshot'],
-    bills: ['tax_snapshot'],
+    bills: ['tax_snapshot', 'service_charge'],
   };
   for (const [table, expected] of Object.entries(expectedTaxColumns)) {
     const columns = db.prepare(`PRAGMA table_info(${table})`).all().map((column: any) => column.name);

--- a/tests/tax-pack-management.test.ts
+++ b/tests/tax-pack-management.test.ts
@@ -396,6 +396,16 @@ async function main() {
       headers: owner.authHeader,
     });
     assertEqual(malformedServiceCharge.status, 400, 'malformed service charge is rejected');
+    const overflowServiceCharge = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'takeaway',
+        service_charge: '1e1000',
+        items: [{ product_id: 'override-product', quantity: 1 }],
+      },
+      headers: owner.authHeader,
+    });
+    assertEqual(overflowServiceCharge.status, 400, 'overflow service charge is rejected');
     const negativeServiceCharge = await api(baseUrl, '/api/orders', {
       method: 'POST',
       body: {

--- a/tests/tax-pack-management.test.ts
+++ b/tests/tax-pack-management.test.ts
@@ -385,6 +385,153 @@ async function main() {
     assertEqual(chargeBillDiscount.data.bill.tax_amount, 2, 'bill discount leaves charge tax unscaled');
     assertEqual(chargeBillDiscount.data.bill.total, 137, 'bill discount scales items but not charges');
 
+    console.log('\n5a. Explicit service-charge amounts persist through billing and splits');
+    const malformedServiceCharge = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'takeaway',
+        service_charge: 'not-a-number',
+        items: [{ product_id: 'override-product', quantity: 1 }],
+      },
+      headers: owner.authHeader,
+    });
+    assertEqual(malformedServiceCharge.status, 400, 'malformed service charge is rejected');
+    const negativeServiceCharge = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'takeaway',
+        service_charge: -1,
+        items: [{ product_id: 'override-product', quantity: 1 }],
+      },
+      headers: owner.authHeader,
+    });
+    assertEqual(negativeServiceCharge.status, 400, 'negative service charge is rejected');
+
+    const zeroServiceCharge = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'takeaway',
+        items: [{ product_id: 'override-product', quantity: 1 }],
+      },
+      headers: owner.authHeader,
+    });
+    assertEqual(zeroServiceCharge.status, 201, 'missing service charge keeps the default path');
+    assertEqual(zeroServiceCharge.data.order.service_charge, 0, 'missing service charge persists as zero');
+
+    const serviceOrder = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'takeaway',
+        service_charge: 20,
+        items: [{ product_id: 'override-product', quantity: 1 }],
+      },
+      headers: owner.authHeader,
+    });
+    assertEqual(serviceOrder.status, 201, 'explicit service charge order is created');
+    const serviceOrderId = serviceOrder.data.order.id;
+    assertEqual(serviceOrder.data.order.service_charge, 20, 'order returns the server-validated service charge');
+    const serviceOrderRead = await api(baseUrl, `/api/orders/${serviceOrderId}`, { headers: owner.authHeader });
+    assertEqual(serviceOrderRead.data.order.service_charge, 20, 'order read API returns the persisted service charge');
+    assertEqual(serviceOrder.data.order.tax_amount, 1, 'configured service charge is taxed once');
+    assertEqual(serviceOrder.data.order.total, 121, 'service charge is included in payable total once');
+    const serviceSnapshots = typeof serviceOrder.data.order.tax_snapshot === 'string'
+      ? JSON.parse(serviceOrder.data.order.tax_snapshot)
+      : serviceOrder.data.order.tax_snapshot;
+    assertEqual(serviceSnapshots.length, 1, 'service charge contributes one tax snapshot');
+    assertEqual(serviceSnapshots[0].chargeKind, 'service_charge', 'service tax snapshot identifies its source');
+    const serviceBill = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: serviceOrderId },
+      headers: owner.authHeader,
+    });
+    assertEqual(serviceBill.status, 201, 'service bill is generated');
+    assertEqual(serviceBill.data.bill.service_charge, 20, 'bill persists the order service charge');
+    const serviceBillRead = await api(baseUrl, `/api/bills/${serviceBill.data.bill.id}`, { headers: owner.authHeader });
+    assertEqual(serviceBillRead.data.bill.service_charge, 20, 'bill read API returns the persisted service charge');
+    assertEqual(serviceBill.data.bill.total, 121, 'bill total matches the order total');
+    const regeneratedServiceBill = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: serviceOrderId },
+      headers: owner.authHeader,
+    });
+    assertEqual(regeneratedServiceBill.status, 200, 'regenerating a service bill is idempotent');
+    assertEqual(regeneratedServiceBill.data.bill.service_charge, 20, 'regeneration does not drop the service charge');
+    assertEqual(regeneratedServiceBill.data.bill.total, 121, 'regeneration does not duplicate the service charge');
+
+    const recomputeServiceOrder = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: { type: 'takeaway', service_charge: 20, items: [{ product_id: 'override-product', quantity: 1 }] },
+      headers: owner.authHeader,
+    });
+    const recomputeOrderDiscount = await api(baseUrl, `/api/orders/${recomputeServiceOrder.data.order.id}/discount`, {
+      method: 'PATCH',
+      body: { discount_type: 'percentage', discount_value: 50 },
+      headers: owner.authHeader,
+    });
+    assertEqual(recomputeOrderDiscount.data.order.service_charge, 20, 'order discount retains the service amount');
+    assertEqual(recomputeOrderDiscount.data.order.tax_amount, 1, 'order discount retains service tax once');
+    assertEqual(recomputeOrderDiscount.data.order.total, 71, 'order discount includes the service amount once');
+    const recomputeServiceBill = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: recomputeServiceOrder.data.order.id },
+      headers: owner.authHeader,
+    });
+    const recomputeBillDiscount = await api(baseUrl, `/api/bills/${recomputeServiceBill.data.bill.id}/applyDiscount`, {
+      method: 'POST',
+      body: { type: 'percentage', value: 50 },
+      headers: owner.authHeader,
+    });
+    assertEqual(recomputeBillDiscount.data.bill.service_charge, 20, 'bill discount retains the service amount');
+    assertEqual(recomputeBillDiscount.data.bill.tax_amount, 1, 'bill discount retains service tax once');
+    assertEqual(recomputeBillDiscount.data.bill.total, 71, 'bill discount includes the service amount once');
+
+    const paidServiceBill = await api(baseUrl, `/api/bills/${serviceBill.data.bill.id}/payments`, {
+      method: 'POST',
+      body: { payments: [{ method: 'cash', amount: 121 }] },
+      headers: owner.authHeader,
+    });
+    assertEqual(paidServiceBill.status, 200, 'service bill can be paid at its authoritative total');
+    assertEqual(paidServiceBill.data.bill.payment_status, 'paid', 'service bill becomes immutable after payment');
+    db.prepare('UPDATE orders SET service_charge = 99, total = 200 WHERE id = ?').run(serviceOrderId);
+    const regeneratePaidServiceBill = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: serviceOrderId },
+      headers: owner.authHeader,
+    });
+    assertEqual(regeneratePaidServiceBill.data.bill.service_charge, 20, 'paid bill service charge is not silently rewritten');
+    assertEqual(regeneratePaidServiceBill.data.bill.total, 121, 'paid bill total remains immutable');
+
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('split_checks_enabled', 'true', datetime('now'))").run();
+    const splitServiceOrder = await api(baseUrl, '/api/orders', {
+      method: 'POST',
+      body: {
+        type: 'dine_in',
+        service_charge: 20,
+        items: [{ product_id: 'override-product', quantity: 2 }],
+      },
+      headers: owner.authHeader,
+    });
+    const splitServiceBill = await api(baseUrl, '/api/bills/generate', {
+      method: 'POST',
+      body: { order_id: splitServiceOrder.data.order.id },
+      headers: owner.authHeader,
+    });
+    const splitResponse = await api(baseUrl, `/api/bills/${splitServiceBill.data.bill.id}/split-check`, {
+      method: 'POST',
+      body: {
+        checks: [
+          { label: 'Guest 1', items: [{ order_item_id: splitServiceOrder.data.order.items[0].id, quantity: 1 }] },
+          { label: 'Guest 2', items: [{ order_item_id: splitServiceOrder.data.order.items[0].id, quantity: 1 }] },
+        ],
+      },
+      headers: owner.authHeader,
+    });
+    assertEqual(splitResponse.status, 201, 'service charge order can be split');
+    assertEqual(splitResponse.data.bills[0].service_charge, 10, 'split allocates service charge to first check');
+    assertEqual(splitResponse.data.bills[1].service_charge, 10, 'split allocates service charge to second check');
+    assertEqual(splitResponse.data.bills[0].total, 110.5, 'split total includes allocated service tax once');
+    assertEqual(splitResponse.data.bills[1].total, 110.5, 'split totals reconcile to the source bill');
+
     for (const overrideIdToRemove of chargeOverrideIds) {
       const resetCharge = await api(baseUrl, `/api/tax-packs/overrides/${overrideIdToRemove}`, {
         method: 'DELETE',


### PR DESCRIPTION
## Intent

Investigate and fix FloCafe’s service-charge behavior end to end. Separate Settings tax-category configuration from amount/rate policy, make amounts server-authoritative and persisted through orders/bills/APIs, include them exactly once in tax/payable totals, regeneration, splits, payments, and receipts, preserve zero defaults and paid-bill immutability, and add focused regression coverage without inventing pricing UI. Preserve the explicit boundary that Settings currently configures tax treatment while any amount/rate source remains server-authoritative and validated; do not add an automatic nonzero default, rate, or pricing UI.

## What Changed

- Added server-validated, explicitly supplied service-charge amounts with zero defaults, persisted on orders and bills; tax-category settings now control treatment only.
- Included service charges exactly once in tax/payable totals, recalculation, bill regeneration, split checks, payment display, and receipts while preserving paid-bill immutability.
- Updated API and printing documentation and added focused regression coverage for validation, persistence, taxation, splits, regeneration, receipts, and schema columns.

## Risk Assessment

⚠️ Medium: The implementation is consistent across persistence, tax calculation, billing, splits, payments, and receipts, but the financial change spans multiple critical subsystems.

## Testing

The initial integration attempt was setup-blocked by absent dependencies; lockfile dependencies were restored locally, after which backend integration, tax, migration, receipt, billing API, and payment-modal visual checks passed. Evidence includes a rendered PaymentModal-style breakdown showing Service Charge $20.00 and Total $121.00. No linters or static-analysis tools were run, per phase instructions.

- Evidence: PaymentModal service-charge breakdown (local file: <code>~/.no-mistakes/evidence/01M1HCACYBPQ5JEDHFCENTVKKX/payment-modal-service-charge.png</code>)

<details>
<summary>Evidence: Rendered payment-modal evidence HTML</summary>

```text
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <title>Payment - service charge breakdown</title>
  <style>
    * { box-sizing: border-box; }
    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; font: 16px Inter, system-ui, sans-serif; }
    .modal { width: 600px; background: #fff; border-radius: 24px; overflow: hidden; box-shadow: 0 24px 80px #02061799; }
    .header { padding: 24px 28px 20px; border-bottom: 1px solid #e5e7eb; }
    h1 { margin: 0; color: #111827; font-size: 24px; }
    .bill { margin-top: 6px; color: #9ca3af; font-size: 14px; }
    .content { padding: 24px 28px; }
    .summary { padding: 24px; color: #fff; border-radius: 22px; background: linear-gradient(135deg, #1e293b, #0f172a); }
    .eyebrow { color: #94a3b8; font-size: 13px; font-weight: 700; letter-spacing: .12em; }
    .due { margin: 6px 0 22px; font-size: 44px; font-weight: 800; }
    .row { display: flex; justify-content: space-between; padding: 9px 0; color: #cbd5e1; }
    .row.total { margin-top: 5px; padding-top: 14px; border-top: 1px solid #ffffff22; color: #fff; font-weight: 700; }
    .row.service { color: #e2e8f0; }
    .pay { margin-top: 20px; padding: 16px; text-align: center; color: #fff; background: #2563eb; border-radius: 14px; font-weight: 800; }
  </style>
</head>
<body>
  <main class="modal" aria-label="Payment modal with service charge">
    <header class="header"><h1>Payment</h1><div class="bill">Bill #BILL-SERVICE-0020</div></header>
    <section class="content">
      <div class="summary">
        <div class="eyebrow">TOTAL DUE</div>
        <div class="due">$121.00</div>
        <div class="row"><span>Subtotal</span><span>$100.00</span></div>
        <div class="row"><span>Tax</span><span>$1.00</span></div>
        <div class="row service"><span>Service Charge</span><span>$20.00</span></div>
        <div class="row total"><span>Total</span><span>$121.00</span></div>
      </div>
      <div class="pay">Pay $121.00</div>
    </section>
  </main>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a25a7f6c3fced8eee7f8615d3ad17244d8473d6f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `main/services/tax.ts:355` - `Decimal.isFinite()` passes for values such as `&#34;1e1000&#34;`, but `toNumber()` returns `Infinity`. This reaches SQLite/order-total handling and returns 500 instead of a 400 validation error. Check `Number.isFinite()` after conversion; packaging and delivery now share this regression.
- ⚠️ `frontend/src/lib/types.ts:208` - Nonzero service charges affect the payable total and payment endpoint, but the live PaymentModal omits the service-charge line. Staff can be asked to collect 121 while seeing no 20 service-charge component. Confirm whether this user-visible breakdown is required.

🔧 Fix: Reject overflow charges; regression test blocked by missing Electron
1 warning still open:

- ⚠️ `frontend/src/lib/types.ts:208` - The new server-returned `Bill.service_charge` is included in the payable total, but the active PaymentModal breakdown still renders only discount, tax, delivery, and packaging. A bill with total 121 and service charge 20 asks staff to collect 121 without showing the 20 component. Confirm whether the payment breakdown must expose this required charge.

🔧 Fix: Show service charges in PaymentModal; focused lint blocked
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:tax-pack-management`
- `npm run test:print-document`
- `npm run test:tax-engine`
- `npm run test:schema-health`
- `npm run test:receipt-printing`
- `npm run test:print-parity`
- `node tests/run-electron-node-test.cjs tests/bills-print-api.test.ts`
- `EVIDENCE_DIR=... REQUIRE_VISUAL_EVIDENCE=1 npm run test:payment-modal-currency-adapter`
- `Viewed the rendered service-charge PaymentModal evidence`
- `git diff --check 26d10fc..4661b9d`
- `Verified clean worktree after removing test-installed dependencies`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ Configured ESLint checks could not run because the repository&#39;s eslint executable is unavailable; no tests were run.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
