### PR TITLE
fix(release-gate): skip stable Latest assertion for ordinary publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -938,13 +938,6 @@ jobs:
             echo "::error::No release found for tag $VERSION"
             exit 1
           fi
-          # Draft and prerelease state are changed only after verification. The
-          # explicit false prevents an ordinary stable or beta build from
-          # moving the stable pointer. Promotion remains a separate job.
-          gh api --method PATCH "repos/${{ github.repository }}/releases/${RELEASE_ID}" \
-            -F draft=false \
-            -F prerelease="${PRERELEASE}" \
-            -f make_latest=false
           # Beta publishing must not change Stable Latest; capture the current
           # Latest before publishing so the readiness check can assert
           # immutability. Stable publishing skips this assertion because GitHub's
@@ -960,6 +953,13 @@ jobs:
             LATEST_BEFORE=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name 2>/dev/null || true)
             READINESS_ARGS+=(--expected-latest "$LATEST_BEFORE")
           fi
+          # Draft and prerelease state are changed only after verification. The
+          # explicit false prevents an ordinary stable or beta build from
+          # moving the stable pointer. Promotion remains a separate job.
+          gh api --method PATCH "repos/${{ github.repository }}/releases/${RELEASE_ID}" \
+            -F draft=false \
+            -F prerelease="${PRERELEASE}" \
+            -f make_latest=false
           node scripts/release-gate/published-readiness.cjs "${READINESS_ARGS[@]}"
           echo "Published ${VERSION} (${CHANNEL})"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -961,8 +961,9 @@ jobs:
             READINESS_ARGS+=(--expected-latest "$LATEST_BEFORE")
           fi
           # Draft and prerelease state are changed only after verification. The
-          # explicit false prevents an ordinary stable or beta build from
-          # moving the stable pointer. Promotion remains a separate job.
+          # explicit false prevents the request from explicitly selecting this
+          # release as Latest. A newly published stable may still resolve via
+          # /releases/latest by created_at. Promotion remains a separate job.
           gh api --method PATCH "repos/${{ github.repository }}/releases/${RELEASE_ID}" \
             -F draft=false \
             -F prerelease="${PRERELEASE}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -944,11 +944,17 @@ jobs:
             -F draft=false \
             -F prerelease="${PRERELEASE}" \
             -f make_latest=false
-          node scripts/release-gate/published-readiness.cjs \
-            --repo "${{ github.repository }}" \
-            --tag "$VERSION" \
-            --commit "${{ github.sha }}" \
+          READINESS_ARGS=(
+            --repo "${{ github.repository }}"
+            --tag "$VERSION"
+            --commit "${{ github.sha }}"
             --channel "${{ needs.create-release.outputs.channel }}"
+          )
+          if [ "${{ needs.create-release.outputs.channel }}" = "beta" ]; then
+            LATEST_BEFORE=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name 2>/dev/null || true)
+            READINESS_ARGS+=(--expected-latest "$LATEST_BEFORE")
+          fi
+          node scripts/release-gate/published-readiness.cjs "${READINESS_ARGS[@]}"
           echo "Published ${VERSION} (${{ needs.create-release.outputs.channel }})"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -937,7 +937,6 @@ jobs:
             echo "::error::No release found for tag $VERSION"
             exit 1
           fi
-          LATEST_BEFORE=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name 2>/dev/null || true)
           # Draft and prerelease state are changed only after verification. The
           # explicit false prevents an ordinary stable or beta build from
           # moving the stable pointer. Promotion remains a separate job.
@@ -949,9 +948,8 @@ jobs:
             --repo "${{ github.repository }}" \
             --tag "$VERSION" \
             --commit "${{ github.sha }}" \
-            --channel "${{ needs.create-release.outputs.channel }}" \
-            --expected-latest "$LATEST_BEFORE"
-          echo "Published ${VERSION} (${{ needs.create-release.outputs.channel }}); Stable Latest remained ${LATEST_BEFORE:-'(none)'}"
+            --channel "${{ needs.create-release.outputs.channel }}"
+          echo "Published ${VERSION} (${{ needs.create-release.outputs.channel }})"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -927,6 +927,7 @@ jobs:
           set -euo pipefail
           VERSION="${{ needs.create-release.outputs.version }}"
           PRERELEASE="${{ needs.create-release.outputs.prerelease }}"
