### PR TITLE
fix(frontend): preserve table state across editing flows

### DIFF
--- a/docs/plans/issue-356-floorplan-editor.md
+++ b/docs/plans/issue-356-floorplan-editor.md
@@ -25,7 +25,7 @@ Common denominators → **best-practice UX**: floor tabs, drag & drop on a canva
 
 1. `frontend/src/lib/types.ts`: add `position_x`/`position_y` to `Table`.
 2. New `frontend/src/components/tables/FloorplanEditor.tsx`: canvas + floor tabs + tray + pointer drag + Save/Discard + legend.
-3. Wire into `frontend/src/app/(dashboard)/tables/page.tsx` (header button + view toggle; editor inherits the page's 10s status polling).
+3. Wire into `frontend/src/app/(dashboard)/tables/page.tsx` (header button + view toggle; editor inherits the page's 10s status polling, including while layout editing is open).
 4. i18n keys ×5 languages.
 5. Backend integration test: PUT `position_x`/`position_y` persists and GET returns them (acceptance criterion 1).
 6. Playwright e2e: login → tables → Edit Floorplan → drag table → Save → reload → position persisted; floor switching works; visual snapshot check.

--- a/frontend/e2e/floorplan-editor.spec.ts
+++ b/frontend/e2e/floorplan-editor.spec.ts
@@ -264,3 +264,43 @@ test('floorplan editor: add a named floor and see it in the all-floors overview'
   await expect(page.getByTestId('floorplan-canvas')).toBeVisible();
   await expect(page.getByTestId(`floorplan-chip-${floorTable}`)).toBeVisible();
 });
+
+test('floorplan editor: live table status refreshes while editing', async ({ page, request }) => {
+  const apiLogin = await request.post(`${BASE}/api/auth/login`, {
+    data: { email: EMAIL, password: PASSWORD },
+  });
+  const { access_token } = await apiLogin.json();
+  const apiAuth = { Authorization: `Bearer ${access_token}` };
+  const tableList = await (await request.get(`${BASE}/api/tables`, { headers: apiAuth })).json();
+  const t1 = (tableList.tables ?? []).find((t: { number: string }) => t.number === 'T1');
+  await request.patch(`${BASE}/api/tables/${t1.id}/status`, {
+    headers: apiAuth,
+    data: { status: 'available' },
+  });
+  await request.patch(`${BASE}/api/tables/positions`, {
+    headers: apiAuth,
+    data: { positions: [{ id: t1.id, position_x: 30, position_y: 30 }] },
+  });
+
+  await login(page);
+  await page.getByRole('button', { name: 'Edit layout' }).click();
+  const chip = page.getByTestId('floorplan-chip-T1');
+  await expect(chip).toHaveAttribute('aria-label', /Available/);
+
+  await request.patch(`${BASE}/api/tables/${t1.id}/status`, {
+    headers: apiAuth,
+    data: { status: 'occupied' },
+  });
+  await expect(chip).toHaveAttribute('aria-label', /Occupied/, { timeout: 15_000 });
+});
+
+test('list view: Add Table keeps the selected floor', async ({ page }) => {
+  await login(page);
+
+  await page.getByRole('button', { name: 'List', exact: true }).click();
+  await page.getByRole('button', { name: 'First', exact: true }).click();
+  await page.getByRole('button', { name: 'Add Table', exact: true }).click();
+
+  const form = page.locator('form').filter({ hasText: 'Floor' });
+  await expect(form.locator('input').nth(2)).toHaveValue('First');
+});

--- a/frontend/e2e/floorplan-editor.spec.ts
+++ b/frontend/e2e/floorplan-editor.spec.ts
@@ -294,6 +294,58 @@ test('floorplan editor: live table status refreshes while editing', async ({ pag
   await expect(chip).toHaveAttribute('aria-label', /Occupied/, { timeout: 15_000 });
 });
 
+test('floorplan editor: live order status refreshes while editing', async ({ page, request }) => {
+  const apiLogin = await request.post(`${BASE}/api/auth/login`, {
+    data: { email: EMAIL, password: PASSWORD },
+  });
+  const { access_token } = await apiLogin.json();
+  const apiAuth = { Authorization: `Bearer ${access_token}` };
+  const tableList = await (await request.get(`${BASE}/api/tables`, { headers: apiAuth })).json();
+  const t1 = (tableList.tables ?? []).find((t: { number: string }) => t.number === 'T1');
+  if (!t1) throw new Error('missing seeded table T1');
+  await request.patch(`${BASE}/api/tables/${t1.id}/status`, {
+    headers: apiAuth,
+    data: { status: 'available' },
+  });
+  await request.patch(`${BASE}/api/tables/positions`, {
+    headers: apiAuth,
+    data: { positions: [{ id: t1.id, position_x: 30, position_y: 30 }] },
+  });
+  const orderRes = await request.post(`${BASE}/api/orders`, {
+    headers: apiAuth,
+    data: {
+      table_id: t1.id,
+      type: 'dine_in',
+      guest_count: 2,
+      items: [{ product_id: 'e2e-product', quantity: 1 }],
+    },
+  });
+  expect(orderRes.ok()).toBeTruthy();
+  const { order } = await orderRes.json();
+
+  await login(page);
+  await page.getByRole('button', { name: 'Edit layout' }).click();
+  await expect(page.getByTestId('floorplan-chip-T1')).toContainText(`#${order.order_number}`);
+
+  const waitForOrderStatus = (status: string) => page.waitForResponse(async (response) => {
+    if (response.request().method() !== 'GET' || !response.url().includes('/api/orders')) return false;
+    try {
+      const body = await response.json();
+      return body.orders?.some((candidate: { order_number: string; status: string }) =>
+        candidate.order_number === order.order_number && candidate.status === status);
+    } catch {
+      return false;
+    }
+  }, { timeout: 15_000 });
+
+  await waitForOrderStatus('pending');
+  await request.patch(`${BASE}/api/orders/${order.id}/status`, {
+    headers: apiAuth,
+    data: { status: 'preparing' },
+  });
+  await waitForOrderStatus('preparing');
+});
+
 test('list view: Add Table keeps the selected floor', async ({ page }) => {
   await login(page);
 

--- a/frontend/src/app/(dashboard)/tables/page.tsx
+++ b/frontend/src/app/(dashboard)/tables/page.tsx
@@ -244,7 +244,6 @@ export default function TablesPage() {
   };
 
   useEffect(() => {
-    if (layoutMode) return;
     const load = () => {
       api.get('/tables')
         .then(({ data }) => setTables(data.tables || []))
@@ -267,7 +266,6 @@ export default function TablesPage() {
   }
 
   useEffect(() => {
-    if (layoutMode) return;
     if (view !== 'plan' && !showDetails) return;
     const fetchOrders = () => {
       api.get('/orders', { params: { status: 'pending,preparing,ready,served', per_page: 500 } })
@@ -298,9 +296,9 @@ export default function TablesPage() {
     setForm({ name: '', capacity: '4', floor: 'Ground', section: '' });
   };
 
-  const openCreate = () => {
+  const openCreate = (floor = 'Ground') => {
     setEditingTable(null);
-    setForm({ name: '', capacity: '4', floor: 'Ground', section: '' });
+    setForm({ name: '', capacity: '4', floor, section: '' });
     setShowForm(true);
   };
 
@@ -444,10 +442,7 @@ export default function TablesPage() {
             </label>
           )}
           {view === 'list' && canManageTables && (
-            <Button onClick={() => {
-              setForm((p) => ({ ...p, floor: [...new Set(tables.map((tb) => tb.floor).filter((f): f is string => Boolean(f)))][0] ?? '' }));
-              openCreate();
-            }}>
+            <Button onClick={() => openCreate(activeFloor === 'all' ? 'Ground' : activeFloor)}>
               <Plus size={16} className="me-1" /> {tTables('addTable')}
             </Button>
           )}


### PR DESCRIPTION
## Intent

Verify and fix the two tables-page issues identified during regression review: keep live table and order status polling active while floorplan layout editing is open, and preserve the selected list-view floor when opening Add Table. Add behavioral end-to-end regression coverage for both. Make the fixes normally in a separate PR, preserve unrelated work, run the normal validation, push through the no-mistakes pipeline, and drive the PR through merge.

## What Changed

- Kept table and order status polling active while floorplan layout editing is open.
- Preserved the selected list-view floor when opening Add Table, defaulting to Ground when all floors are selected.
- Added Playwright regression coverage for live table/order refresh and selected-floor form state, and updated the floorplan editor plan.

## Risk Assessment

✅ Low: Small, bounded UI fix; requested polling and selected-floor behaviors are implemented without unrelated or architectural changes.

## Testing

Backend/frontend builds and all three focused Playwright scenarios passed: table polling, order polling, and selected-floor preservation. Rendered screenshots confirm the live editor status transition and Add Table retaining First. No linters or full-suite tests were run per the targeted test-phase boundary.

- Evidence: Floorplan editor before status refresh (local file: <code>~/.no-mistakes/evidence/01M1N9QQ7PY3CSX3NEXDSJRW4P/floorplan-editing-available.png</code>)
- Evidence: Floorplan editor after status refresh (local file: <code>~/.no-mistakes/evidence/01M1N9QQ7PY3CSX3NEXDSJRW4P/floorplan-editing-refreshed-occupied.png</code>)
- Evidence: Add Table retaining First floor (local file: <code>~/.no-mistakes/evidence/01M1N9QQ7PY3CSX3NEXDSJRW4P/list-add-table-selected-first.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"61eef3afa75ce6c6366b5bd1ceb1ef22e679f24a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `frontend/e2e/floorplan-editor.spec.ts:268` - The requirement covers both table and order polling, but this test only changes and observes table status. A regression in order polling could still pass. Add an order-status scenario or clarify table-only coverage.

🔧 Fix: Added live order polling E2E regression coverage
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run build`
- `NEXT_BUILD_MODE=desktop npm run build`
- `npx playwright test floorplan-editor.spec.ts --grep "live (table|order) status|Add Table keeps"`
- `Manual browser verification with API fixture setup and screenshots`
- `git diff --check`
- <code>Final `git status --short` and transient-artifact cleanup</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ Frontend TypeScript analysis still reports unrelated existing errors: implicit-any parameters in frontend/e2e/desktop files and missing types for jsonwebtoken and libphonenumber-js. No errors were reported in the changed files.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New tables created from list view now retain the currently selected floor.
  * New tables default to the Ground floor when no floor is selected.

* **Bug Fixes**
  * Table and order statuses now continue refreshing while editing the floorplan.
  * Order updates remain available when viewing the floorplan, ensuring the displayed information stays current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->