### PR TITLE
test: make harness output portable and accurate

### DIFF
--- a/tests/integration-discount-settings.test.ts
+++ b/tests/integration-discount-settings.test.ts
@@ -76,6 +76,7 @@ function assertEqual(actual: any, expected: any, message: string) {
 }
 
 function assertIncludes(haystack: string, needle: string, message: string) {
+  total++;
   const ok = haystack.includes(needle);
   if (ok) {
     passed++;

--- a/tests/window-load-retry.test.ts
+++ b/tests/window-load-retry.test.ts
@@ -17,6 +17,7 @@
 import * as assert from 'node:assert/strict';
 import * as http from 'node:http';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import {
@@ -269,7 +270,7 @@ async function run(): Promise<void> {
   // Write evidence file
   const evidenceDir =
     process.env.EVIDENCE_DIR ||
-    '/Users/gurkiratkhaira/.no-mistakes/evidence/01M0X477YW5R40AKNFPT47AMHZ';
+    path.join(os.tmpdir(), 'flo-window-load-retry-evidence');
   try {
     fs.mkdirSync(evidenceDir, { recursive: true });
     const evidencePath = path.join(evidenceDir, 'window-load-retry-resilience.log');


### PR DESCRIPTION
## Summary

- write window-load retry evidence under the operating system temporary directory when EVIDENCE_DIR is unset
- count assertIncludes checks so the discount settings summary reports 17/17 instead of 17/16

## Verification

- npm run test:window-load-retry
- npm run test:integration-discount-settings
- npm run lint (baseline: 1013 backend warnings, 5 frontend warnings; zero errors)
- git diff --check