### PR TITLE
fix: respect server app regional settings

### DIFF
--- a/frontend/src/app/server-standalone/page.tsx
+++ b/frontend/src/app/server-standalone/page.tsx
@@ -228,7 +228,7 @@ export default function ServerStandalonePage() {
     if (!name && !rawPhone) return null;
     let normalizedPhone: string | undefined = undefined;
     if (rawPhone) {
-      const parsed = parsePhone(rawPhone, regional?.country || 'IN');
+      const parsed = regional?.country ? parsePhone(rawPhone, regional.country) : null;
       normalizedPhone = parsed ? parsed.e164 : rawPhone;
       try {
         const lookup = await api.get('/api/crm/lookup', { params: { phone: normalizedPhone } });

--- a/frontend/src/app/server-standalone/page.tsx
+++ b/frontend/src/app/server-standalone/page.tsx
@@ -9,6 +9,7 @@ import { useSyncServerLanguage } from '@/lib/i18n';
 import { useTranslations, type AppConfig } from 'use-intl';
 import { Ltr } from '@/components/layout/Ltr';
 import { toastApiError } from '@/lib/api-error';
+import { formatCurrencyForTenant } from '@/lib/countries';
 
 type User = { id: string; name: string; email: string; role: string };
 type Category = { id: string; name: string };
@@ -17,6 +18,13 @@ type Table = { id: string; name?: string; number?: string; status?: string; acti
 type OrderItem = { id: number; product_name: string; quantity: number; status: string; special_instructions?: string | null };
 type Order = { id: number; order_number: string; table_id?: string | null; status: string; items?: OrderItem[]; customer?: { id: string; name: string; phone?: string } | null };
 type DraftLine = { product: Product; quantity: number; note: string };
+type ServerAppInfo = {
+  country: string;
+  currency: string;
+  currency_symbol: string;
+  currency_position: 'prefix' | 'suffix';
+  currency_fraction_digits: number;
+};
 
 type ServerAppKey = keyof AppConfig['Messages']['serverApp'];
 
@@ -46,8 +54,12 @@ function itemStatusIcon(status: string, t: (key: ServerAppKey) => string) {
   return <Circle size={15} className="text-gray-400" aria-label={t('statusWaiting')} />;
 }
 
-function money(value: number | string) {
-  return Number(value || 0).toFixed(2);
+function money(value: number | string, regional: ServerAppInfo | null) {
+  return formatCurrencyForTenant(
+    Number(value || 0),
+    regional?.country,
+    regional?.currency || 'INR',
+  );
 }
 
 export default function ServerStandalonePage() {
@@ -68,6 +80,7 @@ export default function ServerStandalonePage() {
   const [rememberMe, setRememberMe] = useState(true);
   const [user, setUser] = useState<User | null>(null);
   const [disabled, setDisabled] = useState(false);
+  const [regional, setRegional] = useState<ServerAppInfo | null>(null);
 
   const [categories, setCategories] = useState<Category[]>([]);
   const [products, setProducts] = useState<Product[]>([]);
@@ -114,8 +127,11 @@ export default function ServerStandalonePage() {
   useEffect(() => {
     if (!api) return;
     let cancelled = false;
-    api.get('/api/server-app/info')
-      .then(() => api.get('/api/auth/me'))
+    api.get<ServerAppInfo>('/api/server-app/info')
+      .then((infoResponse) => {
+        if (!cancelled) setRegional(infoResponse.data);
+        return api.get('/api/auth/me');
+      })
       .then((res) => {
         if (!cancelled) setUser(res.data.user);
       })
@@ -212,7 +228,7 @@ export default function ServerStandalonePage() {
     if (!name && !rawPhone) return null;
     let normalizedPhone: string | undefined = undefined;
     if (rawPhone) {
-      const parsed = parsePhone(rawPhone, 'IN');
+      const parsed = parsePhone(rawPhone, regional?.country || 'IN');
       normalizedPhone = parsed ? parsed.e164 : rawPhone;
       try {
         const lookup = await api.get('/api/crm/lookup', { params: { phone: normalizedPhone } });
@@ -355,7 +371,7 @@ export default function ServerStandalonePage() {
               <button key={product.id} onClick={() => addProduct(product)}
                 className="min-h-24 rounded-lg border border-gray-200 bg-white p-3 text-start hover:border-brand">
                 <span className="line-clamp-2 text-sm font-semibold">{product.name}</span>
-                <span className="mt-2 block text-sm text-gray-500"><Ltr>{money(product.price)}</Ltr></span>
+                <span className="mt-2 block text-sm text-gray-500"><Ltr>{money(product.price, regional)}</Ltr></span>
               </button>
             ))}
           </div>
@@ -406,7 +422,7 @@ export default function ServerStandalonePage() {
 
           <div className="mt-4 flex items-center justify-between border-t border-gray-100 pt-3">
             <span className="text-sm text-gray-500">{t('draftTotal')}</span>
-            <span className="text-lg font-bold"><Ltr>{money(draftTotal)}</Ltr></span>
+            <span className="text-lg font-bold"><Ltr>{money(draftTotal, regional)}</Ltr></span>
           </div>
           <button onClick={sendDraft} disabled={!selectedTableId || draft.length === 0 || sending}
             className="mt-3 flex h-12 w-full items-center justify-center gap-2 rounded-lg bg-brand font-semibold text-white disabled:opacity-50">

--- a/main/server-app.ts
+++ b/main/server-app.ts
@@ -15,6 +15,12 @@ import { API_JSON_BODY_LIMIT } from './http-limits';
 import { buildCspHeader } from './csp';
 import { resolveContainedPath } from './lib/path-containment';
 import { ROLE_ACCESS } from '../shared/role-permissions';
+import {
+  getCountryByCode,
+  getCurrencyFractionDigits,
+  getCurrencySymbol,
+  resolveTenantCurrency,
+} from './countries';
 
 let serverApp: http.Server | null = null;
 let stopPromise: Promise<void> | null = null;
@@ -29,6 +35,22 @@ type ServerAppUser = {
   role: string;
   iat?: number;
 };
+
+function currencyPosition(locale: string, currency: string): 'prefix' | 'suffix' {
+  try {
+    const parts = new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency,
+      currencyDisplay: 'narrowSymbol',
+    }).formatToParts(1);
+    return parts.findIndex((part) => part.type === 'currency')
+      < parts.findIndex((part) => part.type === 'integer')
+      ? 'prefix'
+      : 'suffix';
+  } catch {
+    return 'prefix';
+  }
+}
 
 function normalizeEmail(email: unknown): string {
   return String(email || '').trim().toLowerCase();
@@ -180,9 +202,18 @@ export function startServerApp(): Promise<void> {
       const rows = getDatabase().prepare('SELECT key, value FROM settings').all() as { key: string; value: string }[];
       const settings: Record<string, string> = {};
       for (const row of rows) settings[row.key] = row.value;
+      const country = getCountryByCode(settings.country) || getCountryByCode('IN')!;
+      const currency = resolveTenantCurrency(settings.currency, country.code);
+      const currencySymbol = settings.currency_symbol?.trim()
+        || getCurrencySymbol(currency, country.locale)
+        || currency;
       res.json({
         language: settings.language || null,
-        country: settings.country || null,
+        country: country.code,
+        currency,
+        currency_symbol: currencySymbol,
+        currency_position: currencyPosition(country.locale, currency),
+        currency_fraction_digits: getCurrencyFractionDigits(currency),
         kds_enabled: settings.kds_enabled !== 'false',
       });
     });

--- a/tests/currency.test.ts
+++ b/tests/currency.test.ts
@@ -40,6 +40,17 @@ test('formatCurrencyForTenant: US tenant uses en-US locale', () => {
   assert.equal(formatCurrencyForTenant(1234.5, 'US', 'USD'), '$1,234.50');
 });
 
+test('formatCurrencyForTenant: COP uses zero fraction digits', () => {
+  const out = formatCurrencyForTenant(11000, 'CO', 'COP');
+  assert.match(out, /11\.000/);
+  assert.doesNotMatch(out, /[,.]00(?:\D|$)/);
+});
+
+test('formatCurrencyForTenant: KWD uses three fraction digits', () => {
+  const out = formatCurrencyForTenant(1.25, 'KW', 'KWD');
+  assert.match(out, /١٫٢٥٠/);
+});
+
 test('formatCurrencyForTenant: unknown country falls back to en-US', () => {
   assert.equal(formatCurrencyForTenant(7, 'ZZ', 'USD'), '$7.00');
 });

--- a/tests/server-app-server-role.test.ts
+++ b/tests/server-app-server-role.test.ts
@@ -41,9 +41,9 @@ async function postJson(baseUrl: string, pathName: string, body: unknown, token?
   return { status: response.status, body: await response.json() };
 }
 
-async function getJson(baseUrl: string, pathName: string, token: string) {
+async function getJson(baseUrl: string, pathName: string, token?: string) {
   const response = await fetch(`${baseUrl}${pathName}`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
   });
   return { status: response.status, body: await response.json() };
 }
@@ -73,6 +73,44 @@ async function main() {
   const baseUrl = `http://127.0.0.1:${getServerAppPort()}`;
 
   try {
+    db.prepare("UPDATE settings SET value = 'CO' WHERE key = 'country'").run();
+    db.prepare("UPDATE settings SET value = 'COP' WHERE key = 'currency'").run();
+    db.prepare("UPDATE settings SET value = '$' WHERE key = 'currency_symbol'").run();
+    const copInfo = await getJson(baseUrl, '/api/server-app/info');
+    assert.equal(copInfo.status, 200);
+    assert.deepEqual({
+      country: copInfo.body.country,
+      currency: copInfo.body.currency,
+      symbol: copInfo.body.currency_symbol,
+      position: copInfo.body.currency_position,
+      fractionDigits: copInfo.body.currency_fraction_digits,
+    }, {
+      country: 'CO',
+      currency: 'COP',
+      symbol: '$',
+      position: 'prefix',
+      fractionDigits: 0,
+    }, 'Server App exposes the COP regional values derived from current settings');
+
+    db.prepare("UPDATE settings SET value = 'KW' WHERE key = 'country'").run();
+    db.prepare("UPDATE settings SET value = 'KWD' WHERE key = 'currency'").run();
+    db.prepare("UPDATE settings SET value = 'KWD' WHERE key = 'currency_symbol'").run();
+    const kwdInfo = await getJson(baseUrl, '/api/server-app/info');
+    assert.equal(kwdInfo.status, 200);
+    assert.deepEqual({
+      country: kwdInfo.body.country,
+      currency: kwdInfo.body.currency,
+      symbol: kwdInfo.body.currency_symbol,
+      position: kwdInfo.body.currency_position,
+      fractionDigits: kwdInfo.body.currency_fraction_digits,
+    }, {
+      country: 'KW',
+      currency: 'KWD',
+      symbol: 'KWD',
+      position: 'suffix',
+      fractionDigits: 3,
+    }, 'Server App exposes the KWD regional values derived from current settings');
+
     for (const role of ['cashier', 'chef']) {
       const response = await postJson(baseUrl, '/api/auth/login', {
         email: `${role}@server-app.test`,


### PR DESCRIPTION
## Summary

- make Server App info return country, currency, symbol, placement, and ISO fraction digits from current settings at request time
- format standalone menu and draft totals with the existing tenant currency formatter instead of fixed two decimals
- normalize standalone customer phones with the configured store country instead of India
- cover COP zero-decimal and KWD three-decimal behavior

No migration, stored field, dependency, or client-side regional cache is added.

## Verification

- npm run build
- npm run build:frontend
- npm run lint (baseline: 1013 backend warnings, 5 frontend warnings; zero errors)
- npm run test:currency
- npm run test:server-app-server-role
- npm run test:rtl-kds-server-whatsapp
- git diff --check