### PR TITLE
fix: preserve stable release pointer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -945,6 +945,12 @@ jobs:
             -F draft=false \
             -F prerelease="${PRERELEASE}" \
             -f make_latest=false
+          LATEST_AFTER=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name 2>/dev/null || true)
+          if [ "$LATEST_AFTER" != "$LATEST_BEFORE" ] && [ -n "$LATEST_BEFORE" ]; then
+            PREVIOUS_RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases/tags/${LATEST_BEFORE}" --jq .id)
+            gh api --method PATCH "repos/${{ github.repository }}/releases/${PREVIOUS_RELEASE_ID}" \
+              -f make_latest=true
+          fi
           node scripts/release-gate/published-readiness.cjs \
             --repo "${{ github.repository }}" \
             --tag "$VERSION" \

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -122,8 +122,10 @@ non-manifest assets are checked for positive size and HTTP availability; their
 SHA-512 is not independently recomputed because GitHub/electron-builder does
 not publish a second expected SHA-512 for them.
 6. The dedicated publish job changes `draft` to false. It sets `make_latest`
-   false for every normal release. A separate explicit stable-promotion dispatch
-   is the only path that changes GitHub's `Latest` pointer.
+   false for every normal release and restores the previously recorded Latest
+   release if GitHub moves the pointer while publishing the draft. A separate
+   explicit stable-promotion dispatch is the only path that intentionally
+   changes GitHub's `Latest` pointer.
 7. After all platform uploads, the workflow creates and attaches the immutable
    candidate manifest and sanitized release summary defined in the [release
    evidence index](release-evidence-index.md). The candidate manifest is made

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -634,6 +634,41 @@ exit 1
   );
   assert.doesNotMatch(publishStable.log, /make_latest=true/);
 
+  const fakeGhMovesLatest = `#!/bin/sh
+printf '%s\n' "$*" >> "$RELEASE_TEST_LOG"
+case "$*" in
+  *"releases --paginate --jq"*) printf '42\n' ;;
+  *"releases/latest --jq .tag_name"*)
+    if [ -f "$RUNNER_TEMP/latest-restored" ]; then
+      printf '3.7.5\n'
+    elif [ -f "$RUNNER_TEMP/published" ]; then
+      printf '3.7.6\n'
+    else
+      printf '3.7.5\n'
+    fi
+    ;;
+  *"--method PATCH"*"releases/42"*) touch "$RUNNER_TEMP/published"; printf '{}\n' ;;
+  *"releases/tags/3.7.5 --jq .id"*) printf '41\n' ;;
+  *"--method PATCH"*"releases/41"*"make_latest=true"*) touch "$RUNNER_TEMP/latest-restored"; printf '{}\n' ;;
+  *) printf '{}\n' ;;
+esac
+`;
+  const publishWithMovedLatest = executeWorkflowStep(publishStep, {
+    expressions: {
+      'needs.create-release.outputs.version': '3.7.6',
+      'needs.create-release.outputs.prerelease': 'false',
+      'needs.create-release.outputs.make_latest': 'false',
+      'needs.create-release.outputs.channel': 'stable',
+      'github.repository': 'FreeOpenSourcePOS/FloCafe',
+      'github.sha': 'a'.repeat(40),
+    },
+    fakeNodeVersion: '3.7.6',
+    fakeCommands: { gh: fakeGhMovesLatest },
+  });
+  assert.equal(publishWithMovedLatest.status, 0, publishWithMovedLatest.stderr);
+  assert.match(publishWithMovedLatest.log, /releases\/tags\/3\.7\.5 --jq \.id/);
+  assert.match(publishWithMovedLatest.log, /--method PATCH repos\/FreeOpenSourcePOS\/FloCafe\/releases\/41 -f make_latest=true/);
+
   const publishBeta = executeWorkflowStep(publishStep, {
     expressions: {
       'needs.create-release.outputs.version': '3.3.1-beta.1',


### PR DESCRIPTION
## Summary

The fully verified 3.7.6 release exposed that GitHub can move the repository's Latest pointer when a draft stable release is published even when the PATCH request includes `make_latest=false`.

- compare Latest immediately after publication with the pre-publication value
- restore the previously selected release when GitHub moved it
- keep the existing fail-closed readiness verification after restoration
- document the behavior and add a workflow execution regression test

This restores the explicit-promotion contract; the 3.7.6 release remains public while 3.7.5 stays selected as Latest until a deliberate promotion.

## Verification

- `npm run test:release-config`
- `git diff --check`

Observed on release run: https://github.com/FreeOpenSourcePOS/FloCafe/actions/runs/34463542349


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Normal releases now preserve the existing GitHub Latest release, even if publishing temporarily changes the Latest pointer.
  - Stable promotion remains the only workflow that intentionally updates GitHub Latest.

- **Documentation**
  - Updated release-process guidance to clarify how Latest release handling works.

- **Tests**
  - Added coverage for restoring the previous Latest release when publishing causes the pointer to change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->