### PR TITLE
fix(macos): exit process cleanly after cleanup on quit (#644)

### DIFF
--- a/main/shutdown.ts
+++ b/main/shutdown.ts
@@ -455,8 +455,7 @@ export function createShutdownEntrypoints({
         const exitCode = getQuitExitCode();
         destroyWindow();
         if (isInstallingUpdate()) return;
-        if (exitCode === 0) app.quit();
-        else app.exit(exitCode);
+        app.exit(exitCode);
       },
       (error) => {
         reportFailure('quit', error);

--- a/tests/shutdown-lifecycle.test.ts
+++ b/tests/shutdown-lifecycle.test.ts
@@ -416,7 +416,7 @@ async function testEntrypointCoverage(): Promise<void> {
     await entrypoints.runCleanup();
     await delay(0);
     assert.equal(firstWillQuit.prevented, true, `${label} waits for cleanup`);
-    assert.equal(app.quitCount, 1, `${label} resumes Electron quit after cleanup`);
+    assert.deepEqual(app.exitCodes, [0], `${label} exits Electron cleanly after cleanup`);
     assert.equal(cleanupCalls, 1, `${label} runs cleanup once`);
     assert.equal(quittingCalls, trayQuit ? 3 : 2, `${label} marks both quit entrypoints as quitting`);
     assert.equal(windowDestroyCalls, 1, `${label} destroys the window after cleanup`);
@@ -1047,6 +1047,7 @@ async function testQuitAndInstallCleanupOrdering(): Promise<void> {
     await delay(0);
 
     assert.equal(app.quitCount, 0, 'normal quit does not preempt quitAndInstall after cleanup');
+    assert.deepEqual(app.exitCodes, [], 'normal quit does not call app.exit when installing update');
     isInstallingUpdate = false;
   }
 


### PR DESCRIPTION
Fixes #644

### Problem
On macOS, closing the application window hides it to the Dock. However, when right-clicking the app in the Dock and selecting Quit (or pressing Cmd+Q), the app only partially quits:
- `will-quit` prevents default to run asynchronous cleanup.
- Once cleanup finishes, `app.quit()` was called.
- Because Cocoa termination was already aborted and all windows are closed/destroyed, calling `app.quit()` from an asynchronous Promise callback does not re-terminate the headless Cocoa run loop, leaving the process in the Dock as an unresponsive zombie requiring a second quit.

### Solution
- In `main/shutdown.ts`, after `runCleanup()` completes and verifies `!isInstallingUpdate()`, call `app.exit(exitCode)` directly (matching the non-zero and signal exit paths), ensuring the process cleanly terminates on the first quit attempt.
- Updated `tests/shutdown-lifecycle.test.ts` to assert that `app.exitCodes` receives `[0]` on completed cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown behavior to consistently return the intended exit status after cleanup, including during updater handoffs.

* **Tests**
  * Updated shutdown lifecycle coverage to verify clean exit statuses during normal application closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->