### PR TITLE
fix(frontend): surface detailed printer error messages in user toasts

### DIFF
--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -562,7 +562,9 @@ export default function OrdersPage() {
           { isReprint: false }
         );
         showPrintWarningsToast(printWarnings);
-        await api.post(`/bills/${bill.id}/print`, { print_type: 'receipt' });
+        try {
+          await api.post(`/bills/${bill.id}/print`, { print_type: 'receipt' });
+        } catch { /* best-effort history tracking */ }
       } catch (err) {
         const msg = extractPrinterErrorMessage(err);
         toast.error(formatReceiptErrorToast(msg, tOrders('receiptPrintFailedHint')));
@@ -596,10 +598,12 @@ export default function OrdersPage() {
         },
         { isReprint }
       );
-      await api.post(`/bills/${billId}/print`, { print_type: isReprint ? 'reprint' : 'receipt' });
       toast.success(isReprint ? tOrders('printReceiptReprint') : tOrders('printReceipt'));
       showPrintWarningsToast(printWarnings);
-      fetchPrintHistory(billId);
+      try {
+        await api.post(`/bills/${billId}/print`, { print_type: isReprint ? 'reprint' : 'receipt' });
+        fetchPrintHistory(billId);
+      } catch { /* best-effort history tracking */ }
     } catch (err) {
       const detail = extractPrinterErrorMessage(err);
       toast.error(formatReceiptErrorToast(detail, tOrders('printReceiptFailed')));

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -18,7 +18,7 @@ import { getDiscountInputStep, normalizeFixedDiscountValue } from '@/lib/currenc
 import { parseDbTimestamp } from '@/lib/utils';
 import { usePrinterStore } from '@/hooks/usePrinter';
 import { showPrintWarningsToast } from '@/lib/printer/warnings-toast';
-import { formatReceiptErrorToast } from '@/lib/printer/warnings';
+import { formatReceiptErrorToast, extractPrinterErrorMessage } from '@/lib/printer/warnings';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useHeldOrdersStore } from '@/store/held-orders';
 import { useRouter } from 'next/navigation';
@@ -564,7 +564,7 @@ export default function OrdersPage() {
         showPrintWarningsToast(printWarnings);
         await api.post(`/bills/${bill.id}/print`, { print_type: 'receipt' });
       } catch (err) {
-        const msg = err instanceof Error ? err.message : '';
+        const msg = extractPrinterErrorMessage(err);
         toast.error(formatReceiptErrorToast(msg, tOrders('receiptPrintFailedHint')));
       }
     }
@@ -601,7 +601,7 @@ export default function OrdersPage() {
       showPrintWarningsToast(printWarnings);
       fetchPrintHistory(billId);
     } catch (err) {
-      const detail = err instanceof Error ? err.message : undefined;
+      const detail = extractPrinterErrorMessage(err);
       toast.error(formatReceiptErrorToast(detail, tOrders('printReceiptFailed')));
     } finally {
       setPrintingBillId(null);

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -602,7 +602,7 @@ export default function OrdersPage() {
       fetchPrintHistory(billId);
     } catch (err) {
       const detail = err instanceof Error ? err.message : undefined;
-      toast.error(detail ? `${tOrders('printReceiptFailed')}: ${detail}` : tOrders('printReceiptFailed'));
+      toast.error(formatReceiptErrorToast(detail, tOrders('printReceiptFailed')));
     } finally {
       setPrintingBillId(null);
       setConfirmPrintBillId(null);

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -18,6 +18,7 @@ import { getDiscountInputStep, normalizeFixedDiscountValue } from '@/lib/currenc
 import { parseDbTimestamp } from '@/lib/utils';
 import { usePrinterStore } from '@/hooks/usePrinter';
 import { showPrintWarningsToast } from '@/lib/printer/warnings-toast';
+import { formatReceiptErrorToast } from '@/lib/printer/warnings';
 import { useFormatCurrency } from '@/hooks/useFormatCurrency';
 import { useHeldOrdersStore } from '@/store/held-orders';
 import { useRouter } from 'next/navigation';
@@ -562,8 +563,9 @@ export default function OrdersPage() {
         );
         showPrintWarningsToast(printWarnings);
         await api.post(`/bills/${bill.id}/print`, { print_type: 'receipt' });
-      } catch {
-        toast.error(tOrders('receiptPrintFailedHint'));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : '';
+        toast.error(formatReceiptErrorToast(msg, tOrders('receiptPrintFailedHint')));
       }
     }
   };

