### PR TITLE
chore: release 3.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "3.7.5",
+      "version": "3.7.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary

- bumps the desktop version from 3.7.5 to 3.7.6
- contains no product changes beyond the already-merged cashier payment fix in #698

## Verification

- [x] `npm run test:release-config`
- [x] `git diff --check`
- [x] release commit is SSH-signed

After this version-only PR passes CI and is merged, an annotated signed `3.7.6` tag will trigger the cross-platform release workflow.
