### PR TITLE
ci(release): build release-mac on the self-hosted signing runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,7 +472,16 @@ jobs:
             --file "$SNAP_EVIDENCE"
 
   release-mac:
-    runs-on: macos-latest
+    # Self-hosted: the release signing keychain has repeatedly failed to
+    # unlock on GitHub-hosted macos-latest runners with
+    # "SecKeychainUnlock: The user name or passphrase you entered is not
+    # correct" during `security set-key-partition-list`, even against
+    # freshly re-exported, locally-verified-working certs/password (the
+    # exact same `security import` + `set-key-partition-list` sequence
+    # succeeds reliably on the signing Mac itself). Building here sidesteps
+    # whatever host-specific keychain behavior causes that on the hosted
+    # image.
+    runs-on: [self-hosted, macOS]
     needs: create-release
     if: needs.create-release.outputs.promotion_only != 'true'
     # Was two parallel 60-minute matrix jobs (one per arch); now one job builds,


### PR DESCRIPTION
## Summary
- \`release-mac\` in the tag-triggered release workflow now runs on \`[self-hosted, macOS]\` instead of GitHub-hosted \`macos-latest\`.
- GitHub-hosted macos-latest has failed the last two release attempts (3.5.7, 3.7.0) with an identical \`SecKeychainUnlock\` error during \`security set-key-partition-list\`, even against a freshly re-exported and locally-verified-working MAC_CERTS/MAC_CERTS_PASSWORD pair. The exact same command sequence succeeds reliably when run directly on the signing Mac, so this sidesteps the host-specific keychain issue rather than continuing to chase it blind.
- This machine is already the self-hosted runner target for the separate MAS publish workflow, so no new secrets/infrastructure are needed beyond the runner itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS release process to run on a designated macOS build environment.
  * Existing build, signing, notarization, verification, and upload steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->