--- a/frontend/src/app/(dashboard)/pos/page.tsx
+++ b/frontend/src/app/(dashboard)/pos/page.tsx
@@ -26,6 +26,7 @@ import PrepaidCheckoutModal, { type PrepaidPayment, type PrepaidDiscount } from 
 import PosTopbar from '@/components/pos/PosTopbar';
 import { usePrinterStore } from '@/hooks/usePrinter';
 import { showPrintWarningsToast } from '@/lib/printer/warnings-toast';
+import { formatKotErrorToast, formatReceiptErrorToast } from '@/lib/printer/warnings';
 import { useBarcodeScanner } from '@/hooks/useBarcodeScanner';
 import { useTranslations } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
@@ -270,7 +271,7 @@ export default function POSPage() {
         message: t('kotPrintFailed'),
         payload: { event_code: code, message: msg, category: 'printer', diagnostics: { order_id: order.id, stage: 'kot_print' } },
       });
-      toast.error(t('kotPrintFailed'));
+      toast.error(formatKotErrorToast(msg, t('kotPrintFailed')));
     }
   };
 
@@ -349,7 +350,7 @@ export default function POSPage() {
         message: t('receiptPrintFailed'),
         payload: { event_code: code, message: supportMessage, category: 'printer', diagnostics: { bill_id: bill.id, stage: 'receipt_print' } },
       });
-      toast.error(t('receiptPrintFailed'));
+      toast.error(formatReceiptErrorToast(msg, t('receiptPrintFailed')));
     }
   };
 

--- a/frontend/src/hooks/usePrinter.ts
+++ b/frontend/src/hooks/usePrinter.ts
@@ -210,13 +210,12 @@ export const usePrinterStore = create<PrinterState>()(
               const response = await api.post<{ warnings?: PrintWarning[] }>('/printers/print-bill', { billId: bill.id, useUnicode: printerUseUnicode, arabicShaping: printerArabicShaping, isReprint });
               return response.data.warnings || [];
             } catch (err: unknown) {
-              const e = err as { response?: { data?: { error?: string } }; message?: string };
-              const errorMsg = e.response?.data?.error || e.message || 'Print failed';
+              const e = err as { response?: { data?: { error?: string; detail?: string } }; message?: string };
+              const errorMsg = e.response?.data?.error || e.response?.data?.detail || e.message || 'Print failed';
               if (errorMsg.includes('No default printer configured')) {
                 toast('No thermal printer configured — printing via system print', { icon: 'ℹ️' });
                 return await executeBrowserPrint();
               }
-              if (errorMsg.startsWith('Receipt not printed:')) toast.error(errorMsg);
               throw new Error(errorMsg);
             }
           }
@@ -460,8 +459,8 @@ export const usePrinterStore = create<PrinterState>()(
               const response = await api.post<{ warnings?: PrintWarning[] }>('/printers/print-kot', { orderId: order.id, items: opts?.items, stationName: opts?.stationName, useUnicode: printerUseUnicode, arabicShaping: printerArabicShaping });
               return response.data.warnings || [];
             } catch (err: unknown) {
-              const e = err as { response?: { data?: { error?: string } }; message?: string };
-              throw new Error(e.response?.data?.error || e.message || 'KOT print failed');
+              const e = err as { response?: { data?: { error?: string; detail?: string } }; message?: string };
+              throw new Error(e.response?.data?.error || e.response?.data?.detail || e.message || 'KOT print failed');
             }
           }
 

