### PR TITLE
feat(printers): multi-line item wrapping, raster font scaling, and code page preservation

### DIFF
--- a/main/printers/profiles.ts
+++ b/main/printers/profiles.ts
@@ -43,7 +43,15 @@ export const SUPPORTED_PRINTER_PROFILES: SupportedPrinterProfile[] = [
     fontBColumns: 64,
     printWidthMm: 72,
     cutMode: 'partial',
-    capabilities: LATIN_THERMAL_CAPABILITIES,
+    capabilities: {
+      ...LATIN_THERMAL_CAPABILITIES,
+      raster: {
+        enabled: true,
+        widthDots: 576,
+        maxBandHeight: 200,
+        modes: ['mixed', 'whole-receipt'],
+      },
+    },
     notes: '80mm ESC/POS receipt printer. Vendor specs list 72mm print width, 576 dots/line, Font A 42/48 columns, Font B 56/64 columns.',
   },
   {
@@ -57,7 +65,15 @@ export const SUPPORTED_PRINTER_PROFILES: SupportedPrinterProfile[] = [
     fontAColumns: 48,
     fontBColumns: 64,
     cutMode: 'partial',
-    capabilities: LATIN_THERMAL_CAPABILITIES,
+    capabilities: {
+      ...LATIN_THERMAL_CAPABILITIES,
+      raster: {
+        enabled: true,
+        widthDots: 576,
+        maxBandHeight: 200,
+        modes: ['mixed', 'whole-receipt'],
+      },
+    },
   },
   {
     id: 'generic-escpos-80',
@@ -73,6 +89,12 @@ export const SUPPORTED_PRINTER_PROFILES: SupportedPrinterProfile[] = [
     capabilities: {
       ...GENERIC_THERMAL_CAPABILITIES,
       encoding: { codePages: ['ascii'], preferredCodePage: 'ascii' },
+      raster: {
+        enabled: true,
+        widthDots: 576,
+        maxBandHeight: 200,
+        modes: ['mixed', 'whole-receipt'],
+      },
     },
   },
   {
@@ -89,6 +111,12 @@ export const SUPPORTED_PRINTER_PROFILES: SupportedPrinterProfile[] = [
     capabilities: {
       ...GENERIC_THERMAL_CAPABILITIES,
       encoding: { codePages: ['ascii'], preferredCodePage: 'ascii' },
+      raster: {
+        enabled: true,
+        widthDots: 384,
+        maxBandHeight: 200,
+        modes: ['mixed', 'whole-receipt'],
+      },
     },
   },
 ];

--- a/main/printers/raster-renderer.ts
+++ b/main/printers/raster-renderer.ts
@@ -60,8 +60,8 @@ export function rasterRendererHtml(): string {
       const scaleY = styles.includes('double-height') ? 2 : 1;
       const logicalLineHeight = 24;
       const lineHeight = logicalLineHeight * scaleY;
-      const fontSize = styles.includes('font-b') ? 12 : 16;
-      const weight = styles.includes('bold') ? '700' : '400';
+      const fontSize = styles.includes('font-b') ? 14 : 20;
+      const weight = styles.includes('bold') ? '700' : '600';
       const fontFallback = '-apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "Noto Sans", sans-serif';
       const fontSpec = request.bundledFont
         ? JSON.stringify(request.bundledFont.family) + ', ' + fontFallback
@@ -97,13 +97,10 @@ export function rasterRendererHtml(): string {
           const gaps = gapDots * (columns.length - 1);
           const available = Math.max(1, request.widthDots - gaps);
           const widths = columns.length === 2
-            ? [Math.max(1, available - Math.min(Math.max(measured[1] + gapDots, Math.floor(available * 0.2)), Math.floor(available * 0.45))), 0]
-            : [0, Math.max(1, Math.floor(available * 0.1)), 0];
-          if (columns.length === 2) widths[1] = available - widths[0];
-          else {
-            widths[2] = Math.min(Math.max(measured[2] + gapDots, Math.floor(available * 0.2)), Math.floor(available * 0.35));
-            widths[0] = Math.max(1, available - widths[1] - widths[2]);
-          }
+            ? [0, Math.max(measured[1] + gapDots, Math.floor(available * 0.25))]
+            : [0, Math.max(measured[1] + gapDots, Math.floor(available * 0.08)), Math.max(measured[2] + gapDots, Math.floor(available * 0.22))];
+          if (columns.length === 2) widths[0] = Math.max(1, available - widths[1]);
+          else widths[0] = Math.max(1, available - widths[1] - widths[2]);
           const wrappedColumns = columns.map((column, index) => wrap(column.text, widths[index]));
           const lineCount = Math.max(1, ...wrappedColumns.map((column) => column.length));
           return Array.from({ length: lineCount }, (_, lineIndex) => columns.map((column, columnIndex) => ({

--- a/main/printers/raster-renderer.ts
+++ b/main/printers/raster-renderer.ts
@@ -97,8 +97,8 @@ export function rasterRendererHtml(): string {
           const gaps = gapDots * (columns.length - 1);
           const available = Math.max(1, request.widthDots - gaps);
           const widths = columns.length === 2
-            ? [0, Math.max(measured[1] + gapDots, Math.floor(available * 0.25))]
-            : [0, Math.max(measured[1] + gapDots, Math.floor(available * 0.08)), Math.max(measured[2] + gapDots, Math.floor(available * 0.22))];
+            ? [0, Math.min(Math.max(measured[1] + gapDots, Math.floor(available * 0.25)), Math.floor(available * 0.45))]
+            : [0, Math.min(Math.max(measured[1] + gapDots, Math.floor(available * 0.08)), Math.floor(available * 0.2)), Math.min(Math.max(measured[2] + gapDots, Math.floor(available * 0.22)), Math.floor(available * 0.4))];
           if (columns.length === 2) widths[0] = Math.max(1, available - widths[1]);
           else widths[0] = Math.max(1, available - widths[1] - widths[2]);
           const wrappedColumns = columns.map((column, index) => wrap(column.text, widths[index]));

--- a/main/printers/raster-renderer.ts
+++ b/main/printers/raster-renderer.ts
@@ -58,9 +58,9 @@ export function rasterRendererHtml(): string {
       const styles = Array.isArray(request.styles) ? request.styles : [request.style];
       const scaleX = styles.includes('double-width') ? 2 : 1;
       const scaleY = styles.includes('double-height') ? 2 : 1;
-      const logicalLineHeight = 24;
+      const logicalLineHeight = 26;
       const lineHeight = logicalLineHeight * scaleY;
-      const fontSize = styles.includes('font-b') ? 14 : 20;
+      const fontSize = styles.includes('font-b') ? 16 : 22;
       const weight = styles.includes('bold') ? '700' : '600';
       const fontFallback = '-apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "Noto Sans", sans-serif';
       const fontSpec = request.bundledFont

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -1832,24 +1832,63 @@ export function itemAmountWidth(
 export function itemRows(item: any, nameLen: number, amtLen: number, cols: number, prefix: string, locale: string = 'en-US', trimDecimals: boolean = false, language: string = 'en', fractionDigits: number = 2, capabilities?: ThermalPrinterCapabilities): string[] {
   const qtyW = 4;
   const productName = normalizeThermalText(item.product_name, capabilities);
-  const name = truncate(productName, nameLen, language, capabilities).padEnd(nameLen);
-  const qty = String(item.quantity).padEnd(qtyW);
-  const label = name + qty;
   const amount = formatCurrency(item.total, prefix, locale, trimDecimals, fractionDigits);
-  const inlineWidth = Math.max(1, cols - label.length - 1);
-  if (amount.length <= inlineWidth) return [label + rightAlign(amount, cols - label.length)];
-  return [label.trimEnd(), ...wrapValue(amount, cols)];
+  const qty = String(item.quantity).padEnd(qtyW);
+
+  if (capabilities?.raster.enabled === true && !isThermalTextRepresentable(productName, capabilities)) {
+    const name = productName.padEnd(nameLen);
+    const label = name + qty;
+    return [label + rightAlign(amount, Math.max(amtLen, cols - label.length))];
+  }
+
+  if (productName.length <= nameLen) {
+    const label = productName.padEnd(nameLen) + qty;
+    return [label + rightAlign(amount, Math.max(amtLen, cols - label.length))];
+  }
+
+  const nameLines = wrapText(productName, nameLen);
+  const firstLineName = (nameLines[0] || '').padEnd(nameLen);
+  const firstRowLabel = firstLineName + qty;
+  const firstRow = firstRowLabel + rightAlign(amount, Math.max(amtLen, cols - firstRowLabel.length));
+
+  const result = [firstRow];
+  for (let i = 1; i < nameLines.length; i++) {
+    result.push(nameLines[i]);
+  }
+  return result;
 }
 
 export function addonRows(addon: any, nameLen: number, amtLen: number, cols: number, prefix: string, locale: string = 'en-US', trimDecimals: boolean = false, language: string = 'en', fractionDigits: number = 2, capabilities?: ThermalPrinterCapabilities): string[] {
   const addonName = normalizeThermalText(addon.name, capabilities);
   const quantity = typeof addon.quantity === 'number' && addon.quantity > 1 ? ` x${addon.quantity}` : '';
-  const label = truncate('  + ' + addonName + quantity, nameLen, language, capabilities).padEnd(nameLen);
-  if (!addon.price) return [label + ' '.repeat(Math.max(0, cols - label.length))];
+  const fullName = '  + ' + addonName + quantity;
+
+  if (!addon.price) {
+    const lines = wrapText(fullName, cols);
+    return lines.map((l) => l + ' '.repeat(Math.max(0, cols - l.length)));
+  }
+
   const price = formatCurrency(addon.price, prefix, locale, trimDecimals, fractionDigits);
-  const inlineWidth = Math.max(1, cols - label.length - 1);
-  if (price.length <= inlineWidth) return [label + rightAlign(price, cols - label.length)];
-  return [label.trimEnd(), ...wrapValue(price, cols)];
+
+  if (capabilities?.raster.enabled === true && !isThermalTextRepresentable(addonName, capabilities)) {
+    const label = fullName.padEnd(nameLen);
+    return [label + rightAlign(price, Math.max(amtLen, cols - label.length))];
+  }
+
+  if (fullName.length <= nameLen) {
+    const label = fullName.padEnd(nameLen);
+    return [label + rightAlign(price, Math.max(amtLen, cols - label.length))];
+  }
+
+  const nameLines = wrapText(fullName, nameLen);
+  const firstLine = (nameLines[0] || '').padEnd(nameLen);
+  const firstRow = firstLine + rightAlign(price, Math.max(amtLen, cols - firstLine.length));
+
+  const result = [firstRow];
+  for (let i = 1; i < nameLines.length; i++) {
+    result.push('    ' + nameLines[i]);
+  }
+  return result;
 }
 
 export function financialRows(label: string, value: string, cols: number, _language: string = 'en', capabilities?: ThermalPrinterCapabilities): string[] {

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -1834,22 +1834,17 @@ export function itemRows(item: any, nameLen: number, amtLen: number, cols: numbe
   const productName = normalizeThermalText(item.product_name, capabilities);
   const amount = formatCurrency(item.total, prefix, locale, trimDecimals, fractionDigits);
   const qty = String(item.quantity).padEnd(qtyW);
+  const maxLine1Name = Math.max(1, nameLen - 1);
 
-  if (capabilities?.raster.enabled === true && !isThermalTextRepresentable(productName, capabilities)) {
-    const name = productName.padEnd(nameLen);
-    const label = name + qty;
-    return [label + rightAlign(amount, Math.max(amtLen, cols - label.length))];
-  }
-
-  if (productName.length <= nameLen) {
+  if (productName.length <= maxLine1Name) {
     const label = productName.padEnd(nameLen) + qty;
-    return [label + rightAlign(amount, Math.max(amtLen, cols - label.length))];
+    return [label + rightAlign(amount, cols - label.length)];
   }
 
-  const nameLines = wrapText(productName, nameLen);
+  const nameLines = wrapText(productName, maxLine1Name);
   const firstLineName = (nameLines[0] || '').padEnd(nameLen);
   const firstRowLabel = firstLineName + qty;
-  const firstRow = firstRowLabel + rightAlign(amount, Math.max(amtLen, cols - firstRowLabel.length));
+  const firstRow = firstRowLabel + rightAlign(amount, cols - firstRowLabel.length);
 
   const result = [firstRow];
   for (let i = 1; i < nameLines.length; i++) {
@@ -1870,19 +1865,14 @@ export function addonRows(addon: any, nameLen: number, amtLen: number, cols: num
 
   const price = formatCurrency(addon.price, prefix, locale, trimDecimals, fractionDigits);
 
-  if (capabilities?.raster.enabled === true && !isThermalTextRepresentable(addonName, capabilities)) {
-    const label = fullName.padEnd(nameLen);
-    return [label + rightAlign(price, Math.max(amtLen, cols - label.length))];
-  }
-
   if (fullName.length <= nameLen) {
     const label = fullName.padEnd(nameLen);
-    return [label + rightAlign(price, Math.max(amtLen, cols - label.length))];
+    return [label + rightAlign(price, cols - label.length)];
   }
 
   const nameLines = wrapText(fullName, nameLen);
   const firstLine = (nameLines[0] || '').padEnd(nameLen);
-  const firstRow = firstLine + rightAlign(price, Math.max(amtLen, cols - firstLine.length));
+  const firstRow = firstLine + rightAlign(price, cols - firstLine.length);
 
   const result = [firstRow];
   for (let i = 1; i < nameLines.length; i++) {
@@ -2334,7 +2324,7 @@ export function buildEscPos(lines: string[], _useUnicode: boolean = false, optio
       printableLine = line.replace(ESC_POS_CONTROL_TOKEN_RE, '');
       if (Number.isInteger(options.columns) && (options.columns as number) > 0) {
         const maxCols = lineDW ? Math.floor((options.columns as number) / 2) : (options.columns as number);
-        line = truncate(printableLine, Math.max(1, maxCols));
+        line = truncate(printableLine, Math.max(1, maxCols), options.language, capabilities);
       }
     }
 

--- a/tests/print-parity.test.ts
+++ b/tests/print-parity.test.ts
@@ -285,7 +285,9 @@ function expectContent(
   }
   warn(text.includes(expectations.businessName), `${label}: business header`);
   if (expectations.truncationMarker) {
-    warn(text.includes(LONG_NAME_STEM) && (text.includes('..') || text.includes('\n')), `${label}: long item truncated with marker or wrapped`);
+    const stemRowIndex = rows.findIndex((r) => r.includes(LONG_NAME_STEM));
+    const isTruncatedOrWrapped = stemRowIndex >= 0 && (rows[stemRowIndex].includes('..') || rows[stemRowIndex + 1]?.length > 0);
+    warn(isTruncatedOrWrapped, `${label}: long item truncated with marker or wrapped`);
   }
   for (const addon of expectations.addons ?? []) {
     const normalizedText = normalizeSemanticContent(text);

--- a/tests/print-parity.test.ts
+++ b/tests/print-parity.test.ts
@@ -285,7 +285,7 @@ function expectContent(
   }
   warn(text.includes(expectations.businessName), `${label}: business header`);
   if (expectations.truncationMarker) {
-    warn(text.includes(LONG_NAME_STEM) && text.includes('..'), `${label}: long item truncated with marker`);
+    warn(text.includes(LONG_NAME_STEM) && (text.includes('..') || text.includes('\n')), `${label}: long item truncated with marker or wrapped`);
   }
   for (const addon of expectations.addons ?? []) {
     const normalizedText = normalizeSemanticContent(text);

--- a/tests/printer.test.ts
+++ b/tests/printer.test.ts
@@ -728,10 +728,10 @@ console.log('\n✅ Test 2: Compact receipt (80mm, 48 cols)');
   assert('renders UPI payment', text.includes('UPI') && text.includes('₹450.00'));
   assert('renders tax registration number', text.includes('TAXID-0001'));
   assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('https://flopos.com'));
-  assert('long product name wraps cleanly onto multiple lines', text.includes('Very Long Product Name That') && text.includes('Truncated By Formatter'));
-  assert('ends with cut byte sequence', bytesContain(buf, [GS, 0x56, 0x00]));
-
   const rowLines = visiblePreview(buf, 48).split('\n');
+  const longRowIndex = rowLines.findIndex((l) => l.includes('Very Long Product Name That'));
+  assert('long product name wraps cleanly onto multiple lines', longRowIndex >= 0 && rowLines[longRowIndex + 1]?.includes('Truncated By Formatter'));
+  assert('ends with cut byte sequence', bytesContain(buf, [GS, 0x56, 0x00]));
   const cheeseLine = rowLines.find((l) => l.startsWith('Cheeseburger') && l.includes('₹540'));
   assert('item row columns are aligned (no smashed qty)', !!cheeseLine && !/Cheeseburger\d/.test(cheeseLine), cheeseLine);
   assert('item row right-edge total lines up at col 48', !!cheeseLine && cheeseLine.length <= 48);

--- a/tests/printer.test.ts
+++ b/tests/printer.test.ts
@@ -728,7 +728,7 @@ console.log('\n✅ Test 2: Compact receipt (80mm, 48 cols)');
   assert('renders UPI payment', text.includes('UPI') && text.includes('₹450.00'));
   assert('renders tax registration number', text.includes('TAXID-0001'));
   assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('https://flopos.com'));
-  assert('long product name is truncated to fit', !text.includes('Truncated By Formatter'));
+  assert('long product name wraps cleanly onto multiple lines', text.includes('Very Long Product Name That') && text.includes('Truncated By Formatter'));
   assert('ends with cut byte sequence', bytesContain(buf, [GS, 0x56, 0x00]));
 
   const rowLines = visiblePreview(buf, 48).split('\n');

--- a/tests/raster-printing.test.ts
+++ b/tests/raster-printing.test.ts
@@ -105,7 +105,7 @@ async function run(): Promise<void> {
   assert.equal(rasterWebUsbPathEnabled(caps, true, undefined), false);
   assert.equal(rasterWebUsbPathEnabled(caps, true, 'validated-profile'), true);
   assert.equal(rasterCapabilityEnabled(GENERIC_THERMAL_CAPABILITIES), false);
-  assert.equal(getSupportedPrinterProfiles().every((profile) => profile.capabilities.raster.enabled === false), true);
+  assert.equal(getSupportedPrinterProfiles().every((profile) => profile.capabilities.raster.enabled === true), true);
   assert.equal(isPrintDocument({
     version: 1,
     direction: { base: 'ltr', document: 'ltr', block: 'ltr', value: 'ltr' },


### PR DESCRIPTION
## Related work

Issue / Discussion: #438 (Epic: multilingual printing architecture & physical hardware validation)

## Summary

- **Multi-line item and add-on wrapping:** Wraps long item names and add-ons across multiple lines rather than truncating them or pushing the quantity and amount off the right edge.
- **Code page preservation during truncation:** Passes active capabilities and language to `truncate()` in `buildEscPos` so native code pages (like CP437 for German umlauts `ä`, `ö`, `ü`) are preserved instead of falling back to ASCII transliteration pairs (`ae`, `oe`, `ue`) which expanded string length and caused amount truncation to `..`.
- **Raster font scaling and column safety:** Increased raster font sizes by ~10% (standard font from 20px -> 22px, font B from 14px -> 16px, line-height from 24 -> 26). Capped measured quantity and amount column widths against canvas limits to prevent cumulative overflow.
- **Printer profiles:** Enabled raster printing capabilities across built-in printer profiles following physical hardware validation.

## Scope

- Additional non-Latin font bundling is out of scope.
- Cash drawer pulse settings and migration are untouched.

## Verification

Commands run:
- `npm run lint`: passed (no errors)
- `npm run build`: passed
- `npm run test:print-parity`: passed (495/495 assertions passed)
- `npm run test:printer`: passed (all unit, API, and IPC printer tests passed)
- `npm run test:raster`: passed (all raster tests and Electron chromium rendering passed)
- `npm test`: passed (full test suite passed)
- Physical hardware validation on EPSON TM-T20II 80mm thermal printer

Results: All automated checks and physical prints clean and aligned.

## Compatibility & data safety

- **Database/data impact:** None.
- **Migration:** None.
- **User-visible behavior:** Long receipt items now wrap to subsequent lines instead of single-line truncation; raster output typography is scaled ~10% larger for improved legibility; native code page characters on thermal receipts no longer transliterate to multi-character ASCII pairs.
- **Offline/network impact:** Core offline receipt printing is preserved; no network dependencies added.

## Screenshots

N/A (Thermal receipt print layout)

## Contributor checklist

- [x] This is a small isolated fix/doc update OR follows an approved issue/direction.
- [x] Unrelated cleanups, refactors, and dependency changes were kept out of this PR.
- [x] Tests were added or updated for any behavior changes.
- [x] Verification commands were run and documented above.
- [x] Customer data and upgrade safety were preserved (if touching database/storage).
- [x] Documentation or translations were updated where relevant.
- [x] I understand and can explain all submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added raster printing support for all supported printer profiles.
  - Long product and add-on names now wrap across multiple lines instead of being truncated.
  - Amounts remain aligned on the first line, with indented continuation lines for add-ons.
  - Improved multi-column receipt layouts to preserve readable content widths.

- **Tests**
  - Updated printing coverage for wrapped text and raster support across printer profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->