### PR TITLE
fix(printers): throttle large network print buffers to prevent microcontroller overrun

### DIFF
--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -2412,26 +2412,75 @@ function decodeThermalPreviewBytes(bytes: number[], codePage: ThermalCodePage | 
   return bytes.map((byte) => byte < 0x80 ? String.fromCharCode(byte) : highHalf[byte - 0x80] ?? '\uFFFD').join('');
 }
 
+export const NETWORK_PRINT_CHUNK_SIZE = 4096;
+export const NETWORK_PRINT_CHUNK_DELAY_MS = 10;
+
 export async function printViaNetwork(ip: string, port: number, data: Buffer, signal?: AbortSignal): Promise<DispatchResult> {
   return new Promise((resolve) => {
     const client = new net.Socket();
     let settled = false;
+    let timer: NodeJS.Timeout | null = null;
+
     const onAbort = (): void => {
+      if (timer) clearTimeout(timer);
       client.destroy();
       finish({ ok: false, detail: 'Print cancelled during shutdown' });
     };
     const finish = (result: DispatchResult): void => {
       if (settled) return;
       settled = true;
+      if (timer) clearTimeout(timer);
       signal?.removeEventListener('abort', onAbort);
       resolve(result);
     };
 
     client.connect(port, ip, () => {
-      client.write(data, () => {
-        client.end();
-        finish({ ok: true });
-      });
+      // For small payloads (typical text receipts <4KB), write directly in a single pass.
+      if (data.length <= NETWORK_PRINT_CHUNK_SIZE) {
+        client.write(data, () => {
+          client.end();
+          finish({ ok: true });
+        });
+        return;
+      }
+
+      // For large payloads (e.g. raster graphics, multi-language bitmaps), chunk to avoid overrunning
+      // small microcontroller receive buffers on budget thermal printers.
+      let offset = 0;
+      const sendNextChunk = (): void => {
+        if (settled) return;
+        if (offset >= data.length) {
+          client.end();
+          finish({ ok: true });
+          return;
+        }
+
+        const chunk = data.subarray(offset, offset + NETWORK_PRINT_CHUNK_SIZE);
+        offset += chunk.length;
+
+        const scheduleNext = (): void => {
+          if (offset < data.length) {
+            timer = setTimeout(sendNextChunk, NETWORK_PRINT_CHUNK_DELAY_MS);
+          } else {
+            client.end();
+            finish({ ok: true });
+          }
+        };
+
+        const canContinue = client.write(chunk, () => {
+          if (canContinue) {
+            scheduleNext();
+          }
+        });
+
+        if (!canContinue) {
+          client.once('drain', () => {
+            scheduleNext();
+          });
+        }
+      };
+
+      sendNextChunk();
     });
 
     client.on('error', (err) => {

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -2459,6 +2459,7 @@ export async function printViaNetwork(ip: string, port: number, data: Buffer, si
         offset += chunk.length;
 
         const scheduleNext = (): void => {
+          if (settled) return;
           if (offset < data.length) {
             timer = setTimeout(sendNextChunk, NETWORK_PRINT_CHUNK_DELAY_MS);
           } else {
@@ -2474,9 +2475,7 @@ export async function printViaNetwork(ip: string, port: number, data: Buffer, si
         });
 
         if (!canContinue) {
-          client.once('drain', () => {
-            scheduleNext();
-          });
+          client.once('drain', scheduleNext);
         }
       };
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test:merchant-template-transfer": "ts-node --transpile-only -P tests/tsconfig.json tests/merchant-template-import-export.test.ts",
     "test:print-document": "ts-node --transpile-only -P tests/tsconfig.json tests/print-document.test.ts",
     "test:print-kernel": "ts-node --transpile-only -P tests/tsconfig.json tests/print-kernel.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/kernel-purity.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/print-language-settings.test.ts",
-    "test:thermal-capabilities": "ts-node --transpile-only -P tests/tsconfig.json tests/thermal-capabilities.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/windows-print-stderr.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/printer-error-toast-clarity.test.ts",
+    "test:thermal-capabilities": "ts-node --transpile-only -P tests/tsconfig.json tests/thermal-capabilities.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/windows-print-stderr.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/printer-error-toast-clarity.test.ts && ts-node --transpile-only -P tests/tsconfig.json tests/network-print-chunking.test.ts",
     "test:raster": "ts-node --transpile-only -P tests/tsconfig.json tests/raster-printing.test.ts && npm run test:raster-electron",
     "test:raster-electron": "npm run build && electron --no-sandbox tests/raster-renderer-electron.test.cjs",
     "test:cancel-override": "node tests/run-electron-node-test.cjs tests/cancel-override.test.ts && node tests/run-electron-node-test.cjs tests/manager-pin-rate-limit-bypass.test.ts",

--- a/tests/network-print-chunking.test.ts
+++ b/tests/network-print-chunking.test.ts
@@ -143,11 +143,49 @@ async function testAbortSignalCancelsPrint(): Promise<void> {
   }
 }
 
+async function testAbortBeforeDrain(): Promise<void> {
+  const originalSocket = net.Socket;
+  let mock: MockSocket | null = null;
+  (net as any).Socket = function () {
+    mock = new MockSocket();
+    // Do not immediately emit drain; stay paused in backpressure
+    mock.write = function (chunk: Buffer, cb?: () => void): boolean {
+      this.writtenChunks.push(Buffer.from(chunk));
+      if (cb) process.nextTick(cb);
+      return false; // Backpressured, awaiting drain
+    };
+    return mock;
+  };
+
+  try {
+    const controller = new AbortController();
+    const largePayload = Buffer.alloc(10000, 0xdd);
+    const printPromise = printViaNetwork("192.168.1.100", 9100, largePayload, controller.signal);
+
+    // Let the first chunk write happen
+    await new Promise((r) => setImmediate(r));
+    assert.equal(mock!.writtenChunks.length, 1);
+
+    // Abort before drain fires
+    controller.abort();
+    const result = await printPromise;
+    assert.equal(result.ok, false);
+
+    // Emitting drain after settlement must be a no-op and must not trigger another chunk write
+    mock!.emit("drain");
+    await new Promise((r) => setTimeout(r, 25));
+    assert.equal(mock!.writtenChunks.length, 1);
+  } finally {
+    (net as any).Socket = originalSocket;
+  }
+}
+
 async function run(): Promise<void> {
   await testSmallPayloadDirectSend();
   await testLargePayloadChunkedSend();
   await testLargePayloadWithBackpressure();
   await testAbortSignalCancelsPrint();
+  await testAbortBeforeDrain();
   console.log("✓ All network print chunking tests passed.");
 }
 

--- a/tests/network-print-chunking.test.ts
+++ b/tests/network-print-chunking.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import net from "node:net";
+import { EventEmitter } from "node:events";
+import { printViaNetwork, NETWORK_PRINT_CHUNK_SIZE, NETWORK_PRINT_CHUNK_DELAY_MS } from "../main/printers/thermal";
+
+class MockSocket extends EventEmitter {
+  public writtenChunks: Buffer[] = [];
+  public destroyed = false;
+  public ended = false;
+  public timeoutMs = 0;
+  public timeoutCb?: () => void;
+  public simulateBackpressure = false;
+
+  connect(port: number, host: string, cb?: () => void): this {
+    process.nextTick(() => {
+      if (cb) cb();
+    });
+    return this;
+  }
+
+  write(chunk: Buffer, cb?: () => void): boolean {
+    this.writtenChunks.push(Buffer.from(chunk));
+    if (this.simulateBackpressure) {
+      // Simulate socket buffer full: return false and drain later
+      process.nextTick(() => {
+        if (cb) cb();
+        this.emit("drain");
+      });
+      return false;
+    }
+    process.nextTick(() => {
+      if (cb) cb();
+    });
+    return true;
+  }
+
+  end(): this {
+    this.ended = true;
+    return this;
+  }
+
+  destroy(): this {
+    this.destroyed = true;
+    return this;
+  }
+
+  setTimeout(ms: number, cb?: () => void): this {
+    this.timeoutMs = ms;
+    this.timeoutCb = cb;
+    return this;
+  }
+}
+
+async function testSmallPayloadDirectSend(): Promise<void> {
+  const originalSocket = net.Socket;
+  let mock: MockSocket | null = null;
+  (net as any).Socket = function () {
+    mock = new MockSocket();
+    return mock;
+  };
+
+  try {
+    const smallPayload = Buffer.from("Small receipt content under 4KB");
+    const result = await printViaNetwork("192.168.1.100", 9100, smallPayload);
+    assert.equal(result.ok, true);
+    assert(mock);
+    assert.equal(mock!.writtenChunks.length, 1);
+    assert.deepEqual(mock!.writtenChunks[0], smallPayload);
+    assert.equal(mock!.ended, true);
+  } finally {
+    (net as any).Socket = originalSocket;
+  }
+}
+
+async function testLargePayloadChunkedSend(): Promise<void> {
+  const originalSocket = net.Socket;
+  let mock: MockSocket | null = null;
+  (net as any).Socket = function () {
+    mock = new MockSocket();
+    return mock;
+  };
+
+  try {
+    // 10KB payload (> 2 chunks of 4KB)
+    const largePayload = Buffer.alloc(10 * 1024, 0xaa);
+    const result = await printViaNetwork("192.168.1.100", 9100, largePayload);
+    assert.equal(result.ok, true);
+    assert(mock);
+    assert.equal(mock!.writtenChunks.length, 3); // 4096 + 4096 + 2048
+    assert.equal(mock!.writtenChunks[0].length, 4096);
+    assert.equal(mock!.writtenChunks[1].length, 4096);
+    assert.equal(mock!.writtenChunks[2].length, 2048);
+    const reassembled = Buffer.concat(mock!.writtenChunks);
+    assert.deepEqual(reassembled, largePayload);
+    assert.equal(mock!.ended, true);
+  } finally {
+    (net as any).Socket = originalSocket;
+  }
+}
+
+async function testLargePayloadWithBackpressure(): Promise<void> {
+  const originalSocket = net.Socket;
+  let mock: MockSocket | null = null;
+  (net as any).Socket = function () {
+    mock = new MockSocket();
+    mock.simulateBackpressure = true;
+    return mock;
+  };
+
+  try {
+    const largePayload = Buffer.alloc(9000, 0xbb);
+    const result = await printViaNetwork("192.168.1.100", 9100, largePayload);
+    assert.equal(result.ok, true);
+    assert(mock);
+    assert.equal(mock!.writtenChunks.length, 3); // 4096 + 4096 + 808
+    const reassembled = Buffer.concat(mock!.writtenChunks);
+    assert.deepEqual(reassembled, largePayload);
+    assert.equal(mock!.ended, true);
+  } finally {
+    (net as any).Socket = originalSocket;
+  }
+}
+
+async function testAbortSignalCancelsPrint(): Promise<void> {
+  const originalSocket = net.Socket;
+  let mock: MockSocket | null = null;
+  (net as any).Socket = function () {
+    mock = new MockSocket();
+    return mock;
+  };
+
+  try {
+    const controller = new AbortController();
+    const largePayload = Buffer.alloc(10000, 0xcc);
+    setTimeout(() => controller.abort(), 2);
+    const result = await printViaNetwork("192.168.1.100", 9100, largePayload, controller.signal);
+    assert.equal(result.ok, false);
+    assert.match(result.detail || "", /Print cancelled during shutdown/);
+    assert(mock);
+    assert.equal(mock!.destroyed, true);
+  } finally {
+    (net as any).Socket = originalSocket;
+  }
+}
+
+async function run(): Promise<void> {
+  await testSmallPayloadDirectSend();
+  await testLargePayloadChunkedSend();
+  await testLargePayloadWithBackpressure();
+  await testAbortSignalCancelsPrint();
+  console.log("✓ All network print chunking tests passed.");
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Related work

Issue / Discussion: Multilingual printer operational clarity & buffer overrun protection on budget hardware

## Summary

Low-cost ESC/POS thermal network printers (e.g. 58mm clones, older Ethernet models) frequently have microcontrollers with limited hardware receive buffers (often 512B-1KB). When sending mixed-mode receipts containing multi-kilobyte raster bands (such as rendered Arabic, Persian, or CJK text), blasting the full 20KB-60KB payload in a single socket write can saturate the printer's receive buffer, resulting in dropped scanlines, corrupted graphics, or broken receipt output.

Key changes:
1. **Network Chunking & Pacing**: In `main/printers/thermal.ts`, `printViaNetwork` now checks payload size. Payloads under 4KB (normal text receipts) continue sending immediately in a single pass with zero overhead.
2. **Microcontroller Clearing**: Payloads exceeding 4KB are sliced into 4096-byte chunks with a 10ms pacing delay between chunks, giving printer microcontrollers time to process receive buffers.
3. **Socket Backpressure & Abort Support**: Respects `client.write()` return value by awaiting `drain` events if socket buffers fill up, and cleans up pacing timers on abort or completion.
4. **Automated Testing**: Added `tests/network-print-chunking.test.ts` to verify single-chunk pass-through for small receipts, exact byte integrity and chunk division for large receipts, socket backpressure drain handling, and abort signal cancellations.

## Verification

Commands run:
- `npm run test:thermal-capabilities` (passed, includes network-print-chunking.test.ts)
- `npm run lint` (passed, 0 errors)
- `npm run build` (passed)
- `tests/dev-tooling-scripts.test.ts` (passed, 128 suites sharding intact)

## Contributor checklist

- [x] This is a small isolated fix/doc update OR follows an approved issue/direction.
- [x] Unrelated cleanups, refactors, and dependency changes were kept out of this PR.
- [x] Tests were added or updated for any behavior changes.
- [x] Verification commands were run and documented above.
- [x] Customer data and upgrade safety were preserved (if touching database/storage).
- [x] Documentation or translations were updated where relevant.
- [x] I understand and can explain all submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network printing reliability for large print jobs by sending data in manageable chunks.
  * Improved handling of network backpressure to prevent overwhelming connections.
  * Prevented pending print operations from continuing after cancellation, failure, or completion.
  * Ensured interrupted print jobs do not write additional data after cancellation.

* **Tests**
  * Added regression coverage for cancellation during network backpressure.
  * Expanded coverage for payload sizes, connection backpressure, and cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->