### PR TITLE
fix(ci): run Linux matrix test suite under xvfb

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -79,6 +79,7 @@ jobs:
         run: npm run build
 
       - name: Run full platform test suite
+        shell: bash
         run: |
           if [ "${{ runner.os }}" = "Linux" ]; then
             xvfb-run -a --server-args='-screen 0 1280x800x24' npm test

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -28,7 +28,7 @@ jobs:
             os: ubuntu-latest
             arch: x64
             target: --linux
-            extra-deps: sudo apt-get update -qq && sudo apt-get install -y fakeroot dpkg
+            extra-deps: sudo apt-get update -qq && sudo apt-get install -y fakeroot dpkg xvfb
           # better-sqlite3 >= v13 ships prebuilt binaries for all platforms,
           # so no native cross-compilation is needed. Both builds run on the
           # same ARM64 runner; electron-builder packages the correct prebuild
@@ -79,7 +79,12 @@ jobs:
         run: npm run build
 
       - name: Run full platform test suite
-        run: npm test
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            xvfb-run -a --server-args='-screen 0 1280x800x24' npm test
+          else
+            npm test
+          fi
 
       - name: Package (unpacked directory, no installer)
         run: npx electron-builder ${{ matrix.target }} --dir --publish never

--- a/tests/dev-tooling-scripts.test.ts
+++ b/tests/dev-tooling-scripts.test.ts
@@ -489,10 +489,13 @@ exit 0
   assert.ok(buildMatrixJob, 'nightly-release.yml must define build-matrix job');
   const linuxRow = buildMatrixJob.strategy?.matrix?.include?.find((entry: any) => entry.name === 'linux-x64');
   assert.ok(linuxRow, 'nightly-release.yml matrix must define linux-x64 row');
-  assert.match(linuxRow['extra-deps'], /\bxvfb\b/, 'linux-x64 matrix row must install xvfb in extra-deps');
+  assert.match(linuxRow['extra-deps'], /apt-get\s+install(?:-[a-z]+)*\s+.*?\bxvfb\b/, 'linux-x64 matrix row must install xvfb via apt-get in extra-deps');
   const testStep = buildMatrixJob.steps.find((step: any) => step.name === 'Run full platform test suite');
   assert.ok(testStep, 'nightly-release.yml must define full platform test suite step');
-  assert.match(testStep.run, /\bxvfb-run\b/, 'full platform test suite step must run under xvfb-run on Linux');
+  assert.strictEqual(testStep.shell, 'bash', 'Run full platform test suite step must explicitly use bash shell for cross-platform compatibility');
+  assert.match(testStep.run, /if\s+\[\s*"\${{\s*runner\.os\s*}}"\s*=\s*"Linux"\s*\];\s*then/, 'test step must check for Linux runner OS');
+  assert.match(testStep.run, /xvfb-run\s+-a\s+--server-args='-screen 0 1280x800x24'\s+npm test/, 'test step must execute npm test under xvfb-run on Linux');
+  assert.match(testStep.run, /else\s+npm test\s+fi/, 'test step must execute direct npm test fallback on non-Linux');
 
   console.log('✓ Nightly full cross-platform matrix Linux xvfb configuration verified');
 

--- a/tests/dev-tooling-scripts.test.ts
+++ b/tests/dev-tooling-scripts.test.ts
@@ -482,6 +482,20 @@ exit 0
 
   console.log('✓ Windows uninstaller CI boundary avoids application postinstall');
 
+  // Validate nightly-release.yml full matrix workflow configuration
+  const nightlyPath = path.join(rootDir, '.github/workflows/nightly-release.yml');
+  const nightlyConfig = YAML.load(fs.readFileSync(nightlyPath, 'utf8')) as any;
+  const buildMatrixJob = nightlyConfig.jobs['build-matrix'];
+  assert.ok(buildMatrixJob, 'nightly-release.yml must define build-matrix job');
+  const linuxRow = buildMatrixJob.strategy?.matrix?.include?.find((entry: any) => entry.name === 'linux-x64');
+  assert.ok(linuxRow, 'nightly-release.yml matrix must define linux-x64 row');
+  assert.match(linuxRow['extra-deps'], /\bxvfb\b/, 'linux-x64 matrix row must install xvfb in extra-deps');
+  const testStep = buildMatrixJob.steps.find((step: any) => step.name === 'Run full platform test suite');
+  assert.ok(testStep, 'nightly-release.yml must define full platform test suite step');
+  assert.match(testStep.run, /\bxvfb-run\b/, 'full platform test suite step must run under xvfb-run on Linux');
+
+  console.log('✓ Nightly full cross-platform matrix Linux xvfb configuration verified');
+
   console.log('All dev tooling script tests passed cleanly!');
 }
 


### PR DESCRIPTION
### Problem
The `Full Cross-Platform Matrix` workflow (`.github/workflows/nightly-release.yml`) was failing on the `build-linux-x64` job during `npm test`. Specifically, the raster-printing test suite launches an Electron window to verify Chromium raster rendering (`tests/raster-renderer-electron.test.cjs`). Because headless Ubuntu runners do not have an X server or `$DISPLAY` by default, Electron crashed on startup with:
```
Missing X server or $DISPLAY
The platform failed to initialize. Exiting.
electron exited with signal SIGTRAP
```

### Solution
1. In `.github/workflows/nightly-release.yml`:
   - Add `xvfb` to the `extra-deps` for the `linux-x64` matrix entry.
   - Run the `Run full platform test suite` step using `xvfb-run -a --server-args='-screen 0 1280x800x24' npm test` when running on Linux (preserving direct execution on macOS and Windows).
2. In `tests/dev-tooling-scripts.test.ts`:
   - Add assertions to ensure `nightly-release.yml` maintains the `xvfb` package in `extra-deps` and wraps the full platform test suite with `xvfb-run` on Linux.

### Verification
- Ran `npx ts-node --transpile-only -P tests/tsconfig.json tests/dev-tooling-scripts.test.ts` (passed).
- Ran `npm run test:dev-tooling` (passed).
- Ran `npm run lint:backend` (passed, 0 errors).
- Ran `git diff --check` (clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nightly release validation for Linux environments by supporting automated tests that require a virtual display.
  - Preserved the standard direct test process on non-Linux platforms.

- **Tests**
  - Added validation to confirm platform-specific test execution and Linux virtual-display support.
  - Strengthened checks for required Linux release-testing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->