### PR TITLE
Potential fix for code scanning alert no. 288: Missing rate limiting

### DIFF
--- a/main/kds-server.ts
+++ b/main/kds-server.ts
@@ -153,7 +153,7 @@ export function startKdsServer(): Promise<void> {
     });
 
     // Public tenant metadata: language and KDS defaults for pre-login display.
-    app.get('/api/kds/info', (_req: Request, res: Response) => {
+    app.get('/api/kds/info', rateLimit(), (_req: Request, res: Response) => {
       // Return 404 when disabled to avoid revealing KDS presence to unauthorized LAN clients.
       if (!isKdsEnabled()) {
         return res.status(404).json({ error: 'Not found' });

--- a/main/kds-server.ts
+++ b/main/kds-server.ts
@@ -1,4 +1,5 @@
 import express, { Express, Request, Response, NextFunction } from 'express';
+import expressRateLimit from 'express-rate-limit';
 import cors from 'cors';
 import jwt from 'jsonwebtoken';
 import { WebSocketServer } from 'ws';
@@ -153,7 +154,12 @@ export function startKdsServer(): Promise<void> {
     });
 
     // Public tenant metadata: language and KDS defaults for pre-login display.
-    app.get('/api/kds/info', rateLimit(), (_req: Request, res: Response) => {
+    app.get('/api/kds/info', expressRateLimit({
+      windowMs: 60 * 1000,
+      limit: 100,
+      standardHeaders: true,
+      legacyHeaders: false,
+    }), (_req: Request, res: Response) => {
       // Return 404 when disabled to avoid revealing KDS presence to unauthorized LAN clients.
       if (!isKdsEnabled()) {
         return res.status(404).json({ error: 'Not found' });

--- a/tests/kds-integration.test.ts
+++ b/tests/kds-integration.test.ts
@@ -248,6 +248,14 @@ async function run() {
     const infoRes = await request(`http://127.0.0.1:${port}`).get('/api/kds/info');
     assert(infoRes.status === 200, 'Public info endpoint returns 200');
 
+    // The public endpoint must also throttle LAN clients before repeated database reads.
+    for (let i = 1; i < 100; i += 1) {
+      const allowedInfoRes = await request(`http://127.0.0.1:${port}`).get('/api/kds/info');
+      assert(allowedInfoRes.status === 200, `Public info request ${i + 1} remains within the rate limit`);
+    }
+    const throttledInfoRes = await request(`http://127.0.0.1:${port}`).get('/api/kds/info');
+    assert(throttledInfoRes.status === 429, 'Public info endpoint rate-limits repeated LAN requests');
+
     console.log('✅ KDS Integration & Auth Role Contract tests passed!');
   } finally {
     stopKdsServer();


### PR DESCRIPTION
Potential fix for [https://github.com/FreeOpenSourcePOS/FloCafe/security/code-scanning/288](https://github.com/FreeOpenSourcePOS/FloCafe/security/code-scanning/288)

Add a rate-limiting middleware to the `/api/kds/info` route so requests are throttled before the database access executes.

Best fix with minimal behavioral change:
- In `main/kds-server.ts`, update the route declaration at the `/api/kds/info` endpoint (around lines 156–175).
- Change `app.get('/api/kds/info', (_req, res) => { ... })` to `app.get('/api/kds/info', rateLimit(), (_req, res) => { ... })`.
- No new imports are needed because `rateLimit` is already imported from `./middleware/security` on line 13.
- This preserves current endpoint behavior and response shape, while adding abuse protection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added request throttling to the public KDS information endpoint.
  - Requests exceeding 100 within a 60-second period now receive a rate-limit response.

- **Tests**
  - Added coverage verifying that requests within the limit succeed and additional requests are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->