### PR TITLE
fix(mas): resolve Fastfile paths relative to repo root, not fastlane/

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ end
 platform :mac do
   desc "Build and publish the Mac App Store package through App Store Connect"
   lane :publish_mas do
-    version = sh("node -p \"require('#{ROOT}/package.json').version\"", log: false).strip
+    version = Dir.chdir(ROOT) { sh("node -p \"require('./package.json').version\"", log: false) }.strip
     notes_path = File.expand_path(ENV.fetch("MAS_RELEASE_NOTES_PATH", "release/mas-release-notes.txt"), ROOT)
     notes = File.read(notes_path).strip
 
@@ -37,10 +37,12 @@ platform :mac do
       duration: 1200
     )
 
-    sh("cd #{ROOT} && npm run build:mas") unless env_bool("SKIP_MAS_BUILD", false)
+    Dir.chdir(ROOT) { sh("npm run build:mas") } unless env_bool("SKIP_MAS_BUILD", false)
 
-    pkg = Dir["#{ROOT}/release/*.pkg"].max_by { |path| File.mtime(path) }
-    UI.user_error!("No Mac App Store .pkg was produced in release/") if pkg.nil?
+    release_dir = File.join(ROOT, "release")
+    pkg_name = Dir.glob("*.pkg", base: release_dir).max_by { |name| File.mtime(File.join(release_dir, name)) }
+    UI.user_error!("No Mac App Store .pkg was produced in release/") if pkg_name.nil?
+    pkg = File.join(release_dir, pkg_name)
 
     deliver(
       api_key: api_key,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,10 @@
 default_platform(:mac)
 
+# fastlane always runs lanes with the working directory set to this
+# `fastlane/` folder, not the repo root — every path below must be
+# resolved against ROOT explicitly rather than assumed relative.
+ROOT = File.expand_path("..", __dir__)
+
 def env_bool(name, default)
   value = ENV[name]
   return default if value.nil? || value.strip.empty?
@@ -17,8 +22,8 @@ end
 platform :mac do
   desc "Build and publish the Mac App Store package through App Store Connect"
   lane :publish_mas do
-    version = sh("node -p \"require('./package.json').version\"", log: false).strip
-    notes_path = ENV.fetch("MAS_RELEASE_NOTES_PATH", "release/mas-release-notes.txt")
+    version = sh("node -p \"require('#{ROOT}/package.json').version\"", log: false).strip
+    notes_path = File.expand_path(ENV.fetch("MAS_RELEASE_NOTES_PATH", "release/mas-release-notes.txt"), ROOT)
     notes = File.read(notes_path).strip
 
     UI.user_error!("Mac App Store release notes are empty: #{notes_path}") if notes.empty?
@@ -32,9 +37,9 @@ platform :mac do
       duration: 1200
     )
 
-    sh("npm run build:mas") unless env_bool("SKIP_MAS_BUILD", false)
+    sh("cd #{ROOT} && npm run build:mas") unless env_bool("SKIP_MAS_BUILD", false)
 
-    pkg = Dir["release/*.pkg"].max_by { |path| File.mtime(path) }
+    pkg = Dir["#{ROOT}/release/*.pkg"].max_by { |path| File.mtime(path) }
     UI.user_error!("No Mac App Store .pkg was produced in release/") if pkg.nil?
 
     deliver(


### PR DESCRIPTION
## Summary
- \`publish_mas\` failed immediately on its very first line (\`Cannot find module './package.json'\`) because fastlane always runs lanes with CWD set to the \`fastlane/\` folder, not the repo root — every relative path in the lane (version fetch, release-notes path, \`npm run build:mas\`, the \`release/*.pkg\` glob) was resolving one level too deep.
- This appears to have never been caught before because Mac App Store publishing had no self-hosted runner registered until today — the lane had never actually been exercised end-to-end.
- Introduces \`ROOT = File.expand_path("..", __dir__)\` and resolves every path against it explicitly, rather than assuming the working directory.
- Verified locally: the version fetch, release-notes read, and \`.pkg\` glob directory all resolve correctly when run from inside \`fastlane/\`, matching the real runtime context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation reliability when run from different working directories.
  * Ensured version lookup, release-note loading, builds, and package discovery consistently use repository-based paths.
  * Reduced the risk of release tasks targeting incorrect files or directories during packaging and distribution.
  * Release outputs are now selected more consistently regardless of the location from which the process is started.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->