### PR TITLE
test: handle optional playwright browser in currency keypad test

### DIFF
--- a/tests/payment-modal-currency-adapter.test.ts
+++ b/tests/payment-modal-currency-adapter.test.ts
@@ -186,56 +186,72 @@ async function runCurrencyInputBehaviorTests() {
   assert.equal(allowCurrencyDecimalKey(jpyAdapter.maxDecimals, 'discount', 'percentage'), true);
   assert.equal(allowCurrencyDecimalKey(kwdAdapter.maxDecimals, 'payment', 'amount'), true);
 
-  const { chromium } = frontendRequire('playwright');
-  const browser = await chromium.launch({ headless: true });
-  try {
-    const renderKeypad = (
-      currencyMaxDecimals: number,
-      amountTarget: 'payment' | 'wallet' | 'discount',
-      discountType: 'percentage' | 'amount',
-    ) => ReactDOMServer.renderToStaticMarkup(
-      React.createElement(CurrencyTouchNumberPad, {
-        value: '',
-        onChange: () => undefined,
-        ariaLabel: 'Amount keypad',
-        clearLabel: 'Clear',
-        backspaceLabel: 'Backspace',
-        currencyMaxDecimals,
-        amountTarget,
-        discountType,
-      }),
-    );
+  const renderKeypad = (
+    currencyMaxDecimals: number,
+    amountTarget: 'payment' | 'wallet' | 'discount',
+    discountType: 'percentage' | 'amount',
+  ) => ReactDOMServer.renderToStaticMarkup(
+    React.createElement(CurrencyTouchNumberPad, {
+      value: '',
+      onChange: () => undefined,
+      ariaLabel: 'Amount keypad',
+      clearLabel: 'Clear',
+      backspaceLabel: 'Backspace',
+      currencyMaxDecimals,
+      amountTarget,
+      discountType,
+    }),
+  );
 
+  const jpyKeypadMarkup = renderKeypad(jpyAdapter.maxDecimals, 'payment', 'amount');
+  assert.equal(jpyKeypadMarkup.includes('>.<'), false, 'JPY keypad omits the decimal button in static markup');
+
+  const usdKeypadMarkup = renderKeypad(usdAdapter.maxDecimals, 'payment', 'amount');
+  assert.equal(usdKeypadMarkup.includes('>.<'), true, 'USD keypad renders the decimal button in static markup');
+
+  const kwdKeypadMarkup = renderKeypad(kwdAdapter.maxDecimals, 'payment', 'amount');
+  assert.equal(kwdKeypadMarkup.includes('>.<'), true, 'KWD keypad renders the decimal button in static markup');
+
+  const jpyDiscountMarkup = renderKeypad(jpyAdapter.maxDecimals, 'discount', 'percentage');
+  assert.equal(jpyDiscountMarkup.includes('>.<'), true, 'Percentage discount keypad renders the decimal button in static markup');
+
+  let browser: any;
+  try {
+    const { chromium } = frontendRequire('playwright');
+    browser = await chromium.launch({ headless: true });
     const page = await browser.newPage();
-    await page.setContent(renderKeypad(jpyAdapter.maxDecimals, 'payment', 'amount'));
+    await page.setContent(jpyKeypadMarkup);
     assert.equal(
       await page.getByRole('button', { name: '.', exact: true }).count(),
       0,
       'JPY keypad omits the decimal button',
     );
 
-    await page.setContent(renderKeypad(usdAdapter.maxDecimals, 'payment', 'amount'));
+    await page.setContent(usdKeypadMarkup);
     assert.equal(
       await page.getByRole('button', { name: '.', exact: true }).count(),
       1,
       'USD keypad renders the decimal button',
     );
 
-    await page.setContent(renderKeypad(kwdAdapter.maxDecimals, 'payment', 'amount'));
+    await page.setContent(kwdKeypadMarkup);
     assert.equal(
       await page.getByRole('button', { name: '.', exact: true }).count(),
       1,
       'KWD keypad renders the decimal button',
     );
 
-    await page.setContent(renderKeypad(jpyAdapter.maxDecimals, 'discount', 'percentage'));
+    await page.setContent(jpyDiscountMarkup);
     assert.equal(
       await page.getByRole('button', { name: '.', exact: true }).count(),
       1,
       'Percentage discount keypad renders the decimal button',
     );
+  } catch (err: any) {
+    if (process.env.REQUIRE_VISUAL_EVIDENCE === '1') throw err;
+    console.warn(`  ! Playwright browser not available in this runner; static markup verified: ${err?.message || err}`);
   } finally {
-    await browser.close();
+    await browser?.close().catch(() => undefined);
   }
   console.log('  ✓ Currency steps and rendered keypad precision behavior verified');
 }
@@ -315,8 +331,20 @@ async function runModalKeypadIntegrationTests() {
       }) as typeof React.useState;
       return ReactDOMServer.renderToStaticMarkup(React.createElement(Modal, props));
     };
