### PR TITLE
feat(print): thermal receipt layout and raster

### DIFF
--- a/frontend/src/lib/printer/branding.ts
+++ b/frontend/src/lib/printer/branding.ts
@@ -1,2 +1,3 @@
-export const RECEIPT_BRANDING_NAME = 'Powered by FloPOS';
-export const RECEIPT_BRANDING_URL = 'https://flopos.com';
+export const RECEIPT_BRANDING = 'Powered by FloPOS (flopos.com)';
+export const RECEIPT_BRANDING_NAME = RECEIPT_BRANDING;
+export const RECEIPT_BRANDING_URL = 'flopos.com';

--- a/frontend/src/lib/printer/receipt-encoder.ts
+++ b/frontend/src/lib/printer/receipt-encoder.ts
@@ -119,7 +119,9 @@ function printPoweredByFooter(enc: ReceiptPrinterEncoder): void {
   enc
     .align('center')
     .size('small')
+    .italic(true)
     .text(RECEIPT_BRANDING_NAME)
+    .italic(false)
     .newline()
     .size('normal')
     .align('left');

--- a/frontend/src/lib/printer/receipt-encoder.ts
+++ b/frontend/src/lib/printer/receipt-encoder.ts
@@ -8,7 +8,7 @@ import { formatDate } from './format-date';
 import { formatTaxComponentLabel, resolveTaxComponents } from './tax-components';
 import { parseDbTimestamp } from '@/lib/utils';
 import { safePrinterText as writeSafePrinterText, type PrintWarning } from './warnings';
-import { RECEIPT_BRANDING_NAME, RECEIPT_BRANDING_URL } from './branding';
+import { RECEIPT_BRANDING_NAME } from './branding';
 import {
   buildFrontendBillDocument,
   printLabelResolver,
@@ -120,8 +120,6 @@ function printPoweredByFooter(enc: ReceiptPrinterEncoder): void {
     .align('center')
     .size('small')
     .text(RECEIPT_BRANDING_NAME)
-    .newline()
-    .text(RECEIPT_BRANDING_URL)
     .newline()
     .size('normal')
     .align('left');

--- a/frontend/src/lib/printer/receipt-encoder.ts
+++ b/frontend/src/lib/printer/receipt-encoder.ts
@@ -119,9 +119,7 @@ function printPoweredByFooter(enc: ReceiptPrinterEncoder): void {
   enc
     .align('center')
     .size('small')
-    .italic(true)
     .text(RECEIPT_BRANDING_NAME)
-    .italic(false)
     .newline()
     .size('normal')
     .align('left');

--- a/frontend/src/lib/printer/tax-bill-encoder.ts
+++ b/frontend/src/lib/printer/tax-bill-encoder.ts
@@ -54,9 +54,7 @@ function printPoweredByFooter(enc: ReceiptPrinterEncoder): void {
   enc
     .align('center')
     .size('small')
-    .italic(true)
     .text(RECEIPT_BRANDING_NAME)
-    .italic(false)
     .newline()
     .size('normal')
     .align('left');

--- a/frontend/src/lib/printer/tax-bill-encoder.ts
+++ b/frontend/src/lib/printer/tax-bill-encoder.ts
@@ -6,7 +6,7 @@ import { getCountryByCode, getCurrencyFractionDigits, getCurrencySymbol, resolve
 import { formatDate } from './format-date';
 import { formatTaxComponentLabel, resolveTaxComponents } from './tax-components';
 import { hasUnsupportedPrinterChars, isArabicShapingSafeLine, safePrinterText as writeSafePrinterText, type PrintWarning } from './warnings';
-import { RECEIPT_BRANDING_NAME, RECEIPT_BRANDING_URL } from './branding';
+import { RECEIPT_BRANDING_NAME } from './branding';
 import { printLabelResolver } from './print-document';
 import { GENERIC_THERMAL_CAPABILITIES, isThermalTextRepresentable, selectThermalCodePage, type ThermalPrinterCapabilities } from '@print/thermal-capabilities';
 
@@ -55,8 +55,6 @@ function printPoweredByFooter(enc: ReceiptPrinterEncoder): void {
     .align('center')
     .size('small')
     .text(RECEIPT_BRANDING_NAME)
-    .newline()
-    .text(RECEIPT_BRANDING_URL)
     .newline()
     .size('normal')
     .align('left');

--- a/frontend/src/lib/printer/tax-bill-encoder.ts
+++ b/frontend/src/lib/printer/tax-bill-encoder.ts
@@ -54,7 +54,9 @@ function printPoweredByFooter(enc: ReceiptPrinterEncoder): void {
   enc
     .align('center')
     .size('small')
+    .italic(true)
     .text(RECEIPT_BRANDING_NAME)
+    .italic(false)
     .newline()
     .size('normal')
     .align('left');

--- a/frontend/src/lib/printer/web-print.ts
+++ b/frontend/src/lib/printer/web-print.ts
@@ -479,7 +479,7 @@ function getPaperStyles(size: PaperSize): string {
     .totals-table td { padding: 6px 8px; }
     .total-row { border-top: 2px solid #333; font-size: 16px; }
     .footer { text-align: center; margin-top: 30px; padding-top: 15px; border-top: 1px solid #ccc; }
-    .powered-by { font-size: 10px; margin-top: 8px; color: #555; }
+    .powered-by { font-size: 10px; margin-top: 8px; color: #555; font-style: italic; }
     .text-end { text-align: end !important; }
     .num { unicode-bidi: isolate; white-space: nowrap; }
     .ltr { direction: ltr; unicode-bidi: isolate; }

--- a/frontend/src/lib/printer/web-print.ts
+++ b/frontend/src/lib/printer/web-print.ts
@@ -19,7 +19,7 @@ import {
   printLabelResolver,
   resolveBillPrintLanguages,
 } from './print-document';
-import { RECEIPT_BRANDING_NAME, RECEIPT_BRANDING_URL } from './branding';
+import { RECEIPT_BRANDING_NAME } from './branding';
 import { LANGUAGES, type Language } from '@/lib/i18n/languages';
 import {
   getBlock,
@@ -405,7 +405,7 @@ export function generateBillHtml(
     <div class="footer">
       ${messages?.footerNote ? `<p>${escapeHtml(messages.footerNote.text)}</p>` : `<p>${escapeHtml(L.thankYou)}</p>`}
       ${hasTax ? `<p>${escapeHtml(L.taxIncluded)}</p>` : ''}
-      <p class="powered-by">${escapeHtml(RECEIPT_BRANDING_NAME)}<br>${escapeHtml(RECEIPT_BRANDING_URL)}</p>
+      <p class="powered-by">${escapeHtml(RECEIPT_BRANDING_NAME)}</p>
     </div>
   </div>
 

--- a/frontend/src/lib/printer/web-print.ts
+++ b/frontend/src/lib/printer/web-print.ts
@@ -479,7 +479,7 @@ function getPaperStyles(size: PaperSize): string {
     .totals-table td { padding: 6px 8px; }
     .total-row { border-top: 2px solid #333; font-size: 16px; }
     .footer { text-align: center; margin-top: 30px; padding-top: 15px; border-top: 1px solid #ccc; }
-    .powered-by { font-size: 10px; margin-top: 8px; color: #555; font-style: italic; }
+    .powered-by { font-size: 10px; margin-top: 8px; color: #555; }
     .text-end { text-align: end !important; }
     .num { unicode-bidi: isolate; white-space: nowrap; }
     .ltr { direction: ltr; unicode-bidi: isolate; }

--- a/frontend/src/types/receipt-printer-encoder.d.ts
+++ b/frontend/src/types/receipt-printer-encoder.d.ts
@@ -8,6 +8,7 @@ declare module '@point-of-sale/receipt-printer-encoder' {
     initialize(): this;
     align(alignment: 'left' | 'center' | 'right'): this;
     bold(enabled: boolean): this;
+    italic(enabled?: boolean): this;
     width(n: 1 | 2): this;
     height(n: 1 | 2): this;
     size(size: 'normal' | 'small'): this;

--- a/main/printers/document-classic.ts
+++ b/main/printers/document-classic.ts
@@ -283,8 +283,8 @@ export function renderBillDocumentToClassicLines(
     target.sourceLayouts.main.push(sourceLabel !== undefined && sourceValue !== undefined ? {
       kind: 'financial-summary',
       columns: [
-        { text: sourceLabel, align: 'left' },
-        { text: sourceValue.trimStart(), align: 'right' },
+        { text: sourceLabel, align: 'left', widthRatio: Math.max(0.1, (cols - 12) / cols) },
+        { text: sourceValue.trimStart(), align: 'right', widthRatio: Math.min(0.9, 12 / cols) },
       ],
     } : undefined);
   };
@@ -441,9 +441,9 @@ export function renderBillDocumentToClassicLines(
           const sourceLayouts: Array<RasterTextLayout | undefined> = [{
             kind: 'financial-item',
             columns: [
-              { text: row.name.text, align: 'left' },
-              { text: String(row.quantity), align: 'left' },
-              { text: amount.trimStart(), align: 'right' },
+              { text: row.name.text, align: 'left', widthRatio: nameLen / cols },
+              { text: String(row.quantity), align: 'left', widthRatio: 4 / cols },
+              { text: amount.trimStart(), align: 'right', widthRatio: amtLen / cols },
             ],
           }];
           const financialSourceLines = [true];
@@ -462,8 +462,8 @@ export function renderBillDocumentToClassicLines(
             sourceLayouts.push(addon.price ? {
               kind: 'financial-summary',
               columns: [
-                { text: addonLabel, align: 'left' },
-                { text: addonAmount.trimStart(), align: 'right' },
+                { text: addonLabel, align: 'left', widthRatio: nameLen / cols },
+                { text: addonAmount.trimStart(), align: 'right', widthRatio: (cols - nameLen) / cols },
               ],
             } : undefined);
             financialSourceLines.push(Boolean(addon.price));
@@ -576,8 +576,8 @@ export function renderBillDocumentToClassicLines(
             segment.sourceLayouts.post.push({
               kind: 'financial-summary',
               columns: [
-                { text: label, align: 'left' },
-                { text: value.trimStart(), align: 'right' },
+                { text: label, align: 'left', widthRatio: Math.max(0.1, (cols - 12) / cols) },
+                { text: value.trimStart(), align: 'right', widthRatio: Math.min(0.9, 12 / cols) },
               ],
             });
           }
@@ -599,8 +599,8 @@ export function renderBillDocumentToClassicLines(
           segment.sourceLayouts.main.push({
             kind: 'financial-summary',
             columns: [
-              { text: rawMethodLabel, align: 'left' },
-              { text: value.trimStart(), align: 'right' },
+              { text: rawMethodLabel, align: 'left', widthRatio: Math.max(0.1, (cols - 12) / cols) },
+              { text: value.trimStart(), align: 'right', widthRatio: Math.min(0.9, 12 / cols) },
             ],
           });
         }

--- a/main/printers/document-compact.ts
+++ b/main/printers/document-compact.ts
@@ -230,9 +230,9 @@ export function renderBillDocumentToCompactLines(
       const sourceLayouts: Array<RasterTextLayout | undefined> = [{
         kind: 'financial-item',
         columns: [
-          { text: row.name.text, align: 'left' },
-          { text: String(row.quantity), align: 'left' },
-          { text: amount.trimStart(), align: 'right' },
+          { text: row.name.text, align: 'left', widthRatio: nameLen / cols },
+          { text: String(row.quantity), align: 'left', widthRatio: 4 / cols },
+          { text: amount.trimStart(), align: 'right', widthRatio: amtLen / cols },
         ],
       }];
       const financialSourceLines = [true];
@@ -249,8 +249,8 @@ export function renderBillDocumentToCompactLines(
         sourceLayouts.push(addon.price ? {
           kind: 'financial-summary',
           columns: [
-            { text: addonLabel, align: 'left' },
-            { text: addonAmount.trimStart(), align: 'right' },
+            { text: addonLabel, align: 'left', widthRatio: nameLen / cols },
+            { text: addonAmount.trimStart(), align: 'right', widthRatio: (cols - nameLen) / cols },
           ],
         } : undefined);
         financialSourceLines.push(Boolean(addon.price));
@@ -287,8 +287,8 @@ export function renderBillDocumentToCompactLines(
     totalsSourceLayouts.push(sourceLabel !== undefined && sourceValue !== undefined ? {
       kind: 'financial-summary',
       columns: [
-        { text: sourceLabel, align: 'left' },
-        { text: sourceValue.trimStart(), align: 'right' },
+        { text: sourceLabel, align: 'left', widthRatio: Math.max(0.1, (cols - 12) / cols) },
+        { text: sourceValue.trimStart(), align: 'right', widthRatio: Math.min(0.9, 12 / cols) },
       ],
     } : undefined);
   };
@@ -350,8 +350,8 @@ export function renderBillDocumentToCompactLines(
       paymentSourceLayouts.push({
         kind: 'financial-summary',
         columns: [
-          { text: rawMethodLabel, align: 'left' },
-          { text: value.trimStart(), align: 'right' },
+          { text: rawMethodLabel, align: 'left', widthRatio: Math.max(0.1, (cols - 12) / cols) },
+          { text: value.trimStart(), align: 'right', widthRatio: Math.min(0.9, 12 / cols) },
         ],
       });
     }

--- a/main/printers/profiles.ts
+++ b/main/printers/profiles.ts
@@ -162,32 +162,18 @@ export function getPrinterCapabilities(
   return mergeThermalCapabilities(profile.capabilities || GENERIC_THERMAL_CAPABILITIES, arabicShapingOverride);
 }
 
-/**
- * Maps a paper_width string to the canonical raster dot width for that paper
- * size, or null when the string is unrecognized. Parallel to columnsForPaperWidth
- * in thermal.ts but in dots rather than characters.
- */
+/** Maps paper_width string to canonical raster dot width, or null if unrecognized. */
 export function dotsForPaperWidth(paperWidth: string): number | null {
   const colsMatch = String(paperWidth || '').match(/^cols-(3[2-9]|4[0-8])$/);
-  const cols = colsMatch ? Number(colsMatch[1]) : ({ '58mm': 32, '58mm-36': 36, '80mm-42': 42, '80mm': null } as Record<string, number | null>)[paperWidth] ?? null;
+  const cols = colsMatch ? Number(colsMatch[1]) : ({ '58mm': 32, '58mm-36': 36, '80mm-42': 42, '80mm': 48 } as Record<string, number>)[paperWidth] ?? null;
   if (cols === null) return null;
   if (cols <= 32) return 384;
   if (cols <= 36) return 432;
   if (cols <= 40) return 480;
-  if (cols <= 42) return 512;
-  if (cols <= 44) return 528;
   return 576;
 }
 
-/**
- * Returns capabilities for a printer, capping raster.widthDots to the dot
- * width implied by the configured paper_width when narrower than the hardware
- * profile default. Never increases the profile dot width.
- *
- * Use this everywhere you need capabilities for an actual print job.
- * getPrinterCapabilities() returns raw hardware capabilities and should only
- * be used internally or when paper_width is irrelevant.
- */
+/** Returns printer capabilities, capping raster widthDots if paper_width is narrower than hardware. */
 export function capabilitiesForPrinter(
   profile: SupportedPrinterProfile,
   paperWidth: string | null | undefined,

--- a/main/printers/profiles.ts
+++ b/main/printers/profiles.ts
@@ -161,3 +161,41 @@ export function getPrinterCapabilities(
 ): ThermalPrinterCapabilities {
   return mergeThermalCapabilities(profile.capabilities || GENERIC_THERMAL_CAPABILITIES, arabicShapingOverride);
 }
+
+/**
+ * Maps a paper_width string to the canonical raster dot width for that paper
+ * size, or null when the string is unrecognized. Parallel to columnsForPaperWidth
+ * in thermal.ts but in dots rather than characters.
+ */
+export function dotsForPaperWidth(paperWidth: string): number | null {
+  const colsMatch = String(paperWidth || '').match(/^cols-(3[2-9]|4[0-8])$/);
+  const cols = colsMatch ? Number(colsMatch[1]) : ({ '58mm': 32, '58mm-36': 36, '80mm-42': 42, '80mm': null } as Record<string, number | null>)[paperWidth] ?? null;
+  if (cols === null) return null;
+  if (cols <= 32) return 384;
+  if (cols <= 36) return 432;
+  if (cols <= 40) return 480;
+  if (cols <= 42) return 512;
+  if (cols <= 44) return 528;
+  return 576;
+}
+
+/**
+ * Returns capabilities for a printer, capping raster.widthDots to the dot
+ * width implied by the configured paper_width when narrower than the hardware
+ * profile default. Never increases the profile dot width.
+ *
+ * Use this everywhere you need capabilities for an actual print job.
+ * getPrinterCapabilities() returns raw hardware capabilities and should only
+ * be used internally or when paper_width is irrelevant.
+ */
+export function capabilitiesForPrinter(
+  profile: SupportedPrinterProfile,
+  paperWidth: string | null | undefined,
+  arabicShapingOverride?: boolean,
+): ThermalPrinterCapabilities {
+  const capabilities = getPrinterCapabilities(profile, arabicShapingOverride);
+  if (!capabilities.raster.enabled || !capabilities.raster.widthDots) return capabilities;
+  const configuredDots = dotsForPaperWidth(String(paperWidth || ''));
+  if (configuredDots === null || configuredDots >= capabilities.raster.widthDots) return capabilities;
+  return { ...capabilities, raster: { ...capabilities.raster, widthDots: configuredDots } };
+}

--- a/main/printers/raster-renderer.ts
+++ b/main/printers/raster-renderer.ts
@@ -481,7 +481,7 @@ function semanticLineGroups(lines: readonly string[]): RasterSemanticLineGroupWi
   return groups;
 }
 
-const RASTER_CONTROL_TOKEN_RE = /\{(?:\/?(?:CENTER|BOLD|DOUBLE_HEIGHT|DOUBLE_WIDTH|FONT_B)|INIT|CUT|FEED|STORE_NAME|FINANCIAL)\}/g;
+const RASTER_CONTROL_TOKEN_RE = /\{(?:\/?(?:CENTER|BOLD|DOUBLE_HEIGHT|DOUBLE_WIDTH|FONT_B|ITALIC)|INIT|CUT|FEED|STORE_NAME|FINANCIAL)\}/g;
 
 function stripRasterControlTokens(line: string): string {
   return line.replace(RASTER_CONTROL_TOKEN_RE, '');

--- a/main/printers/raster-renderer.ts
+++ b/main/printers/raster-renderer.ts
@@ -92,11 +92,21 @@ export function rasterRendererHtml(): string {
           const measured = columns.map((column) => Math.max(1, measure(column.text)));
           const gaps = gapDots * (columns.length - 1);
           const available = Math.max(1, request.widthDots - gaps);
-          const widths = columns.length === 2
-            ? [0, Math.min(Math.max(measured[1] + gapDots, Math.floor(available * 0.25)), Math.floor(available * 0.45))]
-            : [0, Math.min(Math.max(measured[1] + gapDots, Math.floor(available * 0.08)), Math.floor(available * 0.2)), Math.min(Math.max(measured[2] + gapDots, Math.floor(available * 0.22)), Math.floor(available * 0.4))];
-          if (columns.length === 2) widths[0] = Math.max(1, available - widths[1]);
-          else widths[0] = Math.max(1, available - widths[1] - widths[2]);
+          const hasRatios = columns.every((c) => typeof c.widthRatio === 'number' && c.widthRatio > 0);
+          const widths = hasRatios
+            ? (() => {
+              const allocated = columns.map((c) => Math.max(1, Math.round(available * c.widthRatio)));
+              const totalAllocated = allocated.reduce((sum, w) => sum + w, 0);
+              allocated[0] = Math.max(1, allocated[0] + (available - totalAllocated));
+              return allocated;
+            })()
+            : (columns.length === 2
+              ? [0, Math.min(Math.max(measured[1] + gapDots, Math.floor(available * 0.25)), Math.floor(available * 0.45))]
+              : [0, Math.min(Math.max(measured[1] + gapDots, Math.floor(available * 0.08)), Math.floor(available * 0.2)), Math.min(Math.max(measured[2] + gapDots, Math.floor(available * 0.22)), Math.floor(available * 0.4))]);
+          if (!hasRatios) {
+            if (columns.length === 2) widths[0] = Math.max(1, available - widths[1]);
+            else widths[0] = Math.max(1, available - widths[1] - widths[2]);
+          }
           const wrappedColumns = columns.map((column, index) => wrap(column.text, widths[index]));
           const lineCount = Math.max(1, ...wrappedColumns.map((column) => column.length));
           return Array.from({ length: lineCount }, (_, lineIndex) => columns.map((column, columnIndex) => ({

--- a/main/printers/raster-renderer.ts
+++ b/main/printers/raster-renderer.ts
@@ -54,10 +54,11 @@ export function rasterRendererHtml(): string {
       const styles = Array.isArray(request.styles) ? request.styles : [request.style];
       const scaleX = styles.includes('double-width') ? 2 : 1;
       const scaleY = styles.includes('double-height') ? 2 : 1;
-      const logicalLineHeight = 26;
+      const logicalLineHeight = 30;
       const lineHeight = logicalLineHeight * scaleY;
       const fontSize = styles.includes('font-b') ? 16 : 22;
-      const weight = styles.includes('bold') ? '700' : '600';
+      const topPad = 3;
+      const weight = styles.includes('bold') ? '700' : '400';
       const fontFallback = '-apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "Noto Sans", sans-serif';
       const fontSpec = request.bundledFont
         ? JSON.stringify(request.bundledFont.family) + ', ' + fontFallback
@@ -144,7 +145,7 @@ export function rasterRendererHtml(): string {
         line.forEach((cell, cellIndex) => {
           context.textAlign = cell.align === 'center' ? 'center' : cell.align;
           const cellX = cell.align === 'right' ? x + cell.width : cell.align === 'center' ? x + cell.width / 2 : x;
-          context.fillText(cell.text, cellX / scaleX, lineIndex * logicalLineHeight);
+          context.fillText(cell.text, cellX / scaleX, lineIndex * logicalLineHeight + topPad);
           x += cell.width;
           if (cellIndex < line.length - 1) x += gapDots;
         });

--- a/main/printers/raster-renderer.ts
+++ b/main/printers/raster-renderer.ts
@@ -54,9 +54,9 @@ export function rasterRendererHtml(): string {
       const styles = Array.isArray(request.styles) ? request.styles : [request.style];
       const scaleX = styles.includes('double-width') ? 2 : 1;
       const scaleY = styles.includes('double-height') ? 2 : 1;
-      const logicalLineHeight = 30;
+      const logicalLineHeight = 32;
       const lineHeight = logicalLineHeight * scaleY;
-      const fontSize = styles.includes('font-b') ? 16 : 22;
+      const fontSize = styles.includes('font-b') ? 17 : 24;
       const topPad = 3;
       const weight = styles.includes('bold') ? '700' : '400';
       const fontFallback = '-apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "Noto Sans", sans-serif';
@@ -481,7 +481,7 @@ function semanticLineGroups(lines: readonly string[]): RasterSemanticLineGroupWi
   return groups;
 }
 
-const RASTER_CONTROL_TOKEN_RE = /\{(?:\/?(?:CENTER|BOLD|DOUBLE_HEIGHT|DOUBLE_WIDTH|FONT_B|ITALIC)|INIT|CUT|FEED|STORE_NAME|FINANCIAL)\}/g;
+const RASTER_CONTROL_TOKEN_RE = /\{(?:\/?(?:CENTER|BOLD|DOUBLE_HEIGHT|DOUBLE_WIDTH|FONT_B)|INIT|CUT|FEED|STORE_NAME|FINANCIAL)\}/g;
 
 function stripRasterControlTokens(line: string): string {
   return line.replace(RASTER_CONTROL_TOKEN_RE, '');

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -5,7 +5,15 @@ import * as path from 'path';
 import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { getDatabase, getSettingValue, parseDbTimestamp } from '../db';
-import { PrinterCutMode, resolvePrinterProfile, matchSupportedPrinterProfile, getPrinterCapabilities, SupportedPrinterProfile } from './profiles';
+import {
+  PrinterCutMode,
+  resolvePrinterProfile,
+  matchSupportedPrinterProfile,
+  getPrinterCapabilities,
+  SupportedPrinterProfile,
+  dotsForPaperWidth,
+  capabilitiesForPrinter,
+} from './profiles';
 import { getCountryByCode, getCurrencyFractionDigits, getCurrencySymbol, resolveTenantCurrency } from '../countries';
 import { resolveTaxComponents } from '../services/tax-components';
 import { loadInstalledPrintTemplate, parseBillTemplateSelection } from '../services/print-templates';
@@ -804,9 +812,7 @@ export async function printKOT(order: any, items: any[], stationName: string, us
     }
     console.log('[Printer] Using printer:', printer.name, printer.connection_type);
 
-    const profile = resolvePrinterProfile(printer);
-    const cols = getColumnsForPrinter(printer, profile);
-
+    const { profile, columns: cols, capabilities } = resolvePrinterContext(printer, arabicShapingOverride);
     const db = getDatabase();
     const biz = db.prepare('SELECT * FROM settings LIMIT 1').get() as any;
     const locale = biz?.country ? getCountryByCode(biz.country)?.locale ?? 'en-US' : 'en-US';
@@ -814,8 +820,6 @@ export async function printKOT(order: any, items: any[], stationName: string, us
     const tzOptions = { timeZone: timezone };
 
     const warnings: PrintWarning[] = [];
-    // Request-body shaping override takes precedence over profile default.
-    const capabilities = capabilitiesForPrinter(profile, printer.paper_width || profile.defaultPaperWidth, arabicShapingOverride);
     const nativeCapabilities = nativeFallbackCapabilities(capabilities);
     let data: Buffer;
     if (rasterCapabilityEnabled(capabilities)) {
@@ -1011,36 +1015,26 @@ export function columnsForPaperWidth(paperWidth: string): number | null {
   }
 }
 
-/**
- * Returns the canonical raster dot width for a paper_width string, or null
- * when the string is unknown. Mirrors columnsForPaperWidth but in dots.
- */
-export function dotsForPaperWidth(paperWidth: string): number | null {
-  const cols = columnsForPaperWidth(paperWidth);
-  if (cols === null) return null;
-  if (cols <= 32) return 384;
-  if (cols <= 36) return 432;
-  if (cols <= 40) return 480;
-  if (cols <= 42) return 512;
-  if (cols <= 44) return 528;
-  return 576;
+export { dotsForPaperWidth, capabilitiesForPrinter };
+
+export interface PrinterContext {
+  profile: SupportedPrinterProfile;
+  columns: number;
+  capabilities: ThermalPrinterCapabilities;
 }
 
 /**
- * Returns capabilities for the printer, capping raster.widthDots to the
- * configured paper_width when the user has set a narrower width than the
- * hardware profile's default. Never increases the profile dot width.
+ * Standardized entrypoint to resolve profile, columns, and capabilities for a printer.
+ * Guarantees that columns and raster widthDots always stay aligned with paper_width.
  */
-function capabilitiesForPrinter(
-  profile: SupportedPrinterProfile,
-  paperWidth: string | null | undefined,
+export function resolvePrinterContext(
+  printer: any,
   arabicShapingOverride?: boolean,
-): ThermalPrinterCapabilities {
-  const capabilities = getPrinterCapabilities(profile, arabicShapingOverride);
-  if (!capabilities.raster.enabled || !capabilities.raster.widthDots) return capabilities;
-  const configuredDots = dotsForPaperWidth(String(paperWidth || ''));
-  if (configuredDots === null || configuredDots >= capabilities.raster.widthDots) return capabilities;
-  return { ...capabilities, raster: { ...capabilities.raster, widthDots: configuredDots } };
+): PrinterContext {
+  const profile = resolvePrinterProfile(printer);
+  const columns = getColumnsForPrinter(printer, profile);
+  const capabilities = capabilitiesForPrinter(profile, printer?.paper_width || profile.defaultPaperWidth, arabicShapingOverride);
+  return { profile, columns, capabilities };
 }
 
 async function dispatchPrint(printer: any, data: Buffer, signal?: AbortSignal): Promise<DispatchResult> {
@@ -1091,11 +1085,8 @@ export function prepareReceipt(order: any, bill: any, business?: any, template: 
     };
   }
 
-  const profile = resolvePrinterProfile(printer);
-  const columns = getColumnsForPrinter(printer, profile);
+  const { profile, columns, capabilities } = resolvePrinterContext(printer, arabicShapingOverride);
   const warnings: PrintWarning[] = [];
-  // Request-body shaping override takes precedence over profile default.
-  const capabilities = capabilitiesForPrinter(profile, printer.paper_width || profile.defaultPaperWidth, arabicShapingOverride);
   const nativeCapabilities = nativeFallbackCapabilities(capabilities);
   const data = formatReceipt(order, bill, business, template, columns, useUnicode, isReprint, profile.cutMode, warnings, nativeCapabilities.shaping.arabic, language, additionalLanguage, nativeCapabilities);
   return { printer, data, warnings, columns };
@@ -1315,8 +1306,7 @@ async function rasterizeReceiptIfEnabled(
   language: string | undefined,
   additionalLanguage: string | undefined,
 ): Promise<ReturnType<typeof prepareReceipt>> {
-  const profile = resolvePrinterProfile(prepared.printer);
-  const capabilities = capabilitiesForPrinter(profile, prepared.printer?.paper_width || profile.defaultPaperWidth, arabicShapingOverride);
+  const { profile, capabilities } = resolvePrinterContext(prepared.printer, arabicShapingOverride);
   if (!rasterCapabilityEnabled(capabilities)) return prepared;
   const document = receiptDocumentLines(
     order,
@@ -2297,9 +2287,7 @@ export async function printZReport(z: any, signal?: AbortSignal, targetPrinter?:
     // F3: resolve the printer's profile so `buildZReportBody` can use the
     // right columns and capabilities (58mm/36/42 cols, profile-specific
     // code pages, etc.). Same pattern as `prepareReceipt` (`:1043-1056`).
-    const profile = resolvePrinterProfile(printer);
-    const columns = columnsForPaperWidth(printer.paper_width || profile.defaultPaperWidth) || 48;
-    const capabilities = getPrinterCapabilities(profile, false);
+    const { profile, columns, capabilities } = resolvePrinterContext(printer, false);
     const zWithMarker = { ...z, __isReprint: !!z?.__isReprint };
     // No language: the Z body is English-literal by design (see the route's
     // F7 note); buildZReportBody falls back to its default language.

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -176,8 +176,9 @@ const isMasBuild =
   (process as NodeJS.Process & { mas?: boolean }).mas === true;
 const PRINTER_DETECTION_TIMEOUT_MS = 10_000;
 
-const RECEIPT_BRANDING_NAME = 'Powered by FloPOS';
-const RECEIPT_BRANDING_URL = 'https://flopos.com';
+const RECEIPT_BRANDING = 'Powered by FloPOS (flopos.com)';
+const RECEIPT_BRANDING_NAME = RECEIPT_BRANDING;
+const RECEIPT_BRANDING_URL = 'flopos.com';
 export type PrinterColumnWidth = 36 | 42 | 48;
 
 export interface PrinterInfo {
@@ -1576,8 +1577,7 @@ function renderEscposLineTemplateV1(payload: any, profile: { columns: number; la
 
 export function appendPoweredByFooter(lines: string[]): void {
   lines.push('', '');
-  lines.push('{CENTER}{FONT_B}' + RECEIPT_BRANDING_NAME + '{/FONT_B}{/CENTER}');
-  lines.push('{CENTER}{FONT_B}' + RECEIPT_BRANDING_URL + '{/FONT_B}{/CENTER}');
+  lines.push('{CENTER}{FONT_B}' + RECEIPT_BRANDING + '{/FONT_B}{/CENTER}');
 }
 
 /** Compact thermal receipt: builds PrintDocument and renders via document-compact pipeline. */

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -815,7 +815,7 @@ export async function printKOT(order: any, items: any[], stationName: string, us
 
     const warnings: PrintWarning[] = [];
     // Request-body shaping override takes precedence over profile default.
-    const capabilities = getPrinterCapabilities(profile, arabicShapingOverride);
+    const capabilities = capabilitiesForPrinter(profile, printer.paper_width || profile.defaultPaperWidth, arabicShapingOverride);
     const nativeCapabilities = nativeFallbackCapabilities(capabilities);
     let data: Buffer;
     if (rasterCapabilityEnabled(capabilities)) {
@@ -1011,6 +1011,38 @@ export function columnsForPaperWidth(paperWidth: string): number | null {
   }
 }
 
+/**
+ * Returns the canonical raster dot width for a paper_width string, or null
+ * when the string is unknown. Mirrors columnsForPaperWidth but in dots.
+ */
+export function dotsForPaperWidth(paperWidth: string): number | null {
+  const cols = columnsForPaperWidth(paperWidth);
+  if (cols === null) return null;
+  if (cols <= 32) return 384;
+  if (cols <= 36) return 432;
+  if (cols <= 40) return 480;
+  if (cols <= 42) return 512;
+  if (cols <= 44) return 528;
+  return 576;
+}
+
+/**
+ * Returns capabilities for the printer, capping raster.widthDots to the
+ * configured paper_width when the user has set a narrower width than the
+ * hardware profile's default. Never increases the profile dot width.
+ */
+function capabilitiesForPrinter(
+  profile: SupportedPrinterProfile,
+  paperWidth: string | null | undefined,
+  arabicShapingOverride?: boolean,
+): ThermalPrinterCapabilities {
+  const capabilities = getPrinterCapabilities(profile, arabicShapingOverride);
+  if (!capabilities.raster.enabled || !capabilities.raster.widthDots) return capabilities;
+  const configuredDots = dotsForPaperWidth(String(paperWidth || ''));
+  if (configuredDots === null || configuredDots >= capabilities.raster.widthDots) return capabilities;
+  return { ...capabilities, raster: { ...capabilities.raster, widthDots: configuredDots } };
+}
+
 async function dispatchPrint(printer: any, data: Buffer, signal?: AbortSignal): Promise<DispatchResult> {
   switch (printer.connection_type) {
     case 'network':
@@ -1063,7 +1095,7 @@ export function prepareReceipt(order: any, bill: any, business?: any, template: 
   const columns = getColumnsForPrinter(printer, profile);
   const warnings: PrintWarning[] = [];
   // Request-body shaping override takes precedence over profile default.
-  const capabilities = getPrinterCapabilities(profile, arabicShapingOverride);
+  const capabilities = capabilitiesForPrinter(profile, printer.paper_width || profile.defaultPaperWidth, arabicShapingOverride);
   const nativeCapabilities = nativeFallbackCapabilities(capabilities);
   const data = formatReceipt(order, bill, business, template, columns, useUnicode, isReprint, profile.cutMode, warnings, nativeCapabilities.shaping.arabic, language, additionalLanguage, nativeCapabilities);
   return { printer, data, warnings, columns };
@@ -1205,7 +1237,7 @@ export async function rasterizePrintDocumentForWebUsb(
   },
 ): Promise<{ ok: true; data: Buffer; warnings: PrintWarning[]; rasterSelected: boolean; rasterFailed: boolean } | { ok: false; error: string }> {
   const profile = resolvePrinterProfile({ profile_id: profileId });
-  const capabilities = getPrinterCapabilities(profile, options.arabicShaping);
+  const capabilities = capabilitiesForPrinter(profile, `cols-${options.columns}`, options.arabicShaping);
   if (!rasterCapabilityEnabled(capabilities, 'mixed')) return { ok: false, error: 'Raster output is not enabled for this printer profile' };
   const rasterGroups: RasterSemanticLineGroup[] = [];
   const lines = template === 'compact'
@@ -1250,7 +1282,7 @@ export async function rasterizeKotDocumentForWebUsb(
   },
 ): Promise<{ ok: true; data: Buffer; warnings: PrintWarning[]; rasterSelected: boolean; rasterFailed: boolean } | { ok: false; error: string }> {
   const profile = resolvePrinterProfile({ profile_id: profileId });
-  const capabilities = getPrinterCapabilities(profile, options.arabicShaping);
+  const capabilities = capabilitiesForPrinter(profile, `cols-${options.columns}`, options.arabicShaping);
   if (!rasterCapabilityEnabled(capabilities, 'mixed')) return { ok: false, error: 'Raster output is not enabled for this printer profile' };
   const rasterGroups: RasterSemanticLineGroup[] = [];
   const lines = renderKotDocumentToLines(document, {
@@ -1284,7 +1316,7 @@ async function rasterizeReceiptIfEnabled(
   additionalLanguage: string | undefined,
 ): Promise<ReturnType<typeof prepareReceipt>> {
   const profile = resolvePrinterProfile(prepared.printer);
-  const capabilities = getPrinterCapabilities(profile, arabicShapingOverride);
+  const capabilities = capabilitiesForPrinter(profile, prepared.printer?.paper_width || profile.defaultPaperWidth, arabicShapingOverride);
   if (!rasterCapabilityEnabled(capabilities)) return prepared;
   const document = receiptDocumentLines(
     order,

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -1575,6 +1575,7 @@ function renderEscposLineTemplateV1(payload: any, profile: { columns: number; la
 }
 
 export function appendPoweredByFooter(lines: string[]): void {
+  lines.push('', '');
   lines.push('{CENTER}{FONT_B}' + RECEIPT_BRANDING_NAME + '{/FONT_B}{/CENTER}');
   lines.push('{CENTER}{FONT_B}' + RECEIPT_BRANDING_URL + '{/FONT_B}{/CENTER}');
 }

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -1577,7 +1577,7 @@ function renderEscposLineTemplateV1(payload: any, profile: { columns: number; la
 
 export function appendPoweredByFooter(lines: string[]): void {
   lines.push('', '');
-  lines.push('{CENTER}{FONT_B}' + RECEIPT_BRANDING + '{/FONT_B}{/CENTER}');
+  lines.push('{CENTER}{FONT_B}{ITALIC}' + RECEIPT_BRANDING + '{/ITALIC}{/FONT_B}{/CENTER}');
 }
 
 /** Compact thermal receipt: builds PrintDocument and renders via document-compact pipeline. */
@@ -2330,7 +2330,7 @@ const CURRENCY_TOKEN_RE = new RegExp(
   'g',
 );
 
-const ESC_POS_CONTROL_TOKEN_RE = /\{\/?(?:CENTER|BOLD|DOUBLE_HEIGHT|DOUBLE_WIDTH|FONT_B)\}|\{(?:CUT|FEED|INIT|STORE_NAME|FINANCIAL)\}/g;
+const ESC_POS_CONTROL_TOKEN_RE = /\{\/?(?:CENTER|BOLD|DOUBLE_HEIGHT|DOUBLE_WIDTH|FONT_B|ITALIC)\}|\{(?:CUT|FEED|INIT|STORE_NAME|FINANCIAL)\}/g;
 
 export function normalizeThermalText(text: string, capabilities: ThermalPrinterCapabilities = GENERIC_THERMAL_CAPABILITIES): string {
   if (capabilities.raster.enabled === true && !isThermalTextRepresentable(text, capabilities)) return text;
@@ -2456,6 +2456,7 @@ export function buildEscPos(lines: string[], _useUnicode: boolean = false, optio
 
   const resetAllStyles = () => {
     buf.push(0x1B, 0x45, 0x00);
+    buf.push(0x1B, 0x34, 0x00);
     buf.push(0x1B, 0x21, 0x00);
     buf.push(0x1B, 0x61, 0x00);
   };
@@ -2516,6 +2517,7 @@ export function buildEscPos(lines: string[], _useUnicode: boolean = false, optio
     const lineDH = line.includes('{DOUBLE_HEIGHT}');
     const lineDW = line.includes('{DOUBLE_WIDTH}');
     const lineFontB = line.includes('{FONT_B}');
+    const lineItalic = line.includes('{ITALIC}');
     const center = line.startsWith('{CENTER}') && line.includes('{/CENTER}');
     const textWithoutSupportedCurrency = printableLine.replace(CURRENCY_TOKEN_RE, '');
     const selectedCodePage = selectThermalCodePage(textWithoutSupportedCurrency, capabilities);
@@ -2579,12 +2581,18 @@ export function buildEscPos(lines: string[], _useUnicode: boolean = false, optio
     if (lineBold) {
       buf.push(0x1B, 0x45, 0x01);
     }
+    if (lineItalic) {
+      buf.push(0x1B, 0x34, 0x01);
+    }
 
     const encodedText = !useLegacyUnicode && selectedCodePage
       ? CodepageEncoder.encode(line, selectedCodePage)
       : Buffer.from(line, 'utf8');
     buf.push(...encodedText);
     buf.push(0x0A);
+    if (lineItalic) {
+      buf.push(0x1B, 0x34, 0x00);
+    }
   }
 
   return financialTextFailure ? Buffer.alloc(0) : Buffer.from(buf);
@@ -2615,7 +2623,7 @@ export function escPosToText(data: Buffer | Uint8Array): string {
         flushLine();
         activeCodePage = THERMAL_CODE_PAGE_BY_ID[bytes[i + 2]] ?? 'utf8';
         i += 3;
-      } else if (command === 0x21 || command === 0x45 || command === 0x61) {
+      } else if (command === 0x21 || command === 0x45 || command === 0x61 || command === 0x34) {
         i += 3;
       } else if (command === 0x64) {
         flushLine();

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -1577,7 +1577,7 @@ function renderEscposLineTemplateV1(payload: any, profile: { columns: number; la
 
 export function appendPoweredByFooter(lines: string[]): void {
   lines.push('', '');
-  lines.push('{CENTER}{FONT_B}{ITALIC}' + RECEIPT_BRANDING + '{/ITALIC}{/FONT_B}{/CENTER}');
+  lines.push('{CENTER}{FONT_B}' + RECEIPT_BRANDING + '{/FONT_B}{/CENTER}');
 }
 
 /** Compact thermal receipt: builds PrintDocument and renders via document-compact pipeline. */
@@ -2330,7 +2330,7 @@ const CURRENCY_TOKEN_RE = new RegExp(
   'g',
 );
 
-const ESC_POS_CONTROL_TOKEN_RE = /\{\/?(?:CENTER|BOLD|DOUBLE_HEIGHT|DOUBLE_WIDTH|FONT_B|ITALIC)\}|\{(?:CUT|FEED|INIT|STORE_NAME|FINANCIAL)\}/g;
+const ESC_POS_CONTROL_TOKEN_RE = /\{\/?(?:CENTER|BOLD|DOUBLE_HEIGHT|DOUBLE_WIDTH|FONT_B)\}|\{(?:CUT|FEED|INIT|STORE_NAME|FINANCIAL)\}/g;
 
 export function normalizeThermalText(text: string, capabilities: ThermalPrinterCapabilities = GENERIC_THERMAL_CAPABILITIES): string {
   if (capabilities.raster.enabled === true && !isThermalTextRepresentable(text, capabilities)) return text;
@@ -2456,7 +2456,6 @@ export function buildEscPos(lines: string[], _useUnicode: boolean = false, optio
 
   const resetAllStyles = () => {
     buf.push(0x1B, 0x45, 0x00);
-    buf.push(0x1B, 0x34, 0x00);
     buf.push(0x1B, 0x21, 0x00);
     buf.push(0x1B, 0x61, 0x00);
   };
@@ -2517,7 +2516,6 @@ export function buildEscPos(lines: string[], _useUnicode: boolean = false, optio
     const lineDH = line.includes('{DOUBLE_HEIGHT}');
     const lineDW = line.includes('{DOUBLE_WIDTH}');
     const lineFontB = line.includes('{FONT_B}');
-    const lineItalic = line.includes('{ITALIC}');
     const center = line.startsWith('{CENTER}') && line.includes('{/CENTER}');
     const textWithoutSupportedCurrency = printableLine.replace(CURRENCY_TOKEN_RE, '');
     const selectedCodePage = selectThermalCodePage(textWithoutSupportedCurrency, capabilities);
@@ -2557,15 +2555,7 @@ export function buildEscPos(lines: string[], _useUnicode: boolean = false, optio
 
     line = line.replace(ESC_POS_CONTROL_TOKEN_RE, '');
 
-    const cols = options.columns;
-    if (center && typeof cols === 'number' && cols > 0 && cols < 48) {
-      const maxSlots = lineDW ? Math.floor(cols / 2) : cols;
-      const padding = Math.max(0, Math.floor((maxSlots - line.length) / 2));
-      line = ' '.repeat(padding) + line;
-      buf.push(0x1B, 0x61, 0x00);
-    } else {
-      buf.push(0x1B, 0x61, center ? 0x01 : 0x00);
-    }
+    buf.push(0x1B, 0x61, center ? 0x01 : 0x00);
 
     let mode = 0;
     if (lineDH) mode |= 0x10;
@@ -2581,18 +2571,12 @@ export function buildEscPos(lines: string[], _useUnicode: boolean = false, optio
     if (lineBold) {
       buf.push(0x1B, 0x45, 0x01);
     }
-    if (lineItalic) {
-      buf.push(0x1B, 0x34, 0x01);
-    }
 
     const encodedText = !useLegacyUnicode && selectedCodePage
       ? CodepageEncoder.encode(line, selectedCodePage)
       : Buffer.from(line, 'utf8');
     buf.push(...encodedText);
     buf.push(0x0A);
-    if (lineItalic) {
-      buf.push(0x1B, 0x34, 0x00);
-    }
   }
 
   return financialTextFailure ? Buffer.alloc(0) : Buffer.from(buf);
@@ -2623,7 +2607,7 @@ export function escPosToText(data: Buffer | Uint8Array): string {
         flushLine();
         activeCodePage = THERMAL_CODE_PAGE_BY_ID[bytes[i + 2]] ?? 'utf8';
         i += 3;
-      } else if (command === 0x21 || command === 0x45 || command === 0x61 || command === 0x34) {
+      } else if (command === 0x21 || command === 0x45 || command === 0x61) {
         i += 3;
       } else if (command === 0x64) {
         flushLine();

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -1024,10 +1024,7 @@ export interface PrinterContext {
   capabilities: ThermalPrinterCapabilities;
 }
 
-/**
- * Standardized entrypoint to resolve profile, columns, and capabilities for a printer.
- * Guarantees that columns and raster widthDots always stay aligned with paper_width.
- */
+/** Resolves profile, column count, and capabilities aligned with printer paper_width. */
 export function resolvePrinterContext(
   printer: any,
   arabicShapingOverride?: boolean,

--- a/main/printers/thermal.ts
+++ b/main/printers/thermal.ts
@@ -2030,13 +2030,14 @@ export function buildTestPage(paperWidth: string = '80mm', cutMode: PrinterCutMo
     bar,
     '{CUT}',
   ];
-  if (!capabilities || !rasterCapabilityEnabled(capabilities)) return buildEscPos(lines, false, { cutMode, language: lang });
+  if (!capabilities || !rasterCapabilityEnabled(capabilities)) return buildEscPos(lines, false, { cutMode, language: lang, columns: width });
   // Explicit shaping capability prevents raster profile passing unshaped Arabic to text.
   const textData = buildEscPos(lines.slice(0, -1), false, {
     cutMode,
     language: lang,
     capabilities,
     arabicShaping: capabilities.shaping.arabic,
+    columns: width,
   });
   const rasterData = encodeRasterUnits([{
     unitId: 'diagnostic-test-page',
@@ -2553,7 +2554,15 @@ export function buildEscPos(lines: string[], _useUnicode: boolean = false, optio
 
     line = line.replace(ESC_POS_CONTROL_TOKEN_RE, '');
 
-    buf.push(0x1B, 0x61, center ? 0x01 : 0x00);
+    const cols = options.columns;
+    if (center && typeof cols === 'number' && cols > 0 && cols < 48) {
+      const maxSlots = lineDW ? Math.floor(cols / 2) : cols;
+      const padding = Math.max(0, Math.floor((maxSlots - line.length) / 2));
+      line = ' '.repeat(padding) + line;
+      buf.push(0x1B, 0x61, 0x00);
+    } else {
+      buf.push(0x1B, 0x61, center ? 0x01 : 0x00);
+    }
 
     let mode = 0;
     if (lineDH) mode |= 0x10;

--- a/main/routes/printers.ts
+++ b/main/routes/printers.ts
@@ -11,7 +11,7 @@ import {
   type ReceiptLanguagePolicy,
   isKotItemPending,
 } from '../../shared/print';
-import { getSupportedPrinterProfiles, resolvePrinterProfile } from '../printers/profiles';
+import { getSupportedPrinterProfiles, resolvePrinterProfile, capabilitiesForPrinter } from '../printers/profiles';
 import { requireRole } from '../middleware/security';
 import { ROLE_ACCESS } from '../../shared/role-permissions';
 import { getCountryByCode, getCurrencySymbol, resolveTenantCurrency } from '../countries';
@@ -68,6 +68,7 @@ function ensureDefaultPrinter(db: any): void {
 function printerShape(printer: any) {
   if (!printer) return printer;
   const profile = resolvePrinterProfile(printer);
+  const capabilities = capabilitiesForPrinter(profile, printer.paper_width || profile.defaultPaperWidth);
   return {
     id: printer.id,
     name: printer.name,
@@ -81,7 +82,7 @@ function printerShape(printer: any) {
     updated_at: printer.updated_at,
     profile_id: profile.id,
     profile_name: `${profile.make} ${profile.model}`,
-    capabilities: profile.capabilities,
+    capabilities,
   };
 }
 
@@ -299,12 +300,13 @@ router.post('/:id/test', requireRole(...ROLE_ACCESS.ownerManager), asyncHandler(
     if (!printer) return res.status(404).json({ error: 'Printer not found' });
 
     const profile = resolvePrinterProfile(printer);
+    const capabilities = capabilitiesForPrinter(profile, printer.paper_width || profile.defaultPaperWidth);
     const testData = buildTestPage(
       printer.paper_width || profile.defaultPaperWidth,
       profile.cutMode,
       tenantLanguage(db),
       tenantSettingValue(db, 'timezone') || 'Asia/Kolkata',
-      req.body?.rasterProbe === true ? profile.capabilities : undefined,
+      req.body?.rasterProbe === true ? capabilities : undefined,
     );
     let result: { ok: boolean; detail?: string } = { ok: false };
 

--- a/shared/print/raster.ts
+++ b/shared/print/raster.ts
@@ -270,6 +270,7 @@ export function isRasterRenderRequest(value: unknown): value is RasterRenderRequ
         && column.text.length <= 16_000
         && (column.align === 'left' || column.align === 'right')
         && (column.widthRatio === undefined || (typeof column.widthRatio === 'number' && Number.isFinite(column.widthRatio) && column.widthRatio > 0 && column.widthRatio <= 1)))
+      && request.layout.columns.reduce((sum, col) => sum + (typeof col?.widthRatio === 'number' ? col.widthRatio : 0), 0) <= 1.000001
     ))
     && ['normal', 'bold', 'double-height', 'double-width', 'font-b'].includes(request.style as string)
     && (request.styles === undefined || (Array.isArray(request.styles) && request.styles.length > 0 && request.styles.length <= 4

--- a/shared/print/raster.ts
+++ b/shared/print/raster.ts
@@ -22,6 +22,7 @@ export interface RasterTextLayout {
   readonly columns: readonly {
     readonly text: string;
     readonly align: 'left' | 'right';
+    readonly widthRatio?: number;
   }[];
 }
 
@@ -267,7 +268,8 @@ export function isRasterRenderRequest(value: unknown): value is RasterRenderRequ
       && request.layout.columns.every((column) => !!column
         && typeof column.text === 'string'
         && column.text.length <= 16_000
-        && (column.align === 'left' || column.align === 'right'))
+        && (column.align === 'left' || column.align === 'right')
+        && (column.widthRatio === undefined || (typeof column.widthRatio === 'number' && Number.isFinite(column.widthRatio) && column.widthRatio > 0 && column.widthRatio <= 1)))
     ))
     && ['normal', 'bold', 'double-height', 'double-width', 'font-b'].includes(request.style as string)
     && (request.styles === undefined || (Array.isArray(request.styles) && request.styles.length > 0 && request.styles.length <= 4

--- a/tests/printer.test.ts
+++ b/tests/printer.test.ts
@@ -148,7 +148,7 @@ function visiblePreview(buf: Buffer, cols: number): string {
   let i = 0;
   while (i < buf.length) {
     const b = buf[i];
-    if (b === ESC && (buf[i + 1] === 0x21 || buf[i + 1] === 0x61 || buf[i + 1] === 0x45 || buf[i + 1] === 0x64 || buf[i + 1] === 0x40 || buf[i + 1] === 0x34)) {
+    if (b === ESC && (buf[i + 1] === 0x21 || buf[i + 1] === 0x61 || buf[i + 1] === 0x45 || buf[i + 1] === 0x64 || buf[i + 1] === 0x40)) {
       i += buf[i + 1] === 0x40 ? 2 : 3;
       continue;
     }
@@ -728,7 +728,6 @@ console.log('\n✅ Test 2: Compact receipt (80mm, 48 cols)');
   assert('renders UPI payment', text.includes('UPI') && text.includes('₹450.00'));
   assert('renders tax registration number', text.includes('TAXID-0001'));
   assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('(flopos.com)'));
-  assert('renders footer with italic ESC sequence', bytesContain(buf, [ESC, 0x34, 0x01]));
   const rowLines = visiblePreview(buf, 48).split('\n');
   const longRowIndex = rowLines.findIndex((l) => l.includes('Very Long Product Name That'));
   assert('long product name wraps cleanly onto multiple lines', longRowIndex >= 0 && rowLines[longRowIndex + 1]?.includes('Truncated By Formatter'));

--- a/tests/printer.test.ts
+++ b/tests/printer.test.ts
@@ -727,7 +727,7 @@ console.log('\n✅ Test 2: Compact receipt (80mm, 48 cols)');
   assert('renders Cash payment', text.includes('Cash') && text.includes('₹500.00'));
   assert('renders UPI payment', text.includes('UPI') && text.includes('₹450.00'));
   assert('renders tax registration number', text.includes('TAXID-0001'));
-  assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('https://flopos.com'));
+  assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('(flopos.com)'));
   const rowLines = visiblePreview(buf, 48).split('\n');
   const longRowIndex = rowLines.findIndex((l) => l.includes('Very Long Product Name That'));
   assert('long product name wraps cleanly onto multiple lines', longRowIndex >= 0 && rowLines[longRowIndex + 1]?.includes('Truncated By Formatter'));
@@ -811,7 +811,7 @@ console.log('\n✅ Test 4: Classic receipt template');
 
   assert('renders business name', text.includes('Flo Test Cafe'));
   assert('renders item and total', text.includes('Cheeseburger') && text.includes('₹950.00'));
-  assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('https://flopos.com'));
+  assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('(flopos.com)'));
   assert('ends with cut', bytesContain(buf, [GS, 0x56, 0x00]));
 
   console.log('\n   — Rendered classic —');
@@ -825,7 +825,7 @@ console.log('\n✅ Test 5: Tax-specific labels fall back to the default template
 
   assert('legacy detailed label renders the default classic receipt', text.includes('Invoice #:'));
   assert('legacy detailed label does not render the GST-style tax invoice', !text.includes('TAX INVOICE'));
-  assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('https://flopos.com'));
+  assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('(flopos.com)'));
 
   console.log('\n   — Rendered detailed fallback —');
   console.log(visiblePreview(buf, 48));

--- a/tests/printer.test.ts
+++ b/tests/printer.test.ts
@@ -148,7 +148,7 @@ function visiblePreview(buf: Buffer, cols: number): string {
   let i = 0;
   while (i < buf.length) {
     const b = buf[i];
-    if (b === ESC && (buf[i + 1] === 0x21 || buf[i + 1] === 0x61 || buf[i + 1] === 0x45 || buf[i + 1] === 0x64 || buf[i + 1] === 0x40)) {
+    if (b === ESC && (buf[i + 1] === 0x21 || buf[i + 1] === 0x61 || buf[i + 1] === 0x45 || buf[i + 1] === 0x64 || buf[i + 1] === 0x40 || buf[i + 1] === 0x34)) {
       i += buf[i + 1] === 0x40 ? 2 : 3;
       continue;
     }
@@ -728,6 +728,7 @@ console.log('\n✅ Test 2: Compact receipt (80mm, 48 cols)');
   assert('renders UPI payment', text.includes('UPI') && text.includes('₹450.00'));
   assert('renders tax registration number', text.includes('TAXID-0001'));
   assert('renders non-configurable FloPOS footer', text.includes('Powered by FloPOS') && text.includes('(flopos.com)'));
+  assert('renders footer with italic ESC sequence', bytesContain(buf, [ESC, 0x34, 0x01]));
   const rowLines = visiblePreview(buf, 48).split('\n');
   const longRowIndex = rowLines.findIndex((l) => l.includes('Very Long Product Name That'));
   assert('long product name wraps cleanly onto multiple lines', longRowIndex >= 0 && rowLines[longRowIndex + 1]?.includes('Truncated By Formatter'));

--- a/tests/raster-printing.test.ts
+++ b/tests/raster-printing.test.ts
@@ -1014,6 +1014,45 @@ async function run(): Promise<void> {
   assert.equal(isRasterRenderRequest({ ...request, bundledFont: { ...request.bundledFont, dataUrl: 'https://example.invalid/font.woff2' } }), false);
   assert.equal(isRasterRenderRequest({ ...request, bundledFont: { ...request.bundledFont, dataUrl: null } }), false);
   assert.equal(isRasterRenderRequest({ ...request, bundledFont: { ...request.bundledFont, family: 'bad;url(x)' } }), false);
+
+  const baseLayout = {
+    kind: 'financial-item' as const,
+    columns: [
+      { text: 'Item', align: 'left' as const },
+      { text: '10.00', align: 'right' as const },
+    ],
+  };
+  assert.equal(isRasterRenderRequest({ ...request, layout: baseLayout }), true);
+  assert.equal(isRasterRenderRequest({
+    ...request,
+    layout: {
+      ...baseLayout,
+      columns: [
+        { text: 'Item', align: 'left' as const, widthRatio: 0.5 },
+        { text: '10.00', align: 'right' as const, widthRatio: 0.4 },
+      ],
+    },
+  }), true);
+  assert.equal(isRasterRenderRequest({
+    ...request,
+    layout: {
+      ...baseLayout,
+      columns: [
+        { text: 'Item', align: 'left' as const, widthRatio: 0.6 },
+        { text: '10.00', align: 'right' as const, widthRatio: 0.4 },
+      ],
+    },
+  }), true);
+  assert.equal(isRasterRenderRequest({
+    ...request,
+    layout: {
+      ...baseLayout,
+      columns: [
+        { text: 'Item', align: 'left' as const, widthRatio: 0.7 },
+        { text: '10.00', align: 'right' as const, widthRatio: 0.4 },
+      ],
+    },
+  }), false);
   assert.equal(isRasterRenderResult({ version: 1, requestId: 'r1', ok: true }), false);
   assert.equal(isRasterRenderResult({ version: 1, requestId: 'r1', ok: false, code: 'render-failed', detail: 'failed' }), true);
 

--- a/tests/raster-printing.test.ts
+++ b/tests/raster-printing.test.ts
@@ -17,7 +17,7 @@ import { buildBillDocument, buildKotDocument, isKotDocument, isPrintDocument } f
 import { resolveTenantCurrency } from '../main/countries';
 import { buildBackendMixedRasterBytes } from '../main/printers/raster-output';
 import { getSupportedPrinterProfiles } from '../main/printers/profiles';
-import { buildEscPos, escPosToText, financialRows, itemRows, normalizeThermalText } from '../main/printers/thermal';
+import { buildEscPos, escPosToText, financialRows, itemRows, normalizeThermalText, dotsForPaperWidth } from '../main/printers/thermal';
 import { buildTestPage } from '../main/printers/thermal';
 import { buildKotPrintData, renderKotDocumentToLines } from '../main/printers/document-kot';
 import { renderBillDocumentToClassicLines, renderClassicReceiptViaDocument } from '../main/printers/document-classic';
@@ -333,8 +333,8 @@ async function run(): Promise<void> {
   assert.equal(grandTotalRequests[0].style, 'bold');
   const pointsRequest = financialRequests.find((request) => request.text === 'نقاط مستردة -5 pts');
   assert.deepEqual(pointsRequest?.layout?.columns, [
-    { text: 'نقاط مستردة', align: 'left' },
-    { text: '-5 pts', align: 'right' },
+    { text: 'نقاط مستردة', align: 'left', widthRatio: 30 / 42 },
+    { text: '-5 pts', align: 'right', widthRatio: 12 / 42 },
   ]);
   assert.equal(financialRequests.some((request) => request.text.includes(':')), false);
   const kotDocument = buildKotDocument({
@@ -1091,7 +1091,65 @@ async function run(): Promise<void> {
   assert.equal(fontlessResult.failures.length, 0);
   assert.equal(fontlessRequests.length, 2);
   assert.equal(fontlessRequests[0].bundledFont, undefined);
-  assert.equal(fontlessRequests[1].bundledFont, undefined);
+  // Verify widthRatio on financial-item and financial-summary raster layouts
+  const ratioRequests: any[] = [];
+  await renderUnsupportedRasterLines({
+    render: async (req) => {
+      ratioRequests.push(req);
+      return { version: 1, requestId: (req as any).requestId, ok: true, unit: { unitId: (req as any).requestId, financial: true, complete: true, bands: [twoRows] } };
+    },
+  }, ['{FINANCIAL}宫保鸡丁 2 $424.00'], caps, 'ratio-test', [
+    {
+      groupId: 'item-table-row-0',
+      lineIndex: 0,
+      lineCount: 1,
+      sourceLines: ['宫保鸡丁 2 $424.00'],
+      sourceControlLines: ['{FINANCIAL}宫保鸡丁 2 $424.00'],
+      sourceLayouts: [{
+        kind: 'financial-item',
+        columns: [
+          { text: '宫保鸡丁', align: 'left', widthRatio: 18 / 32 },
+          { text: '2', align: 'left', widthRatio: 4 / 32 },
+          { text: '$424.00', align: 'right', widthRatio: 10 / 32 },
+        ],
+      }],
+      financial: true,
+    },
+  ]);
+  assert.equal(ratioRequests.length, 1);
+  assert.equal(ratioRequests[0].layout.columns[0].widthRatio, 18 / 32);
+  assert.equal(ratioRequests[0].layout.columns[1].widthRatio, 4 / 32);
+  assert.equal(ratioRequests[0].layout.columns[2].widthRatio, 10 / 32);
+
+  // Verify itemRows on narrow 32-column printer never exceeds 32 columns
+  const narrow32Item = itemRows(
+    { product_name: 'Croque-Monsieur Special Long Name Here', quantity: 1, total: 32 },
+    18,
+    10,
+    32,
+    '$',
+    'en-US',
+    false,
+    'en',
+    2,
+    caps,
+  );
+  for (const line of narrow32Item) {
+    assert.ok(line.length <= 32, `Item row line "${line}" exceeds 32 characters (was ${line.length})`);
+  }
+
+  // dotsForPaperWidth: paper_width string → canonical raster dot width
+  assert.equal(dotsForPaperWidth('58mm'), 384);
+  assert.equal(dotsForPaperWidth('cols-32'), 384);
+  assert.equal(dotsForPaperWidth('58mm-36'), 432);
+  assert.equal(dotsForPaperWidth('cols-36'), 432);
+  assert.equal(dotsForPaperWidth('cols-40'), 480);
+  assert.equal(dotsForPaperWidth('80mm-42'), 512);
+  assert.equal(dotsForPaperWidth('cols-42'), 512);
+  assert.equal(dotsForPaperWidth('cols-44'), 528);
+  assert.equal(dotsForPaperWidth('80mm'), null);
+  assert.equal(dotsForPaperWidth('cols-48'), 576);
+  assert.equal(dotsForPaperWidth('unknown'), null);
 
   console.log('Raster encoder and mixed-mode contract checks passed.');
 }

--- a/tests/raster-printing.test.ts
+++ b/tests/raster-printing.test.ts
@@ -16,8 +16,8 @@ import { GENERIC_THERMAL_CAPABILITIES, type ThermalPrinterCapabilities } from '.
 import { buildBillDocument, buildKotDocument, isKotDocument, isPrintDocument } from '../shared/print/document';
 import { resolveTenantCurrency } from '../main/countries';
 import { buildBackendMixedRasterBytes } from '../main/printers/raster-output';
-import { getSupportedPrinterProfiles } from '../main/printers/profiles';
-import { buildEscPos, escPosToText, financialRows, itemRows, normalizeThermalText, dotsForPaperWidth } from '../main/printers/thermal';
+import { getSupportedPrinterProfiles, dotsForPaperWidth, capabilitiesForPrinter } from '../main/printers/profiles';
+import { buildEscPos, escPosToText, financialRows, itemRows, normalizeThermalText, resolvePrinterContext } from '../main/printers/thermal';
 import { buildTestPage } from '../main/printers/thermal';
 import { buildKotPrintData, renderKotDocumentToLines } from '../main/printers/document-kot';
 import { renderBillDocumentToClassicLines, renderClassicReceiptViaDocument } from '../main/printers/document-classic';
@@ -1150,6 +1150,22 @@ async function run(): Promise<void> {
   assert.equal(dotsForPaperWidth('80mm'), null);
   assert.equal(dotsForPaperWidth('cols-48'), 576);
   assert.equal(dotsForPaperWidth('unknown'), null);
+
+  // resolvePrinterContext: reconciles profile, columns, and raster dot width into single context
+  const narrowPrinter = { name: 'XP-58 Test', paper_width: 'cols-32' };
+  const narrowContext = resolvePrinterContext(narrowPrinter);
+  assert.equal(narrowContext.columns, 32);
+  assert.equal(narrowContext.capabilities.raster.widthDots, 384);
+
+  const widePrinter = { name: 'XP-80 Test', paper_width: 'cols-48' };
+  const wideContext = resolvePrinterContext(widePrinter);
+  assert.equal(wideContext.columns, 48);
+  assert.equal(wideContext.capabilities.raster.widthDots, 576);
+
+  const defaultNarrowPrinter = { name: 'Generic 58mm', paper_width: '58mm' };
+  const defaultNarrowContext = resolvePrinterContext(defaultNarrowPrinter);
+  assert.equal(defaultNarrowContext.columns, 32);
+  assert.equal(defaultNarrowContext.capabilities.raster.widthDots, 384);
 
   console.log('Raster encoder and mixed-mode contract checks passed.');
 }

--- a/tests/raster-printing.test.ts
+++ b/tests/raster-printing.test.ts
@@ -1144,10 +1144,10 @@ async function run(): Promise<void> {
   assert.equal(dotsForPaperWidth('58mm-36'), 432);
   assert.equal(dotsForPaperWidth('cols-36'), 432);
   assert.equal(dotsForPaperWidth('cols-40'), 480);
-  assert.equal(dotsForPaperWidth('80mm-42'), 512);
-  assert.equal(dotsForPaperWidth('cols-42'), 512);
-  assert.equal(dotsForPaperWidth('cols-44'), 528);
-  assert.equal(dotsForPaperWidth('80mm'), null);
+  assert.equal(dotsForPaperWidth('80mm-42'), 576);
+  assert.equal(dotsForPaperWidth('cols-42'), 576);
+  assert.equal(dotsForPaperWidth('cols-44'), 576);
+  assert.equal(dotsForPaperWidth('80mm'), 576);
   assert.equal(dotsForPaperWidth('cols-48'), 576);
   assert.equal(dotsForPaperWidth('unknown'), null);
 
@@ -1166,6 +1166,11 @@ async function run(): Promise<void> {
   const defaultNarrowContext = resolvePrinterContext(defaultNarrowPrinter);
   assert.equal(defaultNarrowContext.columns, 32);
   assert.equal(defaultNarrowContext.capabilities.raster.widthDots, 384);
+
+  const default80Printer = { name: 'Generic 80mm', paper_width: 'cols-42' };
+  const default80Context = resolvePrinterContext(default80Printer);
+  assert.equal(default80Context.columns, 42);
+  assert.equal(default80Context.capabilities.raster.widthDots, 576);
 
   console.log('Raster encoder and mixed-mode contract checks passed.');
 }


### PR DESCRIPTION
## Related work

Issue / Discussion: None (hardware printer testing and layout refinements)

## Summary

This PR addresses thermal printer layout inconsistencies on narrow (58mm / 32-col) and wide (80mm / 48-col) paper formats:
- **Raster Column Alignment & Resolution**: Standardized `resolvePrinterContext` so dot width (384 dots for 58mm, 576 dots for 80mm) and text column counts are atomically resolved. Added proportional `widthRatio` support across `RasterTextLayout` columns and document builders (`document-classic.ts`, `document-compact.ts`) so mixed-language raster items align precisely with text headers and Latin items.
- **Raster Typography**: Dropped semi-bold weight from 600 to 400 (regular) for crisp non-bold receipt rows. Added 3px top offset and scaled logical line height (30 -> 32px) and font size (22 -> 24px) so multilingual scripts (such as Hindi/Devanagari maatras and Arabic diacritics) have breathing room and render cleanly without clipping.
- **Receipt Branding Footer**: Standardized the footer to a single line `Powered by FloPOS (flopos.com)` preceded by blank lines to avoid crowding receipt totals.
- **Receipt Hardware Centering**: Uses standard ESC/POS hardware centering (`ESC a 1`) across all printer widths so centered lines (headers, store names, and footers) are positioned in the center of the printable area on both 58mm and 80mm paper.

## Scope

- Out of scope: Changes to database schema, migrations, or unrelated print paths.

## Verification

Commands run:
- `npm run lint:backend`: 0 errors
- `npm run build`: Success (dist/ built cleanly)
- `npx ts-node --transpile-only -P tests/tsconfig.json tests/printer.test.ts`: 419 passed, 0 failed
- `npm run test:raster`: Passed (unit checks and Chromium raster renderer Electron test)
- `npm run test:print-document`: 28 passed, 0 failed
- `npm run build:frontend`: Next.js 16 build and static export passed cleanly

## Compatibility & data safety

- **Database/data impact:** None
- **Migration:** None
- **User-visible behavior:** Thermal receipt output on physical printers is aligned and cleanly spaced across 58mm and 80mm rolls.
- **Offline/network impact:** None

## Contributor checklist

- [x] This is a small isolated fix/doc update OR follows an approved issue/direction.
- [x] Unrelated cleanups, refactors, and dependency changes were kept out of this PR.
- [x] Tests were added or updated for any behavior changes.
- [x] Verification commands were run and documented above.
- [x] Customer data and upgrade safety were preserved (if touching database/storage).
- [x] Documentation or translations were updated where relevant.
- [x] I understand and can explain all submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Receipt footers now display “Powered by FloPOS (flopos.com)” consistently across printing methods.
  - Printer capabilities and paper-width settings are resolved automatically for each configured printer.
  - Improved raster receipt layouts provide more accurate column sizing for items, totals, payments, and financial summaries.
  - Narrower paper configurations now receive appropriately scaled output.

- **Bug Fixes**
  - Improved text spacing, line height, font sizing, and alignment in raster-printed receipts.
  - Printer test pages and reports now use the selected printer’s effective paper width and capabilities.
  - Raster layouts now validate column proportions to prevent invalid output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->