### PR TITLE
perf(printers): warm Chromium raster singleton and system CJK font fallbacks

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -14,6 +14,7 @@ import { googleDrive } from './services/google-drive';
 import { startKdsServer, stopKdsServer, getKdsPort, isKdsServerRunning } from './kds-server';
 import { startServerApp, stopServerApp, getServerAppPort, isServerAppRunning } from './server-app';
 import { initPrinter } from './printers/thermal';
+import { destroySharedRasterRenderer } from './printers/raster-renderer';
 import { registerIpcHandlers, isTrustedSender } from './ipc';
 import { authorizeMasterPin } from './services/master-pin';
 import { initFromDb as initWhatsAppFromDb, requestShutdown as requestWhatsAppShutdown, shutdown as shutdownWhatsApp } from './services/whatsapp';
@@ -1575,6 +1576,7 @@ const cleanupCoordinator = createShutdownCoordinator(() => [
       if (currentTray) currentTray.destroy();
     },
   },
+  { name: 'raster surface', run: () => destroySharedRasterRenderer() },
   // The Server App can be forwarding an active request to the main API, so
   // drain it before closing the API listener it depends on.
   { name: 'Server App', run: () => stopServerApp(), blocksDatabase: true },

--- a/main/printers/raster-renderer.ts
+++ b/main/printers/raster-renderer.ts
@@ -54,7 +54,8 @@ export function rasterRendererHtml(): string {
       const lineHeight = logicalLineHeight * scaleY;
       const fontSize = styles.includes('font-b') ? 12 : 16;
       const weight = styles.includes('bold') ? '700' : '400';
-      context.font = weight + ' ' + fontSize + 'px ' + JSON.stringify(request.bundledFont.family);
+      const fontFallback = ', -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "Noto Sans", sans-serif';
+      context.font = weight + ' ' + fontSize + 'px ' + JSON.stringify(request.bundledFont.family) + fontFallback;
       context.textBaseline = 'top';
       context.direction = request.direction;
       context.textAlign = request.align === 'center' ? 'center' : 'left';
@@ -116,7 +117,7 @@ export function rasterRendererHtml(): string {
       canvas.height = Math.max(1, renderLines.length * lineHeight);
       // Resizing a canvas resets its drawing state, so restore the measured
       // font and bidi direction before painting the final pixels.
-      context.font = weight + ' ' + fontSize + 'px ' + JSON.stringify(request.bundledFont.family);
+      context.font = weight + ' ' + fontSize + 'px ' + JSON.stringify(request.bundledFont.family) + fontFallback;
       context.textBaseline = 'top';
       context.direction = request.direction;
       context.textAlign = request.align === 'center' ? 'center' : 'left';
@@ -162,6 +163,7 @@ export interface RasterRendererOptions {
   readonly windowFactory?: (options: Electron.BrowserWindowConstructorOptions) => RasterSurface;
   readonly ipc?: Pick<Electron.IpcMain, 'on' | 'removeListener'>;
   readonly timeoutMs?: number;
+  readonly onActivity?: () => void;
 }
 
 /** Main-process owner for the dedicated, hidden Chromium raster surface. */
@@ -169,6 +171,7 @@ export class ChromiumRasterRenderer {
   private readonly surface: RasterSurface;
   private readonly timeoutMs: number;
   private readonly ipc: Pick<Electron.IpcMain, 'on' | 'removeListener'>;
+  private readonly onActivity?: () => void;
   private readonly pending = new Map<string, { resolve: (result: RasterRenderResult) => void; timer: ReturnType<typeof setTimeout> }>();
   private ready: Promise<void>;
   private readyResolve!: () => void;
@@ -208,6 +211,7 @@ export class ChromiumRasterRenderer {
   constructor(options: RasterRendererOptions = {}) {
     this.timeoutMs = options.timeoutMs ?? RENDER_TIMEOUT_MS;
     this.ipc = options.ipc ?? ipcMain;
+    this.onActivity = options.onActivity;
     this.ready = new Promise<void>((resolve) => { this.readyResolve = resolve; });
     const windowFactory = options.windowFactory ?? ((windowOptions) => new BrowserWindow(windowOptions));
     this.surface = windowFactory({
@@ -261,6 +265,7 @@ export class ChromiumRasterRenderer {
     if (this.destroyed || this.surface.isDestroyed()) {
       return { version: 1, requestId: request.requestId, ok: false, code: 'render-failed', detail: 'Raster surface is unavailable' };
     }
+    this.onActivity?.();
     await this.ready;
     if (this.readyError) return { version: 1, requestId: request.requestId, ok: false, code: 'render-failed', detail: this.readyError };
     return await new Promise<RasterRenderResult>((resolve) => {
@@ -289,6 +294,10 @@ export class ChromiumRasterRenderer {
     });
   }
 
+  isDestroyed(): boolean {
+    return this.destroyed || this.surface.isDestroyed();
+  }
+
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
@@ -299,6 +308,62 @@ export class ChromiumRasterRenderer {
     this.surface.webContents.removeListener('render-process-gone', this.onRenderProcessGone);
     this.failSurface('Raster surface was closed');
     if (!this.surface.isDestroyed()) this.surface.close();
+  }
+}
+
+export const DEFAULT_RASTER_IDLE_TIMEOUT_MS = 300_000;
+
+let sharedRasterRenderer: ChromiumRasterRenderer | null = null;
+let sharedRasterIdleTimer: ReturnType<typeof setTimeout> | null = null;
+let sharedRasterIdleTimeoutMs = DEFAULT_RASTER_IDLE_TIMEOUT_MS;
+
+function resetSharedRasterIdleTimer(): void {
+  if (sharedRasterIdleTimer) {
+    clearTimeout(sharedRasterIdleTimer);
+    sharedRasterIdleTimer = null;
+  }
+  if (sharedRasterRenderer && !sharedRasterRenderer.isDestroyed()) {
+    sharedRasterIdleTimer = setTimeout(() => {
+      destroySharedRasterRenderer();
+    }, sharedRasterIdleTimeoutMs);
+  }
+}
+
+/**
+ * Obtain the warm shared Chromium raster singleton.
+ * If the instance does not exist or has been destroyed/closed, a new one is instantiated.
+ * The singleton automatically tears down after an idle timeout.
+ */
+export function getSharedRasterRenderer(options?: RasterRendererOptions & { idleTimeoutMs?: number }): ChromiumRasterRenderer {
+  if (options?.idleTimeoutMs !== undefined) {
+    sharedRasterIdleTimeoutMs = options.idleTimeoutMs;
+  }
+  if (!sharedRasterRenderer || sharedRasterRenderer.isDestroyed()) {
+    const userOnActivity = options?.onActivity;
+    sharedRasterRenderer = new ChromiumRasterRenderer({
+      ...options,
+      onActivity: () => {
+        userOnActivity?.();
+        resetSharedRasterIdleTimer();
+      },
+    });
+  }
+  resetSharedRasterIdleTimer();
+  return sharedRasterRenderer;
+}
+
+/**
+ * Teardown the shared raster singleton if active.
+ */
+export function destroySharedRasterRenderer(): void {
+  if (sharedRasterIdleTimer) {
+    clearTimeout(sharedRasterIdleTimer);
+    sharedRasterIdleTimer = null;
+  }
+  if (sharedRasterRenderer) {
+    const renderer = sharedRasterRenderer;
+    sharedRasterRenderer = null;
+    renderer.destroy();
   }
 }
 

--- a/main/printers/raster-renderer.ts
+++ b/main/printers/raster-renderer.ts
@@ -32,17 +32,23 @@ export function rasterRendererHtml(): string {
   if (!api) return;
   const familyName = (value) => /^[A-Za-z0-9 _-]{1,64}$/.test(value);
   const makeFailure = (request, code, detail) => ({ version: 1, requestId: request.requestId, ok: false, code, detail });
+  const loadedFonts = new Map();
   const render = async (request) => {
     if (!request || request.version !== 1 || typeof request.text !== 'string' || typeof request.financial !== 'boolean' || !familyName(request.bundledFont?.family)) {
       return makeFailure(request || { requestId: '' }, 'invalid-request', 'Raster request failed validation');
     }
     try {
-      const font = new FontFace(request.bundledFont.family, 'url(' + request.bundledFont.dataUrl + ')');
-      try {
-        await font.load();
-        document.fonts.add(font);
-      } catch (error) {
-        return makeFailure(request, 'font-unavailable', error instanceof Error ? error.message : String(error));
+      const fontKey = request.bundledFont.family + '|' + request.bundledFont.dataUrl;
+      let font = loadedFonts.get(fontKey);
+      if (!font) {
+        font = new FontFace(request.bundledFont.family, 'url(' + request.bundledFont.dataUrl + ')');
+        try {
+          await font.load();
+          document.fonts.add(font);
+          loadedFonts.set(fontKey, font);
+        } catch (error) {
+          return makeFailure(request, 'font-unavailable', error instanceof Error ? error.message : String(error));
+        }
       }
       const canvas = document.createElement('canvas');
       const context = canvas.getContext('2d', { alpha: false });
@@ -247,12 +253,23 @@ export class ChromiumRasterRenderer {
   }
 
   private failSurface(detail: string): void {
+    this.destroyed = true;
     this.settleReady(detail);
     for (const [requestId, entry] of this.pending.entries()) {
       clearTimeout(entry.timer);
       entry.resolve({ version: 1, requestId, ok: false, code: 'render-failed', detail });
     }
     this.pending.clear();
+    this.ipc.removeListener('flo:raster-ready', this.onReady);
+    this.ipc.removeListener('flo:raster-result', this.onResult);
+    this.surface.removeListener('closed', this.onSurfaceClosed);
+    this.surface.webContents.removeListener('did-fail-load', this.onLoadFailure);
+    this.surface.webContents.removeListener('render-process-gone', this.onRenderProcessGone);
+    if (!this.surface.isDestroyed()) {
+      try {
+        this.surface.close();
+      } catch {}
+    }
   }
 
   async render(request: unknown): Promise<RasterRenderResult> {
@@ -263,7 +280,13 @@ export class ChromiumRasterRenderer {
       return { version: 1, requestId, ok: false, code: 'invalid-request', detail: 'Raster request failed validation' };
     }
     if (this.destroyed || this.surface.isDestroyed()) {
-      return { version: 1, requestId: request.requestId, ok: false, code: 'render-failed', detail: 'Raster surface is unavailable' };
+      return {
+        version: 1,
+        requestId: request.requestId,
+        ok: false,
+        code: 'render-failed',
+        detail: this.readyError ?? 'Raster surface is unavailable',
+      };
     }
     this.onActivity?.();
     await this.ready;
@@ -300,14 +323,7 @@ export class ChromiumRasterRenderer {
 
   destroy(): void {
     if (this.destroyed) return;
-    this.destroyed = true;
-    this.ipc.removeListener('flo:raster-ready', this.onReady);
-    this.ipc.removeListener('flo:raster-result', this.onResult);
-    this.surface.removeListener('closed', this.onSurfaceClosed);
-    this.surface.webContents.removeListener('did-fail-load', this.onLoadFailure);
-    this.surface.webContents.removeListener('render-process-gone', this.onRenderProcessGone);
     this.failSurface('Raster surface was closed');
-    if (!this.surface.isDestroyed()) this.surface.close();
   }
 }
 

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -1145,11 +1145,11 @@ async function rasterizeDocumentLines(
     });
     return { data: Buffer.alloc(0), warnings, rasterSelected: false, rasterFailed: true };
   };
-  let renderer: Pick<import('./raster-renderer').ChromiumRasterRenderer, 'render' | 'destroy'> | undefined;
+  let renderer: Pick<import('./raster-renderer').ChromiumRasterRenderer, 'render'> | undefined;
   let result = failureResult(new Error('Raster renderer was not initialized'));
   try {
-    const { ChromiumRasterRenderer, renderUnsupportedRasterLines } = await import('./raster-renderer');
-    renderer = new ChromiumRasterRenderer();
+    const { getSharedRasterRenderer, renderUnsupportedRasterLines } = await import('./raster-renderer');
+    renderer = getSharedRasterRenderer();
     const raster = await renderUnsupportedRasterLines(renderer, lines, options.capabilities, options.requestPrefix, rasterGroups);
     selectedFinancial = raster.units.some((unit) => unit.unit.financial) || raster.failures.some((failure) => failure.financial);
     const warnings = sourceWarnings.filter((warning) => warning.kind !== 'line' && warning.kind !== 'financial');
@@ -1173,13 +1173,6 @@ async function rasterizeDocumentLines(
     result = { data, warnings, rasterSelected: raster.units.length > 0, rasterFailed: raster.failures.length > 0 || warnings.some((warning) => warning.kind === 'line' || warning.kind === 'financial') };
   } catch (error) {
     result = failureResult(error);
-  }
-  if (renderer) {
-    try {
-      renderer.destroy();
-    } catch (error) {
-      result = failureResult(error);
-    }
   }
   return result;
 }

--- a/tests/raster-printing.test.ts
+++ b/tests/raster-printing.test.ts
@@ -22,7 +22,14 @@ import { buildTestPage } from '../main/printers/thermal';
 import { buildKotPrintData, renderKotDocumentToLines } from '../main/printers/document-kot';
 import { renderBillDocumentToClassicLines, renderClassicReceiptViaDocument } from '../main/printers/document-classic';
 import { renderBillDocumentToCompactLines, renderCompactReceiptViaDocument } from '../main/printers/document-compact';
-import { ChromiumRasterRenderer, renderRasterSemanticUnit, renderUnsupportedRasterLines } from '../main/printers/raster-renderer';
+import {
+  ChromiumRasterRenderer,
+  getSharedRasterRenderer,
+  destroySharedRasterRenderer,
+  rasterRendererHtml,
+  renderRasterSemanticUnit,
+  renderUnsupportedRasterLines,
+} from '../main/printers/raster-renderer';
 
 function loadFrontendRasterEncoder(): typeof import('../frontend/src/lib/printer/raster-encoder') {
   const path = require('node:path') as typeof import('node:path');
@@ -1007,6 +1014,49 @@ async function run(): Promise<void> {
   assert.equal(isRasterRenderRequest({ ...request, bundledFont: { ...request.bundledFont, family: 'bad;url(x)' } }), false);
   assert.equal(isRasterRenderResult({ version: 1, requestId: 'r1', ok: true }), false);
   assert.equal(isRasterRenderResult({ version: 1, requestId: 'r1', ok: false, code: 'render-failed', detail: 'failed' }), true);
+
+  // Verify raster HTML includes system CJK fallbacks
+  const html = rasterRendererHtml();
+  assert.ok(html.includes('PingFang SC'));
+  assert.ok(html.includes('Microsoft YaHei'));
+  assert.ok(html.includes('Noto Sans CJK SC'));
+
+  // Test shared raster renderer lifecycle and idle teardown
+  destroySharedRasterRenderer();
+  let activityCount = 0;
+  const sharedRenderer1 = getSharedRasterRenderer({
+    timeoutMs: 100,
+    idleTimeoutMs: 50,
+    ipc: ipc as any,
+    windowFactory: () => surface as any,
+    onActivity: () => { activityCount++; },
+  });
+  assert.equal(sharedRenderer1.isDestroyed(), false);
+  const sharedRenderer2 = getSharedRasterRenderer();
+  assert.equal(sharedRenderer1, sharedRenderer2);
+
+  // Render on shared renderer to exercise onActivity
+  ipc.emit('flo:raster-ready', { sender: webContents });
+  const sharedRenderPromise = sharedRenderer1.render(request);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  ipc.emit('flo:raster-result', { sender: webContents }, { version: 1, result: { version: 1, requestId: request.requestId, ok: true, unit } });
+  assert.deepEqual(await sharedRenderPromise, { version: 1, requestId: request.requestId, ok: true, unit });
+  assert.equal(activityCount, 1);
+
+  // Wait for idle teardown
+  await new Promise<void>((resolve) => setTimeout(resolve, 80));
+  assert.equal(sharedRenderer1.isDestroyed(), true);
+
+  // Re-requesting after idle teardown spawns a new instance
+  const sharedRenderer3 = getSharedRasterRenderer({
+    timeoutMs: 100,
+    ipc: ipc as any,
+    windowFactory: () => surface as any,
+  });
+  assert.notEqual(sharedRenderer1, sharedRenderer3);
+  assert.equal(sharedRenderer3.isDestroyed(), false);
+  destroySharedRasterRenderer();
+  assert.equal(sharedRenderer3.isDestroyed(), true);
 
   console.log('Raster encoder and mixed-mode contract checks passed.');
 }

--- a/tests/raster-printing.test.ts
+++ b/tests/raster-printing.test.ts
@@ -1055,8 +1055,19 @@ async function run(): Promise<void> {
   });
   assert.notEqual(sharedRenderer1, sharedRenderer3);
   assert.equal(sharedRenderer3.isDestroyed(), false);
-  destroySharedRasterRenderer();
+
+  // Terminal failure disposes instance and next acquisition spawns fresh renderer
+  webContents.emit('render-process-gone');
   assert.equal(sharedRenderer3.isDestroyed(), true);
+  const sharedRenderer4 = getSharedRasterRenderer({
+    timeoutMs: 100,
+    ipc: ipc as any,
+    windowFactory: () => surface as any,
+  });
+  assert.notEqual(sharedRenderer3, sharedRenderer4);
+  assert.equal(sharedRenderer4.isDestroyed(), false);
+  destroySharedRasterRenderer();
+  assert.equal(sharedRenderer4.isDestroyed(), true);
 
   console.log('Raster encoder and mixed-mode contract checks passed.');
 }

--- a/tests/raster-renderer-electron.test.cjs
+++ b/tests/raster-renderer-electron.test.cjs
@@ -81,6 +81,8 @@ async function run() {
     });
     assert.equal(normal.ok, true);
     assert.equal(styled.ok, true);
+    const fontCount = await surface.webContents.executeJavaScript('document.fonts.size');
+    assert.equal(fontCount, 1);
     assert.equal(normal.unit.complete, true);
     assert.equal(styled.unit.complete, true);
     assert.equal(normal.unit.bands[0].widthDots, 120);

--- a/tests/raster-renderer-electron.test.cjs
+++ b/tests/raster-renderer-electron.test.cjs
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const path = require('node:path');
 const { app, BrowserWindow } = require('electron');
-const { ChromiumRasterRenderer } = require('../dist/main/printers/raster-renderer.js');
+const { ChromiumRasterRenderer, getSharedRasterRenderer, destroySharedRasterRenderer } = require('../dist/main/printers/raster-renderer.js');
 
 const font = { family: 'FloRaster', dataUrl: 'data:font/woff2;base64,AA==' };
 
@@ -115,8 +115,21 @@ async function run() {
       detail: 'Raster renderer process exited',
     });
     console.log('Chromium raster surface rendered styled RTL output.');
+
+    // Verify shared singleton operates cleanly under real Electron
+    destroySharedRasterRenderer();
+    const shared1 = getSharedRasterRenderer({
+      preloadPath: path.join(__dirname, '../dist/main/raster-preload.js'),
+    });
+    assert.equal(shared1.isDestroyed(), false);
+    const shared2 = getSharedRasterRenderer();
+    assert.equal(shared1, shared2);
+    destroySharedRasterRenderer();
+    assert.equal(shared1.isDestroyed(), true);
+    console.log('Warm Chromium raster singleton lifecycle passed.');
   } finally {
     renderer.destroy();
+    destroySharedRasterRenderer();
     if (app.isReady()) app.quit();
   }
 }


### PR DESCRIPTION
## Related work

Issue / Discussion: None (performance and reliability optimization for world-language raster printing)

## Summary

Refactors the dedicated hidden Chromium raster surface used for unsupported printer scripts (Hebrew, Arabic, CJK, symbols) from a per-receipt `new BrowserWindow()` instantiation/destruction cycle to a warm shared singleton with idle teardown. Also adds system CJK font fallbacks to the canvas rendering context so Chinese, Japanese, and Korean characters render without bundling large CJK font files.

Key changes:
1. **Warm Chromium Raster Singleton**: `getSharedRasterRenderer()` and `destroySharedRasterRenderer()` in `main/printers/raster-renderer.ts`, resetting an idle timer (default 5 minutes) on each render activity, and disposing on terminal failure.
2. **Eliminated Per-Receipt Creation Lag**: In `main/printers/thermal.ts`, updated `rasterizeDocumentLines` to use `getSharedRasterRenderer()` without destroying it after each print.
3. **System CJK Font Fallback**: Added standard platform CJK and sans-serif fonts (`-apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', 'Noto Sans', sans-serif`) to `context.font` in `rasterRendererHtml()`.
4. **FontFace Caching**: Loaded `FontFace` objects are cached in the raster page environment to prevent memory growth across warm prints.
5. **App Lifecycle**: Cleanly tears down the shared raster surface via `cleanupCoordinator` when the application shuts down.

## Scope

- Bundling binary CJK font files is out of scope (platform system fonts are utilized).
- No changes to native ESC/POS code page encoding paths.

## Verification

Commands run:
- `npm run build` (passed)
- `npm run test:raster` (passed unit tests + headless Electron tests)
- `npm run test:printer` (passed)
- `npm run test:print-document` (passed)
- `npm run test:print-parity` (passed)
- `npm run test:print-labels` (passed)
- `npm run test:print-kernel` (passed)
- `npm run test:thermal-capabilities` (passed)
- `npm run lint` (0 errors)

Results:
All tests and lints passed cleanly with 0 errors.

## Compatibility & data safety

- **Database/data impact:** None
- **Migration:** None
- **User-visible behavior:** Eliminates per-receipt window creation latency when printing receipts with rasterized scripts (Hebrew, Arabic, CJK).
- **Offline/network impact:** None; operates 100% offline.

## Screenshots

N/A (backend thermal printer rasterization pipeline)

## Contributor checklist

- [x] This is a small isolated fix/doc update OR follows an approved issue/direction.
- [x] Unrelated cleanups, refactors, and dependency changes were kept out of this PR.
- [x] Tests were added or updated for any behavior changes.
- [x] Verification commands were run and documented above.
- [x] Customer data and upgrade safety were preserved (if touching database/storage).
- [x] Documentation or translations were updated where relevant.
- [x] I understand and can explain all submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved raster printing with broader system-font fallback support, including CJK characters.
  * Improved font handling for repeated bundled-font printing to reduce redundant loading.
  * Improved renderer lifecycle management by reusing resources during printing and cleaning them up after inactivity or application shutdown.
  * Ensured subsequent print requests can create a fresh renderer after cleanup or terminal rendering failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->