### PR TITLE
feat(printers): support native Latin code pages in thermal profiles

### DIFF
--- a/main/printers/profiles.ts
+++ b/main/printers/profiles.ts
@@ -1,5 +1,6 @@
 import {
   GENERIC_THERMAL_CAPABILITIES,
+  LATIN_THERMAL_CAPABILITIES,
   mergeThermalCapabilities,
   type ThermalPrinterCapabilities,
 } from '../../shared/print/thermal-capabilities';
@@ -42,7 +43,7 @@ export const SUPPORTED_PRINTER_PROFILES: SupportedPrinterProfile[] = [
     fontBColumns: 64,
     printWidthMm: 72,
     cutMode: 'partial',
-    capabilities: GENERIC_THERMAL_CAPABILITIES,
+    capabilities: LATIN_THERMAL_CAPABILITIES,
     notes: '80mm ESC/POS receipt printer. Vendor specs list 72mm print width, 576 dots/line, Font A 42/48 columns, Font B 56/64 columns.',
   },
   {
@@ -56,7 +57,7 @@ export const SUPPORTED_PRINTER_PROFILES: SupportedPrinterProfile[] = [
     fontAColumns: 48,
     fontBColumns: 64,
     cutMode: 'partial',
-    capabilities: GENERIC_THERMAL_CAPABILITIES,
+    capabilities: LATIN_THERMAL_CAPABILITIES,
   },
   {
     id: 'generic-escpos-80',

--- a/shared/print/thermal-capabilities.ts
+++ b/shared/print/thermal-capabilities.ts
@@ -55,6 +55,13 @@ export const GENERIC_THERMAL_CAPABILITIES: ThermalPrinterCapabilities = {
   raster: { enabled: false, widthDots: 0, maxBandHeight: 0, modes: [] },
 };
 
+export const LATIN_THERMAL_CAPABILITIES: ThermalPrinterCapabilities = {
+  ...GENERIC_THERMAL_CAPABILITIES,
+  encoding: { codePages: ['cp437', 'cp850', 'cp858', 'windows1252', 'ascii'], preferredCodePage: 'cp437' },
+  representability: { scripts: ['ascii', 'latin'] },
+  transliteration: { enabled: true },
+};
+
 // The shipped fallback preserves the established German thermal transliteration
 // without claiming quality coverage for every accented locale.
 const LATIN_ASCII_MAP: Record<string, string> = {

--- a/shared/print/thermal-capabilities.ts
+++ b/shared/print/thermal-capabilities.ts
@@ -82,8 +82,20 @@ const THERMAL_CURRENCY_TOKEN_RE = new RegExp(`(?:${CURRENCY_TOKEN_PATTERN})`, 'g
 const LATIN_LETTER_RE = /\p{Script=Latin}/u;
 const LETTER_RE = /\p{Letter}/u;
 
+function codePageCanRepresent(text: string, codePage: ThermalCodePage): boolean {
+  if (codePage === 'ascii') return !/[^\x00-\x7F]/.test(text);
+  const characters = CODE_PAGE_CHARACTERS[codePage];
+  return [...text].every((character) => character <= '\x7F' || characters.includes(character));
+}
+
 export function normalizeThermalText(text: string, capabilities: ThermalPrinterCapabilities): string {
   if (!capabilities.transliteration.enabled) return text;
+  if (capabilities.representability.scripts.includes('latin')) {
+    const hasNativeCodePage = capabilities.encoding.codePages.some(
+      (codePage) => codePage !== 'ascii' && codePageCanRepresent(text, codePage),
+    );
+    if (hasNativeCodePage) return text;
+  }
   return text.replace(/[À-ÿ]/g, (character) => LATIN_ASCII_MAP[character] ?? character);
 }
 
@@ -97,12 +109,6 @@ export function isArabicShapingSafeLine(text: string): boolean {
   return !/[^\x00-\x7F]/.test(
     textWithoutCurrency.replace(ARABIC_SCRIPT_GLOBAL_RE, '').replace(SHAPING_ALLOWED_GLOBAL_RE, ''),
   );
-}
-
-function codePageCanRepresent(text: string, codePage: ThermalCodePage): boolean {
-  if (codePage === 'ascii') return !/[^\x00-\x7F]/.test(text);
-  const characters = CODE_PAGE_CHARACTERS[codePage];
-  return [...text].every((character) => character <= '\x7F' || characters.includes(character));
 }
 
 export function selectThermalCodePage(text: string, capabilities: ThermalPrinterCapabilities): ThermalCodePage | null {

--- a/tests/thermal-capabilities.test.ts
+++ b/tests/thermal-capabilities.test.ts
@@ -104,6 +104,13 @@ function run(): void {
   assert.ok(epsonCamaronBytes.length > 0);
   assert.equal(escPosToText(epsonCamaronBytes).includes('Burrito de Camarón'), true);
 
+  assert.equal(normalizeThermalText('Küche', epson.capabilities), 'Küche');
+  assert.equal(normalizeThermalText('Straße', epson.capabilities), 'Straße');
+  assert.equal(selectThermalCodePage('Küche', epson.capabilities), 'cp437');
+  assert.equal(selectThermalCodePage('Straße', epson.capabilities), 'cp437');
+  const epsonKuecheBytes = buildEscPos(['{INIT}', 'Küche Straße'], false, { capabilities: epson.capabilities });
+  assert.equal(escPosToText(epsonKuecheBytes).includes('Küche Straße'), true);
+
   assert.equal(selectThermalCodePage('Cafe', latinCodePageCapabilities), 'cp437');
   assert.equal(selectThermalCodePage('√2', latinCodePageCapabilities), 'cp437');
   assert.equal(selectThermalCodePage('π', latinCodePageCapabilities), 'cp437');

--- a/tests/thermal-capabilities.test.ts
+++ b/tests/thermal-capabilities.test.ts
@@ -85,6 +85,24 @@ function run(): void {
   assert.deepEqual(generic.capabilities.encoding.codePages, ['ascii']);
   assert.equal(generic.capabilities.warnings.financialText, 'refuse');
   assert.equal(normalizeThermalText('Küche', generic.capabilities), 'Kueche');
+  assert.equal(isThermalTextRepresentable('Burrito de Camarón 1 $550', generic.capabilities), false);
+  const genericCamaronWarnings: any[] = [];
+  const genericCamaronBytes = buildEscPos(['Burrito de Camarón 1 $550'], false, { capabilities: generic.capabilities, financialLineRanges: [{ lineIndex: 0, lineCount: 1 }] }, genericCamaronWarnings);
+  assert.equal(genericCamaronWarnings.length, 1);
+  assert.equal(genericCamaronWarnings[0].kind, 'financial');
+  assert.equal(genericCamaronBytes.length, 0);
+
+  const epson = resolvePrinterProfile({ profile_id: 'epson-tm-series' });
+  const xprinter = resolvePrinterProfile({ profile_id: 'xprinter-xp-v320m-v330m' });
+  assert.equal(epson.capabilities.representability.scripts.includes('latin'), true);
+  assert.equal(xprinter.capabilities.representability.scripts.includes('latin'), true);
+  assert.equal(isThermalTextRepresentable('Burrito de Camarón 1 $550', epson.capabilities), true);
+  assert.equal(selectThermalCodePage('Burrito de Camarón', epson.capabilities), 'cp437');
+  const epsonCamaronWarnings: any[] = [];
+  const epsonCamaronBytes = buildEscPos(['{INIT}', 'Burrito de Camarón 1 $550'], false, { capabilities: epson.capabilities, financialLineRanges: [{ lineIndex: 1, lineCount: 1 }] }, epsonCamaronWarnings);
+  assert.deepEqual(epsonCamaronWarnings, []);
+  assert.ok(epsonCamaronBytes.length > 0);
+  assert.equal(escPosToText(epsonCamaronBytes).includes('Burrito de Camarón'), true);
 
   assert.equal(selectThermalCodePage('Cafe', latinCodePageCapabilities), 'cp437');
   assert.equal(selectThermalCodePage('√2', latinCodePageCapabilities), 'cp437');


### PR DESCRIPTION
## Related work

Issue / Discussion: None (unsupported Latin financial receipt refusal fix)

## Summary

Enables native Latin code-page encoding (`cp437`, `cp850`, `cp858`, `windows1252`) for supported ESC/POS thermal printer profiles (`epson-tm-series` and `xprinter-xp-v320m-v330m`).

- Introduces `LATIN_THERMAL_CAPABILITIES` in `shared/print/thermal-capabilities.ts` declaring Latin code pages and Latin script representability.
- Updates `normalizeThermalText` to preserve original text if any declared native code page can represent it, preventing premature digraph transliteration (e.g. keeping `Küche` and `Straße` native instead of `Kueche` and `Strasse`).
- Wires `LATIN_THERMAL_CAPABILITIES` into `epson-tm-series` and `xprinter-xp-v320m-v330m` profiles in `main/printers/profiles.ts`.
- Preserves generic profile (`generic-escpos-80` / `58`) strict ASCII-only refusal safety.
- Adds comprehensive regression tests in `tests/thermal-capabilities.test.ts`.

## Scope

- Raster graphics pipeline and CJK system font fallback are out of scope (handled separately in follow-up).
- Generic profile default capabilities remain strictly ASCII-only.

## Verification

Commands run:
- `npm run test:thermal-capabilities` (PASS)
- `npm run test:printer` (PASS)
- `npm run test:raster` (PASS)
- `npm run test:print-document` (PASS)
- `npm run test:print-parity` (PASS)
- `npm run test:print-labels` (PASS)
- `npm run test:print-kernel` (PASS)
- `npm run lint` (PASS, 0 errors)
- `npm run build` (PASS)

Results:
All 9 test suites and checks passed locally and on CI (16/16 checks passed).

## Compatibility & data safety

- **Database/data impact:** None.
- **Migration:** None.
- **User-visible behavior:** Thermal receipts with Spanish, German, French, and Latin accented items print natively on Epson and Xprinter profiles rather than being refused.
- **Offline/network impact:** None.

## Screenshots

N/A (hardware ESC/POS byte encoding changes).

## Contributor checklist

- [x] This is a small isolated fix/doc update OR follows an approved issue/direction.
- [x] Unrelated cleanups, refactors, and dependency changes were kept out of this PR.
- [x] Tests were added or updated for any behavior changes.
- [x] Verification commands were run and documented above.
- [x] Customer data and upgrade safety were preserved (if touching database/storage).
- [x] Documentation or translations were updated where relevant.
- [x] I understand and can explain all submitted changes.