### PR TITLE
fix(frontend): improve native select readability in dark mode

### DIFF
--- a/frontend/e2e/desktop/theme.electron.spec.ts
+++ b/frontend/e2e/desktop/theme.electron.spec.ts
@@ -56,6 +56,19 @@ async function clickThemeRadio(label: 'Light' | 'Dark' | 'System'): Promise<void
   await expect.poll(() => radio.isDisabled(), { timeout: 10_000 }).toBe(false);
 }
 
+async function expectNativeSelectColorScheme(expected: 'light' | 'dark'): Promise<void> {
+  await harness.page.goto(`http://localhost:${harness.ports.main}/orders`, {
+    waitUntil: 'domcontentloaded',
+  });
+  const select = harness.page.locator('select').first();
+  await select.waitFor({ state: 'visible', timeout: 10_000 });
+  await expect.poll(
+    () => select.evaluate((element) => getComputedStyle(element).colorScheme),
+    { timeout: 10_000 },
+  ).toBe(expected);
+  await navigateToAppearance();
+}
+
 test('real Electron flips the renderer palette when the owner toggles Dark in Settings', async () => {
   await harness.authenticateDashboard();
   await navigateToAppearance();
@@ -84,11 +97,16 @@ test('real Electron flips the renderer palette when the owner toggles Dark in Se
   expect(runtime.htmlHasDark).toBe(true);
   expect(runtime.mirror).toBe('dark');
 
+  await expectNativeSelectColorScheme('dark');
+
   if (process.env.FLO_E2E_EVIDENCE_DIR) {
     await harness.page.screenshot({
       path: `${process.env.FLO_E2E_EVIDENCE_DIR}/03-theme-dark-toggle.png`,
     });
   }
+
+  await clickThemeRadio('Light');
+  await expectNativeSelectColorScheme('light');
 });
 
 test('real System mode follows nativeTheme.themeSource through the renderer matchMedia listener', async () => {
@@ -106,6 +124,7 @@ test('real System mode follows nativeTheme.themeSource through the renderer matc
     undefined,
     { timeout: 10_000 },
   );
+  await expectNativeSelectColorScheme('dark');
 
   await harness.app.evaluate((electron) => {
     electron.nativeTheme.themeSource = 'light';
@@ -115,6 +134,7 @@ test('real System mode follows nativeTheme.themeSource through the renderer matc
     undefined,
     { timeout: 10_000 },
   );
+  await expectNativeSelectColorScheme('light');
 
   await harness.app.evaluate((electron) => {
     electron.nativeTheme.themeSource = 'system';

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -369,6 +369,12 @@ div:hover > .flo-toast-drain,
   body {
     @apply bg-background text-foreground;
   }
+  select {
+    color-scheme: light;
+  }
+  .dark select {
+    color-scheme: dark;
+  }
 }
 
 @keyframes shake-centered {


### PR DESCRIPTION
## Intent

Investigate and fix FloCafe issue #681, where native dropdown option text and background become unreadable in dark mode on Windows. Implement the smallest platform-neutral shared fix by applying light and dark color-scheme rules to native HTML select controls, leave Radix dropdowns and backend, API, database, translation, and Electron-main behavior unchanged, add executable Electron regression coverage for dark, light, and System mode, manually validate native popup readability on Windows 10/11 when available, and deliver the committed change through the no-mistakes pipeline with review, tests, lint, push, PR creation, and CI validation; do not merge.

## What Changed

- Added light and dark `color-scheme` rules for native HTML select controls.
- Added Electron regression coverage for native select readability in Dark, Light, and System modes.

## Risk Assessment

✅ Low: Minimal shared CSS fix with focused real-Electron coverage; no concrete reachable regression or intent violation found.

## Testing

After installing missing locked dependencies, the targeted Electron build and three-test theme regression completed successfully, exercising native select color-scheme in Dark, Light, and System transitions plus SQLite persistence and capturing rendered UI evidence; Windows 10/11 native popup validation was unavailable on this macOS runner. No lint or full repository suite was run, per phase constraints.

![Dark theme settings evidence](https://github.com/user-attachments/assets/e5b06ec4-1db9-4ac6-9388-24464406ff5f)
![System theme evidence](https://github.com/user-attachments/assets/5c0c801d-fc27-4a46-88b2-5ab8392fbe7e)
![Persisted dark POS evidence with native select](https://github.com/user-attachments/assets/c4c6ff83-4f88-4a50-9ad1-9dea13ef37eb)
- Outcome: ⚠️ 1 warning across 1 run (4m59s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e5aed987c2af0ba3ce553e27e3c8663e17f13534","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Windows 10/11 native popup readability could not be manually validated because this runner is macOS. Electron regression coverage verified computed color-scheme and rendered native select behavior, but OS-specific popup rendering remains unconfirmed.
- <code>`npm ci` in the worktree root</code>
- <code>`npm ci` in `frontend/`</code>
- `FLO_E2E_EVIDENCE_DIR=~/.no-mistakes/evidence/01M23SDW0N8V0P3EAZ6ZMNR8C7 npm run test:e2e:electron -- --grep "theme"`
- `git diff --check 45ddad0dec5bdff08d38c53c9e9c31418d71e912 e5aed987c2af0ba3ce553e27e3c8663e17f13534`
- `Visual inspection of all three captured PNG screenshots`
- <code>Final `git status --short --untracked-files=all` and transient-artifact cleanup verification</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 5 warnings</summary>

- ⚠️ `frontend/e2e/helpers/electron-fixture.ts:116` - Pre-existing unused `_isDark` warning in unchanged Electron fixture.
- ⚠️ `frontend/src/components/pos/PaymentModal.tsx:59` - Pre-existing unused `currency` warning in unchanged payment modal.
- ⚠️ `frontend/src/components/pos/PrepaidCheckoutModal.tsx:80` - Pre-existing unused `currency` warning in unchanged prepaid checkout modal.
- ⚠️ `frontend/src/components/pos/PrepaidCheckoutModal.tsx:235` - Pre-existing unused `totalPayment` warning in unchanged prepaid checkout modal.
- ⚠️ `frontend/src/lib/api.ts:38` - Pre-existing internal navigation warning in unchanged API module.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
