### PR TITLE
feat(tables): rename and delete floors

### DIFF
--- a/frontend/src/components/tables/FloorplanEditor.tsx
+++ b/frontend/src/components/tables/FloorplanEditor.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import api from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import toast from 'react-hot-toast';
-import { ChevronRight, Eye, LayoutGrid, Maximize2, Minimize2, Pencil, Plus, Sparkles, Table2, Trash2, Users } from 'lucide-react';
+import { ChevronRight, Eye, LayoutGrid, Maximize2, Minimize2, MoreHorizontal, Pencil, Plus, Sparkles, Table2, Trash2, Users } from 'lucide-react';
 import type { Order, Table } from '@/lib/types';
 import { useTranslations } from 'use-intl';
 import { TABLE_STATUS_LABEL_KEYS } from '@/lib/i18n';
@@ -202,6 +202,12 @@ export default function FloorplanEditor({ mode, canManage = false, tables, order
   const [floorForm, setFloorForm] = useState({ name: '', tableName: '', capacity: '4' });
   const [floorFormSaving, setFloorFormSaving] = useState(false);
   const [actionTable, setActionTable] = useState<Table | null>(null);
+  // Floor management state — Issue #646.
+  const [floorMenuFor, setFloorMenuFor] = useState<string | null>(null);
+  const [floorRenameOpen, setFloorRenameOpen] = useState<{ from: string; to: string } | null>(null);
+  const [floorDeleteTarget, setFloorDeleteTarget] = useState<string | null>(null);
+  const [floorActionSaving, setFloorActionSaving] = useState(false);
+  const floorMenuRef = useRef<HTMLDivElement>(null);
 
   // Drop stale action-sheet selection when entering edit mode
   // so it does not pop up when returning to service mode.
@@ -224,10 +230,25 @@ export default function FloorplanEditor({ mode, canManage = false, tables, order
       setFormOpen(false);
       setEditingId(null);
       setFloorFormOpen(false);
+      setFloorMenuFor(null);
+      setFloorRenameOpen(null);
+      setFloorDeleteTarget(null);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, []);
+
+  // Close the per-floor action menu on outside click.
+  useEffect(() => {
+    if (!floorMenuFor) return;
+    const onDocPointer = (e: PointerEvent) => {
+      const node = floorMenuRef.current;
+      if (node && e.target instanceof Node && node.contains(e.target)) return;
+      setFloorMenuFor(null);
+    };
+    window.addEventListener('pointerdown', onDocPointer);
+    return () => window.removeEventListener('pointerdown', onDocPointer);
+  }, [floorMenuFor]);
 
   // Render-time prop adjustment: drop converged or deleted-table overrides.
   const [syncedTables, setSyncedTables] = useState(tables);
@@ -560,6 +581,51 @@ export default function FloorplanEditor({ mode, canManage = false, tables, order
     }
   };
 
+  // Rename a floor; backend merges into an existing target if the name collides.
+  const submitFloorRename = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!floorRenameOpen) return;
+    const target = floorRenameOpen.to.trim();
+    if (!target || target === floorRenameOpen.from) {
+      setFloorRenameOpen(null);
+      return;
+    }
+    setFloorActionSaving(true);
+    try {
+      const { from } = floorRenameOpen;
+      await api.patch(`/tables/floors/${encodeURIComponent(from)}`, { newName: target });
+      toast.success(t('floorRenamed'), { position: 'top-center' });
+      setFloorRenameOpen(null);
+      setActiveFloor(target);
+      onSaved?.();
+    } catch {
+      toast.error(t('floorRenameFailed'), { position: 'top-center' });
+    } finally {
+      setFloorActionSaving(false);
+    }
+  };
+
+  // Remove a floor; tables stay, just fall back into the Unassigned bucket.
+  const submitFloorDelete = async () => {
+    if (!floorDeleteTarget) return;
+    setFloorActionSaving(true);
+    try {
+      await api.delete(`/tables/floors/${encodeURIComponent(floorDeleteTarget)}`);
+      toast.success(t('floorDeleted'), { position: 'top-center' });
+      const target = floorDeleteTarget;
+      setFloorDeleteTarget(null);
+      setActiveFloor((cur) => (cur === target ? '' : cur));
+      onSaved?.();
+    } catch {
+      toast.error(t('floorDeleteFailed'), { position: 'top-center' });
+    } finally {
+      setFloorActionSaving(false);
+    }
+  };
+
+  const tablesOnFloor = (floorName: string): number =>
+    tables.filter((tb) => (tb.floor || '') === floorName).length;
+
   const seats = (capacity: number) => (
     <span className="flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
       <Users size={10} className="text-muted-foreground" />
@@ -709,24 +775,86 @@ export default function FloorplanEditor({ mode, canManage = false, tables, order
           {floors.map((f) => {
             const count = floorCounts.get(f) ?? 0;
             const label = f || t('floorplanUnassigned');
+            // Hide the menu trigger on the implicit Unassigned bucket.
+            const isUnassigned = f === '';
+            const menuOpen = floorMenuFor === f;
             return (
-              <button
+              <div
                 key={f || 'unassigned'}
-                onClick={() => setActiveFloor(f)}
-                className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-all ${
-                  !overview && f === floor ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+                ref={menuOpen ? floorMenuRef : undefined}
+                className={`relative flex items-center gap-0.5 rounded-lg ${
+                  !overview && f === floor ? 'bg-card shadow-sm' : ''
                 }`}
-                title={f === '' ? t('floorplanUnassignedHint') : undefined}
               >
-                {label}
-                {count > 0 && (
-                  <span className={`rounded-full px-1.5 text-[10px] font-semibold ${
-                    !overview && f === floor ? 'bg-muted text-foreground' : 'bg-card/70 text-muted-foreground'
-                  }`}>
-                    {count}
-                  </span>
+                <button
+                  onClick={() => setActiveFloor(f)}
+                  className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-all ${
+                    !overview && f === floor ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                  title={f === '' ? t('floorplanUnassignedHint') : undefined}
+                >
+                  {label}
+                  {count > 0 && (
+                    <span className={`rounded-full px-1.5 text-[10px] font-semibold ${
+                      !overview && f === floor ? 'bg-muted text-foreground' : 'bg-card/70 text-muted-foreground'
+                    }`}>
+                      {count}
+                    </span>
+                  )}
+                </button>
+                {edit && !isUnassigned && (
+                  <>
+                    <button
+                      type="button"
+                      data-testid={`floorplan-menu-${f}`}
+                      aria-label={t('floorActions')}
+                      aria-haspopup="menu"
+                      aria-expanded={menuOpen}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setFloorMenuFor((cur) => (cur === f ? null : f));
+                      }}
+                      className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+                        menuOpen
+                          ? 'bg-muted text-foreground'
+                          : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      }`}
+                    >
+                      <MoreHorizontal size={14} />
+                    </button>
+                    {menuOpen && (
+                      <div
+                        role="menu"
+                        data-testid={`floorplan-menu-panel-${f}`}
+                        className="absolute end-0 top-full z-30 mt-1 min-w-[160px] rounded-xl border border-border bg-card p-1 shadow-lg"
+                      >
+                        <button
+                          type="button"
+                          role="menuitem"
+                          onClick={() => {
+                            setFloorMenuFor(null);
+                            setFloorRenameOpen({ from: f, to: f });
+                          }}
+                          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-start text-sm text-foreground hover:bg-muted"
+                        >
+                          <Pencil size={14} /> {t('renameFloor')}
+                        </button>
+                        <button
+                          type="button"
+                          role="menuitem"
+                          onClick={() => {
+                            setFloorMenuFor(null);
+                            setFloorDeleteTarget(f);
+                          }}
+                          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-start text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40"
+                        >
+                          <Trash2 size={14} /> {t('deleteFloor')}
+                        </button>
+                      </div>
+                    )}
+                  </>
                 )}
-              </button>
+              </div>
             );
           })}
           {canManage && (
@@ -1214,6 +1342,73 @@ export default function FloorplanEditor({ mode, canManage = false, tables, order
                 </Button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {floorRenameOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={() => setFloorRenameOpen(null)}>
+          <div className="bg-card text-foreground rounded-2xl p-6 w-full max-w-sm shadow-2xl" onClick={(e) => e.stopPropagation()} data-testid="floorplan-floor-rename-form" role="dialog" aria-modal="true">
+            <h2 className="text-lg font-bold mb-1">{t('renameFloorTitle', { name: floorRenameOpen.from })}</h2>
+            <p className="text-xs text-muted-foreground mb-4">{t('renameFloorHint')}</p>
+            <form onSubmit={submitFloorRename} className="space-y-4">
+              <div>
+                <label htmlFor="floorplan-rename-name" className="block text-sm font-medium text-foreground mb-1">
+                  {t('floorName')}
+                </label>
+                <input
+                  id="floorplan-rename-name"
+                  type="text"
+                  value={floorRenameOpen.to}
+                  onChange={(e) => setFloorRenameOpen({ from: floorRenameOpen!.from, to: e.target.value })}
+                  className="w-full px-3 py-2 border border-border bg-card rounded-lg outline-none focus:ring-2 focus:ring-brand"
+                  autoFocus
+                  required
+                />
+              </div>
+              {floorRenameOpen.to.trim() && floorRenameOpen.to.trim() !== floorRenameOpen.from && namedFloors.includes(floorRenameOpen.to.trim()) && (
+                <div className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                  {t('renameFloorMergeHint', { target: floorRenameOpen.to.trim() })}
+                </div>
+              )}
+              <div className="flex gap-2 pt-1">
+                <Button type="button" variant="outline" className="flex-1" onClick={() => setFloorRenameOpen(null)} disabled={floorActionSaving}>
+                  {tCommon('cancel')}
+                </Button>
+                <Button
+                  type="submit"
+                  className="flex-1"
+                  disabled={floorActionSaving || !floorRenameOpen.to.trim() || floorRenameOpen.to.trim() === floorRenameOpen.from}
+                >
+                  {floorActionSaving ? tCommon('saving') : t('renameFloorConfirm')}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {floorDeleteTarget && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={() => setFloorDeleteTarget(null)}>
+          <div className="bg-card text-foreground rounded-2xl p-6 w-full max-w-sm shadow-2xl" onClick={(e) => e.stopPropagation()} data-testid="floorplan-floor-delete-form" role="dialog" aria-modal="true">
+            <h2 className="text-lg font-bold mb-1">{t('deleteFloorTitle', { name: floorDeleteTarget })}</h2>
+            <p className="text-xs text-muted-foreground mb-4">
+              {t('deleteFloorHint', { count: tablesOnFloor(floorDeleteTarget) })}
+            </p>
+            <div className="flex gap-2 pt-1">
+              <Button type="button" variant="outline" className="flex-1" onClick={() => setFloorDeleteTarget(null)} disabled={floorActionSaving}>
+                {tCommon('cancel')}
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                className="flex-1"
+                onClick={submitFloorDelete}
+                disabled={floorActionSaving}
+              >
+                {floorActionSaving ? tCommon('saving') : t('deleteFloorConfirm')}
+              </Button>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/lib/i18n/messages/de.json
+++ b/frontend/src/lib/i18n/messages/de.json
@@ -2085,7 +2085,21 @@
     "floorplanViewPlan": "Grundriss",
     "floorplanViewList": "Liste",
     "editLayout": "Layout bearbeiten",
-    "backToPlan": "Zurück zum Grundriss"
+    "backToPlan": "Zurück zum Grundriss",
+    "floorActions": "Etagenaktionen",
+    "renameFloor": "Etage umbenennen",
+    "deleteFloor": "Etage löschen",
+    "renameFloorTitle": "Etage {name} umbenennen",
+    "renameFloorConfirm": "Etage umbenennen",
+    "renameFloorMergeHint": "Eine Etage mit dem Namen {target} existiert bereits. Die Tische beider Etagen werden zusammengeführt.",
+    "renameFloorHint": "Die Tische bleiben an ihrem Platz. Umbenennen in eine bestehende Etage führt sie zusammen.",
+    "deleteFloorTitle": "Etage {name} löschen?",
+    "deleteFloorHint": "{count, plural, one {# Tisch} other {# Tische}} auf dieser Etage werden auf \"Nicht zugewiesen\" verschoben. Die Tische selbst bleiben erhalten.",
+    "deleteFloorConfirm": "Etage löschen",
+    "floorRenamed": "Etage umbenannt",
+    "floorRenameFailed": "Etage konnte nicht umbenannt werden",
+    "floorDeleted": "Etage gelöscht",
+    "floorDeleteFailed": "Etage konnte nicht gelöscht werden"
   },
   "tax": {
     "actionActivate": "Steuerpaket aktiviert",

--- a/frontend/src/lib/i18n/messages/en.json
+++ b/frontend/src/lib/i18n/messages/en.json
@@ -2085,7 +2085,21 @@
     "floorplanViewPlan": "Floor plan",
     "floorplanViewList": "List",
     "editLayout": "Edit layout",
-    "backToPlan": "Back to floor plan"
+    "backToPlan": "Back to floor plan",
+    "floorActions": "Floor actions",
+    "renameFloor": "Rename floor",
+    "deleteFloor": "Delete floor",
+    "renameFloorTitle": "Rename floor {name}",
+    "renameFloorConfirm": "Rename floor",
+    "renameFloorMergeHint": "A floor named {target} already exists. Tables on both floors will be merged.",
+    "renameFloorHint": "Tables stay in place. Renaming to an existing floor merges them.",
+    "deleteFloorTitle": "Delete floor {name}?",
+    "deleteFloorHint": "{count, plural, one {# table} other {# tables}} on this floor will move to Unassigned. The tables themselves stay.",
+    "deleteFloorConfirm": "Delete floor",
+    "floorRenamed": "Floor renamed",
+    "floorRenameFailed": "Failed to rename floor",
+    "floorDeleted": "Floor deleted",
+    "floorDeleteFailed": "Failed to delete floor"
   },
   "tax": {
     "actionActivate": "Pack activated",

--- a/frontend/src/lib/i18n/messages/es.json
+++ b/frontend/src/lib/i18n/messages/es.json
@@ -2085,7 +2085,21 @@
     "floorplanViewPlan": "Plano",
     "floorplanViewList": "Lista",
     "editLayout": "Editar distribución",
-    "backToPlan": "Volver al plano"
+    "backToPlan": "Volver al plano",
+    "floorActions": "Acciones del piso",
+    "renameFloor": "Renombrar piso",
+    "deleteFloor": "Eliminar piso",
+    "renameFloorTitle": "Renombrar piso {name}",
+    "renameFloorConfirm": "Renombrar piso",
+    "renameFloorMergeHint": "Ya existe un piso llamado {target}. Las mesas de ambos pisos se combinarán.",
+    "renameFloorHint": "Las mesas quedan en su lugar. Renombrar a un piso existente las fusiona.",
+    "deleteFloorTitle": "¿Eliminar piso {name}?",
+    "deleteFloorHint": "{count, plural, one {# mesa} other {# mesas}} de este piso se moverán a Sin asignar. Las mesas en sí se conservan.",
+    "deleteFloorConfirm": "Eliminar piso",
+    "floorRenamed": "Piso renombrado",
+    "floorRenameFailed": "No se pudo renombrar el piso",
+    "floorDeleted": "Piso eliminado",
+    "floorDeleteFailed": "No se pudo eliminar el piso"
   },
   "tax": {
     "actionActivate": "Paquete activado",

--- a/frontend/src/lib/i18n/messages/fa.json
+++ b/frontend/src/lib/i18n/messages/fa.json
@@ -2085,7 +2085,21 @@
     "floorplanViewPlan": "نقشه سالن",
     "floorplanViewList": "فهرست",
     "editLayout": "ویرایش چیدمان",
-    "backToPlan": "بازگشت به نقشه سالن"
+    "backToPlan": "بازگشت به نقشه سالن",
+    "floorActions": "عملیات طبقه",
+    "renameFloor": "تغییر نام طبقه",
+    "deleteFloor": "حذف طبقه",
+    "renameFloorTitle": "تغییر نام طبقهٔ {name}",
+    "renameFloorConfirm": "تغییر نام طبقه",
+    "renameFloorMergeHint": "طبقه‌ای با نام {target} از قبل وجود دارد. میزهای هر دو طبقه ادغام می‌شوند.",
+    "renameFloorHint": "میزها در جای خود می‌مانند. تغییر نام به یک طبقهٔ موجود باعث ادغام می‌شود.",
+    "deleteFloorTitle": "حذف طبقهٔ {name}؟",
+    "deleteFloorHint": "{count, plural, one {# میز} other {# میز}} از این طبقه به دستهٔ بدون طبقه منتقل می‌شوند. خود میزها باقی می‌مانند.",
+    "deleteFloorConfirm": "حذف طبقه",
+    "floorRenamed": "نام طبقه تغییر کرد",
+    "floorRenameFailed": "تغییر نام طبقه ناموفق بود",
+    "floorDeleted": "طبقه حذف شد",
+    "floorDeleteFailed": "حذف طبقه ناموفق بود"
   },
   "tax": {
     "actionActivate": "بسته فعال شد",

--- a/frontend/src/lib/i18n/messages/fil.json
+++ b/frontend/src/lib/i18n/messages/fil.json
@@ -2085,7 +2085,21 @@
     "floorplanViewPlan": "Plano ng palapag",
     "floorplanViewList": "Listahan",
     "editLayout": "I-edit ang layout",
-    "backToPlan": "Bumalik sa plano"
+    "backToPlan": "Bumalik sa plano",
+    "floorActions": "Mga aksyon sa palapag",
+    "renameFloor": "Palitan ang pangalan ng palapag",
+    "deleteFloor": "Tanggalin ang palapag",
+    "renameFloorTitle": "Palitan ang pangalan ng palapag na {name}",
+    "renameFloorConfirm": "Palitan ang pangalan",
+    "renameFloorMergeHint": "May umiiral nang palapag na {target}. Pagsasamahin ang mga mesa mula sa parehong palapag.",
+    "renameFloorHint": "Mananatili ang mga mesa sa kanilang lugar. Ang pagpapalit ng pangalan sa umiiral na palapag ay nagsasanhi ng pagsasama.",
+    "deleteFloorTitle": "Tanggalin ang palapag na {name}?",
+    "deleteFloorHint": "{count, plural, one {# mesa} other {# mesa}} sa palapag na ito ay ililipat sa Hindi nakatala. Ang mga mesa mismo ay mananatili.",
+    "deleteFloorConfirm": "Tanggalin ang palapag",
+    "floorRenamed": "Pinalitan ang pangalan ng palapag",
+    "floorRenameFailed": "Hindi pinalitan ang pangalan ng palapag",
+    "floorDeleted": "Tinanggal ang palapag",
+    "floorDeleteFailed": "Hindi tinanggal ang palapag"
   },
   "tax": {
     "actionActivate": "Na-activate ang pack",

--- a/frontend/src/lib/i18n/messages/fr.json
+++ b/frontend/src/lib/i18n/messages/fr.json
@@ -2085,7 +2085,21 @@
     "floorplanViewPlan": "Plan",
     "floorplanViewList": "Liste",
     "editLayout": "Modifier la disposition",
-    "backToPlan": "Retour au plan"
+    "backToPlan": "Retour au plan",
+    "floorActions": "Actions de l'étage",
+    "renameFloor": "Renommer l'étage",
+    "deleteFloor": "Supprimer l'étage",
+    "renameFloorTitle": "Renommer l'étage {name}",
+    "renameFloorConfirm": "Renommer l'étage",
+    "renameFloorMergeHint": "Un étage nommé {target} existe déjà. Les tables des deux étages seront fusionnées.",
+    "renameFloorHint": "Les tables restent en place. Renommer vers un étage existant les fusionne.",
+    "deleteFloorTitle": "Supprimer l'étage {name} ?",
+    "deleteFloorHint": "{count, plural, one {# table} other {# tables}} de cet étage seront déplacées vers Non attribuées. Les tables elles-mêmes sont conservées.",
+    "deleteFloorConfirm": "Supprimer l'étage",
+    "floorRenamed": "Étage renommé",
+    "floorRenameFailed": "Impossible de renommer l'étage",
+    "floorDeleted": "Étage supprimé",
+    "floorDeleteFailed": "Impossible de supprimer l'étage"
   },
   "tax": {
     "actionActivate": "Module activé",

--- a/frontend/src/lib/i18n/messages/pt.json
+++ b/frontend/src/lib/i18n/messages/pt.json
@@ -2085,7 +2085,21 @@
     "floorplanViewPlan": "Planta",
     "floorplanViewList": "Lista",
     "editLayout": "Editar layout",
-    "backToPlan": "Voltar à planta"
+    "backToPlan": "Voltar à planta",
+    "floorActions": "Ações do andar",
+    "renameFloor": "Renomear andar",
+    "deleteFloor": "Excluir andar",
+    "renameFloorTitle": "Renomear andar {name}",
+    "renameFloorConfirm": "Renomear andar",
+    "renameFloorMergeHint": "Já existe um andar chamado {target}. As mesas de ambos os andares serão mescladas.",
+    "renameFloorHint": "As mesas permanecem onde estão. Renomear para um andar existente as mescla.",
+    "deleteFloorTitle": "Excluir andar {name}?",
+    "deleteFloorHint": "{count, plural, one {# mesa} other {# mesas}} deste andar serão movidas para Sem andar. As mesas em si são mantidas.",
+    "deleteFloorConfirm": "Excluir andar",
+    "floorRenamed": "Andar renomeado",
+    "floorRenameFailed": "Falha ao renomear o andar",
+    "floorDeleted": "Andar excluído",
+    "floorDeleteFailed": "Falha ao excluir o andar"
   },
   "tax": {
     "actionActivate": "Pacote ativado",

--- a/frontend/src/lib/i18n/messages/tr.json
+++ b/frontend/src/lib/i18n/messages/tr.json
@@ -2085,7 +2085,21 @@
     "floorplanViewPlan": "Yerleşim planı",
     "floorplanViewList": "Liste",
     "editLayout": "Düzeni düzenle",
-    "backToPlan": "Plana dön"
+    "backToPlan": "Plana dön",
+    "floorActions": "Kat işlemleri",
+    "renameFloor": "Katı yeniden adlandır",
+    "deleteFloor": "Katı sil",
+    "renameFloorTitle": "{name} katını yeniden adlandır",
+    "renameFloorConfirm": "Katı yeniden adlandır",
+    "renameFloorMergeHint": "{target} adında bir kat zaten var. Her iki kattaki masalar birleştirilecek.",
+    "renameFloorHint": "Masalar yerinde kalır. Var olan bir kata yeniden adlandırmak masaları birleştirir.",
+    "deleteFloorTitle": "{name} katı silinsin mi?",
+    "deleteFloorHint": "Bu kattaki {count, plural, one {# masa} other {# masa}} Atanmamış'a taşınacak. Masaların kendisi kalır.",
+    "deleteFloorConfirm": "Katı sil",
+    "floorRenamed": "Kat yeniden adlandırıldı",
+    "floorRenameFailed": "Kat yeniden adlandırılamadı",
+    "floorDeleted": "Kat silindi",
+    "floorDeleteFailed": "Kat silinemedi"
   },
   "tax": {
     "actionActivate": "Vergi paketi etkinleştirildi",

--- a/main/routes/tables.ts
+++ b/main/routes/tables.ts
@@ -114,6 +114,57 @@ router.get('/:id', (req: Request, res: Response) => {
   }
 });
 
+// Rename a floor across every table. Renaming to an existing floor name merges
+// every row from `:name` into the target in one UPDATE. Issue #646.
+router.patch('/floors/:name', requireRole(...ROLE_ACCESS.ownerManager), (req: Request, res: Response) => {
+  try {
+    const oldName = String(req.params.name || '');
+    if (!oldName) {
+      return res.status(400).json({ code: 'FLOOR_NAME_REQUIRED', error: 'Floor name is required' });
+    }
+    const newName = normalizeOptionalTableLabel(req.body?.newName);
+    if (newName === undefined || newName === null || !newName) {
+      return res.status(400).json({ code: 'FLOOR_NAME_REQUIRED', error: 'Floor name is required' });
+    }
+    if (newName === oldName) {
+      return res.json({ floor: newName, affected: 0 });
+    }
+
+    const db = getDatabase();
+    const result = db.prepare(`
+      UPDATE tables SET floor = ?, updated_at = ?
+      WHERE floor = ?
+    `).run(newName, now(), oldName);
+
+    res.json({ floor: newName, previousFloor: oldName, affected: result.changes });
+  } catch (error: any) {
+    console.error('[API] Floor rename failed:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Remove a floor label from every table that uses it; tables stay and fall
+// back into the Unassigned bucket. Issue #646.
+router.delete('/floors/:name', requireRole(...ROLE_ACCESS.ownerManager), (req: Request, res: Response) => {
+  try {
+    const name = String(req.params.name || '');
+    if (!name) {
+      return res.status(400).json({ code: 'FLOOR_NAME_REQUIRED', error: 'Floor name is required' });
+    }
+
+    const db = getDatabase();
+    const result = db.prepare(`
+      UPDATE tables SET floor = NULL, updated_at = ?
+      WHERE floor = ?
+    `).run(now(), name);
+
+    res.json({ floor: null, removedFloor: name, affected: result.changes });
+  } catch (error: any) {
+    console.error('[API] Floor delete failed:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 router.post('/', requireRole(...ROLE_ACCESS.ownerManager), (req: Request, res: Response) => {
   try {
     // Accept `number` (schema column) or `name` (legacy frontend field)

--- a/tests/issue-646-floor-management.test.ts
+++ b/tests/issue-646-floor-management.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Integration Test: Floor management (Issue #646)
+ *
+ * Tests that:
+ * A) PATCH /api/tables/floors/:name renames every table on that floor
+ * B) PATCH to an existing floor merges the source into the target in one UPDATE
+ * C) DELETE /api/tables/floors/:name moves all tables on that floor to NULL
+ *    (the Unassigned bucket) — tables themselves are preserved
+ * D) Both endpoints reject empty / missing new names with 400
+ * E) Both endpoints require owner/manager role (cashier is denied)
+ * F) URL-encoded floor names (with %20, etc.) work end-to-end
+ *
+ * Regression test for Issue #646: edit/manage floors in table settings.
+ *
+ * Usage: node tests/run-electron-node-test.cjs tests/issue-646-floor-management.test.ts
+ */
+
+// ── Electron Mock ────────────────────────────────────────────────────────────
+const Module = require('module');
+const originalLoad = Module._load;
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-floors-'));
+Module._load = function (request: string, parent: unknown, isMain: boolean) {
+  if (request === 'electron') return { app: { isPackaged: true, getPath: () => testDir, getVersion: () => 'test' } };
+  return originalLoad.apply(this, arguments as any);
+};
+
+const {
+  initTestDb, createApp, startServer,
+  seedOwnerUser, seedManagerUser,
+  api, assert, assertEqual, assertGreaterThan,
+  closeDatabase, getDatabase, now,
+} = require('./helpers/test-setup');
+
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { getJWTSecret } = require('../main/routes/auth');
+const { tableRoutes } = require('../main/routes/tables');
+
+async function main() {
+  console.log('Integration Test: Floor management (Issue #646)');
+  console.log('='.repeat(50));
+
+  const db = initTestDb();
+  const { authHeader: ownerAuth } = seedOwnerUser(db);
+  const { authHeader: managerAuth } = seedManagerUser(db);
+
+  // Inline cashier seed — no test-setup helper exists for it, and we only need it
+  // to assert that the owner/manager-only floor endpoints reject the cashier role.
+  const cashierId = 'cash-test-001';
+  const cashierHash = bcrypt.hashSync('testpass123', 10);
+  db.prepare(
+    `INSERT INTO users (id, name, email, password, role, pin_hash, is_active, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(cashierId, 'Test Cashier', 'cashier@test.local', cashierHash, 'cashier', null, 1, now(), now());
+  const cashierToken = jwt.sign(
+    { userId: cashierId, email: 'cashier@test.local', role: 'cashier' },
+    getJWTSecret(),
+    { expiresIn: '1h' },
+  );
+  const cashierAuth = { Authorization: `Bearer ${cashierToken}` };
+
+  const app = createApp({
+    '/api/tables': tableRoutes,
+  });
+  const { baseUrl, server } = await startServer(app);
+
+  try {
+    // ═══════════════════════════════════════════════════════════════════
+    // Seed: three tables on "Ground", two on "First", one unassigned.
+    // ═══════════════════════════════════════════════════════════════════
+    console.log('\n─── Seed: tables across multiple floors ───');
+
+    const seedRows: Array<[string, string, string | null]> = [
+      ['tbl-g-1', 'G1', 'Ground'],
+      ['tbl-g-2', 'G2', 'Ground'],
+      ['tbl-g-3', 'G3', 'Ground'],
+      ['tbl-f-1', 'F1', 'First'],
+      ['tbl-f-2', 'F2', 'First'],
+      ['tbl-u-1', 'U1', null],
+    ];
+    const insert = db.prepare(
+      `INSERT INTO tables (id, number, capacity, floor, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+    for (const [id, number, floor] of seedRows) {
+      insert.run(id, number, 4, floor, now(), now());
+    }
+    console.log(`   ✓ Seeded ${seedRows.length} tables across three buckets`);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Scenario A: Rename floor "Ground" → "Main"
+    // ═══════════════════════════════════════════════════════════════════
+    console.log('\n─── Scenario A: PATCH /api/tables/floors/Ground renames every row ───');
+
+    const renameRes = await api(baseUrl, '/api/tables/floors/Ground', {
+      method: 'PATCH',
+      headers: ownerAuth,
+      body: JSON.stringify({ newName: 'Main' }),
+    });
+
+    assertEqual(renameRes.status, 200, 'PATCH /floors/Ground returns 200');
+    assertEqual(renameRes.data.floor, 'Main', 'Response echoes new floor name');
+    assertEqual(renameRes.data.previousFloor, 'Ground', 'Response echoes previous name');
+    assertEqual(renameRes.data.affected, 3, 'affected count equals tables on Ground');
+
+    const afterRename = db.prepare(
+      `SELECT id, floor FROM tables WHERE id IN ('tbl-g-1', 'tbl-g-2', 'tbl-g-3', 'tbl-f-1', 'tbl-f-2', 'tbl-u-1') ORDER BY id`,
+    ).all() as Array<{ id: string; floor: string | null }>;
+    const groundFloor = afterRename.filter((r) => r.floor === 'Ground');
+    const mainFloor = afterRename.filter((r) => r.floor === 'Main');
+    const firstFloor = afterRename.filter((r) => r.floor === 'First');
+    assertEqual(groundFloor.length, 0, 'No tables left on "Ground" after rename');
+    assertEqual(mainFloor.length, 3, 'All three Ground tables now on "Main"');
+    assertEqual(firstFloor.length, 2, '"First" tables untouched');
+    console.log(`   ✓ Ground (0) → Main (3); First (2), Unassigned (1) unchanged`);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Scenario B: Rename "Main" → "First" merges into the existing target
+    // ═══════════════════════════════════════════════════════════════════
+    console.log('\n─── Scenario B: Rename to an existing floor merges them ───');
+
+    const mergeRes = await api(baseUrl, '/api/tables/floors/Main', {
+      method: 'PATCH',
+      headers: ownerAuth,
+      body: JSON.stringify({ newName: 'First' }),
+    });
+
+    assertEqual(mergeRes.status, 200, 'Merge rename returns 200');
+    assertEqual(mergeRes.data.affected, 3, 'affected count is 3 (Main tables moved)');
+
+    const afterMerge = db.prepare(
+      `SELECT COUNT(*) AS n FROM tables WHERE floor = 'First'`,
+    ).get() as { n: number };
+    assertEqual(afterMerge.n, 5, 'First now holds all 5 tables (2 original + 3 merged)');
+
+    const mainLeft = db.prepare(
+      `SELECT COUNT(*) AS n FROM tables WHERE floor = 'Main'`,
+    ).get() as { n: number };
+    assertEqual(mainLeft.n, 0, 'No tables left on "Main" after merge');
+    console.log(`   ✓ Main (3 tables) merged into First (now 5)`);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Scenario C: DELETE floor "First" → all 5 tables move to Unassigned
+    // ═══════════════════════════════════════════════════════════════════
+    console.log('\n─── Scenario C: DELETE /api/tables/floors/First unassigns every table ───');
+
+    const deleteRes = await api(baseUrl, '/api/tables/floors/First', {
+      method: 'DELETE',
+      headers: ownerAuth,
+    });
+
+    assertEqual(deleteRes.status, 200, 'DELETE /floors/First returns 200');
+    assertEqual(deleteRes.data.removedFloor, 'First', 'Response echoes removed floor');
+    assertEqual(deleteRes.data.affected, 5, 'affected count is 5');
+    assertEqual(deleteRes.data.floor, null, 'Response confirms new floor is null');
+
+    const afterDelete = db.prepare(
+      `SELECT COUNT(*) AS n FROM tables WHERE floor IS NULL`,
+    ).get() as { n: number };
+    assertEqual(afterDelete.n, 6, 'All 6 tables now unassigned (5 + the original unassigned)');
+
+    const stillFirst = db.prepare(
+      `SELECT COUNT(*) AS n FROM tables WHERE floor = 'First'`,
+    ).get() as { n: number };
+    assertEqual(stillFirst.n, 0, 'No tables left on "First"');
+    console.log(`   ✓ All 5 tables on First moved to Unassigned; tables preserved`);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Scenario D: 400 on empty / missing newName
+    // ═══════════════════════════════════════════════════════════════════
+    console.log('\n─── Scenario D: empty / missing newName is rejected ───');
+
+    const missingName = await api(baseUrl, '/api/tables/floors/Ground', {
+      method: 'PATCH',
+      headers: ownerAuth,
+      body: JSON.stringify({}),
+    });
+    assertEqual(missingName.status, 400, 'Missing newName returns 400');
+    assertEqual(missingName.data.code, 'FLOOR_NAME_REQUIRED', 'Error code is FLOOR_NAME_REQUIRED');
+
+    const blankName = await api(baseUrl, '/api/tables/floors/Ground', {
+      method: 'PATCH',
+      headers: ownerAuth,
+      body: JSON.stringify({ newName: '   ' }),
+    });
+    assertEqual(blankName.status, 400, 'Whitespace newName returns 400');
+    console.log(`   ✓ Validation rejects empty / whitespace newName`);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Scenario E: RBAC — cashier denied, manager allowed
+    // ═══════════════════════════════════════════════════════════════════
+    console.log('\n─── Scenario E: RBAC enforced ───');
+
+    const cashierPatch = await api(baseUrl, '/api/tables/floors/Ground', {
+      method: 'PATCH',
+      headers: cashierAuth,
+      body: JSON.stringify({ newName: 'X' }),
+    });
+    assertEqual(cashierPatch.status, 403, 'Cashier PATCH is denied');
+
+    const cashierDelete = await api(baseUrl, '/api/tables/floors/Ground', {
+      method: 'DELETE',
+      headers: cashierAuth,
+    });
+    assertEqual(cashierDelete.status, 403, 'Cashier DELETE is denied');
+
+    // 'Ground' has zero rows by this point (Scenario A renamed them all), so a
+    // rename here would return 200 with affected: 0 and prove nothing. Seed a
+    // manager-scoped floor so the allowed-request assertion covers a real move.
+    db.prepare(
+      `INSERT INTO tables (id, number, capacity, floor, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('tbl-mgr-1', 'M1', 4, 'Ground', now(), now());
+
+    const managerRename = await api(baseUrl, '/api/tables/floors/Ground', {
+      method: 'PATCH',
+      headers: managerAuth,
+      body: JSON.stringify({ newName: 'Patio' }),
+    });
+    assertEqual(managerRename.status, 200, 'Manager PATCH is allowed');
+    assertEqual(managerRename.data.affected, 1, 'Manager rename moved the seeded table');
+    const mgrPersisted = db.prepare(
+      `SELECT floor FROM tables WHERE id = 'tbl-mgr-1'`,
+    ).get() as { floor: string };
+    assertEqual(mgrPersisted.floor, 'Patio', 'Persisted row landed on "Patio"');
+    console.log(`   ✓ Cashier denied (403), Manager allowed (200, affected 1, persisted)`);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Scenario F: URL-encoded floor names round-trip
+    // ═══════════════════════════════════════════════════════════════════
+    console.log('\n─── Scenario F: URL-encoded floor names ───');
+
+    // Use a name that actually requires encoding. `encodeURIComponent('Mezzanine')`
+    // is a no-op, so the prior shape of this test passed even when decoding was
+    // broken. "Mezzanine Level" round-trips through `%20` and exercises the
+    // Express path-decoder that feeds `req.params.name`.
+    const encodedFloor = 'Mezzanine Level';
+    const encodedFloorEscaped = encodeURIComponent(encodedFloor);
+    assert(encodedFloorEscaped.includes('%20'), `Encoded form contains %20: ${encodedFloorEscaped}`);
+
+    db.prepare(
+      `INSERT INTO tables (id, number, capacity, floor, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('tbl-sp-1', 'S1', 4, encodedFloor, now(), now());
+    db.prepare(
+      `INSERT INTO tables (id, number, capacity, floor, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('tbl-sp-2', 'S2', 4, encodedFloor, now(), now());
+
+    const encodedRename = await api(baseUrl, `/api/tables/floors/${encodedFloorEscaped}`, {
+      method: 'PATCH',
+      headers: ownerAuth,
+      body: JSON.stringify({ newName: 'Mezz' }),
+    });
+    assertEqual(encodedRename.status, 200, 'URL-encoded rename works');
+    assertEqual(encodedRename.data.previousFloor, encodedFloor, 'Server saw the decoded floor name');
+    assertEqual(encodedRename.data.affected, 2, 'Both Mezzanine tables renamed');
+
+    const stillThere = db.prepare(
+      `SELECT COUNT(*) AS n FROM tables WHERE floor = 'Mezz'`,
+    ).get() as { n: number };
+    assertEqual(stillThere.n, 2, 'Tables land on "Mezz"');
+    console.log(`   ✓ "Mezzanine Level" → "Mezz" via ${encodedFloorEscaped}`);
+
+    console.log('\n✅ All floor management scenarios passed');
+  } catch (error: any) {
+    console.error('\n✗ Test failed:', error?.message || error);
+    if (error?.stack) console.error(error.stack);
+    process.exitCode = 1;
+  } finally {
+    server.close();
+    closeDatabase();
+    fs.rmSync(testDir, { recursive: true, force: true });
+  }
+}
+
+main();


### PR DESCRIPTION
Fixes #646

Adds two owner/manager-only endpoints that let a manager rename or delete a floor label without touching the tables on it:

```
PATCH  /api/tables/floors/:name   body: { newName }
DELETE /api/tables/floors/:name
```

- Rename acts as a merge when the new name already exists on another floor. Both buckets land on the target in one UPDATE — no table is lost.
- Delete clears the floor on every table that used it. Tables stay and fall back into the Unassigned bucket.

The FloorplanEditor exposes both actions behind a per-tab caret menu, Edit layout mode only. The delete confirmation shows the table count; the rename dialog warns about merges when the target name already exists.

i18n keys added across all eight supported locales. New integration test covers rename, merge, delete, validation, RBAC (cashier denied, manager allowed), and URL-encoded floor names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added floor management actions for renaming and deleting named floors.
  * Renaming can merge tables into an existing floor; deleted-floor tables move to Unassigned.
  * Added confirmation dialogs, validation, loading states, and success/error feedback.
  * Added support for floor names containing spaces and role-based access controls.
* **Localization**
  * Added translated floor-management messages across supported languages.
* **Tests**
  * Added coverage for renaming, merging, deletion, validation, permissions, and encoded floor names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->