### PR TITLE
Show tables list by default, floor plan second

### DIFF
--- a/frontend/e2e/floorplan-editor.spec.ts
+++ b/frontend/e2e/floorplan-editor.spec.ts
@@ -49,6 +49,8 @@ async function login(page: import('@playwright/test').Page) {
   await page.getByRole('button', { name: 'Sign In' }).click();
   await page.goto(`${BASE}/tables`);
   await expect(page.getByRole('heading', { name: 'Tables' })).toBeVisible();
+  // List is the default view — switch to the floor plan second view first.
+  await page.getByRole('button', { name: 'Floor plan' }).click();
 }
 
 test('floorplan editor: drag table onto map, save, persist after reload', async ({ page }) => {
@@ -89,6 +91,7 @@ test('floorplan editor: drag table onto map, save, persist after reload', async 
   // Reload: T1 is now on the map (not in the tray) — position persisted
   await page.reload();
   await expect(page.getByRole('heading', { name: 'Tables' })).toBeVisible();
+  await page.getByRole('button', { name: 'Floor plan' }).click();
   await page.getByRole('button', { name: 'Edit layout' }).click();
   await expect(canvas).toBeVisible();
   const chipT1 = page.getByTestId('floorplan-chip-T1');
@@ -152,6 +155,7 @@ test('floorplan editor: drag table back to tray unplaces it', async ({ page, req
   // Reload: T1 stays unplaced — the null positions persisted
   await page.reload();
   await expect(page.getByRole('heading', { name: 'Tables' })).toBeVisible();
+  await page.getByRole('button', { name: 'Floor plan' }).click();
   await page.getByRole('button', { name: 'Edit layout' }).click();
   await expect(page.getByTestId('floorplan-tray-T1')).toBeVisible();
   await expect(page.getByTestId('floorplan-chip-T1')).toBeHidden();

--- a/frontend/e2e/i18n-batch-5c.spec.ts
+++ b/frontend/e2e/i18n-batch-5c.spec.ts
@@ -53,7 +53,8 @@ test('Batch 5C Pages (Dashboard, Orders, Tables, Customers, OrderHistoryGrid) re
   await page.goto(`${BASE}/tables`);
   await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
   await expect(page.getByRole('heading', { level: 1 })).toHaveText('Tables');
-  // The default view is the floor plan; Add Table lives in the List view.
+  // The default view is the list; switch to the floor plan second view.
+  await page.getByRole('button', { name: 'Floor plan' }).click();
   await expect(page.getByRole('button', { name: 'Edit layout' })).toBeVisible();
   await captureScreenshot(page, 'tables-en.png');
 
@@ -98,6 +99,7 @@ test('Batch 5C Pages (Dashboard, Orders, Tables, Customers, OrderHistoryGrid) re
     await page.goto(`${BASE}/tables`);
     await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
     await expect(page.getByRole('heading', { level: 1 })).toHaveText('میزها');
+    await page.getByRole('button', { name: 'نقشه سالن' }).click();
     await expect(page.getByRole('button', { name: 'ویرایش چیدمان' })).toBeVisible();
     await captureScreenshot(page, 'tables-fa.png');
 

--- a/frontend/src/app/(dashboard)/tables/page.tsx
+++ b/frontend/src/app/(dashboard)/tables/page.tsx
@@ -212,10 +212,9 @@ export default function TablesPage() {
   const [editingTable, setEditingTable] = useState<Table | null>(null);
   const [selectedFloor, setSelectedFloor] = useState('all');
   const [reservingTable, setReservingTable] = useState<Table | null>(null);
-  // Plan / List view toggle. Floor plan is the default so the new editor
-  // is visible immediately; List view keeps the legacy card grid and floor
-  // filter from main for staff who prefer it.
-  const [view, setView] = useState<'plan' | 'list'>('plan');
+  // List is the default view (table management + Add table); the floor
+  // plan editor is the second view for visual layout work.
+  const [view, setView] = useState<'plan' | 'list'>('list');
   const [layoutMode, setLayoutMode] = useState(false);
   const [form, setForm] = useState({ name: '', capacity: '4', floor: 'Ground', section: '' });
   const [showDetails, setShowDetails] = useState(() => {
@@ -404,20 +403,20 @@ export default function TablesPage() {
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-1 rounded-xl bg-muted p-1">
             <button
-              onClick={() => { setView('plan'); setLayoutMode(false); }}
-              className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-all ${
-                view === 'plan' ? 'bg-card text-foreground shadow' : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              <MapPinned size={14} /> {tTables('floorplanViewPlan')}
-            </button>
-            <button
               onClick={() => { setView('list'); setLayoutMode(false); }}
               className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-all ${
                 view === 'list' ? 'bg-card text-foreground shadow' : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               <List size={14} /> {tTables('floorplanViewList')}
+            </button>
+            <button
+              onClick={() => { setView('plan'); setLayoutMode(false); }}
+              className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-all ${
+                view === 'plan' ? 'bg-card text-foreground shadow' : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              <MapPinned size={14} /> {tTables('floorplanViewPlan')}
             </button>
           </div>
           {view === 'plan' && !layoutMode && canManageTables && (


### PR DESCRIPTION
## Summary
- The tables page now opens on the list view, with the floor plan as the second tab.
- Staff land on the view that has the Add Table button. Before, the page opened on the floor plan editor, which has no add action in service mode, so there was no visible way to add a table.

## Implementation notes
- One-line default flip plus toggle reorder in tables/page.tsx. No API or schema changes, and no new translation strings.
- The Playwright floorplan spec now selects the Floor plan tab before using the editor, matching the new default.
- Rebased on current upstream main (includes #638, applied cleanly with no conflicts).

## Verification
- npm run lint: 0 errors (5 pre-existing warnings in unrelated files).
- npm run build:frontend: passes, /tables prerenders.
- npm run test:tables-string-ids: passes.
- Full npm test not run (130+ suites, mostly backend/Electron, untouched by this change). E2E spec updated but not run live here; it needs seeded dev servers.

## Risk and rollback
- Revert returns the default tab to the floor plan. No data or migration impact, clean git revert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - The Tables page now opens in List view by default, providing a clearer, more compact overview of tables.
  - The view selector presents List before Floor plan, with updated icons and selection behavior.
  - Floor plan view remains available whenever a visual layout is needed, including for editing the floor plan and reviewing table placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->