### PR TITLE
fix: batch of 5 low-hanging bug fixes

### DIFF
--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -692,7 +692,7 @@ export default function OrdersPage() {
 
     try {
       const opened = await shareBillViaWhatsApp(
-        order.bill,
+        { ...order.bill, order },
         { phone: order.customer.phone, country_code: order.customer.country_code },
         {
           business_name: currentTenant?.business_name || tCommon('businessNameFallback'),
@@ -720,7 +720,7 @@ export default function OrdersPage() {
     setSendingWaOrderId(order.id);
     try {
       await sendBillViaFlo(
-        order.bill,
+        { ...order.bill, order },
         order.customer.phone,
         {
           business_name: currentTenant?.business_name || tCommon('businessNameFallback'),

--- a/frontend/src/app/(dashboard)/orders/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/page.tsx
@@ -8,9 +8,10 @@ import { CreditCard, Trash2, RotateCcw, Clock, MessageCircle, Printer, XCircle, 
 import toast from 'react-hot-toast';
 import PaymentModal from '@/components/pos/PaymentModal';
 import CreateCustomerModal from '@/components/pos/CreateCustomerModal';
+import AddonModal from '@/components/pos/AddonModal';
 import { shareBillViaWhatsApp, sendBillViaFlo } from '@/lib/whatsapp-share';
 import { useConfirm } from '@/hooks/use-confirm';
-import type { OrderItem, Table, Product, Customer } from '@/lib/types';
+import type { OrderItem, Table, Product, Customer, Addon } from '@/lib/types';
 import type { Order, Bill } from '@/lib/types';
 import { getCurrencySymbol, getCountryByCode } from '@/lib/countries';
 import { useCurrencyUnitAdapter } from '@/hooks/useCurrencyUnitAdapter';
@@ -193,8 +194,9 @@ export default function OrdersPage() {
   // Add Item modal states
   const [products, setProducts] = useState<Product[]>([]);
   const [productSearch, setProductSearch] = useState('');
-  const [selectedItems, setSelectedItems] = useState<{ product_id: string; product_name: string; quantity: number; special_instructions: string }[]>([]);
+  const [selectedItems, setSelectedItems] = useState<{ key: string; product_id: string; product_name: string; quantity: number; special_instructions: string; addons: Addon[] }[]>([]);
   const [addingItems, setAddingItems] = useState(false);
+  const [addonPickerProduct, setAddonPickerProduct] = useState<Product | null>(null);
   const addItemsAttemptRef = useRef<AppendAttempt | null>(null);
   const appendAttemptStorageRef = useRef<AppendAttemptStorage | null>(null);
   const appendRecoveryStartedUsersRef = useRef<Set<string>>(new Set());
@@ -804,26 +806,50 @@ export default function OrdersPage() {
   }, [addItemsOrder, tOrders]);
 
   const handleAddItemToSelection = (product: Product) => {
+    if ((product.addon_groups || []).length > 0) {
+      setAddonPickerProduct(product);
+      return;
+    }
     setSelectedItems(prev => {
-      const existing = prev.find(i => i.product_id === product.id);
+      const existing = prev.find(i => i.product_id === product.id && i.addons.length === 0);
       if (existing) {
-        return prev.map(i => i.product_id === product.id ? { ...i, quantity: i.quantity + 1 } : i);
+        return prev.map(i => i === existing ? { ...i, quantity: i.quantity + 1 } : i);
       }
-      return [...prev, { product_id: product.id, product_name: product.name, quantity: 1, special_instructions: '' }];
+      const key = typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : `item-${prev.length}-${Math.random().toString(36).slice(2)}`;
+      return [...prev, { key, product_id: product.id, product_name: product.name, quantity: 1, special_instructions: '', addons: [] }];
     });
   };
 
-  const handleRemoveFromSelection = (productId: string) => {
-    setSelectedItems(prev => prev.filter(i => i.product_id !== productId));
+  const handleAddonPickerAdd = (product: Product, quantity: number, addons: Addon[], instructions: string) => {
+    setSelectedItems(prev => {
+      const key = typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : `item-${prev.length}-${Math.random().toString(36).slice(2)}`;
+      return [...prev, {
+        key,
+        product_id: product.id,
+        product_name: product.name,
+        quantity,
+        special_instructions: instructions,
+        addons,
+      }];
+    });
+    setAddonPickerProduct(null);
   };
 
-  const handleUpdateSelectionQty = (productId: string, quantity: number) => {
+  const handleRemoveFromSelection = (key: string) => {
+    setSelectedItems(prev => prev.filter(i => i.key !== key));
+  };
+
+  const handleUpdateSelectionQty = (key: string, quantity: number) => {
     if (quantity < 1) return;
-    setSelectedItems(prev => prev.map(i => i.product_id === productId ? { ...i, quantity } : i));
+    setSelectedItems(prev => prev.map(i => i.key === key ? { ...i, quantity } : i));
   };
 
-  const handleUpdateSelectionNotes = (productId: string, notes: string) => {
-    setSelectedItems(prev => prev.map(i => i.product_id === productId ? { ...i, special_instructions: notes } : i));
+  const handleUpdateSelectionNotes = (key: string, notes: string) => {
+    setSelectedItems(prev => prev.map(i => i.key === key ? { ...i, special_instructions: notes } : i));
   };
 
   const handleSubmitAddItems = async () => {
@@ -834,6 +860,9 @@ export default function OrdersPage() {
         product_id: i.product_id,
         quantity: i.quantity,
         special_instructions: i.special_instructions || undefined,
+        addons: i.addons.length > 0
+          ? i.addons.map((a) => ({ id: a.id, name: a.name, price: a.price, quantity: a.quantity || 1 }))
+          : undefined,
       }));
       const fingerprint = buildAppendItemsFingerprint(addItemsOrder.id, items);
       const storage = getAppendAttemptStorage();
@@ -1764,7 +1793,7 @@ placeholder={tOrders('managerPin')}
                   <button
                     key={product.id}
                     onClick={() => handleAddItemToSelection(product)}
-                    className="w-full flex items-center justify-between px-3 py-2 hover:bg-green-50 text-start border-b border-gray-50 last:border-0 transition-colors"
+                    className="w-full flex items-center justify-between px-3 py-2 hover:bg-green-50 dark:hover:bg-green-950/40 text-start border-b border-gray-50 last:border-0 transition-colors"
                   >
                     <div>
                       <span className="text-sm font-medium text-foreground">{product.name}</span>
@@ -1786,31 +1815,36 @@ placeholder={tOrders('managerPin')}
               <div className="space-y-2 mb-3">
                 <p className="text-xs font-medium text-muted-foreground uppercase">{tOrders('selectedItems')}</p>
                 {selectedItems.map(item => (
-                  <div key={item.product_id} className="flex items-center gap-2 bg-muted rounded-lg p-2">
+                  <div key={item.key} className="flex items-center gap-2 bg-muted rounded-lg p-2">
                     <div className="flex-1 min-w-0">
                       <span className="text-sm font-medium text-foreground truncate block">{item.product_name}</span>
+                      {item.addons.length > 0 && (
+                        <span className="text-xs text-muted-foreground truncate block">
+                          {item.addons.map((a) => a.name).join(', ')}
+                        </span>
+                      )}
                       <input
                         type="text"
                         placeholder={tOrders('notesOptional')}
                         value={item.special_instructions}
                         maxLength={100}
-                        onChange={(e) => handleUpdateSelectionNotes(item.product_id, e.target.value.slice(0, 100))}
+                        onChange={(e) => handleUpdateSelectionNotes(item.key, e.target.value.slice(0, 100))}
                         className="w-full text-xs text-muted-foreground bg-transparent border-0 p-0 focus:outline-none placeholder:text-gray-300"
                       />
                     </div>
                     <div className="flex items-center gap-1">
                       <button
-                        onClick={() => handleUpdateSelectionQty(item.product_id, item.quantity - 1)}
+                        onClick={() => handleUpdateSelectionQty(item.key, item.quantity - 1)}
                         className="w-6 h-6 rounded bg-gray-200 text-muted-foreground text-xs hover:bg-gray-300"
                       >-</button>
                       <span className="w-6 text-center text-sm font-medium">{item.quantity}</span>
                       <button
-                        onClick={() => handleUpdateSelectionQty(item.product_id, item.quantity + 1)}
+                        onClick={() => handleUpdateSelectionQty(item.key, item.quantity + 1)}
                         className="w-6 h-6 rounded bg-gray-200 text-muted-foreground text-xs hover:bg-gray-300"
                       >+</button>
                     </div>
                     <button
-                      onClick={() => handleRemoveFromSelection(item.product_id)}
+                      onClick={() => handleRemoveFromSelection(item.key)}
                       className="p-1 rounded hover:bg-red-50 text-red-400 hover:text-red-600"
                     >
                       <Trash2 size={14} />
@@ -1841,6 +1875,14 @@ placeholder={tOrders('managerPin')}
             </div>
           </div>
         </div>
+      )}
+      {addonPickerProduct && (
+        <AddonModal
+          product={addonPickerProduct}
+          currency={currency}
+          onAdd={handleAddonPickerAdd}
+          onClose={() => setAddonPickerProduct(null)}
+        />
       )}
       {createCustomerOrderId !== null && (
         <CreateCustomerModal

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -1185,6 +1185,17 @@ export default function SettingsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stations, activeTab]);
 
+  // Cash drawer pulse: active custom payment methods (beyond built-in cash/card)
+  const [pulseCustomMethods, setPulseCustomMethods] = useState<string[]>([]);
+  useEffect(() => {
+    if (activeTab !== 'receipts-printers') return;
+    const controller = new AbortController();
+    api.get('/payment-methods', { signal: controller.signal }).then(({ data }) => {
+      setPulseCustomMethods((data.payment_methods || []).map((m: { name: string }) => m.name));
+    }).catch(() => {});
+    return () => controller.abort();
+  }, [activeTab]);
+
   // Mobile App Pairing
   const [pairingCode, setPairingCode] = useState<string | null>(null);
   const [pairingExpiresAt, setPairingExpiresAt] = useState<string | null>(null);
@@ -4638,11 +4649,11 @@ export default function SettingsPage() {
                       </button>
                       {cashDrawerMethodsOpen && (
                         <div className="border-t border-border bg-muted/30 px-3 py-2 space-y-2">
-                          {[
+                          {([
                             ['cash', t('paymentMethodCash')],
                             ['card', t('paymentMethodCard')],
-                            ['upi', t('paymentMethodUpi')],
-                          ].map(([value, label]) => (
+                            ...pulseCustomMethods.map((name): [string, string] => [name, name]),
+                          ]).map(([value, label]) => (
                             <label key={value} className="flex items-center gap-2 text-sm text-foreground">
                               <input
                                 type="checkbox"

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -1192,8 +1192,12 @@ export default function SettingsPage() {
     const controller = new AbortController();
     api.get('/payment-methods', { signal: controller.signal }).then(({ data }) => {
       setPulseCustomMethods((data.payment_methods || []).map((m: { name: string }) => m.name));
-    }).catch(() => {});
+    }).catch((error) => {
+      if (isRequestCancelled(error)) return;
+      toast.error(t('loadFailed'));
+    });
     return () => controller.abort();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab]);
 
   // Mobile App Pairing

--- a/frontend/src/components/pos/TableCheckoutModal.tsx
+++ b/frontend/src/components/pos/TableCheckoutModal.tsx
@@ -76,7 +76,7 @@ export default function TableCheckoutModal({
     setGenerating(true);
     try {
       if (order.bill) {
-        onPayment(order.bill);
+        onPayment({ ...order.bill, order });
         return;
       }
       const { data } = await api.post('/bills/generate', { order_id: order.id });
@@ -92,7 +92,7 @@ export default function TableCheckoutModal({
     if (!order) return;
     setGenerating(true);
     try {
-      const bill = order.bill || (await api.post('/bills/generate', { order_id: order.id })).data.bill;
+      const bill = order.bill ? { ...order.bill, order } : (await api.post('/bills/generate', { order_id: order.id })).data.bill;
       setSplitBill(bill);
     } catch {
       toast.error(t('generateBillFailed'));

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -1904,7 +1904,7 @@ function calculateCashback(db: ReturnType<typeof getDatabase>, bill: any, custom
   if (enabled !== 'true' && enabled !== '1') return 0;
   const globalRate = parseFloat((db.prepare(`SELECT value FROM settings WHERE key = 'global_cashback_percent'`).get() as any)?.value || '0');
   const order = db.prepare('SELECT subtotal, discount_amount FROM orders WHERE id = ?').get(bill.order_id) as any;
-  const items = db.prepare(`SELECT oi.subtotal, p.cb_percent FROM order_items oi JOIN products p ON p.id = oi.product_id WHERE oi.order_id = ? AND oi.status != 'cancelled'`).all(bill.order_id) as { subtotal: number; cb_percent: number | null }[];
+  const items = db.prepare(`SELECT oi.subtotal, p.cb_percent FROM order_items oi JOIN products p ON p.id = oi.product_id WHERE oi.order_id = ? AND oi.status NOT IN ('cancelled', 'voided', 'void_adjustment', 'refunded')`).all(bill.order_id) as { subtotal: number; cb_percent: number | null }[];
   const fullOrderCashback = items.reduce((sum, item) => {
     const discountShare = order?.discount_amount > 0 && order?.subtotal > 0 ? order.discount_amount * item.subtotal / order.subtotal : 0;
     const rate = item.cb_percent !== null ? item.cb_percent : globalRate;

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -592,7 +592,8 @@ router.post('/generate', requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: 
     });
 
     notifyOrderUpdated();
-    res.status(result.isNew ? 201 : 200).json({ bill: result.bill });
+    const orderWithItems = getOrderWithItems(db, order_id, Number(result.bill.id));
+    res.status(result.isNew ? 201 : 200).json({ bill: { ...result.bill, order: orderWithItems } });
   } catch (error: any) {
     console.error("[API] Internal error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/main/routes/orders.ts
+++ b/main/routes/orders.ts
@@ -1150,7 +1150,7 @@ router.patch('/:id/convert-to-takeaway', orderWriteRateLimit, requireRole(...ROL
   }
 });
 
-router.patch('/:id/discount', orderWriteRateLimit, requireRole(...ROLE_ACCESS.ownerManager), (req: Request, res: Response) => {
+router.patch('/:id/discount', orderWriteRateLimit, requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
     const order = db.prepare('SELECT * FROM orders WHERE id = ?').get(req.params.id) as any;
@@ -1349,7 +1349,7 @@ router.patch('/:id/discount', orderWriteRateLimit, requireRole(...ROLE_ACCESS.ow
   }
 });
 
-router.patch('/:id/items/:itemId/discount', orderWriteRateLimit, requireRole(...ROLE_ACCESS.ownerManager), (req: Request, res: Response) => {
+router.patch('/:id/items/:itemId/discount', orderWriteRateLimit, requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: Request, res: Response) => {
   try {
     const db = getDatabase();
     const order = db.prepare('SELECT * FROM orders WHERE id = ?').get(req.params.id) as any;


### PR DESCRIPTION
## Summary

Five independent low-hanging-fruit bug fixes, picked from the open `type:Bug` issues:

- **Loyalty on voided items** — `calculateCashback()` only excluded `cancelled` order items from the cashback base, so voiding an item after checkout still credited loyalty points on it. Now excludes the same status set (`cancelled`, `voided`, `void_adjustment`, `refunded`) used elsewhere for order totals.
- **Cashier discount blocked instead of PIN-escalated** — the discount routes were gated owner/manager-only, so a cashier got a flat 403 before ever reaching the already-implemented manager-PIN approval flow. Widened the role gate; the PIN check still applies.
- **Bogus payment types in cash-drawer pulse settings** — the pulse method checklist was a hardcoded `[cash, card, upi]` array. Now reflects the tenant's actual active payment methods.
- **WhatsApp receipt missing date/items** — the bill object passed to the message builder never carried its order relation, so the message silently dropped the date and item list. `POST /bills/generate` now embeds order+items like the other bill routes, and two frontend call sites that reused an already-fetched order's bill now attach it.
- **Can't add add-on items from the Orders page** — the "Add Item" picker skipped the add-on selection modal entirely; wired it in and carried add-ons through to the existing backend endpoint. Also fixes an illegible dark-mode hover state noted in the same report.

Each fix is its own commit for reviewability; see commit messages for per-fix detail.

Fixes #720, #716, #714, #711, #721

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run build` (backend) — clean
- [x] `npm run build:frontend` — clean
- [x] Focused suites: loyalty, discount, authz (phase3/orders/staff), addons, printing-settings, payment-methods, whatsapp, refunds, happy-path, cashier-payments — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)