### PR TITLE
chore: release v3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Flo Cafe are documented here. Dates are release dates, not commit dates. Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [3.7.1] - 2026-09-06
+
+### Fixed
+
+- downgrade CFPropertyList to unblock Ruby 3.3 on the MAS publish runner (#662)
+
 ## [3.7.0] - 2026-09-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- Patch release containing only the CFPropertyList/Ruby 3.3 lockfile fix from #662 — no application code changes, functionally identical to 3.7.0.
- Needed because the MAS publish workflow builds strictly from the tagged commit; since 3.7.0 is already published (and this project protects release tags from deletion/force-update), the lockfile fix can only reach a Mac App Store build through a new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 3.7.1 dated September 6, 2026.
  * Documented a publishing compatibility fix for Ruby 3.3 on the Mac App Store runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->