-    const browser = await frontendRequire('playwright').chromium.launch({ headless: true });
+    for (const [Modal, props, label] of [
+      [PaymentModal, { bill, currency: 'JPY', onClose: () => undefined, onPaid: () => undefined }, 'PaymentModal'],
+      [PrepaidCheckoutModal, { currency: 'JPY', onClose: () => undefined, onConfirm: () => undefined }, 'PrepaidCheckoutModal'],
+    ] as const) {
+      const targetStateIndex = 3;
+      const paymentMarkup = renderModal(Modal, props, 'payment', targetStateIndex);
+      assert.equal(paymentMarkup.includes('>.<'), false, `${label} hides JPY payment decimal key in static markup`);
+      const discountMarkup = renderModal(Modal, props, 'discount', targetStateIndex);
+      assert.equal(discountMarkup.includes('>.<'), true, `${label} keeps decimal key for percentage discount in static markup`);
+    }
+
+    let browser: any;
     try {
+      browser = await frontendRequire('playwright').chromium.launch({ headless: true });
       const page = await browser.newPage();
       for (const [Modal, props, label] of [
         [PaymentModal, { bill, currency: 'JPY', onClose: () => undefined, onPaid: () => undefined }, 'PaymentModal'],
@@ -328,8 +356,11 @@ async function runModalKeypadIntegrationTests() {
         await page.setContent(renderModal(Modal, props, 'discount', targetStateIndex));
         assert.equal(await page.getByRole('button', { name: '.', exact: true }).count(), 1, `${label} keeps decimal key for percentage discount`);
       }
+    } catch (err: any) {
+      if (process.env.REQUIRE_VISUAL_EVIDENCE === '1') throw err;
+      console.warn(`  ! Playwright browser not available in this runner; modal static markup verified: ${err?.message || err}`);
     } finally {
-      await browser.close();
+      await browser?.close().catch(() => undefined);
     }
   } finally {
     React.useState = originalUseState;

--- a/tests/payment-modal-currency-adapter.test.ts
+++ b/tests/payment-modal-currency-adapter.test.ts
@@ -219,39 +219,44 @@ async function runCurrencyInputBehaviorTests() {
   try {
     const { chromium } = frontendRequire('playwright');
     browser = await chromium.launch({ headless: true });
-    const page = await browser.newPage();
-    await page.setContent(jpyKeypadMarkup);
-    assert.equal(
-      await page.getByRole('button', { name: '.', exact: true }).count(),
-      0,
-      'JPY keypad omits the decimal button',
-    );
-
-    await page.setContent(usdKeypadMarkup);
-    assert.equal(
-      await page.getByRole('button', { name: '.', exact: true }).count(),
-      1,
-      'USD keypad renders the decimal button',
-    );
-
-    await page.setContent(kwdKeypadMarkup);
-    assert.equal(
-      await page.getByRole('button', { name: '.', exact: true }).count(),
-      1,
-      'KWD keypad renders the decimal button',
-    );
-
-    await page.setContent(jpyDiscountMarkup);
-    assert.equal(
-      await page.getByRole('button', { name: '.', exact: true }).count(),
-      1,
-      'Percentage discount keypad renders the decimal button',
-    );
   } catch (err: any) {
     if (process.env.REQUIRE_VISUAL_EVIDENCE === '1') throw err;
     console.warn(`  ! Playwright browser not available in this runner; static markup verified: ${err?.message || err}`);
-  } finally {
-    await browser?.close().catch(() => undefined);
+  }
+
+  if (browser) {
+    try {
+      const page = await browser.newPage();
+      await page.setContent(jpyKeypadMarkup);
+      assert.equal(
+        await page.getByRole('button', { name: '.', exact: true }).count(),
+        0,
+        'JPY keypad omits the decimal button',
+      );
+
+      await page.setContent(usdKeypadMarkup);
+      assert.equal(
+        await page.getByRole('button', { name: '.', exact: true }).count(),
+        1,
+        'USD keypad renders the decimal button',
+      );
+
+      await page.setContent(kwdKeypadMarkup);
+      assert.equal(
+        await page.getByRole('button', { name: '.', exact: true }).count(),
+        1,
+        'KWD keypad renders the decimal button',
+      );
+
+      await page.setContent(jpyDiscountMarkup);
+      assert.equal(
+        await page.getByRole('button', { name: '.', exact: true }).count(),
+        1,
+        'Percentage discount keypad renders the decimal button',
+      );
+    } finally {
+      await browser.close();
+    }
   }
   console.log('  ✓ Currency steps and rendered keypad precision behavior verified');
 }
@@ -345,22 +350,27 @@ async function runModalKeypadIntegrationTests() {
     let browser: any;
     try {
       browser = await frontendRequire('playwright').chromium.launch({ headless: true });
-      const page = await browser.newPage();
-      for (const [Modal, props, label] of [
-        [PaymentModal, { bill, currency: 'JPY', onClose: () => undefined, onPaid: () => undefined }, 'PaymentModal'],
-        [PrepaidCheckoutModal, { currency: 'JPY', onClose: () => undefined, onConfirm: () => undefined }, 'PrepaidCheckoutModal'],
-      ] as const) {
-        const targetStateIndex = 3;
-        await page.setContent(renderModal(Modal, props, 'payment', targetStateIndex));
-        assert.equal(await page.getByRole('button', { name: '.', exact: true }).count(), 0, `${label} hides JPY payment decimal key`);
-        await page.setContent(renderModal(Modal, props, 'discount', targetStateIndex));
-        assert.equal(await page.getByRole('button', { name: '.', exact: true }).count(), 1, `${label} keeps decimal key for percentage discount`);
-      }
     } catch (err: any) {
       if (process.env.REQUIRE_VISUAL_EVIDENCE === '1') throw err;
       console.warn(`  ! Playwright browser not available in this runner; modal static markup verified: ${err?.message || err}`);
-    } finally {
-      await browser?.close().catch(() => undefined);
+    }
+
+    if (browser) {
+      try {
+        const page = await browser.newPage();
+        for (const [Modal, props, label] of [
+          [PaymentModal, { bill, currency: 'JPY', onClose: () => undefined, onPaid: () => undefined }, 'PaymentModal'],
+          [PrepaidCheckoutModal, { currency: 'JPY', onClose: () => undefined, onConfirm: () => undefined }, 'PrepaidCheckoutModal'],
+        ] as const) {
+          const targetStateIndex = 3;
+          await page.setContent(renderModal(Modal, props, 'payment', targetStateIndex));
+          assert.equal(await page.getByRole('button', { name: '.', exact: true }).count(), 0, `${label} hides JPY payment decimal key`);
+          await page.setContent(renderModal(Modal, props, 'discount', targetStateIndex));
+          assert.equal(await page.getByRole('button', { name: '.', exact: true }).count(), 1, `${label} keeps decimal key for percentage discount`);
+        }
+      } finally {
+        await browser.close();
+      }
     }
   } finally {
     React.useState = originalUseState;


### PR DESCRIPTION
Allows payment modal currency adapter test to run in unit test runners where playwright browsers are not installed by testing static markup directly and making browser launch optional.