+          CHANNEL="${{ needs.create-release.outputs.channel }}"
           # Draft releases are not addressable via /releases/tags/{tag} (that
           # endpoint only matches published releases), so resolve the draft's
           # ID through the releases list. Same root cause as the draft-asset
@@ -944,18 +945,23 @@ jobs:
             -F draft=false \
             -F prerelease="${PRERELEASE}" \
             -f make_latest=false
+          # Beta publishing must not change Stable Latest; capture the current
+          # Latest before publishing so the readiness check can assert
+          # immutability. Stable publishing skips this assertion because GitHub's
+          # /releases/latest returns the newest published non-prerelease by
+          # created_at, making the assertion impossible for new stable releases.
           READINESS_ARGS=(
             --repo "${{ github.repository }}"
             --tag "$VERSION"
             --commit "${{ github.sha }}"
-            --channel "${{ needs.create-release.outputs.channel }}"
+            --channel "$CHANNEL"
           )
-          if [ "${{ needs.create-release.outputs.channel }}" = "beta" ]; then
+          if [ "$CHANNEL" = "beta" ]; then
             LATEST_BEFORE=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name 2>/dev/null || true)
             READINESS_ARGS+=(--expected-latest "$LATEST_BEFORE")
           fi
           node scripts/release-gate/published-readiness.cjs "${READINESS_ARGS[@]}"
-          echo "Published ${VERSION} (${{ needs.create-release.outputs.channel }})"
+          echo "Published ${VERSION} (${CHANNEL})"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -950,7 +950,14 @@ jobs:
             --channel "$CHANNEL"
           )
           if [ "$CHANNEL" = "beta" ]; then
-            LATEST_BEFORE=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name 2>/dev/null || true)
+            if LATEST_RESPONSE=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name --include 2>&1); then
+              LATEST_BEFORE=$(printf '%s\n' "$LATEST_RESPONSE" | tail -n 1)
+            elif grep -qE '^HTTP/[^ ]+ 404 ' <<<"$LATEST_RESPONSE"; then
+              LATEST_BEFORE=""
+            else
+              printf '%s\n' "$LATEST_RESPONSE" >&2
+              exit 1
+            fi
             READINESS_ARGS+=(--expected-latest "$LATEST_BEFORE")
           fi
           # Draft and prerelease state are changed only after verification. The

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -60,8 +60,10 @@ separate concepts. Every release is created with `--draft --latest=false`.
 After all platform uploads have completed, CI downloads each manifest and every
 artifact it references from the same draft release, checks HTTP success, and
 recomputes the manifest SHA-512 values. Only the separate `publish-release` job
-can then publish it. Stable tag pushes publish without moving GitHub's `Latest`
-pointer. To promote an already verified stable release, dispatch the workflow
+can then publish it. Stable tag pushes request publication without explicitly
+selecting the release as GitHub's `Latest`; GitHub may still resolve
+`/releases/latest` to a newly published stable release by `created_at`. To
+promote an already verified stable release intentionally, dispatch the workflow
 from that exact tag with `release_tag` set to the same tag,
 `channel=stable`, `promote_stable=true`, and the candidate manifest asset ID
 and SHA-256 from the verified release; the promotion-only job checks that the
@@ -122,8 +124,11 @@ non-manifest assets are checked for positive size and HTTP availability; their
 SHA-512 is not independently recomputed because GitHub/electron-builder does
 not publish a second expected SHA-512 for them.
 6. The dedicated publish job changes `draft` to false. It sets `make_latest`
-   false for every normal release. A separate explicit stable-promotion dispatch
-   is the only path that changes GitHub's `Latest` pointer.
+   false for every normal release, which avoids explicitly selecting the
+   release as GitHub's `Latest`; GitHub may still resolve `/releases/latest` to
+   the newest published non-prerelease release by `created_at`. A separate
+   explicit stable-promotion dispatch is the only path that intentionally
+   promotes a verified release as the default update target.
 7. After all platform uploads, the workflow creates and attaches the immutable
    candidate manifest and sanitized release summary defined in the [release
    evidence index](release-evidence-index.md). The candidate manifest is made

--- a/scripts/release-gate/published-readiness.cjs
+++ b/scripts/release-gate/published-readiness.cjs
@@ -69,7 +69,9 @@ async function main() {
   } catch (error) {
     if (expectedLatest !== '' || !String(error.message).includes('(404)')) throw error;
   }
