### PR TITLE
chore: release 3.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "3.7.3",
+  "version": "3.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "3.7.3",
+      "version": "3.7.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.7.3",
+  "version": "3.7.5",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- Merges the unmerged follow-up fix from fix/z-report-narrow-layout (`fix: address Z-report review findings`) that simplifies the atomic-settings-save mechanism added in #676
- Bumps version to 3.7.5

## Test plan
- [x] `npm run lint` (0 errors)
- [x] `npm run build`
- [x] `npm run build:frontend`
- [x] `npm run test:cash-closures` (282/282)
- [x] `npm run test:print-kernel`
- [x] `npm run test:print-parity` (495 assertions)
- [x] `npm run test:printer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Settings**
  * Printing preferences are saved individually, including Z-report language policy settings.
  * Changes appear immediately while updates are persisted in the background.
  * The former single-request printing settings save path is no longer available.
  * Save controls remain available while updates are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->