### PR TITLE
fix: patch js-yaml advisory and link CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+AGENTS.md

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "brace-expansion@>=4.0.0 <5.0.9": "5.0.9",
     "fast-uri": "^3.1.7",
     "ip-address": "^10.4.0",
+    "js-yaml@^4": "^4.3.2",
     "undici": "^7.29.0",
     "postcss": "8.5.28",
     "postcss-selector-parser": "^7.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,6 @@
     "brace-expansion@>=4.0.0 <5.0.9": "5.0.9",
     "fast-uri": "^3.1.7",
     "ip-address": "^10.4.0",
-    "js-yaml@^4": "^4.3.2",
     "undici": "^7.29.0",
     "postcss": "8.5.28",
     "postcss-selector-parser": "^7.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2818,9 +2818,9 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -3188,9 +3188,9 @@
       }
     },
     "node_modules/builder-util/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -3888,9 +3888,9 @@
       }
     },
     "node_modules/dmg-builder/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -4260,9 +4260,9 @@
       }
     },
     "node_modules/electron-updater/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
   "overrides": {
     "node-abi": "^4.33.0",
     "brace-expansion": "^5.0.8",
+    "js-yaml@^4": "^4.3.2",
     "minimatch@3.1.5": {
       "brace-expansion": "^1.1.17"
     }


### PR DESCRIPTION
## Intent

Resolve FloCafe Dependabot advisory https://github.com/FreeOpenSourcePOS/FloCafe/security/dependabot/55. The transitive npm dependency js-yaml is affected in versions >=4.0.0 and <4.3.2 because maxTotalMergeKeys does not count empty mappings, allowing crafted YAML merges to consume significant CPU; update to patched version 4.3.2 or newer through the dependency graph and keep the lockfile correct. Also replace the project-root CLAUDE.md file, whose content is only AGENTS.md, with a symlink named CLAUDE.md pointing to AGENTS.md. These two changes must ship together in a single PR.

## What Changed

- Force transitive `js-yaml` dependencies to patched version 4.3.2 and update the lockfile integrity data.
- Replace the root `CLAUDE.md` file with a symlink to `AGENTS.md`.

## Risk Assessment

✅ Low: The change correctly pins all vulnerable transitive js-yaml 4.x entries to 4.3.2 and replaces CLAUDE.md with the required AGENTS.md symlink, with no unrelated changes found.

## Testing

Fresh dependency installs and adversarial resolution checks passed for both lockfiles; CLAUDE.md correctly links to AGENTS.md; backend and frontend production builds passed; final diff check was clean and the worktree contains no transient test artifacts.

- Live validation: ✅ go - 5 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Install FloCafe dependencies from both committed lockfiles | ✅ pass | live | Clean dependency installs |
| Resolve all vulnerable js-yaml v4 paths to patched 4.3.2 or newer | ✅ pass | live | Clean dependency installs |
| Access project guidance through CLAUDE.md | ✅ pass | live | CLAUDE.md symlink check |
| Adversarially confirm clean installation contains no js-yaml v4 below 4.3.2 | ✅ pass | live | Clean dependency installs |
| Build the desktop product with the patched dependency graph | ✅ pass | live | Product build verification |

<details>
<summary>Evidence: Clean dependency installs</summary>

```text
Root and frontend `npm ci --ignore-scripts` succeeded. Installed trees resolved all js-yaml v4 paths to 4.3.2+.
```
</details>
<details>
<summary>Evidence: CLAUDE.md symlink check</summary>

```text
`CLAUDE.md` is a symbolic link targeting `AGENTS.md`; target exists and content matches.
```
</details>
<details>
<summary>Evidence: Product build verification</summary>

```text
Root and frontend production builds completed successfully.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7c625bbe9d7bc37abdc0c61f2f362e02d5dbc18b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":5,"total":5}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `frontend/package.json:55` - The new frontend override is redundant for this change: frontend/package-lock.json already resolved js-yaml to 4.3.2 at the base commit, while this branch fixes the vulnerable root graph. Removing this extra frontend constraint is the smaller scope unless future frontend lockfile updates are intentionally meant to be pinned by policy.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 5 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Install FloCafe dependencies from both committed lockfiles | ✅ pass | live | Clean dependency installs |
| Resolve all vulnerable js-yaml v4 paths to patched 4.3.2 or newer | ✅ pass | live | Clean dependency installs |
| Access project guidance through CLAUDE.md | ✅ pass | live | CLAUDE.md symlink check |
| Adversarially confirm clean installation contains no js-yaml v4 below 4.3.2 | ✅ pass | live | Clean dependency installs |
| Build the desktop product with the patched dependency graph | ✅ pass | live | Product build verification |

- <code>`npm ci --ignore-scripts --no-audit --no-fund` (root)</code>
- <code>`npm ls js-yaml --all --json` (root)</code>
- <code>`npm ci --ignore-scripts --no-audit --no-fund` (frontend)</code>
- <code>`npm ls js-yaml --all --json` (frontend)</code>
- `Parsed installed lockfiles for vulnerable js-yaml versions`
- <code>`node` lstat/readlink/content-equivalence check for CLAUDE.md</code>
- `npm run build`
- `NEXT_BUILD_MODE=desktop npm run build`
- `git diff --check BASE TARGET`
- <code>Final `git status --short` and committed diff audit</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → no changes applied ✅</summary>

- ⚠️ Configured npm lint could not run because the local eslint executable is unavailable.

🔧 No changes applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance documentation by removing a reference to an external instructions file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->