### PR TITLE
fix: keep LAN cashier payment keys unique

### DIFF
--- a/frontend/src/components/pos/PaymentModal.tsx
+++ b/frontend/src/components/pos/PaymentModal.tsx
@@ -28,6 +28,7 @@ import {
   type DiscountMode,
   type DiscountType,
 } from '@/lib/discount-settings';
+import { createPaymentIdempotencyKey } from '@/lib/payment-idempotency';
 
 interface Props {
   bill: Bill;
@@ -374,9 +375,7 @@ export default function PaymentModal({ bill, currency, onClose, onPaid, onBillUp
 
       // Atomic call ensures all split payment lines succeed together
       // or fail together without leaving partial payments.
-      const idempotencyKey = idempotencyKeyRef.current || (typeof globalThis.crypto?.randomUUID === 'function'
-        ? globalThis.crypto.randomUUID()
-        : 'payment-req');
+      const idempotencyKey = idempotencyKeyRef.current || createPaymentIdempotencyKey();
       idempotencyKeyRef.current = idempotencyKey;
       const res = await api.post(
         `/bills/${bill.id}/payments`,

--- a/frontend/src/lib/payment-idempotency.ts
+++ b/frontend/src/lib/payment-idempotency.ts
@@ -1,0 +1,18 @@
+type PaymentCrypto = {
+  randomUUID?: () => string;
+  getRandomValues?: (values: Uint32Array) => Uint32Array;
+};
+
+/** Creates a fresh payment request key in secure and plain-HTTP LAN contexts. */
+export function createPaymentIdempotencyKey(
+  cryptoSource: PaymentCrypto | undefined = globalThis.crypto as PaymentCrypto | undefined,
+): string {
+  if (typeof cryptoSource?.randomUUID === 'function') {
+    return cryptoSource.randomUUID();
+  }
+  if (typeof cryptoSource?.getRandomValues === 'function') {
+    const values = cryptoSource.getRandomValues(new Uint32Array(4));
+    return `payment-${Array.from(values, (value) => value.toString(16).padStart(8, '0')).join('')}`;
+  }
+  return `payment-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/frontend/src/lib/payment-idempotency.ts
+++ b/frontend/src/lib/payment-idempotency.ts
@@ -3,6 +3,8 @@ type PaymentCrypto = {
   getRandomValues?: (values: Uint32Array) => Uint32Array;
 };
 
+let fallbackSequence = 0;
+
 /** Creates a fresh payment request key in secure and plain-HTTP LAN contexts. */
 export function createPaymentIdempotencyKey(
   cryptoSource: PaymentCrypto | undefined = globalThis.crypto as PaymentCrypto | undefined,
@@ -14,5 +16,6 @@ export function createPaymentIdempotencyKey(
     const values = cryptoSource.getRandomValues(new Uint32Array(4));
     return `payment-${Array.from(values, (value) => value.toString(16).padStart(8, '0')).join('')}`;
   }
-  return `payment-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`;
+  fallbackSequence += 1;
+  return `payment-${Date.now().toString(36)}-${fallbackSequence.toString(36)}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`;
 }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "test:timezone-report-boundaries": "node tests/run-electron-node-test.cjs tests/timezone-report-boundaries.test.ts",
     "test:integration-happy": "node tests/run-electron-node-test.cjs tests/integration-happy-path.test.ts",
     "test:integration-tax": "node tests/run-electron-node-test.cjs tests/integration-tax.test.ts",
-    "test:integration-payments": "node tests/run-electron-node-test.cjs tests/integration-payments.test.ts",
+    "test:integration-payments": "node tests/run-electron-node-test.cjs tests/integration-payments.test.ts && node tests/run-electron-node-test.cjs tests/issue-689-cashier-payments.test.ts",
     "test:issue-214": "node tests/run-electron-node-test.cjs tests/issue-214-payment-integrity.test.ts",
     "test:issue-214-auth": "node tests/run-electron-node-test.cjs tests/issue-214-auth-migration.test.ts",
     "test:issue-214-migration": "node tests/run-electron-node-test.cjs tests/issue-214-migration-integrity.test.ts",

--- a/tests/issue-689-cashier-payments.test.ts
+++ b/tests/issue-689-cashier-payments.test.ts
@@ -75,6 +75,18 @@ async function main() {
     }
 
     assertEqual(sequence, 2, 'a fresh fallback key is generated for each payment request');
+    const originalDateNow = Date.now;
+    const originalMathRandom = Math.random;
+    Date.now = () => 1;
+    Math.random = () => 0.5;
+    try {
+      const firstLegacyKey = createPaymentIdempotencyKey({});
+      const secondLegacyKey = createPaymentIdempotencyKey({});
+      assertEqual(firstLegacyKey === secondLegacyKey, false, 'legacy fallback keys remain unique');
+    } finally {
+      Date.now = originalDateNow;
+      Math.random = originalMathRandom;
+    }
     const persisted = db.prepare(`
       SELECT COUNT(*) AS count
       FROM bills

--- a/tests/issue-689-cashier-payments.test.ts
+++ b/tests/issue-689-cashier-payments.test.ts
@@ -1,4 +1,3 @@
-/** Regression coverage for #689: sequential cashier payments from LAN browsers. */
 const Module = require('module');
 const originalLoad = Module._load;
 const fs = require('fs');

--- a/tests/issue-689-cashier-payments.test.ts
+++ b/tests/issue-689-cashier-payments.test.ts
@@ -1,0 +1,99 @@
+/** Regression coverage for #689: sequential cashier payments from LAN browsers. */
+const Module = require('module');
+const originalLoad = Module._load;
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'flo-issue-689-'));
+
+Module._load = function (request: string, parent: unknown, isMain: boolean) {
+  if (request === 'electron') return { app: { isPackaged: true, getPath: () => testDir, getVersion: () => '3.7.5' } };
+  return originalLoad.apply(this, arguments as any);
+};
+
+const {
+  initTestDb, createApp, startServer, seedCategory, seedProduct,
+  api, assertEqual, getResults, closeDatabase, now,
+} = require('./helpers/test-setup');
+const { getJWTSecret } = require('../main/routes/auth');
+const { orderRoutes } = require('../main/routes/orders');
+const { billRoutes } = require('../main/routes/bills');
+const { createPaymentIdempotencyKey } = require('../frontend/src/lib/payment-idempotency');
+
+async function main() {
+  console.log('Issue #689: sequential cashier payments from an insecure LAN context');
+  const db = initTestDb();
+  const cashierId = 'cashier-689';
+  db.prepare(`
+    INSERT INTO users (id, name, email, password, role, is_active, created_at, updated_at)
+    VALUES (?, ?, ?, ?, 'cashier', 1, ?, ?)
+  `).run(cashierId, 'Cashier 689', 'cashier-689@test.local', bcrypt.hashSync('testpass123', 10), now(), now());
+  const token = jwt.sign(
+    { userId: cashierId, email: 'cashier-689@test.local', role: 'cashier' },
+    getJWTSecret(),
+    { expiresIn: '1h' },
+  );
+  const authHeader = { Authorization: `Bearer ${token}` };
+
+  seedCategory(db, 'cat-689', 'Issue 689 menu');
+  seedProduct(db, 'prod-689', 'cat-689', 'Issue 689 item', 10);
+
+  const app = createApp({ '/api/orders': orderRoutes, '/api/bills': billRoutes });
+  const { baseUrl, server } = await startServer(app);
+  let sequence = 0;
+  const insecureContextCrypto = {
+    getRandomValues(values: Uint32Array) {
+      sequence += 1;
+      values.fill(sequence);
+      return values;
+    },
+  };
+
+  try {
+    for (let orderNumber = 1; orderNumber <= 2; orderNumber += 1) {
+      const order = await api(baseUrl, '/api/orders', {
+        method: 'POST',
+        body: { type: 'takeaway', items: [{ product_id: 'prod-689', quantity: 1 }] },
+        headers: authHeader,
+      });
+      assertEqual(order.status, 201, `cashier creates order ${orderNumber}`);
+
+      const bill = await api(baseUrl, '/api/bills/generate', {
+        method: 'POST', body: { order_id: order.data.order.id }, headers: authHeader,
+      });
+      assertEqual(bill.status, 201, `cashier generates bill ${orderNumber}`);
+
+      const idempotencyKey = createPaymentIdempotencyKey(insecureContextCrypto);
+      const payment = await api(baseUrl, `/api/bills/${bill.data.bill.id}/payments`, {
+        method: 'POST',
+        body: { payments: [{ method: 'card', amount: bill.data.bill.total }] },
+        headers: { ...authHeader, 'Idempotency-Key': idempotencyKey },
+      });
+      assertEqual(payment.status, 200, `cashier pays order ${orderNumber}`);
+      assertEqual(payment.data.bill.payment_status, 'paid', `order ${orderNumber} payment persists`);
+    }
+
+    assertEqual(sequence, 2, 'a fresh fallback key is generated for each payment request');
+    const persisted = db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM bills
+      WHERE payment_status = 'paid' AND paid_amount = total
+    `).get() as { count: number };
+    assertEqual(persisted.count, 2, 'both cashier payments remain persisted');
+
+    const { passed, failed } = getResults();
+    console.log(`\nResults: ${passed} passed, ${failed} failed`);
+    if (failed > 0) process.exitCode = 1;
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    closeDatabase();
+    fs.rmSync(testDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes #689.

Cashier payment requests made from plain-HTTP LAN browsers reused the literal `payment-req` whenever `crypto.randomUUID()` was unavailable. Payment idempotency is scoped per user, so each cashier's first bill succeeded and the next distinct bill was rejected with HTTP 409.

- generate a fresh request key with `crypto.getRandomValues()` when `randomUUID()` is unavailable
- retain a last-resort unique fallback for environments without Web Crypto
- add an HTTP regression test covering two sequential cashier orders, bills, and payments from an insecure-context crypto shape

## Verification

- `npm run test:integration-payments` (43 assertions passed)
- `npm test`
- `npm run lint` (passes at the existing warning baseline)
- `npm run build`
- `npm run build:frontend`
- `npm run pack` built and signed the macOS arm64 app; the final artifact-marker helper stopped because the existing local `release/` directory contains multiple unpacked macOS app targets

## Packaged-runtime note

The newly built macOS package was launched against an isolated database and ports, but its HTTP endpoint accepted connections without returning responses, so I am treating that local packaged smoke check as inconclusive rather than a pass. A Windows packaged reproduction cannot be executed from this macOS host. The failing path itself is covered at the browser-capability and real authenticated HTTP/API layers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment request identification when secure browser cryptography is unavailable.
  * Ensured sequential cashier payments from insecure network contexts receive distinct request identifiers and are both processed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->