--- a/frontend/src/hooks/usePrinter.ts
+++ b/frontend/src/hooks/usePrinter.ts
@@ -211,7 +211,7 @@ export const usePrinterStore = create<PrinterState>()(
               return response.data.warnings || [];
             } catch (err: unknown) {
               const e = err as { response?: { data?: { error?: string; detail?: string } }; message?: string };
-              const errorMsg = e.response?.data?.error || e.response?.data?.detail || e.message || 'Print failed';
+              const errorMsg = e.response?.data?.detail || e.response?.data?.error || e.message || 'Print failed';
               if (errorMsg.includes('No default printer configured')) {
                 toast('No thermal printer configured — printing via system print', { icon: 'ℹ️' });
                 return await executeBrowserPrint();
@@ -330,7 +330,6 @@ export const usePrinterStore = create<PrinterState>()(
 
           if (hasFinancialPrintWarning(warnings)) {
             const refusal = makeFinancialPrintRefusalMessage(warnings);
-            toast.error(refusal);
             throw new Error(refusal);
           }
 
@@ -460,7 +459,7 @@ export const usePrinterStore = create<PrinterState>()(
               return response.data.warnings || [];
             } catch (err: unknown) {
               const e = err as { response?: { data?: { error?: string; detail?: string } }; message?: string };
-              throw new Error(e.response?.data?.error || e.response?.data?.detail || e.message || 'KOT print failed');
+              throw new Error(e.response?.data?.detail || e.response?.data?.error || e.message || 'KOT print failed');
             }
           }
 

--- a/frontend/src/lib/printer/warnings.ts
+++ b/frontend/src/lib/printer/warnings.ts
@@ -213,7 +213,27 @@ export function safePrinterText<T extends { text(value: string): T }>(
 }
 
 /**
+ * Extracts the most informative error string from an unknown error or API Axios response.
+ *
+ * @param err - The caught error object, which may be an Error instance or Axios response.
+ * @returns The resolved error message string.
+ */
+export function extractPrinterErrorMessage(err: unknown): string {
+  if (!err) return '';
+  const maybeAxios = err as { response?: { data?: { detail?: string; error?: string } }; message?: string };
+  return (
+    maybeAxios.response?.data?.detail ||
+    maybeAxios.response?.data?.error ||
+    (err instanceof Error ? err.message : String(err))
+  ).trim();
+}
+
+/**
  * Formats a user-facing receipt print error message with operational detail when available.
+ *
+ * @param detail - Optional raw error detail or message from the backend or encoder.
+ * @param fallbackTranslation - Localized fallback text to display if no operational detail exists.
+ * @returns Formatted user-facing error string suitable for toast display.
  */
 export function formatReceiptErrorToast(detail?: string, fallbackTranslation = 'Receipt print failed'): string {
   const msg = String(detail || '').trim();
@@ -226,6 +246,10 @@ export function formatReceiptErrorToast(detail?: string, fallbackTranslation = '
 
 /**
  * Formats a user-facing KOT print error message with operational detail when available.
+ *
+ * @param detail - Optional raw error detail or message from the backend or encoder.
+ * @param fallbackTranslation - Localized fallback text to display if no operational detail exists.
+ * @returns Formatted user-facing error string suitable for toast display.
  */
 export function formatKotErrorToast(detail?: string, fallbackTranslation = 'KOT print failed'): string {
   const msg = String(detail || '').trim();

--- a/frontend/src/lib/printer/warnings.ts
+++ b/frontend/src/lib/printer/warnings.ts
@@ -220,12 +220,15 @@ export function safePrinterText<T extends { text(value: string): T }>(
  */
 export function extractPrinterErrorMessage(err: unknown): string {
   if (!err) return '';
-  const maybeAxios = err as { response?: { data?: { detail?: string; error?: string } }; message?: string };
-  return (
-    maybeAxios.response?.data?.detail ||
-    maybeAxios.response?.data?.error ||
-    (err instanceof Error ? err.message : String(err))
-  ).trim();
+  const maybeAxios = err as { response?: { data?: { detail?: unknown; error?: unknown } }; message?: unknown };
+  const detail = maybeAxios.response?.data?.detail;
+  if (typeof detail === 'string' && detail.trim()) return detail.trim();
+  const error = maybeAxios.response?.data?.error;
+  if (typeof error === 'string' && error.trim()) return error.trim();
+  if (err instanceof Error && typeof err.message === 'string' && err.message.trim()) {
+    return err.message.trim();
+  }
+  return typeof err === 'string' ? err.trim() : '';
 }
 
 /**

--- a/frontend/src/lib/printer/warnings.ts
+++ b/frontend/src/lib/printer/warnings.ts
@@ -211,3 +211,27 @@ export function safePrinterText<T extends { text(value: string): T }>(
   }
   return enc.text(printerValue);
 }
+
+/**
+ * Formats a user-facing receipt print error message with operational detail when available.
+ */
+export function formatReceiptErrorToast(detail?: string, fallbackTranslation = 'Receipt print failed'): string {
+  const msg = String(detail || '').trim();
+  if (msg.startsWith('Receipt not printed:')) return msg;
+  if (msg && msg !== 'print failed' && msg !== 'Print failed') {
+    return `${fallbackTranslation} (${msg})`;
+  }
+  return fallbackTranslation;
+}
+
+/**
+ * Formats a user-facing KOT print error message with operational detail when available.
+ */
+export function formatKotErrorToast(detail?: string, fallbackTranslation = 'KOT print failed'): string {
+  const msg = String(detail || '').trim();
+  if (msg && msg !== 'print failed' && msg !== 'KOT print failed') {
+    return `${fallbackTranslation}: ${msg}`;
+  }
+  return fallbackTranslation;
+}
+

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test:merchant-template-transfer": "ts-node --transpile-only -P tests/tsconfig.json tests/merchant-template-import-export.test.ts",
     "test:print-document": "ts-node --transpile-only -P tests/tsconfig.json tests/print-document.test.ts",
     "test:print-kernel": "ts-node --transpile-only -P tests/tsconfig.json tests/print-kernel.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/kernel-purity.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/print-language-settings.test.ts",
-    "test:thermal-capabilities": "ts-node --transpile-only -P tests/tsconfig.json tests/thermal-capabilities.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/windows-print-stderr.test.ts",
+    "test:thermal-capabilities": "ts-node --transpile-only -P tests/tsconfig.json tests/thermal-capabilities.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/windows-print-stderr.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/printer-error-toast-clarity.test.ts",
     "test:raster": "ts-node --transpile-only -P tests/tsconfig.json tests/raster-printing.test.ts && npm run test:raster-electron",
     "test:raster-electron": "npm run build && electron --no-sandbox tests/raster-renderer-electron.test.cjs",
     "test:cancel-override": "node tests/run-electron-node-test.cjs tests/cancel-override.test.ts && node tests/run-electron-node-test.cjs tests/manager-pin-rate-limit-bypass.test.ts",

--- a/tests/printer-error-toast-clarity.test.ts
+++ b/tests/printer-error-toast-clarity.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import moduleApi from "node:module";
+
+function loadFrontendWarnings(): typeof import("../frontend/src/lib/printer/warnings") {
+  const mod = moduleApi as unknown as { _resolveFilename: (...args: any[]) => string };
+  const originalResolveFilename = mod._resolveFilename;
+  mod._resolveFilename = function (request: string, parent: any, isMain: boolean, options?: any) {
+    const resolvedRequest = request.startsWith("@print/")
+      ? path.resolve(__dirname, "../shared/print", request.slice("@print/".length))
+      : request.startsWith("@/")
+        ? path.resolve(__dirname, "../frontend/src", request.slice("@/".length))
+        : request;
+    return originalResolveFilename.call(this, resolvedRequest, parent, isMain, options);
+  };
+  try {
+    return require("../frontend/src/lib/printer/warnings");
+  } finally {
+    mod._resolveFilename = originalResolveFilename;
+  }
+}
+
+const { formatReceiptErrorToast, formatKotErrorToast } = loadFrontendWarnings();
+
+function runTests(): void {
+  // 1. Receipt formatting: financial refusal is passed as-is without double-wrapping
+  const financialMsg = "Receipt not printed: a financial row contains unsupported printer text: €5.00";
+  assert.equal(
+    formatReceiptErrorToast(financialMsg, "Receipt print failed"),
+    financialMsg,
+  );
+
+  // 2. Receipt formatting: specific operational detail is appended with context
+  const timeoutMsg = "Timed out connecting to 192.168.1.100:9100";
+  assert.equal(
+    formatReceiptErrorToast(timeoutMsg, "Receipt print failed"),
+    "Receipt print failed (Timed out connecting to 192.168.1.100:9100)",
+  );
+
+  // 3. Receipt formatting: generic messages fall back cleanly without empty parentheses
+  assert.equal(formatReceiptErrorToast("print failed", "Receipt print failed"), "Receipt print failed");
+  assert.equal(formatReceiptErrorToast("Print failed", "Receipt print failed"), "Receipt print failed");
+  assert.equal(formatReceiptErrorToast("", "Receipt print failed"), "Receipt print failed");
+  assert.equal(formatReceiptErrorToast(undefined, "Receipt print failed"), "Receipt print failed");
+
+  // 4. KOT formatting: operational detail is appended
+  assert.equal(
+    formatKotErrorToast("Spooler service paused", "KOT print failed"),
+    "KOT print failed: Spooler service paused",
+  );
+
+  // 5. KOT formatting: generic messages fall back cleanly
+  assert.equal(formatKotErrorToast("print failed", "KOT print failed"), "KOT print failed");
+  assert.equal(formatKotErrorToast("KOT print failed", "KOT print failed"), "KOT print failed");
+  assert.equal(formatKotErrorToast("", "KOT print failed"), "KOT print failed");
+  assert.equal(formatKotErrorToast(undefined, "KOT print failed"), "KOT print failed");
+
+  console.log("✓ All printer error toast clarity tests passed.");
+}
+
+runTests();

--- a/tests/printer-error-toast-clarity.test.ts
+++ b/tests/printer-error-toast-clarity.test.ts
@@ -68,8 +68,18 @@ function runTests(): void {
     extractPrinterErrorMessage(new Error("Printer paper out")),
     "Printer paper out",
   );
+  // Non-string detail/error responses should not throw or return object strings
+  assert.equal(
+    extractPrinterErrorMessage({ response: { data: { detail: { nested: "object" } } } }),
+    "",
+  );
+  assert.equal(
+    extractPrinterErrorMessage({ response: { data: { error: 12345 } } }),
+    "",
+  );
   assert.equal(extractPrinterErrorMessage(null), "");
   assert.equal(extractPrinterErrorMessage(undefined), "");
+  assert.equal(extractPrinterErrorMessage({}), "");
 
   console.log("✓ All printer error toast clarity tests passed.");
 }

--- a/tests/printer-error-toast-clarity.test.ts
+++ b/tests/printer-error-toast-clarity.test.ts
@@ -20,7 +20,7 @@ function loadFrontendWarnings(): typeof import("../frontend/src/lib/printer/warn
   }
 }
 
-const { formatReceiptErrorToast, formatKotErrorToast } = loadFrontendWarnings();
+const { formatReceiptErrorToast, formatKotErrorToast, extractPrinterErrorMessage } = loadFrontendWarnings();
 
 function runTests(): void {
   // 1. Receipt formatting: financial refusal is passed as-is without double-wrapping
@@ -54,6 +54,22 @@ function runTests(): void {
   assert.equal(formatKotErrorToast("KOT print failed", "KOT print failed"), "KOT print failed");
   assert.equal(formatKotErrorToast("", "KOT print failed"), "KOT print failed");
   assert.equal(formatKotErrorToast(undefined, "KOT print failed"), "KOT print failed");
+
+    // 6. extractPrinterErrorMessage extracts from Axios response objects and standard errors
+  assert.equal(
+    extractPrinterErrorMessage({ response: { data: { detail: "Driver disconnected" } } }),
+    "Driver disconnected",
+  );
+  assert.equal(
+    extractPrinterErrorMessage({ response: { data: { error: "Network error" } } }),
+    "Network error",
+  );
+  assert.equal(
+    extractPrinterErrorMessage(new Error("Printer paper out")),
+    "Printer paper out",
+  );
+  assert.equal(extractPrinterErrorMessage(null), "");
+  assert.equal(extractPrinterErrorMessage(undefined), "");
 
   console.log("✓ All printer error toast clarity tests passed.");
 }


### PR DESCRIPTION
## Related work

Issue / Discussion: Multilingual printer operational clarity & error toast improvements

## Summary

When printing receipts or KOTs fail, generic error catch-alls often swallowed the specific reason returned by the backend (e.g. `Timed out connecting to 192.168.1.100:9100`, `StartDocPrinter failed`, or `Receipt not printed: a financial row contains unsupported printer text`), presenting cashiers with vague `Print failed. Check printer connection and settings` messages. In addition, financial row refusals caused double toast popups due to both the hook and the caller triggering toasts.

Key changes:
1. **Toast Formatting Helpers**: Added `formatReceiptErrorToast()` and `formatKotErrorToast()` in `frontend/src/lib/printer/warnings.ts` to format user-facing messages with operational detail when available, while cleanly falling back to translated base messages when no detail is provided.
2. **Double-Toast Elimination**: Removed redundant `toast.error()` call inside `usePrinterStore.printBill()` so error toasts are formatted and presented once by the caller (`pos/page.tsx` and `orders/page.tsx`).
3. **Detail Propagation**: Retained response `detail` or `error` in `usePrinterStore` catch blocks for both `printBill` and `printKot`.
4. **Integration**: Updated `pos/page.tsx` (for KOT and receipt printing) and `orders/page.tsx` (for payment-complete auto-print) to surface specific failure causes in toasts.
5. **Testing**: Added `tests/printer-error-toast-clarity.test.ts` verifying formatting across financial refusals, timeout messages, generic messages, and empty inputs.

## Verification

Commands run:
- `npm run build:frontend` (passed)
- `npm run test:thermal-capabilities` (passed, includes printer-error-toast-clarity.test.ts)
- `npm run lint` (passed, 0 errors)
- `tests/dev-tooling-scripts.test.ts` (passed, 128 suites sharding intact)

## Contributor checklist

- [x] This is a small isolated fix/doc update OR follows an approved issue/direction.
- [x] Unrelated cleanups, refactors, and dependency changes were kept out of this PR.
- [x] Tests were added or updated for any behavior changes.
- [x] Verification commands were run and documented above.
- [x] Customer data and upgrade safety were preserved (if touching database/storage).
- [x] Documentation or translations were updated where relevant.
- [x] I understand and can explain all submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt and kitchen order printing notifications with clearer, localized error details.
  * Printer errors now prioritize the most useful information from available responses.
  * Prevented duplicate or misleading alerts when receipt refusals already include specific messaging.
  * Payment completion, manual receipt printing, and kitchen order printing failures now provide more context-aware notifications.
  * Receipt printing continues when print-history tracking encounters an issue.
  * Improved handling of bill-printing refusals to avoid unnecessary error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->