### PR TITLE
fix(printers): add country-pack charge-row parity

### DIFF
--- a/docs/printers.md
+++ b/docs/printers.md
@@ -107,6 +107,7 @@ Signed country tax packs can ship compliance receipt templates that render throu
 | `header` | object | no | Optional author strings: `businessNameTransform` (`uppercase`), `taxTitleWhenTaxPresent`, `titleWhenTaxAbsent` |
 | `fields.taxRegistrationNumberLabel` | string | no | Author label for the tax registration line |
 | `totals.grandTotalLabel` | string | no | Author label for the bold grand-total row |
+| `totals.chargeRows` | array of `serviceCharge`, `deliveryCharge`, `packagingCharge` | no | Explicitly opts into persisted nonzero charge rows; output remains in service, delivery, packaging order and zero values stay absent |
 | `totals.showSubtotal`, `totals.showDiscount` | boolean | no | Toggle subtotal/discount rows (default on) |
 | `totals.showTaxRegistrationNumber` | string | no | `when_tax_present_or_enabled` or default visibility rule |
 | `footer.defaultMessage` | string | no | Author footer message used when no configured footer note applies |
@@ -131,7 +132,7 @@ Packs may ship a payload-root `labels` map to override built-in fallback labels 
 }
 ```
 
-Supported semantic ids (stable public identifiers — never internal i18n keys): `invoice`, `taxInvoice`, `subtotal`, `discount`, `tax`, `total`, `taxIncluded`, `footerThanks`. Once shipped, an id never changes meaning.
+Supported semantic ids (stable public identifiers — never internal i18n keys): `invoice`, `taxInvoice`, `subtotal`, `discount`, `tax`, `total`, `serviceCharge`, `deliveryCharge`, `packagingCharge`, `taxIncluded`, `footerThanks`. Once shipped, an id never changes meaning.
 
 Resolution order for each label: the pack's structural author string (for example `totals.grandTotalLabel`) wins first, then the matching `labels` entry, then the built-in default localized through the canonical print-labels catalog using the receipt language. English defaults are byte-identical to the pre-#445 hardcoded strings.
 

--- a/docs/printing-architecture.md
+++ b/docs/printing-architecture.md
@@ -62,9 +62,9 @@ The document-block renderer rule has explicit active raw-path exceptions:
 
 - Signed [#445](https://github.com/FreeOpenSourcePOS/FloCafe/issues/445) compliance packs use [`main/printers/thermal.ts`](../main/printers/thermal.ts) to render raw
   `Order`/`Bill`/business rows with the signed [`escpos-line-template-v1`](printers.md#country-pack-compliance-receipt-templates-escpos-line-template-v1)
-  payload. This remains a separate compliance format, but its amount-bearing
-  item, add-on, total, and payment lines use the shared ESC/POS financial-warning guard
-  before dispatch; see [the compliance template contract in printers.md](printers.md#country-pack-compliance-receipt-templates-escpos-line-template-v1).
+  payload. This remains a separate compliance format, but all of its
+  amount-bearing lines use the shared ESC/POS financial-warning guard before
+  dispatch; see [the compliance template contract in printers.md](printers.md#country-pack-compliance-receipt-templates-escpos-line-template-v1).
 - [`frontend/src/lib/printer/kot-web-print.ts`](../frontend/src/lib/printer/kot-web-print.ts) renders browser KOT HTML from a
   raw `Order`; it uses the shared catalog and direction helpers but is not a
   `KotDocument` v1 consumer.

--- a/main/print/template-labels.ts
+++ b/main/print/template-labels.ts
@@ -24,6 +24,12 @@ export const TEMPLATE_LABEL_IDS = {
   tax: 'pos.tax',
   /** Bold grand-total row label. */
   total: 'print.grandTotal',
+  /** Persisted service-charge row label. */
+  serviceCharge: 'receipt.serviceCharge',
+  /** Persisted delivery-charge row label. */
+  deliveryCharge: 'pos.delivery',
+  /** Persisted packaging-charge row label. */
+  packagingCharge: 'pos.packaging',
   /** Tax-inclusive pricing note (reserved; mapped to receipt.taxIncluded). */
   taxIncluded: 'receipt.taxIncluded',
   /** Default footer message when no configured footer note applies. */
@@ -31,6 +37,10 @@ export const TEMPLATE_LABEL_IDS = {
 } as const satisfies Record<string, PrintConceptId>;
 
 export type TemplateLabelId = keyof typeof TEMPLATE_LABEL_IDS;
+
+/** Explicit charge-row capabilities in the v1 country-pack template contract. */
+export const TEMPLATE_CHARGE_ROW_IDS = ['serviceCharge', 'deliveryCharge', 'packagingCharge'] as const;
+export type TemplateChargeRowId = typeof TEMPLATE_CHARGE_ROW_IDS[number];
 
 /** Install-time caps for the `labels` map (#445): fail closed on misuse. */
 export const TEMPLATE_LABELS_MAX_ENTRIES = 64;
@@ -80,6 +90,33 @@ export function fitTemplateLabel(text: string, columns: number): string {
  * throws with a clear rejection message that surfaces through pack install.
  * The renderer version stays 1: this is validation only, never a schema bump.
  */
+export function validateTemplateChargeRows(rows: unknown): void {
+  if (rows === undefined || rows === null) return;
+  if (!Array.isArray(rows)) {
+    throw new Error('Print template totals.chargeRows must be an array of supported charge-row ids');
+  }
+  const seen = new Set<string>();
+  for (const row of rows) {
+    if (typeof row !== 'string' || !(TEMPLATE_CHARGE_ROW_IDS as readonly string[]).includes(row)) {
+      throw new Error(
+        `Unknown print template charge row "${String(row)}". Supported ids: ${TEMPLATE_CHARGE_ROW_IDS.join(', ')}`,
+      );
+    }
+    if (seen.has(row)) throw new Error(`Duplicate print template charge row "${row}"`);
+    seen.add(row);
+  }
+}
+
+/**
+ * Resolve the declared rows in the contract's stable legal order. The array
+ * declares capability; its order never changes country/legal output order.
+ */
+export function declaredTemplateChargeRows(rows: unknown): TemplateChargeRowId[] {
+  if (!Array.isArray(rows)) return [];
+  const declared = new Set(rows);
+  return TEMPLATE_CHARGE_ROW_IDS.filter((row) => declared.has(row));
+}
+
 export function validateTemplateLabelsMap(labels: unknown): void {
   if (labels === undefined || labels === null) return;
   if (!labels || typeof labels !== 'object' || Array.isArray(labels)) {

--- a/main/print/template-labels.ts
+++ b/main/print/template-labels.ts
@@ -81,14 +81,13 @@ export function fitTemplateLabel(text: string, columns: number): string {
 }
 
 /**
- * Validate the optional payload-root `labels` map of an
- * `escpos-line-template-v1` payload at install time (#445).
+ * Validate the optional `totals.chargeRows` capability declaration of an
+ * `escpos-line-template-v1` payload at install time.
  *
- * Absent/null maps pass (the field is additive and optional). Structural
- * misuse — non-object maps, unknown semantic ids, more than
- * TEMPLATE_LABELS_MAX_ENTRIES entries, or non-string/empty/oversized values —
- * throws with a clear rejection message that surfaces through pack install.
- * The renderer version stays 1: this is validation only, never a schema bump.
+ * Absent/null declarations pass (the field is additive and optional).
+ * Structural misuse — non-array values, unsupported or duplicate ids — throws
+ * with a clear rejection message that surfaces through pack install. The
+ * renderer version stays 1: this is validation only, never a schema bump.
  */
 export function validateTemplateChargeRows(rows: unknown): void {
   if (rows === undefined || rows === null) return;
@@ -117,6 +116,16 @@ export function declaredTemplateChargeRows(rows: unknown): TemplateChargeRowId[]
   return TEMPLATE_CHARGE_ROW_IDS.filter((row) => declared.has(row));
 }
 
+/**
+ * Validate the optional payload-root `labels` map of an
+ * `escpos-line-template-v1` payload at install time (#445).
+ *
+ * Absent/null maps pass (the field is additive and optional). Structural
+ * misuse — non-object maps, unknown semantic ids, more than
+ * TEMPLATE_LABELS_MAX_ENTRIES entries, or non-string/empty/oversized values —
+ * throws with a clear rejection message that surfaces through pack install.
+ * The renderer version stays 1: this is validation only, never a schema bump.
+ */
 export function validateTemplateLabelsMap(labels: unknown): void {
   if (labels === undefined || labels === null) return;
   if (!labels || typeof labels !== 'object' || Array.isArray(labels)) {

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -16,7 +16,13 @@ import { cloudSync } from '../services/cloud-sync';
 import { randomUUID } from 'crypto';
 import { printLabel, isGeneratedPrintLanguage } from '../print/print-labels.generated';
 import type { PrintConceptId } from '../print/print-labels.generated';
-import { fitTemplateLabel, resolveTemplateLabel, sanitizeTemplateLabelText } from '../print/template-labels';
+import {
+  declaredTemplateChargeRows,
+  fitTemplateLabel,
+  resolveTemplateLabel,
+  sanitizeTemplateLabelText,
+  type TemplateChargeRowId,
+} from '../print/template-labels';
 import { renderClassicReceiptViaDocument } from './document-classic';
 import { renderCompactReceiptViaDocument } from './document-compact';
 import { renderKotViaDocument } from './document-kot';
@@ -1044,6 +1050,20 @@ function renderEscposLineTemplateV1(payload: any, profile: { columns: number; la
   } else if (Number(bill.tax_amount) !== 0) {
     const label = fitTemplateLabel(normalize(resolveTemplateLabel(payload?.labels, 'tax', lang)), rowLabelWidth);
     lines.push(...financialRows(label, formatCurrency(bill.tax_amount, prefix, locale, trimDecimals, fractionDigits), cols, lang));
+  }
+  // `chargeRows` is an explicit capability declaration. Its order is not
+  // presentation authority: country/legal rows remain in this stable order,
+  // and zero-valued persisted charges stay absent.
+  const chargeAmounts: Record<TemplateChargeRowId, number> = {
+    serviceCharge: Number(bill.service_charge) || 0,
+    deliveryCharge: Number(bill.delivery_charge) || 0,
+    packagingCharge: Number(bill.packaging_charge) || 0,
+  };
+  for (const row of declaredTemplateChargeRows(payload?.totals?.chargeRows)) {
+    const amount = chargeAmounts[row];
+    if (amount === 0) continue;
+    const label = fitTemplateLabel(normalize(resolveTemplateLabel(payload?.labels, row, lang)), rowLabelWidth);
+    lines.push(...financialRows(label, formatCurrency(amount, prefix, locale, trimDecimals, fractionDigits), cols, lang));
   }
   lines.push(bar);
   // Label precedence (#445): the author's structural literal (e.g.

--- a/main/tax-packs/catalog.ts
+++ b/main/tax-packs/catalog.ts
@@ -286,10 +286,12 @@ function validPluginPrintTemplate(value: unknown): value is PluginPrintTemplate 
   validateTemplateLabelsMap(payloadObject.labels);
   // Charge rows are an additive v1 capability declaration. Validate only when
   // present so older signed templates retain their existing contract.
-  const totals = payloadObject.totals && typeof payloadObject.totals === 'object' && !Array.isArray(payloadObject.totals)
-    ? payloadObject.totals as Record<string, unknown>
-    : {};
-  validateTemplateChargeRows(totals.chargeRows);
+  if (payloadObject.format === 'escpos-line-template-v1') {
+    const totals = payloadObject.totals && typeof payloadObject.totals === 'object' && !Array.isArray(payloadObject.totals)
+      ? payloadObject.totals as Record<string, unknown>
+      : {};
+    validateTemplateChargeRows(totals.chargeRows);
+  }
   const payloadProfiles = Array.isArray(payloadObject.widthProfiles) ? payloadObject.widthProfiles : [];
   const hasMatchingProfiles = payloadObject.format === 'escpos-line-template-v1'
     && payloadProfiles.length > 0

--- a/main/tax-packs/catalog.ts
+++ b/main/tax-packs/catalog.ts
@@ -1,7 +1,7 @@
 import { createHash, verify, type KeyLike } from 'crypto';
 import type { CountryPack, CountryTaxPackPluginArtifact, PluginPrintTemplate } from './types';
 import { TRUSTED_TAX_PACK_SIGNING_PUBLIC_KEY } from './trusted-signing-key';
-import { validateTemplateLabelsMap } from '../print/template-labels';
+import { validateTemplateChargeRows, validateTemplateLabelsMap } from '../print/template-labels';
 
 const RELEASES_API_URL = 'https://api.github.com/repos/FreeOpenSourcePOS/FloCafe-Plugins/releases';
 const RELEASE_DOWNLOAD_PATH_PREFIX = '/FreeOpenSourcePOS/FloCafe-Plugins/releases/download/';
@@ -284,6 +284,12 @@ function validPluginPrintTemplate(value: unknown): value is PluginPrintTemplate 
   // time. A malformed map throws with a clear rejection message instead of
   // failing silently; templates without labels behave exactly as before.
   validateTemplateLabelsMap(payloadObject.labels);
+  // Charge rows are an additive v1 capability declaration. Validate only when
+  // present so older signed templates retain their existing contract.
+  const totals = payloadObject.totals && typeof payloadObject.totals === 'object' && !Array.isArray(payloadObject.totals)
+    ? payloadObject.totals as Record<string, unknown>
+    : {};
+  validateTemplateChargeRows(totals.chargeRows);
   const payloadProfiles = Array.isArray(payloadObject.widthProfiles) ? payloadObject.widthProfiles : [];
   const hasMatchingProfiles = payloadObject.format === 'escpos-line-template-v1'
     && payloadProfiles.length > 0

--- a/tests/print-parity.test.ts
+++ b/tests/print-parity.test.ts
@@ -462,10 +462,16 @@ function run(): void {
       warn(addonRow != null && digitsOf(addonRow).includes('3000'), `${renderer}: addon 5 × 3 × 2 renders 30.00`);
       const secondAddonRow = contentRows(text).find((row) => /Vanilla syrup/.test(row));
       warn(secondAddonRow != null && digitsOf(secondAddonRow).includes('800'), `${renderer}: second addon extension renders 8.00`);
-      warn(text.includes('7.00') && text.includes('8.00') && text.includes('9.00'), `${renderer}: service, delivery, and packaging charges render`);
+      for (const [label, amount] of [['Service Charge', '700'], ['Delivery', '800'], ['Packaging', '900']] as const) {
+        const chargeRow = contentRows(text).find((row) => row.includes(label));
+        warn(chargeRow != null && digitsOf(chargeRow).includes(amount), `${renderer}: ${label} charge renders its persisted amount`);
+      }
     }
     warn(browserHtml.includes('Extra shot') && browserHtml.includes('×3'), 'browser: addon quantity remains visible');
-    warn(browserHtml.includes('Service Charge') && browserHtml.includes('Delivery Charge') && browserHtml.includes('Packaging'), 'browser: service, delivery, and packaging charges render');
+    for (const [label, amount] of [['Service Charge', '700'], ['Delivery Charge', '800'], ['Packaging', '900']] as const) {
+      const chargeRow = contentRows(browserHtml).find((row) => row.includes(label));
+      warn(chargeRow != null && digitsOf(chargeRow).includes(amount), `browser: ${label} charge renders its persisted amount`);
+    }
 
     const zeroChargeBill = {
       ...quantityBill,

--- a/tests/print-parity.test.ts
+++ b/tests/print-parity.test.ts
@@ -485,7 +485,11 @@ function run(): void {
       ['frontend/webusb/compact', fe.receiptEncoder.buildCompactReceiptBytes],
     ] as const) {
       const zeroText = new TextDecoder().decode(build(zeroChargeBill as any, { ...tenant, business_name: 'Flo Parity Cafe' } as any, { paperWidth: 80, useUnicode: true }, []));
-      warn(!zeroText.includes('Service Charge') && !zeroText.includes('Delivery Charge') && !zeroText.includes('Packaging'), `${renderer}: zero charges do not create rows`);
+      const zeroRows = zeroText.split(/\r?\n/);
+      warn(
+        !zeroRows.some((row) => row.includes('Service Charge') || row.includes('Delivery') || row.includes('Packaging')),
+        `${renderer}: zero charges do not create rows`,
+      );
     }
 
     let malformedPrintSucceeded = true;

--- a/tests/print-parity.test.ts
+++ b/tests/print-parity.test.ts
@@ -437,10 +437,11 @@ function run(): void {
       subtotal: 50,
       discount_amount: 0,
       tax_amount: 0,
+      service_charge: 7,
       delivery_charge: 8,
       packaging_charge: 9,
-      total: 67,
-      payment_details: [{ method: 'cash', amount: 67 }],
+      total: 74,
+      payment_details: [{ method: 'cash', amount: 74 }],
       order: quantityOrder,
     };
     const quantityBusiness = { ...business, name: 'Flo Parity Cafe' };
@@ -461,10 +462,25 @@ function run(): void {
       warn(addonRow != null && digitsOf(addonRow).includes('3000'), `${renderer}: addon 5 × 3 × 2 renders 30.00`);
       const secondAddonRow = contentRows(text).find((row) => /Vanilla syrup/.test(row));
       warn(secondAddonRow != null && digitsOf(secondAddonRow).includes('800'), `${renderer}: second addon extension renders 8.00`);
-      warn(text.includes('8.00') && text.includes('9.00'), `${renderer}: delivery and packaging charges render`);
+      warn(text.includes('7.00') && text.includes('8.00') && text.includes('9.00'), `${renderer}: service, delivery, and packaging charges render`);
     }
     warn(browserHtml.includes('Extra shot') && browserHtml.includes('×3'), 'browser: addon quantity remains visible');
-    warn(browserHtml.includes('Delivery Charge') && browserHtml.includes('Packaging'), 'browser: delivery and packaging charges render');
+    warn(browserHtml.includes('Service Charge') && browserHtml.includes('Delivery Charge') && browserHtml.includes('Packaging'), 'browser: service, delivery, and packaging charges render');
+
+    const zeroChargeBill = {
+      ...quantityBill,
+      service_charge: 0,
+      delivery_charge: 0,
+      packaging_charge: 0,
+      total: 50,
+    };
+    for (const [renderer, build] of [
+      ['frontend/webusb/classic', fe.receiptEncoder.buildClassicReceiptBytes],
+      ['frontend/webusb/compact', fe.receiptEncoder.buildCompactReceiptBytes],
+    ] as const) {
+      const zeroText = new TextDecoder().decode(build(zeroChargeBill as any, { ...tenant, business_name: 'Flo Parity Cafe' } as any, { paperWidth: 80, useUnicode: true }, []));
+      warn(!zeroText.includes('Service Charge') && !zeroText.includes('Delivery Charge') && !zeroText.includes('Packaging'), `${renderer}: zero charges do not create rows`);
+    }
 
     let malformedPrintSucceeded = true;
     for (const addons of [

--- a/tests/tax-pack-management.test.ts
+++ b/tests/tax-pack-management.test.ts
@@ -752,6 +752,7 @@ async function main() {
           showDiscount: 'when_non_zero',
           showTaxRegistrationNumber: 'when_tax_present_or_enabled',
           grandTotalLabel: 'GRAND TOTAL',
+          chargeRows: ['packagingCharge', 'serviceCharge', 'deliveryCharge'],
         },
         footer: {
           useConfiguredFooterNote: true,
@@ -872,8 +873,11 @@ async function main() {
         subtotal: 200,
         discount_amount: 0,
         tax_amount: 10,
-        total: 210,
-        payment_details: [{ method: 'cash', amount: 210 }],
+        service_charge: 20,
+        delivery_charge: 30,
+        packaging_charge: 5,
+        total: 265,
+        payment_details: [{ method: 'cash', amount: 265 }],
       },
       {
         name: 'Flo Test Cafe',
@@ -893,7 +897,40 @@ async function main() {
     assert(pluginReceipt.includes('ITEM'), 'installed GST plugin template renders the plugin item-table layout');
     assert(pluginReceipt.includes('GSTIN: 27ABCDE1234F1Z5'), 'installed GST plugin template renders GSTIN');
     assert(pluginReceipt.includes('CGST @2.5%'), 'installed GST plugin template renders tax components');
+    assert(pluginReceipt.includes('Service Charge') && pluginReceipt.includes('₹20.00'), 'declared plugin service charge row renders its persisted amount');
+    assert(pluginReceipt.includes('Delivery') && pluginReceipt.includes('₹30.00'), 'declared plugin delivery charge row renders its persisted amount');
+    assert(pluginReceipt.includes('Packaging') && pluginReceipt.includes('₹5.00'), 'declared plugin packaging charge row renders its persisted amount');
+    assert(
+      pluginReceipt.indexOf('Service Charge') < pluginReceipt.indexOf('Delivery')
+        && pluginReceipt.indexOf('Delivery') < pluginReceipt.indexOf('Packaging')
+        && pluginReceipt.indexOf('Packaging') < pluginReceipt.indexOf('GRAND TOTAL'),
+      'declared plugin charge rows keep service, delivery, packaging, total order',
+    );
     assert(pluginReceipt.includes('GRAND TOTAL'), 'installed GST plugin template renders plugin grand total label');
+
+    const zeroPluginReceipt = escPosToText(formatReceipt(
+      {
+        order_number: 'ORD-GST-ZERO-CHARGES',
+        created_at: '2026-08-01T10:30:00.000Z',
+        items: [{ product_name: 'Masala Chai', quantity: 1, total: 100 }],
+      },
+      {
+        bill_number: 'BILL-GST-ZERO-CHARGES',
+        subtotal: 100,
+        discount_amount: 0,
+        tax_amount: 0,
+        service_charge: 0,
+        delivery_charge: 0,
+        packaging_charge: 0,
+        total: 100,
+      },
+      { name: 'Flo Test Cafe', country: 'IN', currency_symbol: '₹', show_tax_breakdown: false },
+      'in.gst.tax-invoice.v1',
+      48,
+      true,
+    ));
+    assert(!zeroPluginReceipt.includes('Service Charge') && !zeroPluginReceipt.includes('Delivery') && !zeroPluginReceipt.includes('Packaging'),
+      'declared plugin charge rows omit zero-valued charges');
 
     const widthProfileWarnings: any[] = [];
     const exactWidthReceipt = escPosToText(formatReceipt(
@@ -1141,6 +1178,14 @@ async function main() {
     const labelsTotalReceipt = renderLabeled('in.gst.labels-total.v1');
     assert(labelsTotalReceipt.includes('SUMA TOTAL'), 'labels.total overrides the grand total when no structural label exists');
 
+    const fallbackWithCharges = renderLabeled('in.gst.label-fallback.v1', {
+      service_charge: 20,
+      delivery_charge: 30,
+      packaging_charge: 5,
+      total: 155,
+    });
+    assert(!fallbackWithCharges.includes('Service Charge') && !fallbackWithCharges.includes('Delivery') && !fallbackWithCharges.includes('Packaging'),
+      'plugin templates without charge-row support retain their legacy output');
     const fallbackEnReceipt = renderLabeled('in.gst.label-fallback.v1', {}, 'en');
     assert(fallbackEnReceipt.includes('INVOICE'), 'EN fallback title matches the pre-#445 hardcoded default');
     assert(fallbackEnReceipt.includes('Subtotal'), 'EN fallback subtotal matches the pre-#445 hardcoded default');

--- a/tests/tax-pack-management.test.ts
+++ b/tests/tax-pack-management.test.ts
@@ -897,9 +897,13 @@ async function main() {
     assert(pluginReceipt.includes('ITEM'), 'installed GST plugin template renders the plugin item-table layout');
     assert(pluginReceipt.includes('GSTIN: 27ABCDE1234F1Z5'), 'installed GST plugin template renders GSTIN');
     assert(pluginReceipt.includes('CGST @2.5%'), 'installed GST plugin template renders tax components');
-    assert(pluginReceipt.includes('Service Charge') && pluginReceipt.includes('₹20.00'), 'declared plugin service charge row renders its persisted amount');
-    assert(pluginReceipt.includes('Delivery') && pluginReceipt.includes('₹30.00'), 'declared plugin delivery charge row renders its persisted amount');
-    assert(pluginReceipt.includes('Packaging') && pluginReceipt.includes('₹5.00'), 'declared plugin packaging charge row renders its persisted amount');
+    const pluginRows = pluginReceipt.split(/\r?\n/);
+    const serviceChargeRow = pluginRows.find((row) => row.includes('Service Charge'));
+    const deliveryChargeRow = pluginRows.find((row) => row.includes('Delivery'));
+    const packagingChargeRow = pluginRows.find((row) => row.includes('Packaging'));
+    assert(serviceChargeRow != null && serviceChargeRow.includes('₹20.00'), 'declared plugin service charge row renders its persisted amount');
+    assert(deliveryChargeRow != null && deliveryChargeRow.includes('₹30.00'), 'declared plugin delivery charge row renders its persisted amount');
+    assert(packagingChargeRow != null && packagingChargeRow.includes('₹5.00'), 'declared plugin packaging charge row renders its persisted amount');
     assert(
       pluginReceipt.indexOf('Service Charge') < pluginReceipt.indexOf('Delivery')
         && pluginReceipt.indexOf('Delivery') < pluginReceipt.indexOf('Packaging')


### PR DESCRIPTION
## Intent

Implement Phase 5A of FloCafe's internationalization and printing remediation plan: add safe charge-row parity to country-pack thermal templates under the captain-authorized compatibility decision. Preserve existing legacy country-pack output for templates that do not explicitly support charge rows. Add persisted service-charge, delivery-charge, and packaging-charge rows only through the existing signed country-pack thermal-template contract. Zero-valued charges must remain absent or zero, with no implicit row injection into arbitrary or unversioned templates. Preserve country/legal row ordering and existing thermal safety. Add focused backend and frontend thermal regression coverage for nonzero and zero charges. Keep this as a country-pack charge-row-only change. Do not alter unsupported-text safety, capability architecture, locale bootstrap or translation quality, timezone behavior, currency precision, tax policy, service-charge pricing, broad routing, or unrelated UI. The compatibility decision uses the additive escpos-line-template-v1 totals.chargeRows declaration with stable serviceCharge, deliveryCharge, and packagingCharge IDs; its declared capability order does not override fixed service/delivery/packaging legal presentation order. Refresh safely from the current FloCafe main before validation because PR 628 became out of date after later main merges; use the supported no-mistakes rebase/sync path only, never hand-rebase, reset, force-push, or raw-push. Preserve all existing implementation and pipeline commits, and continue the one-worker-at-a-time sequence.

## What Changed

- Added optional `totals.chargeRows` capability validation and stable charge-row label IDs to the signed `escpos-line-template-v1` contract.
- Rendered persisted nonzero service, delivery, and packaging charges in fixed legal order before the grand total, while preserving zero-charge omission and legacy template output.
- Updated printing documentation and added backend/frontend thermal regression coverage for charge parity, ordering, zero values, and unsupported templates.

## Risk Assessment

✅ Low: The change is narrowly scoped to explicitly declared signed country-pack charge rows, preserves legacy templates, enforces stable ordering and zero omission, and maintains financial-row safety.

## Testing

Installed locked dependencies, ran all three focused tests successfully, and verified the actual rendered country-pack receipt transcript for charge values, legal ordering, grand-total placement, and zero-charge omission. No UI screenshot was applicable.

<details>
<summary>Evidence: Country-pack charge-row transcript</summary>

`Rendered installed country-pack receipt showed Service Charge ₹20.00, Delivery ₹30.00, Packaging ₹5.00 before GRAND TOTAL ₹155.00; zero-charge receipt omitted all three rows.`

```text
Installed escpos-line-template-v1 country-pack receipt

