### PR TITLE
fix(printers): sanitize PowerShell CLIXML stderr in Windows print failures

### DIFF
--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -99,9 +99,47 @@ export type PrintFailureClass =
   | 'unsupported'
   | 'unknown';
 
+/** Strips PowerShell CLIXML serialization envelopes and extracts clean error text. */
+export function sanitizePowerShellStderr(stderr?: string): string {
+  if (!stderr) return '';
+  const raw = String(stderr).trim();
+  if (!raw.includes('#< CLIXML')) {
+    return raw;
+  }
+
+  const errorMatches: string[] = [];
+  const regex = /<S S="Error">(.*?)<\/S>/gs;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(raw)) !== null) {
+    const text = match[1]
+      .replace(/_x000D__x000A_/g, '\n')
+      .replace(/_x([0-9a-fA-F]{4})_/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&')
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .trim();
+    if (text && !text.startsWith('At line:') && !text.startsWith('+ ')) {
+      errorMatches.push(text);
+    }
+  }
+
+  if (errorMatches.length > 0) {
+    return errorMatches.join('\n').trim();
+  }
+
+  return raw
+    .replace(/^#<\s*CLIXML/i, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/_x000D__x000A_/g, '\n')
+    .replace(/_x([0-9a-fA-F]{4})_/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .trim();
+}
+
 /** Stable, privacy-safe classification for fleet telemetry. */
 export function classifyPrintFailure(detail?: string): PrintFailureClass {
-  const value = String(detail || '').toLowerCase();
+  const value = sanitizePowerShellStderr(detail).toLowerCase();
   if (!value) return 'unknown';
   if (value.includes('no printer configured') || value.includes('no windows printer configured')) return 'not_configured';
   if (value.includes('offline') || value.includes('use printer offline') || value.includes('disconnected')) return 'offline';
@@ -2764,7 +2802,9 @@ async function printViaUSBWindows(data: Buffer, printerName?: string, signal?: A
     console.log(`[Printer] Windows raw print accepted for "${printerName}" (${String(stdout).trim()})`);
     return { ok: true, ...metadata };
   } catch (err: any) {
-    const detail = String(err.stderr || err.message || '').trim();
+    const rawStderr = String(err.stderr || '').trim();
+    const cleanStderr = sanitizePowerShellStderr(rawStderr);
+    const detail = cleanStderr || String(err.message || '').trim();
     console.error(`[Printer] Windows raw print failed for "${printerName}": ${detail}`);
     return {
       ok: false,

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -99,6 +99,14 @@ export type PrintFailureClass =
   | 'unsupported'
   | 'unknown';
 
+const XML_ENTITIES: Record<string, string> = {
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&apos;': "'",
+  '&amp;': '&',
+};
+
 /** Strips PowerShell CLIXML serialization envelopes and extracts clean error text. */
 export function sanitizePowerShellStderr(stderr?: string): string {
   if (!stderr) return '';
@@ -114,11 +122,7 @@ export function sanitizePowerShellStderr(stderr?: string): string {
     const text = match[1]
       .replace(/_x000D__x000A_/g, '\n')
       .replace(/_x([0-9a-fA-F]{4})_/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&amp;/g, '&')
-      .replace(/&quot;/g, '"')
-      .replace(/&apos;/g, "'")
+      .replace(/&(?:lt|gt|quot|apos|amp);/g, (entity) => XML_ENTITIES[entity] ?? entity)
       .trim();
     if (text && !text.startsWith('At line:') && !text.startsWith('+ ')) {
       errorMatches.push(text);
@@ -130,8 +134,7 @@ export function sanitizePowerShellStderr(stderr?: string): string {
   }
 
   return raw
-    .replace(/^#<\s*CLIXML/i, '')
-    .replace(/<[^>]+>/g, '')
+    .replace(/^#<\s*CLIXML[\r\n]*/i, '')
     .replace(/_x000D__x000A_/g, '\n')
     .replace(/_x([0-9a-fA-F]{4})_/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
     .trim();

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test:merchant-template-transfer": "ts-node --transpile-only -P tests/tsconfig.json tests/merchant-template-import-export.test.ts",
     "test:print-document": "ts-node --transpile-only -P tests/tsconfig.json tests/print-document.test.ts",
     "test:print-kernel": "ts-node --transpile-only -P tests/tsconfig.json tests/print-kernel.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/kernel-purity.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/print-language-settings.test.ts",
-    "test:thermal-capabilities": "ts-node --transpile-only -P tests/tsconfig.json tests/thermal-capabilities.test.ts",
+    "test:thermal-capabilities": "ts-node --transpile-only -P tests/tsconfig.json tests/thermal-capabilities.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/windows-print-stderr.test.ts",
     "test:raster": "ts-node --transpile-only -P tests/tsconfig.json tests/raster-printing.test.ts && npm run test:raster-electron",
     "test:raster-electron": "npm run build && electron --no-sandbox tests/raster-renderer-electron.test.cjs",
     "test:cancel-override": "node tests/run-electron-node-test.cjs tests/cancel-override.test.ts && node tests/run-electron-node-test.cjs tests/manager-pin-rate-limit-bypass.test.ts",

--- a/tests/windows-print-stderr.test.ts
+++ b/tests/windows-print-stderr.test.ts
@@ -48,9 +48,9 @@ function runTests(): void {
     "Printer spooler service stopped.\nCannot communicate with spooler daemon.",
   );
 
-  // 5. Malformed CLIXML fallback (strips tags)
-  const malformedClixml = "#< CLIXML\r\n<Objs><UnknownTag>Some unexpected error message</UnknownTag></Objs>";
-  assert.equal(sanitizePowerShellStderr(malformedClixml), "Some unexpected error message");
+  // 5. Fallback when no <S S="Error"> blocks match (strips CLIXML header and decodes escapes)
+  const malformedClixml = '#< CLIXML\r\nSome unexpected error message_x000D__x000A_';
+  assert.equal(sanitizePowerShellStderr(malformedClixml), 'Some unexpected error message');
 
   // 6. classifyPrintFailure handles CLIXML-wrapped errors correctly
   assert.equal(classifyPrintFailure(clixmlSingle), "unknown");

--- a/tests/windows-print-stderr.test.ts
+++ b/tests/windows-print-stderr.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { sanitizePowerShellStderr, classifyPrintFailure } from "../main/printers/thermal";
+
+function runTests(): void {
+  // 1. Plain stderr without CLIXML
+  assert.equal(sanitizePowerShellStderr("Printer is offline"), "Printer is offline");
+  assert.equal(sanitizePowerShellStderr(""), "");
+  assert.equal(sanitizePowerShellStderr(undefined), "");
+
+  // 2. Standard PowerShell CLIXML with single error
+  const clixmlSingle = [
+    "#< CLIXML",
+    "<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\">",
+    "  <S S=\"Error\">The RPC server is unavailable._x000D__x000A_</S>",
+    "  <S S=\"Error\">At line:1 char:1_x000D__x000A_</S>",
+    "  <S S=\"Error\">+ [WINSPOOL]::PrintRawFile(\$name, \$file)_x000D__x000A_</S>",
+    "</Objs>",
+  ].join("\r\n");
+
+  assert.equal(sanitizePowerShellStderr(clixmlSingle), "The RPC server is unavailable.");
+
+  // 3. CLIXML with XML entities and quotes
+  const clixmlEntities = [
+    "#< CLIXML",
+    "<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\">",
+    "  <S S=\"Error\">Exception calling &quot;OpenPrinter&quot; with &quot;3&quot; argument(s): &quot;The printer name is invalid&quot;_x000D__x000A_</S>",
+    "  <S S=\"Error\">At line:1 char:1_x000D__x000A_</S>",
+    "</Objs>",
+  ].join("\r\n");
+
+  assert.equal(
+    sanitizePowerShellStderr(clixmlEntities),
+    "Exception calling \"OpenPrinter\" with \"3\" argument(s): \"The printer name is invalid\"",
+  );
+
+  // 4. CLIXML with multiple meaningful error lines
+  const clixmlMulti = [
+    "#< CLIXML",
+    "<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\">",
+    "  <S S=\"Error\">Printer spooler service stopped._x000D__x000A_</S>",
+    "  <S S=\"Error\">Cannot communicate with spooler daemon._x000D__x000A_</S>",
+    "  <S S=\"Error\">At line:1 char:1_x000D__x000A_</S>",
+    "</Objs>",
+  ].join("\r\n");
+
+  assert.equal(
+    sanitizePowerShellStderr(clixmlMulti),
+    "Printer spooler service stopped.\nCannot communicate with spooler daemon.",
+  );
+
+  // 5. Malformed CLIXML fallback (strips tags)
+  const malformedClixml = "#< CLIXML\r\n<Objs><UnknownTag>Some unexpected error message</UnknownTag></Objs>";
+  assert.equal(sanitizePowerShellStderr(malformedClixml), "Some unexpected error message");
+
+  // 6. classifyPrintFailure handles CLIXML-wrapped errors correctly
+  assert.equal(classifyPrintFailure(clixmlSingle), "unknown");
+  const clixmlOffline = "#< CLIXML\r\n<Objs Version=\"1.1.0.1\"><S S=\"Error\">Printer device is offline_x000D__x000A_</S></Objs>";
+  assert.equal(classifyPrintFailure(clixmlOffline), "offline");
+
+  const clixmlSpooler = "#< CLIXML\r\n<Objs Version=\"1.1.0.1\"><S S=\"Error\">StartDocPrinter failed for job_x000D__x000A_</S></Objs>";
+  assert.equal(classifyPrintFailure(clixmlSpooler), "spooler_error");
+
+  const clixmlTimeout = "#< CLIXML\r\n<Objs Version=\"1.1.0.1\"><S S=\"Error\">Operation timed out after 20s_x000D__x000A_</S></Objs>";
+  assert.equal(classifyPrintFailure(clixmlTimeout), "timeout");
+
+  console.log("✓ All Windows PowerShell stderr sanitization tests passed.");
+}
+
+runTests();


### PR DESCRIPTION
## Related work

Issue / Discussion: Windows print failure diagnostics & telemetry polish

## Summary

When raw Windows print jobs fail in `printViaUSBWindows`, PowerShell formats error streams as CLIXML into `stderr` (e.g. `#< CLIXML\r\n<Objs Version="1.1.0.1"...<S S="Error">...`). This raw XML wrapper leaked into the user-facing toast notifications and application logs.

Key changes:
1. **PowerShell Stderr Sanitization**: Added `sanitizePowerShellStderr()` in `main/printers/thermal.ts` to strip the `#< CLIXML` header, extract text from `<S S="Error">...</S>` blocks, decode PowerShell hex escapes (e.g. `_x000D__x000A_` -> newline), and unescape standard XML entities.
2. **Error Detail Cleanup**: Applied `sanitizePowerShellStderr()` in `printViaUSBWindows` to ensure clean, human-readable error messages (`The RPC server is unavailable`, `The printer name is invalid`, etc.) are returned in `detail`.
3. **Classification Resilience**: `classifyPrintFailure()` now pre-sanitizes input so error classification reliably detects failure classes (`offline`, `spooler_error`, `timeout`) even if raw CLIXML is passed.
4. **Automated Testing**: Added `tests/windows-print-stderr.test.ts` verifying sanitization and classification across single-line, multi-line, XML-escaped, and non-XML stderr inputs.

## Verification

Commands run:
- `npm run build` (passed)
- `npm run test:thermal-capabilities` (passed, includes windows-print-stderr.test.ts)
- `npm run lint` (passed, 0 errors)
- `tests/dev-tooling-scripts.test.ts` (passed, 128 sharding suites intact)

## Contributor checklist

- [x] This is a small isolated fix/doc update OR follows an approved issue/direction.
- [x] Unrelated cleanups, refactors, and dependency changes were kept out of this PR.
- [x] Tests were added or updated for any behavior changes.
- [x] Verification commands were run and documented above.
- [x] Customer data and upgrade safety were preserved (if touching database/storage).
- [x] Documentation or translations were updated where relevant.
- [x] I understand and can explain all submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows raw-print error messages by decoding XML entities and removing only PowerShell envelope formatting and encoded line breaks.
  - Preserved meaningful XML-like content in malformed PowerShell errors.
  - Windows print failures are classified more clearly, including unknown, offline, spooler, and timeout errors.

- **Tests**
  - Added coverage for plain and formatted stderr, entity decoding, multiple errors, malformed output, and print-failure classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->