### PR TITLE
fix(mas): downgrade CFPropertyList to unblock Ruby 3.3 on the MAS publish runner

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
+    CFPropertyList (3.0.8)
     abbrev (0.1.2)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)


### PR DESCRIPTION
## Summary
- The MAS publish workflow's \`bundle install\` failed outright: \`Gemfile.lock\` pinned CFPropertyList 3.0.9, which restricts itself to \`ruby_version < 3.2\`, incompatible with the Ruby 3.3 the workflow requests.
- xcodeproj (pulled in via fastlane) still caps CFPropertyList at \`< 4.0\` as of its latest release (1.28.1), and 4.0.0 is the only CFPropertyList release supporting Ruby >= 3.2 — so bumping up isn't an option yet.
- 3.0.8 has no \`ruby_version\` restriction and satisfies every other constraint in the dependency tree, so it's the correct fix. Verified locally: \`bundle install\` completes cleanly and \`bundle exec fastlane --version\` runs under Ruby 3.3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)