### PR TITLE
fix(release): preserve GitHub Latest during publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -944,7 +944,7 @@ jobs:
           gh api --method PATCH "repos/${{ github.repository }}/releases/${RELEASE_ID}" \
             -F draft=false \
             -F prerelease="${PRERELEASE}" \
-            -F make_latest=false
+            -f make_latest=false
           node scripts/release-gate/published-readiness.cjs \
             --repo "${{ github.repository }}" \
             --tag "$VERSION" \
@@ -1012,7 +1012,7 @@ jobs:
             exit 1
           fi
           RELEASE_ID=$(jq -r '.id' <<<"$RELEASE_JSON")
-          gh api --method PATCH "repos/${{ github.repository }}/releases/${RELEASE_ID}" -F make_latest=true
+          gh api --method PATCH "repos/${{ github.repository }}/releases/${RELEASE_ID}" -f make_latest=true
           echo "Promoted ${RELEASE_TAG} to GitHub Latest"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -626,7 +626,12 @@ exit 1
     fakeCommands: { gh: fakeGh },
   });
   assert.equal(publishStable.status, 0, publishStable.stderr);
-  assert.match(publishStable.log, /-F draft=false -F prerelease=false -F make_latest=false/);
+  assert.match(publishStable.log, /-F draft=false -F prerelease=false -f make_latest=false/);
+  assert.doesNotMatch(
+    publishStable.log,
+    /-F make_latest=false/,
+    'GitHub make_latest is a string enum and must not be encoded as a JSON boolean',
+  );
   assert.doesNotMatch(publishStable.log, /make_latest=true/);
 
   const publishBeta = executeWorkflowStep(publishStep, {
@@ -642,7 +647,12 @@ exit 1
     fakeCommands: { gh: fakeGh },
   });
   assert.equal(publishBeta.status, 0, publishBeta.stderr);
-  assert.match(publishBeta.log, /-F draft=false -F prerelease=true -F make_latest=false/);
+  assert.match(publishBeta.log, /-F draft=false -F prerelease=true -f make_latest=false/);
+  assert.doesNotMatch(
+    publishBeta.log,
+    /-F make_latest=false/,
+    'GitHub make_latest is a string enum and must not be encoded as a JSON boolean',
+  );
   assert.doesNotMatch(publishBeta.log, /make_latest=true/);
 
   const promoteStep = findStep(promoteJob, 'Promote published stable release to GitHub Latest');
@@ -656,7 +666,12 @@ exit 1
     fakeCommands: { gh: fakeGh, jq: fakeJq },
   });
   assert.equal(promoteStable.status, 0, promoteStable.stderr);
-  assert.match(promoteStable.log, /-F make_latest=true/);
+  assert.match(promoteStable.log, /-f make_latest=true/);
+  assert.doesNotMatch(
+    promoteStable.log,
+    /-F make_latest=true/,
+    'GitHub make_latest is a string enum and must not be encoded as a JSON boolean',
+  );
 
   const promoteBeta = executeWorkflowStep(promoteStep, {
     env: { RELEASE_TAG: '3.3.1-beta.1', RELEASE_CHANNEL: 'beta' },


### PR DESCRIPTION
## Related work

Issue / Discussion: None (trivial fix identified from the 3.7.0-3.7.2 release failures)

## Summary

Send the GitHub Releases make_latest field as the required string enum rather than a typed JSON boolean. This prevents ordinary stable publication from unexpectedly moving GitHub Latest and prevents the post-publication readiness guard from marking otherwise successful cross-platform releases as failed. The explicit promotion path uses the same corrected encoding.

## Scope

Only the GitHub release publication and promotion API argument encoding plus its focused regression assertions are changed. Platform builds, signing, notarization, App Store submission, and release policy are unchanged.

## Verification

Commands run:
- npm run test:release-config
- npm run lint
- git diff --check

Results:
- Release configuration, Electron runtime classification, asset verification, and release-gate simulations passed.
- Lint completed with zero errors; existing repository warnings remain.
- Diff whitespace validation passed.

## Compatibility & data safety

- **Database/data impact:** None
- **Migration:** None
- **User-visible behavior:** Successful release builds no longer appear failed solely because GitHub moved the Latest pointer unexpectedly.
- **Offline/network impact:** None at runtime; this only changes a GitHub API request in release automation.

## Screenshots

Not applicable; CI-only change.

## Contributor checklist

- [x] This is a small isolated fix/doc update OR follows an approved issue/direction.
- [x] Unrelated cleanups, refactors, and dependency changes were kept out of this PR.
- [x] Tests were added or updated for any behavior changes.
- [x] Verification commands were run and documented above.
- [x] Customer data and upgrade safety were preserved (if touching database/storage).
- [x] Documentation or translations were updated where relevant.
- [x] I understand and can explain all submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected release publishing and stable promotion requests to send the “latest release” setting in the format expected by GitHub.
  * Updated validation to ensure release workflows use the correct request format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->