-  assertStableLatestUnchanged(expectedLatest, latest.tag_name || '');
+  if (expectedLatest !== '') {
+    assertStableLatestUnchanged(expectedLatest, latest.tag_name || '');
+  }
   await verifyCandidateManifest(manifest, release, {
     requestAsset: (asset) => request(asset.url, 'application/octet-stream'),
     tag,

--- a/scripts/release-gate/published-readiness.cjs
+++ b/scripts/release-gate/published-readiness.cjs
@@ -65,14 +65,10 @@ async function main() {
   const manifest = JSON.parse(candidateBytes.toString('utf8'));
   const summary = JSON.parse(summaryBytes.toString('utf8'));
   assertReleaseSummary(summary, { manifest, candidateManifestBytes: candidateBytes });
-  let latest = { tag_name: '' };
-  try {
-    latest = await json(`${apiBase}/releases/latest`);
-  } catch (error) {
-    if (expectedLatest !== '' || !String(error.message).includes('(404)')) throw error;
-  }
+  let latestTag = '';
   if (expectedLatest !== '') {
-    assertStableLatestUnchanged(expectedLatest, latest.tag_name || '');
+    latestTag = (await json(`${apiBase}/releases/latest`)).tag_name || '';
+    assertStableLatestUnchanged(expectedLatest, latestTag);
   }
   await verifyCandidateManifest(manifest, release, {
     requestAsset: (asset) => request(asset.url, 'application/octet-stream'),
@@ -88,7 +84,7 @@ async function main() {
     availableAssetIds: manifest.assets.map((asset) => asset.id),
     ...(expectedLatest === '' ? {} : {
       stableLatestBefore: expectedLatest,
-      stableLatestAfter: latest.tag_name || '',
+      stableLatestAfter: latestTag,
     }),
   });
   console.log(`published ${channel} release ${tag} is ready; candidate manifest SHA-256 ${manifestSha256(candidateBytes)}`);

--- a/scripts/release-gate/published-readiness.cjs
+++ b/scripts/release-gate/published-readiness.cjs
@@ -46,7 +46,8 @@ async function main() {
   const tag = arg(argv, '--tag');
   const commit = arg(argv, '--commit').toLowerCase();
   const channel = arg(argv, '--channel');
-  const expectedLatest = argv.includes('--expected-latest')
+  const hasExpectedLatest = argv.includes('--expected-latest');
+  const expectedLatest = hasExpectedLatest
     ? arg(argv, '--expected-latest', { allowEmpty: true })
     : '';
   if (!SEMVER.test(tag)) throw new Error(`invalid release tag ${tag}`);
@@ -66,8 +67,12 @@ async function main() {
   const summary = JSON.parse(summaryBytes.toString('utf8'));
   assertReleaseSummary(summary, { manifest, candidateManifestBytes: candidateBytes });
   let latestTag = '';
-  if (expectedLatest !== '') {
-    latestTag = (await json(`${apiBase}/releases/latest`)).tag_name || '';
+  if (hasExpectedLatest) {
+    try {
+      latestTag = (await json(`${apiBase}/releases/latest`)).tag_name || '';
+    } catch (error) {
+      if (expectedLatest !== '' || !String(error.message).includes('(404)')) throw error;
+    }
     assertStableLatestUnchanged(expectedLatest, latestTag);
   }
   await verifyCandidateManifest(manifest, release, {
@@ -82,10 +87,10 @@ async function main() {
     channel,
     expectedAssetIds: manifest.assets.map((asset) => asset.id),
     availableAssetIds: manifest.assets.map((asset) => asset.id),
-    ...(expectedLatest === '' ? {} : {
+    ...(hasExpectedLatest ? {
       stableLatestBefore: expectedLatest,
       stableLatestAfter: latestTag,
-    }),
+    } : {}),
   });
   console.log(`published ${channel} release ${tag} is ready; candidate manifest SHA-256 ${manifestSha256(candidateBytes)}`);
 }

--- a/scripts/release-gate/published-readiness.cjs
+++ b/scripts/release-gate/published-readiness.cjs
@@ -46,7 +46,9 @@ async function main() {
   const tag = arg(argv, '--tag');
   const commit = arg(argv, '--commit').toLowerCase();
   const channel = arg(argv, '--channel');
-  const expectedLatest = arg(argv, '--expected-latest', { allowEmpty: true });
+  const expectedLatest = argv.includes('--expected-latest')
+    ? arg(argv, '--expected-latest', { allowEmpty: true })
+    : '';
   if (!SEMVER.test(tag)) throw new Error(`invalid release tag ${tag}`);
 
   const apiBase = `https://api.github.com/repos/${repo}`;
@@ -84,8 +86,10 @@ async function main() {
     channel,
     expectedAssetIds: manifest.assets.map((asset) => asset.id),
     availableAssetIds: manifest.assets.map((asset) => asset.id),
-    stableLatestBefore: expectedLatest,
-    stableLatestAfter: latest.tag_name || '',
+    ...(expectedLatest === '' ? {} : {
+      stableLatestBefore: expectedLatest,
+      stableLatestAfter: latest.tag_name || '',
+    }),
   });
   console.log(`published ${channel} release ${tag} is ready; candidate manifest SHA-256 ${manifestSha256(candidateBytes)}`);
 }

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -622,8 +622,7 @@ exit 1
       'github.repository': 'FreeOpenSourcePOS/FloCafe',
       'github.sha': 'a'.repeat(40),
     },
-    fakeNodeVersion: '3.3.0',
-    fakeCommands: { gh: fakeGh },
+    fakeCommands: { gh: fakeGh, node: captureNodeArgs },
   });
   assert.equal(publishStable.status, 0, publishStable.stderr);
   assert.match(publishStable.log, /-F draft=false -F prerelease=false -f make_latest=false/);
@@ -633,6 +632,8 @@ exit 1
     'GitHub make_latest is a string enum and must not be encoded as a JSON boolean',
   );
   assert.doesNotMatch(publishStable.log, /make_latest=true/);
+  assert.doesNotMatch(publishStable.log, /releases\/latest/);
+  assert.doesNotMatch(publishStable.log, /--expected-latest/);
 
   const publishBeta = executeWorkflowStep(publishStep, {
     expressions: {
@@ -643,8 +644,7 @@ exit 1
       'github.repository': 'FreeOpenSourcePOS/FloCafe',
       'github.sha': 'a'.repeat(40),
     },
-    fakeNodeVersion: '3.3.1-beta.1',
-    fakeCommands: { gh: fakeGh },
+    fakeCommands: { gh: fakeGh, node: captureNodeArgs },
   });
   assert.equal(publishBeta.status, 0, publishBeta.stderr);
   assert.match(publishBeta.log, /-F draft=false -F prerelease=true -f make_latest=false/);
@@ -654,6 +654,8 @@ exit 1
     'GitHub make_latest is a string enum and must not be encoded as a JSON boolean',
   );
   assert.doesNotMatch(publishBeta.log, /make_latest=true/);
+  assert.match(publishBeta.log, /releases\/latest/);
+  assert.match(publishBeta.log, /--expected-latest 42/);
 
   const promoteStep = findStep(promoteJob, 'Promote published stable release to GitHub Latest');
   const promoteStable = executeWorkflowStep(promoteStep, {

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -128,6 +128,10 @@ function executeWorkflowStep(step: any, options: {
 const fakeGh = `#!/bin/sh
 printf '%s\\n' "$*" >> "$RELEASE_TEST_LOG"
 if [ "$1" = "release" ] && [ "$2" = "view" ]; then exit 1; fi
+if [ "$1" = "api" ] && [ "\${2:-}" = "repos/FreeOpenSourcePOS/FloCafe/releases/latest" ] && [ -n "\${RELEASE_TEST_LATEST_FAILURE:-}" ]; then
+  printf 'HTTP/2.0 %s Error\\n' "$RELEASE_TEST_LATEST_FAILURE"
+  exit 1
+fi
 if [ "$1" = "api" ] && [ "\${3:-}" = "--jq" ]; then printf '42\\n'; exit 0; fi
 if [ "$1" = "api" ] && [ "\${2:-}" != "--method" ]; then printf '{"draft":false,"prerelease":false,"id":42}\\n'; fi
 `;
@@ -661,6 +665,35 @@ exit 1
     betaLogLines.findIndex((line) => line.includes('/releases/latest')) < betaLogLines.findIndex((line) => line.includes('api --method PATCH')),
     'beta Latest snapshot must happen before publication',
   );
+
+  const publishBetaWithoutStableLatest = executeWorkflowStep(publishStep, {
+    env: { RELEASE_TEST_LATEST_FAILURE: '404' },
+    expressions: {
+      'needs.create-release.outputs.version': '3.3.1-beta.1',
+      'needs.create-release.outputs.prerelease': 'true',
+      'needs.create-release.outputs.make_latest': 'false',
+      'needs.create-release.outputs.channel': 'beta',
+      'github.repository': 'FreeOpenSourcePOS/FloCafe',
+      'github.sha': 'a'.repeat(40),
+    },
+    fakeCommands: { gh: fakeGh, node: captureNodeArgs },
+  });
+  assert.equal(publishBetaWithoutStableLatest.status, 0, publishBetaWithoutStableLatest.stderr);
+
+  const publishBetaLatestFailure = executeWorkflowStep(publishStep, {
+    env: { RELEASE_TEST_LATEST_FAILURE: '500' },
+    expressions: {
+      'needs.create-release.outputs.version': '3.3.1-beta.1',
+      'needs.create-release.outputs.prerelease': 'true',
+      'needs.create-release.outputs.make_latest': 'false',
+      'needs.create-release.outputs.channel': 'beta',
+      'github.repository': 'FreeOpenSourcePOS/FloCafe',
+      'github.sha': 'a'.repeat(40),
+    },
+    fakeCommands: { gh: fakeGh, node: captureNodeArgs },
+  });
+  assert.notEqual(publishBetaLatestFailure.status, 0, 'beta Latest preflight must reject non-404 failures');
+  assert.match(publishBetaLatestFailure.stderr, /HTTP\/2\.0 500 Error/);
 
   const promoteStep = findStep(promoteJob, 'Promote published stable release to GitHub Latest');
   const promoteStable = executeWorkflowStep(promoteStep, {

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -656,6 +656,11 @@ exit 1
   assert.doesNotMatch(publishBeta.log, /make_latest=true/);
   assert.match(publishBeta.log, /releases\/latest/);
   assert.match(publishBeta.log, /--expected-latest 42/);
+  const betaLogLines = publishBeta.log.trim().split('\n');
+  assert.ok(
+    betaLogLines.findIndex((line) => line.includes('/releases/latest')) < betaLogLines.findIndex((line) => line.includes('api --method PATCH')),
+    'beta Latest snapshot must happen before publication',
+  );
 
   const promoteStep = findStep(promoteJob, 'Promote published stable release to GitHub Latest');
   const promoteStable = executeWorkflowStep(promoteStep, {

--- a/tests/release-gate.test.cjs
+++ b/tests/release-gate.test.cjs
@@ -163,6 +163,12 @@ function releaseRefRequest({
     stableLatestBefore: '3.3.0',
     stableLatestAfter: '3.3.0',
   });
+  assertCandidateReadiness({
+    release: { draft: false, prerelease: false, tag_name: '3.3.0', assets: published.assets },
+    tag: '3.3.0',
+    channel: 'stable',
+    expectedAssetIds: manifest.assets.map((entry) => entry.id),
+  });
   assert.throws(() => assertCandidateReadiness({
     release: published,
     tag: release.tag_name,

--- a/tests/release-gate.test.cjs
+++ b/tests/release-gate.test.cjs
@@ -263,7 +263,10 @@ function releaseRefRequest({
       if (requestUrl.endsWith('/releases/tags/3.7.6')) return { status: 200, json: async () => release };
       if (requestUrl === 'https://assets.test/candidate') return { status: 200, arrayBuffer: async () => candidateBytes };
       if (requestUrl === 'https://assets.test/summary') return { status: 200, arrayBuffer: async () => summaryBytes };
-      if (requestUrl.endsWith('/releases/latest')) return { status: 200, json: async () => ({ tag_name: latestTag }) };
+      if (requestUrl.endsWith('/releases/latest')) {
+        if (!process.argv.includes('--expected-latest')) throw new Error('stable readiness should not request Latest');
+        return { status: 200, json: async () => ({ tag_name: latestTag }) };
+      }
       throw new Error(`unexpected readiness request ${requestUrl}`);
     };
 

--- a/tests/release-gate.test.cjs
+++ b/tests/release-gate.test.cjs
@@ -229,6 +229,7 @@ function releaseRefRequest({
     ],
   };
   let latestTag = '3.7.6';
+  let latestStatus = 200;
   try {
     require.cache[releaseStatePath] = {
       id: releaseStatePath,
@@ -265,6 +266,7 @@ function releaseRefRequest({
       if (requestUrl === 'https://assets.test/summary') return { status: 200, arrayBuffer: async () => summaryBytes };
       if (requestUrl.endsWith('/releases/latest')) {
         if (!process.argv.includes('--expected-latest')) throw new Error('stable readiness should not request Latest');
+        if (latestStatus !== 200) return { status: latestStatus, text: async () => '' };
         return { status: 200, json: async () => ({ tag_name: latestTag }) };
       }
       throw new Error(`unexpected readiness request ${requestUrl}`);
@@ -283,6 +285,20 @@ function releaseRefRequest({
     assert.deepEqual(latestChecks, [['3.7.5', '3.7.5']]);
     assert.equal(readinessCalls[1].stableLatestBefore, '3.7.5');
     assert.equal(readinessCalls[1].stableLatestAfter, '3.7.5');
+
+    latestStatus = 404;
+    process.argv = ['node', publishedReadinessPath, '--repo', 'example/repo', '--tag', '3.7.6', '--commit', 'A'.repeat(40), '--channel', 'beta', '--expected-latest', ''];
+    await publishedReadiness();
+    assert.deepEqual(latestChecks, [['3.7.5', '3.7.5'], ['', '']]);
+    assert.equal(readinessCalls[2].stableLatestBefore, '');
+    assert.equal(readinessCalls[2].stableLatestAfter, '');
+
+    latestStatus = 500;
+    await assert.rejects(
+      publishedReadiness(),
+      /GitHub request failed \(500\)/,
+      'beta readiness must not swallow non-404 Latest lookup failures',
+    );
   } finally {
     process.argv = previousArgv;
     global.fetch = previousFetch;

--- a/tests/release-gate.test.cjs
+++ b/tests/release-gate.test.cjs
@@ -219,7 +219,7 @@ function releaseRefRequest({
   const latestChecks = [];
   const candidateBytes = Buffer.from(JSON.stringify({ assets: [] }));
   const summaryBytes = Buffer.from('{}');
-  let release = {
+  let publishedReadinessRelease = {
     draft: false,
     prerelease: false,
     tag_name: '3.7.6',
@@ -260,7 +260,7 @@ function releaseRefRequest({
     process.env.GH_TOKEN = 'test';
     global.fetch = async (url) => {
       const requestUrl = String(url);
-      if (requestUrl.endsWith('/releases/tags/3.7.6')) return { status: 200, json: async () => release };
+      if (requestUrl.endsWith('/releases/tags/3.7.6')) return { status: 200, json: async () => publishedReadinessRelease };
       if (requestUrl === 'https://assets.test/candidate') return { status: 200, arrayBuffer: async () => candidateBytes };
       if (requestUrl === 'https://assets.test/summary') return { status: 200, arrayBuffer: async () => summaryBytes };
       if (requestUrl.endsWith('/releases/latest')) {
@@ -276,7 +276,7 @@ function releaseRefRequest({
     assert.equal(Object.hasOwn(readinessCalls[0], 'stableLatestBefore'), false);
     assert.equal(Object.hasOwn(readinessCalls[0], 'stableLatestAfter'), false);
 
-    release = { ...release, prerelease: true };
+    publishedReadinessRelease = { ...publishedReadinessRelease, prerelease: true };
     latestTag = '3.7.5';
     process.argv = ['node', publishedReadinessPath, '--repo', 'example/repo', '--tag', '3.7.6', '--commit', 'A'.repeat(40), '--channel', 'beta', '--expected-latest', '3.7.5'];
     await publishedReadiness();

--- a/tests/release-gate.test.cjs
+++ b/tests/release-gate.test.cjs
@@ -205,6 +205,92 @@ function releaseRefRequest({
   assertOrdering(['draft-verified', 'snap-published', 'published', 'promoted-latest'], { channel: 'stable' });
   assert.throws(() => assertOrdering(['draft-verified', 'published', 'promoted-latest'], { channel: 'stable' }), /snap-published.*published/);
 
+  const publishedReadinessPath = require.resolve('../scripts/release-gate/published-readiness.cjs');
+  const releaseStatePath = require.resolve('../scripts/release-gate/release-state.cjs');
+  const evidencePath = require.resolve('../scripts/release-gate/evidence.cjs');
+  const candidateManifestPath = require.resolve('../scripts/release-gate/candidate-manifest.cjs');
+  const modulePaths = [publishedReadinessPath, releaseStatePath, evidencePath, candidateManifestPath];
+  const previousModules = new Map(modulePaths.map((modulePath) => [modulePath, require.cache[modulePath]]));
+  const previousArgv = process.argv;
+  const previousFetch = global.fetch;
+  const hadGhToken = Object.hasOwn(process.env, 'GH_TOKEN');
+  const previousGhToken = process.env.GH_TOKEN;
+  const readinessCalls = [];
+  const latestChecks = [];
+  const candidateBytes = Buffer.from(JSON.stringify({ assets: [] }));
+  const summaryBytes = Buffer.from('{}');
+  let release = {
+    draft: false,
+    prerelease: false,
+    tag_name: '3.7.6',
+    assets: [
+      { name: 'candidate-manifest.json', id: 1, url: 'https://assets.test/candidate' },
+      { name: 'release-summary.json', id: 2, url: 'https://assets.test/summary' },
+    ],
+  };
+  let latestTag = '3.7.6';
+  try {
+    require.cache[releaseStatePath] = {
+      id: releaseStatePath,
+      filename: releaseStatePath,
+      loaded: true,
+      exports: {
+        assertCandidateReadiness: (value) => readinessCalls.push(value),
+        assertPublishedRelease: () => {},
+        assertStableLatestUnchanged: (before, after) => latestChecks.push([before, after]),
+      },
+    };
+    require.cache[evidencePath] = {
+      id: evidencePath,
+      filename: evidencePath,
+      loaded: true,
+      exports: { assertReleaseSummary: () => {} },
+    };
+    require.cache[candidateManifestPath] = {
+      id: candidateManifestPath,
+      filename: candidateManifestPath,
+      loaded: true,
+      exports: {
+        manifestSha256: () => 'digest',
+        resolveTagCommit: async () => 'a'.repeat(40),
+        verifyCandidateManifest: async () => {},
+      },
+    };
+    const { main: publishedReadiness } = require(publishedReadinessPath);
+    process.env.GH_TOKEN = 'test';
+    global.fetch = async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.endsWith('/releases/tags/3.7.6')) return { status: 200, json: async () => release };
+      if (requestUrl === 'https://assets.test/candidate') return { status: 200, arrayBuffer: async () => candidateBytes };
+      if (requestUrl === 'https://assets.test/summary') return { status: 200, arrayBuffer: async () => summaryBytes };
+      if (requestUrl.endsWith('/releases/latest')) return { status: 200, json: async () => ({ tag_name: latestTag }) };
+      throw new Error(`unexpected readiness request ${requestUrl}`);
+    };
+
+    process.argv = ['node', publishedReadinessPath, '--repo', 'example/repo', '--tag', '3.7.6', '--commit', 'A'.repeat(40), '--channel', 'stable'];
+    await publishedReadiness();
+    assert.equal(latestChecks.length, 0);
+    assert.equal(Object.hasOwn(readinessCalls[0], 'stableLatestBefore'), false);
+    assert.equal(Object.hasOwn(readinessCalls[0], 'stableLatestAfter'), false);
+
+    release = { ...release, prerelease: true };
+    latestTag = '3.7.5';
+    process.argv = ['node', publishedReadinessPath, '--repo', 'example/repo', '--tag', '3.7.6', '--commit', 'A'.repeat(40), '--channel', 'beta', '--expected-latest', '3.7.5'];
+    await publishedReadiness();
+    assert.deepEqual(latestChecks, [['3.7.5', '3.7.5']]);
+    assert.equal(readinessCalls[1].stableLatestBefore, '3.7.5');
+    assert.equal(readinessCalls[1].stableLatestAfter, '3.7.5');
+  } finally {
+    process.argv = previousArgv;
+    global.fetch = previousFetch;
+    if (hadGhToken) process.env.GH_TOKEN = previousGhToken;
+    else delete process.env.GH_TOKEN;
+    for (const [modulePath, previousModule] of previousModules) {
+      if (previousModule) require.cache[modulePath] = previousModule;
+      else delete require.cache[modulePath];
+    }
+  }
+
   const summary = createReleaseSummary({ manifest, candidateManifestBytes: Buffer.from('manifest') });
   assertReleaseSummary(summary, { manifest, candidateManifestBytes: Buffer.from('manifest') });
   assert.throws(() => assertReleaseSummary({


### PR DESCRIPTION
## Intent

Captain authorized the minimal fix after the red release action on commit 8a126f445ea6b54c02e21ab6310ef7f9f234cea9: release 3.7.6 published with its assets, but Publish verified release failed because published-readiness compared GitHub Latest before=3.7.5 with after=3.7.6 while the publish request sent make_latest=false. GitHub documents /releases/latest as the newest published non-prerelease release by created_at. Update release automation so ordinary stable publication no longer asserts that the prior Latest tag remains unchanged, while the beta candidate gate retains the old stable Latest immutability check. Keep release artifacts and the existing promotion policy unchanged. Validate the change with the relevant tests.

## What Changed

- Updated publication readiness so ordinary stable releases skip the GitHub Latest immutability assertion, while beta releases retain the pre-publication Latest snapshot and check.
- Preserved the existing artifact and promotion flow, and documented GitHub's `created_at`-based Latest resolution behavior.
- Added regression coverage for stable, beta, missing Latest, and non-404 Latest lookup failures.

## Risk Assessment

✅ Low: The change cleanly separates stable publication from beta Stable Latest verification while preserving artifact handling and promotion behavior; no source-verifiable defects were found.

## Testing

The focused release-config suite passed and exercised the requested stable/beta behavior plus adversarial beta preflight failure handling. No UI or running-product evidence was possible because the change has no live product surface; final diff and worktree status were also checked.

- Live validation: ⚠️ no-surface - 0 of 2 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Stable publication does not assert prior GitHub Latest after publish | ⏸️ untested | no | This is GitHub Actions-only behavior with no live FloCafe product surface; an authorized GitHub release run would be required. |
| Beta publication preserves stable GitHub Latest immutability check | ⏸️ untested | no | This is GitHub Actions-only behavior with no live FloCafe product surface; an authorized GitHub release run would be required. |

<details>
<summary>Evidence: Focused release-gate validation</summary>

```text
`npm run test:release-config` passed, exercising stable readiness without Latest lookup, beta Latest snapshot ordering, beta 404 handling, and beta 500 failure propagation.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (1m31s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f565a0624a146c35fcafa16ad46e3d5183254faa","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `.github/workflows/release.yml:960` - Beta&#39;s supposed pre-publication snapshot is taken after the PATCH that publishes the draft: the `gh api .../releases/latest` call at line 960 follows the `draft=false` update at lines 944-947. If publishing changes Stable Latest, both reads observe the new tag, so the immutability check passes without checking the publication transition. Capture the snapshot before the PATCH.
- 🚨 `scripts/release-gate/published-readiness.cjs:69` - The readiness logic treats `--expected-latest &#34;&#34;` as if the flag were absent. The beta workflow supplies the flag, but an empty value occurs when no stable release exists or when `|| true` masks a lookup failure. The script then skips the post-publication Latest request and assertion, so a change can pass silently. Preserve flag presence separately from an empty baseline and retain the prior 404/failure behavior.

🔧 Fix applied.
1 error still open:

- 🚨 `.github/workflows/release.yml:953` - The intent requires that the beta candidate gate retain the Stable Latest immutability check. The pre-publication lookup at line 953 still uses `|| true`, so a transient/non-404 failure is converted to an empty baseline; if the post-publication lookup also returns 404, `published-readiness.cjs` accepts `(&#39;&#39;, &#39;&#39;)` and the beta passes without verifying Latest. Preserve the legitimate no-stable-release 404 case, but propagate other preflight failures.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ this change has no live-validatable surface; proceed without live validation? (0 of 2 scenarios were driven live against the product); Stable publication does not assert prior GitHub Latest after publish: This is GitHub Actions-only behavior with no live FloCafe product surface; an authorized GitHub release run would be required.; Beta publication preserves stable GitHub Latest immutability check: This is GitHub Actions-only behavior with no live FloCafe product surface; an authorized GitHub release run would be required.
- Live validation: ⚠️ no-surface - 0 of 2 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Stable publication does not assert prior GitHub Latest after publish | ⏸️ untested | no | This is GitHub Actions-only behavior with no live FloCafe product surface; an authorized GitHub release run would be required. |
| Beta publication preserves stable GitHub Latest immutability check | ⏸️ untested | no | This is GitHub Actions-only behavior with no live FloCafe product surface; an authorized GitHub release run would be required. |

- `npm run test:release-config`
- `git diff --check`
- `Workflow-step simulations for stable and beta publication`
- `Published-readiness simulations for stable, beta, empty Latest (404), and non-404 Latest failure paths`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 error</summary>

- 🚨 `frontend/eslint.config.mjs:2` - `npm run lint` could not complete frontend lint because `eslint-config-next` is missing from the worktree; backend lint completed with pre-existing warnings.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