NONZERO PERSISTED CHARGES
Flo Test Cafe
================================================
INVOICE
================================================
Invoice #: BILL-EVIDENCE
Date: 1/8/2026
Time: 6:30:00 am
------------------------------------------------
ITEM                            QTY     AMOUNT
------------------------------------------------
Masala Chai                       1    ₹100.00
------------------------------------------------
Subtotal                                 ₹100.00
Service Charge                            ₹20.00
Delivery                                  ₹30.00
Packaging                                  ₹5.00
================================================
GRAND TOTAL                              ₹155.00
------------------------------------------------
Cash                                     ₹155.00
================================================
Thank you!
Powered by FloPOS
https://flopos.com

ZERO PERSISTED CHARGES
Flo Test Cafe
================================================
INVOICE
================================================
Invoice #: BILL-EVIDENCE-ZERO
Date: 1/8/2026
Time: 6:30:00 am
------------------------------------------------
ITEM                            QTY     AMOUNT
------------------------------------------------
Masala Chai                       1    ₹100.00
------------------------------------------------
Subtotal                                 ₹100.00
================================================
GRAND TOTAL                              ₹100.00
================================================
Thank you!
Powered by FloPOS
https://flopos.com
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"02a5989ea74b43814a5b85a5f2328a9fba3d2d3d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm ci`
- `frontend: npm ci`
- `npm run test:print-parity`
- `npm run test:tax-pack-management`
- `npm run test:print-document`
- `Rendered installed country-pack ESC/POS output with nonzero and zero charges`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin receipts can display service, delivery, and packaging charges.
  * Templates can declare supported charge rows, which appear in a consistent order.
  * Zero-value charge rows are omitted from printed receipts.

* **Bug Fixes**
  * Invalid or duplicate charge-row declarations are rejected.
  * Templates without charge-row support retain their existing receipt output.

* **Documentation**
  * Updated printing documentation to describe charge rows and financial amount safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->