### PR TITLE
fix: remove accidental node_modules symlink

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/gurkiratkhaira/tools/firstmate/projects/FloCafe/node_modules


### PR DESCRIPTION
Removes the accidental node_modules symlink that was tracked in commit 4984c82c and merged in PR #607.