### PR TITLE
fix: 5 more low-hanging bug fixes

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -4171,6 +4171,7 @@ export default function SettingsPage() {
                     <option value="both">{t('discountBoth')}</option>
                     <option value="percentage">{t('discountPercentageOnly')}</option>
                     <option value="flat">{t('discountFlatOnly')}</option>
+                    <option value="none">{t('discountNone')}</option>
                   </select>
                 </div>
 
@@ -4206,25 +4207,27 @@ export default function SettingsPage() {
                   </div>
                 )}
 
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium text-foreground">{t('requireApproval')}</p>
-                    <p className="text-sm text-muted-foreground">{t('requireApprovalHint')}</p>
+                {discountMode !== 'none' && (
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium text-foreground">{t('requireApproval')}</p>
+                      <p className="text-sm text-muted-foreground">{t('requireApprovalHint')}</p>
+                    </div>
+                    <button
+                      onClick={() => {
+                        markHydrationTouched('discountRequiresApproval');
+                        setDiscountRequiresApproval(!discountRequiresApproval);
+                      }}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                        discountRequiresApproval ? 'bg-brand' : 'bg-gray-200 dark:bg-input'
+                      }`}
+                    >
+                      <span className={`inline-block h-4 w-4 transform rounded-full bg-card transition-transform ${
+                        discountRequiresApproval ? 'translate-x-6 rtl:-translate-x-6' : 'translate-x-1 rtl:-translate-x-1'
+                      }`} />
+                    </button>
                   </div>
-                  <button
-                    onClick={() => {
-                      markHydrationTouched('discountRequiresApproval');
-                      setDiscountRequiresApproval(!discountRequiresApproval);
-                    }}
-                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                      discountRequiresApproval ? 'bg-brand' : 'bg-gray-200 dark:bg-input'
-                    }`}
-                  >
-                    <span className={`inline-block h-4 w-4 transform rounded-full bg-card transition-transform ${
-                      discountRequiresApproval ? 'translate-x-6 rtl:-translate-x-6' : 'translate-x-1 rtl:-translate-x-1'
-                    }`} />
-                  </button>
-                </div>
+                )}
 
               </div>
             </div>

--- a/frontend/src/app/(dashboard)/whatsapp/page.tsx
+++ b/frontend/src/app/(dashboard)/whatsapp/page.tsx
@@ -281,11 +281,12 @@ export default function WhatsAppPage() {
   }, []);
 
   const refreshInbox = useCallback(async () => {
+    if (!isAdmin) return;
     try {
       const { data } = await api.get('/whatsapp/inbox', { params: { limit: 100 } });
       setInbox(data.messages ?? []);
     } catch { /* ignore */ }
-  }, []);
+  }, [isAdmin]);
 
   const refreshBlocklist = useCallback(async () => {
     if (!isAdmin) return;

--- a/frontend/src/app/(dashboard)/whatsapp/page.tsx
+++ b/frontend/src/app/(dashboard)/whatsapp/page.tsx
@@ -246,7 +246,8 @@ export default function WhatsAppPage() {
     }
   }, []);
 
-  const effectiveTab = userTab ?? (status?.state === 'connected' ? 'sent' : 'connection');
+  const defaultTab = status?.state === 'connected' ? 'sent' : 'connection';
+  const effectiveTab = (userTab === 'inbox' && !isAdmin) ? defaultTab : userTab ?? defaultTab;
   const onTabChange = (v: string) => {
     setUserTab(v);
     if (typeof window !== 'undefined') window.localStorage.setItem('whatsapp.activeTab', v);
@@ -457,7 +458,9 @@ export default function WhatsAppPage() {
       <Tabs value={effectiveTab} onValueChange={onTabChange}>
         <TabsList>
           <TabsTrigger value="sent"><Send className="size-4" /> {tTabs('sent')}</TabsTrigger>
-          <TabsTrigger value="inbox"><Inbox className="size-4" /> {tTabs('inbox')}</TabsTrigger>
+          {isAdmin && (
+            <TabsTrigger value="inbox"><Inbox className="size-4" /> {tTabs('inbox')}</TabsTrigger>
+          )}
           <TabsTrigger value="connection"><QrCode className="size-4" /> {tTabs('connection')}</TabsTrigger>
         </TabsList>
 
@@ -756,65 +759,67 @@ export default function WhatsAppPage() {
           </Card>
         </TabsContent>
 
-        <TabsContent value="inbox" className="space-y-2">
-          <Card>
-            <CardHeader>
-              <CardTitle>{tInbox('title')}</CardTitle>
-              <CardDescription>{tInbox('description')}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {inbox.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-10 text-center text-sm text-muted-foreground">
-                  <Inbox className="size-8 mb-2 opacity-40" />
-                  <p className="font-medium text-foreground">{tInbox('empty')}</p>
-                  <p className="mt-1 max-w-sm">{tInbox('emptyHint')}</p>
-                </div>
-              ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>{tSent('colWhen')}</TableHead>
-                      <TableHead>{tSent('colPhone')}</TableHead>
-                      <TableHead>{tSent('colBody')}</TableHead>
-                      <TableHead></TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {inbox.map((m) => {
-                      const isBlocked = blocklist.some((b) => b.phone_e164 === m.phone_e164);
-                      return (
-                        <TableRow key={m.id}>
-                          <TableCell className="text-xs text-muted-foreground whitespace-nowrap">{fmt(m.queued_at)}</TableCell>
-                          <TableCell className="font-mono text-xs">
-                            <button
-                              type="button"
-                              onClick={() => copyToClipboard(m.phone_e164, m.phone_e164)}
-                              className="inline-flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
-                              title={tInbox('copyPhone')}
-                            >
-                              <Copy className="size-3 opacity-0 group-hover:opacity-100" />
-                              <Ltr>{m.phone_e164}</Ltr>
-                            </button>
-                          </TableCell>
-                          <TableCell className="text-sm whitespace-pre-line break-words max-w-md">{m.body}</TableCell>
-                          <TableCell>
-                            {isBlocked ? (
-                              <Badge variant="secondary">{tInbox('blocked')}</Badge>
-                            ) : (
-                              <Button size="sm" variant="outline" onClick={() => blockFromInbox(m.phone_e164)}>
-                                <Ban className="size-3" /> {tInbox('blockCta')}
-                              </Button>
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
+        {isAdmin && (
+          <TabsContent value="inbox" className="space-y-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>{tInbox('title')}</CardTitle>
+                <CardDescription>{tInbox('description')}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {inbox.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-10 text-center text-sm text-muted-foreground">
+                    <Inbox className="size-8 mb-2 opacity-40" />
+                    <p className="font-medium text-foreground">{tInbox('empty')}</p>
+                    <p className="mt-1 max-w-sm">{tInbox('emptyHint')}</p>
+                  </div>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>{tSent('colWhen')}</TableHead>
+                        <TableHead>{tSent('colPhone')}</TableHead>
+                        <TableHead>{tSent('colBody')}</TableHead>
+                        <TableHead></TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {inbox.map((m) => {
+                        const isBlocked = blocklist.some((b) => b.phone_e164 === m.phone_e164);
+                        return (
+                          <TableRow key={m.id}>
+                            <TableCell className="text-xs text-muted-foreground whitespace-nowrap">{fmt(m.queued_at)}</TableCell>
+                            <TableCell className="font-mono text-xs">
+                              <button
+                                type="button"
+                                onClick={() => copyToClipboard(m.phone_e164, m.phone_e164)}
+                                className="inline-flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
+                                title={tInbox('copyPhone')}
+                              >
+                                <Copy className="size-3 opacity-0 group-hover:opacity-100" />
+                                <Ltr>{m.phone_e164}</Ltr>
+                              </button>
+                            </TableCell>
+                            <TableCell className="text-sm whitespace-pre-line break-words max-w-md">{m.body}</TableCell>
+                            <TableCell>
+                              {isBlocked ? (
+                                <Badge variant="secondary">{tInbox('blocked')}</Badge>
+                              ) : (
+                                <Button size="sm" variant="outline" onClick={() => blockFromInbox(m.phone_e164)}>
+                                  <Ban className="size-3" /> {tInbox('blockCta')}
+                                </Button>
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+        )}
       </Tabs>
 
       {status?.lastError && status.state !== 'cooldown' && (

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -51,6 +51,19 @@ body {
   font-family: var(--font-sans);
 }
 
+/* Custom +/- controls exist next to numeric fields throughout the POS UI;
+ * the native spinner is redundant and its narrow hit target invites mis-taps. */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
 .touch-target {
   min-height: 44px;
   min-width: 44px;

--- a/frontend/src/app/kds-standalone/page.tsx
+++ b/frontend/src/app/kds-standalone/page.tsx
@@ -68,9 +68,9 @@ export default function KdsStandalonePage() {
 
   if (kdsDisabled) {
     return (
-      <div className="flex flex-col items-center justify-center h-screen gap-3 text-center px-6 bg-gray-900 text-white">
+      <div className="flex flex-col items-center justify-center h-screen gap-3 text-center px-6 bg-background text-foreground">
         <h1 className="text-lg font-semibold">{t('disabledTitle')}</h1>
-        <p className="text-sm text-gray-400 max-w-sm">
+        <p className="text-sm text-muted-foreground max-w-sm">
           {t('disabledHint')}
         </p>
       </div>
@@ -79,8 +79,8 @@ export default function KdsStandalonePage() {
 
   if (conn.loading) {
     return (
-      <div className="flex items-center justify-center h-screen bg-gray-900">
-        <div className="w-10 h-10 border-4 border-white/40 border-t-transparent rounded-full animate-spin" />
+      <div className="flex items-center justify-center h-screen bg-background">
+        <div className="w-10 h-10 border-4 border-brand border-t-transparent rounded-full animate-spin" />
       </div>
     );
   }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import MenuActionHandler from "@/components/layout/MenuActionHandler";
 import AuthGuard from "@/components/layout/AuthGuard";
 import { HtmlLangSync } from "@/components/layout/HtmlLangSync";
 import { ThemeSync } from "@/components/layout/ThemeSync";
+import { NumberInputWheelGuard } from "@/components/layout/NumberInputWheelGuard";
 import { DirectionalToaster } from "@/components/layout/DirectionalToaster";
 import DesktopDragSurface from "@/components/layout/DesktopDragSurface";
 import { I18nProvider } from "@/components/providers/I18nProvider";
@@ -78,6 +79,7 @@ export default function RootLayout({
           <MenuActionHandler />
           <HtmlLangSync />
           <ThemeSync />
+          <NumberInputWheelGuard />
           <AuthGuard>{children}</AuthGuard>
           <DirectionalToaster />
         </I18nProvider>

--- a/frontend/src/app/server-standalone/page.tsx
+++ b/frontend/src/app/server-standalone/page.tsx
@@ -250,19 +250,33 @@ export default function ServerStandalonePage() {
         quantity: line.quantity,
         special_instructions: line.note.trim() || undefined,
       }));
+      let orderId: number;
       if (currentOrder?.id) {
-        await api.post(`/api/orders/${currentOrder.id}/items`, { items });
+        const { data } = await api.post(`/api/orders/${currentOrder.id}/items`, { items });
+        orderId = data.order.id;
       } else {
-        await api.post('/api/orders', {
+        const { data } = await api.post('/api/orders', {
           table_id: selectedTableId,
           customer_id: customerId,
           type: 'dine_in',
           items,
         }, { headers: { 'Idempotency-Key': `server-app-${Date.now()}-${selectedTableId}` } });
+        orderId = data.order.id;
       }
       setDraft([]);
       await Promise.all([loadAll(), loadOrder(selectedTableId)]);
       toast.success(t('orderSent'));
+      try {
+        await api.post('/api/printers/print-kot', { orderId });
+      } catch (printError: unknown) {
+        // Printing isn't configured/enabled for every business — stay quiet for
+        // that expected case, but surface genuine failures (spooler, offline, etc.)
+        // so staff know the kitchen never saw the ticket.
+        const status = axios.isAxiosError(printError) ? printError.response?.status : undefined;
+        if (status !== 400 && status !== 403) {
+          toastApiError(printError, t('kotPrintFailed'), apiErrorT);
+        }
+      }
     } catch (error: unknown) {
       toastApiError(error, t('couldNotSendOrder'), apiErrorT);
     } finally {

--- a/frontend/src/app/server-standalone/page.tsx
+++ b/frontend/src/app/server-standalone/page.tsx
@@ -251,9 +251,13 @@ export default function ServerStandalonePage() {
         special_instructions: line.note.trim() || undefined,
       }));
       let orderId: number;
+      let newItems: OrderItem[];
       if (currentOrder?.id) {
         const { data } = await api.post(`/api/orders/${currentOrder.id}/items`, { items });
         orderId = data.order.id;
+        // Print only what this call added — omitting items reprints every pending item on the order.
+        const existingIds = new Set((currentOrder.items || []).map((item) => item.id));
+        newItems = (data.order.items || []).filter((item: OrderItem) => !existingIds.has(item.id));
       } else {
         const { data } = await api.post('/api/orders', {
           table_id: selectedTableId,
@@ -262,12 +266,13 @@ export default function ServerStandalonePage() {
           items,
         }, { headers: { 'Idempotency-Key': `server-app-${Date.now()}-${selectedTableId}` } });
         orderId = data.order.id;
+        newItems = data.order.items || [];
       }
       setDraft([]);
       await Promise.all([loadAll(), loadOrder(selectedTableId)]);
       toast.success(t('orderSent'));
       try {
-        await api.post('/api/printers/print-kot', { orderId });
+        await api.post('/api/printers/print-kot', { orderId, items: newItems });
       } catch (printError: unknown) {
         // Printing isn't configured/enabled for every business — stay quiet for
         // that expected case, but surface genuine failures (spooler, offline, etc.)

--- a/frontend/src/components/dashboard/CashCloseModal.tsx
+++ b/frontend/src/components/dashboard/CashCloseModal.tsx
@@ -212,9 +212,9 @@ export function CashCloseModal({ model }: { model: CashCloseModel }) {
               <p className="text-xs text-muted-foreground">{t('expectedCash')}</p>
               <p className="text-xl font-bold text-foreground ltr-island"><Ltr>{amountsValid ? fmt(expectedCashTotalCents / minorFactor) : '—'}</Ltr></p>
             </div>
-            <div className={`rounded-lg border p-3 ${varianceCents === 0 ? 'border-border bg-muted/40' : varianceCents < 0 ? 'border-red-300 bg-red-50' : 'border-amber-300 bg-amber-50'}`}>
+            <div className={`rounded-lg border p-3 ${varianceCents === 0 ? 'border-border bg-muted/40' : varianceCents < 0 ? 'border-red-300 dark:border-red-800/40 bg-red-50 dark:bg-red-950/40' : 'border-amber-300 dark:border-amber-800/40 bg-amber-50 dark:bg-amber-950/40'}`}>
               <p className="text-xs text-muted-foreground">{t('variance')}</p>
-              <p className={`text-xl font-bold ltr-island ${varianceCents === 0 ? 'text-foreground' : varianceCents < 0 ? 'text-red-700' : 'text-amber-700'}`}>
+              <p className={`text-xl font-bold ltr-island ${varianceCents === 0 ? 'text-foreground' : varianceCents < 0 ? 'text-red-700 dark:text-red-300' : 'text-amber-700 dark:text-amber-300'}`}>
                 {/* Invalid/empty input renders no figure: the ?? 0 fallback
                     below would show a plausible-but-wrong variance while
                     Close stays disabled. */}
@@ -223,7 +223,7 @@ export function CashCloseModal({ model }: { model: CashCloseModel }) {
             </div>
           </div>
           {submitError && (
-            <div className="flex items-start gap-2 rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+            <div className="flex items-start gap-2 rounded-lg border border-red-300 dark:border-red-800/40 bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
               <AlertTriangle size={16} className="shrink-0 mt-0.5" />
               <span>{submitError}</span>
             </div>
@@ -264,9 +264,9 @@ export function CashCloseModal({ model }: { model: CashCloseModel }) {
               <p className="text-xs text-muted-foreground">{t('countedCash')}</p>
               <p className="text-base font-semibold text-foreground"><Ltr>{fmt(closedZ.counted_cash_cents / minorFactor)}</Ltr></p>
             </div>
-            <div className={`rounded-lg border p-3 ${closedZ.variance_cents === 0 ? 'border-border' : closedZ.variance_cents < 0 ? 'border-red-300 bg-red-50' : 'border-amber-300 bg-amber-50'}`}>
+            <div className={`rounded-lg border p-3 ${closedZ.variance_cents === 0 ? 'border-border' : closedZ.variance_cents < 0 ? 'border-red-300 dark:border-red-800/40 bg-red-50 dark:bg-red-950/40' : 'border-amber-300 dark:border-amber-800/40 bg-amber-50 dark:bg-amber-950/40'}`}>
               <p className="text-xs text-muted-foreground">{t('variance')}</p>
-              <p className={`text-base font-semibold ltr-island ${closedZ.variance_cents === 0 ? 'text-foreground' : closedZ.variance_cents < 0 ? 'text-red-700' : 'text-amber-700'}`}>
+              <p className={`text-base font-semibold ltr-island ${closedZ.variance_cents === 0 ? 'text-foreground' : closedZ.variance_cents < 0 ? 'text-red-700 dark:text-red-300' : 'text-amber-700 dark:text-amber-300'}`}>
                 <Ltr>{fmt(closedZ.variance_cents / minorFactor)}</Ltr>
               </p>
             </div>

--- a/frontend/src/components/layout/NumberInputWheelGuard.tsx
+++ b/frontend/src/components/layout/NumberInputWheelGuard.tsx
@@ -2,12 +2,12 @@
 
 import { useEffect } from 'react';
 
-/** Blurs a focused number input on scroll so it can't be changed by accident. */
+/** Blurs a number input when scrolled over it, so it can't be changed by accident. */
 export function NumberInputWheelGuard() {
   useEffect(() => {
-    const onWheel = () => {
-      const el = document.activeElement;
-      if (el instanceof HTMLInputElement && el.type === 'number') el.blur();
+    const onWheel = (e: WheelEvent) => {
+      const el = e.target;
+      if (el instanceof HTMLInputElement && el.type === 'number' && el === document.activeElement) el.blur();
     };
     document.addEventListener('wheel', onWheel, { passive: true });
     return () => document.removeEventListener('wheel', onWheel);

--- a/frontend/src/components/layout/NumberInputWheelGuard.tsx
+++ b/frontend/src/components/layout/NumberInputWheelGuard.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/** Blurs a focused number input on scroll so it can't be changed by accident. */
+export function NumberInputWheelGuard() {
+  useEffect(() => {
+    const onWheel = () => {
+      const el = document.activeElement;
+      if (el instanceof HTMLInputElement && el.type === 'number') el.blur();
+    };
+    document.addEventListener('wheel', onWheel, { passive: true });
+    return () => document.removeEventListener('wheel', onWheel);
+  }, []);
+  return null;
+}

--- a/frontend/src/components/pos/PaymentModal.tsx
+++ b/frontend/src/components/pos/PaymentModal.tsx
@@ -150,6 +150,7 @@ export default function PaymentModal({ bill, currency, onClose, onPaid, onBillUp
     setDiscountValue('');
     setDiscountReason('');
     setDiscountPin('');
+    setAmountTarget((target) => target?.kind === 'discount' ? null : target);
   }
 
   // Proportionally update payment inputs when remaining balance changes,

--- a/frontend/src/components/pos/PaymentModal.tsx
+++ b/frontend/src/components/pos/PaymentModal.tsx
@@ -549,7 +549,7 @@ export default function PaymentModal({ bill, currency, onClose, onPaid, onBillUp
           )}
 
           {/* Discount */}
-          {!bill.split_group_id && <div className="rounded-xl border border-border overflow-hidden">
+          {!bill.split_group_id && discountMode !== 'none' && <div className="rounded-xl border border-border overflow-hidden">
             <button type="button" onClick={() => setShowDiscount((open) => !open)} className="touch-target w-full justify-between gap-3 px-3 bg-muted text-start">
               <span className="text-sm font-medium text-foreground">
                 {Number(bill.discount_amount) > 0

--- a/frontend/src/components/pos/PrepaidCheckoutModal.tsx
+++ b/frontend/src/components/pos/PrepaidCheckoutModal.tsx
@@ -107,6 +107,7 @@ export default function PrepaidCheckoutModal({ currency, onClose, onConfirm }: P
   const [discountValue, setDiscountValue] = useState('');
   const [discountReason, setDiscountReason] = useState('');
   const [discountMode, setDiscountMode] = useState<DiscountMode>('percentage');
+  const [discountModeLoaded, setDiscountModeLoaded] = useState(false);
   const [discountRequiresApproval, setDiscountRequiresApproval] = useState(false);
   const [discountPin, setDiscountPin] = useState('');
   const [amountTarget, setAmountTarget] = useState<AmountTarget>(null);
@@ -150,6 +151,7 @@ export default function PrepaidCheckoutModal({ currency, onClose, onConfirm }: P
     setDiscountReason('');
     setDiscountPin('');
     setPaymentsTouched(false);
+    setAmountTarget((target) => target?.kind === 'discount' ? null : target);
   }
 
   useEffect(() => {
@@ -161,7 +163,8 @@ export default function PrepaidCheckoutModal({ currency, onClose, onConfirm }: P
         setDiscountMode(normalizeDiscountMode(res.data.discount_mode));
         setDiscountRequiresApproval(!!res.data.discount_requires_approval);
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => setDiscountModeLoaded(true));
     api.get('/payment-methods')
       .then((res) => {
         const methods: CustomPaymentMethod[] = res.data.payment_methods || [];
@@ -435,7 +438,7 @@ export default function PrepaidCheckoutModal({ currency, onClose, onConfirm }: P
             </div>
           )}
 
-          {discountMode !== 'none' && (
+          {discountModeLoaded && discountMode !== 'none' && (
             <button
               type="button"
               onClick={() => setDiscountOpen((open) => !open)}
@@ -451,7 +454,7 @@ export default function PrepaidCheckoutModal({ currency, onClose, onConfirm }: P
         <div className="min-h-0 space-y-3 overflow-y-auto px-5 py-3">
 
           {/* Cart-level discount editor. */}
-          {discountOpen && discountMode !== 'none' && (
+          {discountOpen && discountModeLoaded && discountMode !== 'none' && (
             <div className="overflow-hidden rounded-xl border border-purple-200 dark:border-purple-800/40 bg-purple-50 dark:bg-purple-950/40 p-3 space-y-2">
                 <div className="flex rounded-lg overflow-hidden border border-purple-200 dark:border-purple-800/40">
                   {isDiscountTypeAllowed(discountMode, 'percentage') && (

--- a/frontend/src/components/pos/PrepaidCheckoutModal.tsx
+++ b/frontend/src/components/pos/PrepaidCheckoutModal.tsx
@@ -435,21 +435,23 @@ export default function PrepaidCheckoutModal({ currency, onClose, onConfirm }: P
             </div>
           )}
 
-          <button
-            type="button"
-            onClick={() => setDiscountOpen((open) => !open)}
-            className="mt-2 inline-flex h-7 items-center gap-1 rounded-md border border-border bg-muted px-2 text-xs font-medium text-foreground transition-colors hover:border-brand hover:text-brand"
-            aria-expanded={discountOpen}
-          >
-            {preview?.discountAmount ? `${t('discount')}: -${currencyFmt(preview.discountAmount)}` : t('discounts')}
-            <ChevronDown size={12} className={`transition-transform ${discountOpen ? 'rotate-180' : ''}`} />
-          </button>
+          {discountMode !== 'none' && (
+            <button
+              type="button"
+              onClick={() => setDiscountOpen((open) => !open)}
+              className="mt-2 inline-flex h-7 items-center gap-1 rounded-md border border-border bg-muted px-2 text-xs font-medium text-foreground transition-colors hover:border-brand hover:text-brand"
+              aria-expanded={discountOpen}
+            >
+              {preview?.discountAmount ? `${t('discount')}: -${currencyFmt(preview.discountAmount)}` : t('discounts')}
+              <ChevronDown size={12} className={`transition-transform ${discountOpen ? 'rotate-180' : ''}`} />
+            </button>
+          )}
         </div>
 
         <div className="min-h-0 space-y-3 overflow-y-auto px-5 py-3">
 
           {/* Cart-level discount editor. */}
-          {discountOpen && (
+          {discountOpen && discountMode !== 'none' && (
             <div className="overflow-hidden rounded-xl border border-purple-200 dark:border-purple-800/40 bg-purple-50 dark:bg-purple-950/40 p-3 space-y-2">
                 <div className="flex rounded-lg overflow-hidden border border-purple-200 dark:border-purple-800/40">
                   {isDiscountTypeAllowed(discountMode, 'percentage') && (

--- a/frontend/src/components/pos/TablePickerModal.tsx
+++ b/frontend/src/components/pos/TablePickerModal.tsx
@@ -21,10 +21,10 @@ type PosKey = keyof AppConfig['Messages']['pos'];
 
 const statusStyles: Record<string, { border: string; badge: string; badgeKey: PosKey | null }> = {
   available: { border: 'border-border hover:border-brand/40', badge: '', badgeKey: null },
-  occupied: { border: 'border-orange-300 bg-orange-50', badge: 'bg-orange-500', badgeKey: 'tableOccupied' },
-  reserved: { border: 'border-yellow-300 bg-yellow-50', badge: 'bg-yellow-500', badgeKey: 'tableReserved' },
+  occupied: { border: 'border-orange-300 dark:border-orange-800/40 bg-orange-50 dark:bg-orange-950/40', badge: 'bg-orange-500', badgeKey: 'tableOccupied' },
+  reserved: { border: 'border-yellow-300 dark:border-yellow-800/40 bg-yellow-50 dark:bg-yellow-950/40', badge: 'bg-yellow-500', badgeKey: 'tableReserved' },
   cleaning: { border: 'border-gray-300 dark:border-border bg-muted', badge: 'bg-gray-500', badgeKey: 'tableCleaning' },
-  held: { border: 'border-blue-400 bg-blue-50', badge: 'bg-blue-500', badgeKey: 'tableHeld' },
+  held: { border: 'border-blue-400 dark:border-blue-800/40 bg-blue-50 dark:bg-blue-950/40', badge: 'bg-blue-500', badgeKey: 'tableHeld' },
 };
 
 export default function TablePickerModal({

--- a/frontend/src/lib/discount-settings.ts
+++ b/frontend/src/lib/discount-settings.ts
@@ -1,13 +1,14 @@
-export type DiscountMode = 'percentage' | 'flat' | 'both';
+export type DiscountMode = 'percentage' | 'flat' | 'both' | 'none';
 export type DiscountType = 'percentage' | 'amount';
 
 export const normalizeDiscountMode = (value: unknown): DiscountMode => {
-  return value === 'flat' || value === 'both' || value === 'percentage'
+  return value === 'flat' || value === 'both' || value === 'percentage' || value === 'none'
     ? value
     : 'percentage';
 };
 
 export const isDiscountTypeAllowed = (mode: DiscountMode, type: DiscountType) => {
+  if (mode === 'none') return false;
   if (mode === 'both') return true;
   return mode === 'percentage' ? type === 'percentage' : type === 'amount';
 };

--- a/frontend/src/lib/i18n/messages/de.json
+++ b/frontend/src/lib/i18n/messages/de.json
@@ -1276,6 +1276,7 @@
     "discountModeFlat": "Nur Festbetrag",
     "discountModeHint": "Welche Rabattarten verfügbar sind",
     "discountModePercentage": "Nur Prozentual",
+    "discountNone": "Deaktiviert (keine Rabatte)",
     "discountPercentageOnly": "Nur Prozentual",
     "discountSaved": "Rabatteinstellungen gespeichert",
     "discounts": "Rabatte",

--- a/frontend/src/lib/i18n/messages/de.json
+++ b/frontend/src/lib/i18n/messages/de.json
@@ -1052,6 +1052,7 @@
     "guestFallbackName": "Gast {last4}",
     "itemNotePlaceholder": "Artikelnotiz",
     "kitchen": "Küche",
+    "kotPrintFailed": "Bestellung gesendet, aber der Küchenbon wurde nicht gedruckt",
     "loginHint": "Tischbestellungen für Bedienung, Manager und Inhaber",
     "loginSubtitle": "Tischbestellungen für das Servicepersonal",
     "newItems": "Neue Artikel",

--- a/frontend/src/lib/i18n/messages/en.json
+++ b/frontend/src/lib/i18n/messages/en.json
@@ -1276,6 +1276,7 @@
     "discountModeFlat": "Flat only",
     "discountModeHint": "Which discount types are available",
     "discountModePercentage": "Percentage only",
+    "discountNone": "Disabled (no discounts)",
     "discountPercentageOnly": "Percentage only",
     "discountSaved": "Discount settings saved",
     "discounts": "Discounts",

--- a/frontend/src/lib/i18n/messages/en.json
+++ b/frontend/src/lib/i18n/messages/en.json
@@ -1052,6 +1052,7 @@
     "guestFallbackName": "Guest {last4}",
     "itemNotePlaceholder": "Item note",
     "kitchen": "Kitchen",
+    "kotPrintFailed": "Order sent, but the kitchen ticket didn't print",
     "loginHint": "Tableside ordering for server, manager, and owner accounts",
     "loginSubtitle": "Tableside ordering for service staff",
     "newItems": "New items",

--- a/frontend/src/lib/i18n/messages/es.json
+++ b/frontend/src/lib/i18n/messages/es.json
@@ -1276,6 +1276,7 @@
     "discountModeFlat": "Solo monto fijo",
     "discountModeHint": "Qué tipos de descuento están disponibles",
     "discountModePercentage": "Solo porcentaje",
+    "discountNone": "Desactivado (sin descuentos)",
     "discountPercentageOnly": "Solo porcentaje",
     "discountSaved": "Configuración de descuentos guardada",
     "discounts": "Descuentos",

--- a/frontend/src/lib/i18n/messages/es.json
+++ b/frontend/src/lib/i18n/messages/es.json
@@ -1052,6 +1052,7 @@
     "guestFallbackName": "Invitado {last4}",
     "itemNotePlaceholder": "Nota del ítem",
     "kitchen": "Cocina",
+    "kotPrintFailed": "Pedido enviado, pero el comprobante de cocina no se imprimió",
     "loginHint": "Pedidos desde la mesa para cuentas de mesero, encargado y propietario",
     "loginSubtitle": "Pedidos desde la mesa para el personal de servicio",
     "newItems": "Ítems nuevos",

--- a/frontend/src/lib/i18n/messages/fa.json
+++ b/frontend/src/lib/i18n/messages/fa.json
@@ -1276,6 +1276,7 @@
     "discountModeFlat": "فقط ثابت",
     "discountModeHint": "کدام نوع تخفیف در دسترس است",
     "discountModePercentage": "فقط درصدی",
+    "discountNone": "غیرفعال (بدون تخفیف)",
     "discountPercentageOnly": "فقط درصدی",
     "discountSaved": "تنظیمات تخفیف ذخیره شد",
     "discounts": "تخفیف‌ها",

--- a/frontend/src/lib/i18n/messages/fa.json
+++ b/frontend/src/lib/i18n/messages/fa.json
@@ -1052,6 +1052,7 @@
     "guestFallbackName": "میهمان {last4}",
     "itemNotePlaceholder": "یادداشت کالا",
     "kitchen": "آشپزخانه",
+    "kotPrintFailed": "سفارش ارسال شد، اما فیش آشپزخانه چاپ نشد",
     "loginHint": "ثبت سفارش کنار میز برای حساب‌های گارسون، سرپرست و دارنده",
     "loginSubtitle": "ثبت سفارش کنار میز برای کارکنان خدمات",
     "newItems": "کالاهای تازه",

--- a/frontend/src/lib/i18n/messages/fil.json
+++ b/frontend/src/lib/i18n/messages/fil.json
@@ -1052,6 +1052,7 @@
     "guestFallbackName": "Bisita {last4}",
     "itemNotePlaceholder": "Tala sa item",
     "kitchen": "Kusina",
+    "kotPrintFailed": "Naipadala ang order, pero hindi na-print ang resibo ng kusina",
     "loginHint": "Pag-order sa lamesa para sa mga server, manager, at may-ari",
     "loginSubtitle": "Pag-order sa lamesa para sa service staff",
     "newItems": "Mga bagong item",

--- a/frontend/src/lib/i18n/messages/fil.json
+++ b/frontend/src/lib/i18n/messages/fil.json
@@ -1276,6 +1276,7 @@
     "discountModeFlat": "Fixed lamang",
     "discountModeHint": "Aling mga uri ng discount ang available sa counter",
     "discountModePercentage": "Porsyento lamang",
+    "discountNone": "Naka-disable (walang diskwento)",
     "discountPercentageOnly": "Porsyento lamang",
     "discountSaved": "Nai-save ang mga setting ng discount",
     "discounts": "Mga Discount",

--- a/frontend/src/lib/i18n/messages/fr.json
+++ b/frontend/src/lib/i18n/messages/fr.json
@@ -1276,6 +1276,7 @@
     "discountModeFlat": "Montant fixe uniquement",
     "discountModeHint": "Types de remises disponibles",
     "discountModePercentage": "Pourcentage uniquement",
+    "discountNone": "Désactivées (aucune remise)",
     "discountPercentageOnly": "Pourcentage uniquement",
     "discountSaved": "Paramètres de remise enregistrés",
     "discounts": "Remises",

--- a/frontend/src/lib/i18n/messages/fr.json
+++ b/frontend/src/lib/i18n/messages/fr.json
@@ -1052,6 +1052,7 @@
     "guestFallbackName": "Client {last4}",
     "itemNotePlaceholder": "Note sur l’article",
     "kitchen": "Cuisine",
+    "kotPrintFailed": "Commande envoyée, mais le ticket cuisine ne s'est pas imprimé",
     "loginHint": "Prise de commande à table pour les comptes serveur, responsable et propriétaire",
     "loginSubtitle": "Prise de commande à table pour le personnel de service",
     "newItems": "Nouveaux articles",

--- a/frontend/src/lib/i18n/messages/pt.json
+++ b/frontend/src/lib/i18n/messages/pt.json
@@ -1276,6 +1276,7 @@
     "discountModeFlat": "Somente fixo",
     "discountModeHint": "Quais tipos de desconto estão disponíveis",
     "discountModePercentage": "Somente porcentagem",
+    "discountNone": "Desativado (sem descontos)",
     "discountPercentageOnly": "Somente porcentagem",
     "discountSaved": "Configurações de desconto salvas",
     "discounts": "Descontos",

--- a/frontend/src/lib/i18n/messages/pt.json
+++ b/frontend/src/lib/i18n/messages/pt.json
@@ -1052,6 +1052,7 @@
     "guestFallbackName": "Convidado {last4}",
     "itemNotePlaceholder": "Nota do item",
     "kitchen": "Cozinha",
+    "kotPrintFailed": "Pedido enviado, mas a comanda da cozinha não foi impressa",
     "loginHint": "Pedidos à mesa para contas de garçom, gerente e proprietário",
     "loginSubtitle": "Pedidos à mesa para a equipe de serviço",
     "newItems": "Novos itens",

--- a/frontend/src/lib/i18n/messages/tr.json
+++ b/frontend/src/lib/i18n/messages/tr.json
@@ -1052,6 +1052,7 @@
     "guestFallbackName": "Misafir {last4}",
     "itemNotePlaceholder": "Ürün notu",
     "kitchen": "Mutfak",
+    "kotPrintFailed": "Sipariş gönderildi, ancak mutfak fişi yazdırılamadı",
     "loginHint": "Garson, müdür ve işletme sahibi hesapları için masadan sipariş alma",
     "loginSubtitle": "Servis personeli için masadan sipariş alma",
     "newItems": "Yeni Ürünler",

--- a/frontend/src/lib/i18n/messages/tr.json
+++ b/frontend/src/lib/i18n/messages/tr.json
@@ -1276,6 +1276,7 @@
     "discountModeFlat": "Yalnızca sabit tutar",
     "discountModeHint": "Kasada hangi indirim türlerinin kullanılabileceğini belirler",
     "discountModePercentage": "Yalnızca yüzde",
+    "discountNone": "Devre dışı (indirim yok)",
     "discountPercentageOnly": "Yalnızca yüzde",
     "discountSaved": "İndirim ayarları kaydedildi",
     "discounts": "İndirimler",

--- a/main/routes/bills.ts
+++ b/main/routes/bills.ts
@@ -2136,6 +2136,9 @@ router.post('/:id/applyDiscount', requireRole(...ROLE_ACCESS.ownerManager), (req
 
     // Check discount mode
     const discountMode = getSettingValue('discount_mode') || 'percentage';
+    if (discountMode === 'none') {
+      return res.status(400).json({ error: 'Discounts are disabled' });
+    }
     if (discountMode === 'flat' && type === 'percentage') {
       return res.status(400).json({ error: 'Percentage discounts are disabled' });
     }

--- a/main/routes/orders.ts
+++ b/main/routes/orders.ts
@@ -1203,6 +1203,9 @@ router.patch('/:id/discount', orderWriteRateLimit, requireRole(...ROLE_ACCESS.ow
     // Check discount mode
     if (discount_value > 0) {
       const discountMode = getSettingValue('discount_mode') || 'percentage';
+      if (discountMode === 'none') {
+        return res.status(400).json({ error: 'Discounts are disabled' });
+      }
       if (discountMode === 'flat' && discount_type === 'percentage') {
         return res.status(400).json({ error: 'Percentage discounts are disabled' });
       }
@@ -1407,6 +1410,9 @@ router.patch('/:id/items/:itemId/discount', orderWriteRateLimit, requireRole(...
 
     // Check discount mode
     const discountMode = getSettingValue('discount_mode') || 'percentage';
+    if (discountMode === 'none') {
+      return res.status(400).json({ error: 'Discounts are disabled' });
+    }
     if (discountMode === 'flat' && discount_type === 'percentage') {
       return res.status(400).json({ error: 'Percentage discounts are disabled' });
     }

--- a/main/routes/printers.ts
+++ b/main/routes/printers.ts
@@ -556,8 +556,11 @@ export function routeItemsToStations(db: any, orderItems: any[]): { stationName:
   return result;
 }
 
-// POST /api/printers/print-kot — print KOT via backend (desktop app)
-router.post('/print-kot', requireRole(...ROLE_ACCESS.ownerManagerCashier), asyncHandler(async (req: Request, res: Response) => {
+// POST /api/printers/print-kot — print KOT via backend (desktop app).
+// Uses `sales` (not `ownerManagerCashier`) so the waiter/table terminal's
+// "server" role — which can create orders but not access the main POS —
+// can trigger the kitchen ticket for an order it just placed.
+router.post('/print-kot', requireRole(...ROLE_ACCESS.sales), asyncHandler(async (req: Request, res: Response) => {
   // Enforce master KOT printing toggle for all automatic and manual print requests.
   if (!isKotPrintingEnabled()) {
     return res.status(403).json({ error: 'KOT printing is disabled for this business' });

--- a/main/routes/printers.ts
+++ b/main/routes/printers.ts
@@ -557,9 +557,7 @@ export function routeItemsToStations(db: any, orderItems: any[]): { stationName:
 }
 
 // POST /api/printers/print-kot — print KOT via backend (desktop app).
-// Uses `sales` (not `ownerManagerCashier`) so the waiter/table terminal's
-// "server" role — which can create orders but not access the main POS —
-// can trigger the kitchen ticket for an order it just placed.
+// Uses `sales` so the waiter terminal's "server" role can print its own orders.
 router.post('/print-kot', requireRole(...ROLE_ACCESS.sales), asyncHandler(async (req: Request, res: Response) => {
   // Enforce master KOT printing toggle for all automatic and manual print requests.
   if (!isKotPrintingEnabled()) {
@@ -589,6 +587,10 @@ router.post('/print-kot', requireRole(...ROLE_ACCESS.sales), asyncHandler(async 
     const order: any = db.prepare('SELECT * FROM orders WHERE id = ?').get(orderId);
     if (!order) {
       return res.status(404).json({ error: 'Order not found' });
+    }
+    const authUser = (req as any).user;
+    if (authUser?.role === 'server' && order.user_id !== authUser.userId) {
+      return res.status(403).json({ error: 'Servers can only print their own orders' });
     }
 
     const kotLanguage = resolveTenantKotLanguage(db);

--- a/main/routes/settings.ts
+++ b/main/routes/settings.ts
@@ -427,8 +427,8 @@ router.put('/discount', requireRole(...ROLE_ACCESS.ownerManager), (req: Request,
         return res.status(400).json({ error: 'discount_max_amount must be a number between 0 and 999999' });
       }
     }
-    if (discount_mode !== undefined && !['percentage', 'flat', 'both'].includes(discount_mode)) {
-      return res.status(400).json({ error: 'discount_mode must be "percentage", "flat", or "both"' });
+    if (discount_mode !== undefined && !['percentage', 'flat', 'both', 'none'].includes(discount_mode)) {
+      return res.status(400).json({ error: 'discount_mode must be "percentage", "flat", "both", or "none"' });
     }
 
     const db = getDatabase();

--- a/main/routes/whatsapp.ts
+++ b/main/routes/whatsapp.ts
@@ -150,7 +150,7 @@ router.get('/messages', requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: R
   res.json({ messages: whatsapp.listMessages({ direction, status, phone, billId, limit, offset }) });
 });
 
-router.get('/inbox', requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: Request, res: Response) => {
+router.get('/inbox', requireRole(...ROLE_ACCESS.ownerManager), (req: Request, res: Response) => {
   const limitValue = parsePaginationParam(req.query.limit, 50, 200);
   const offset = parsePaginationParam(req.query.offset, 0);
   if (limitValue === null || limitValue < 1) {
@@ -163,7 +163,7 @@ router.get('/inbox', requireRole(...ROLE_ACCESS.ownerManagerCashier), (req: Requ
   res.json({ messages: whatsapp.listInbox(limit, offset) });
 });
 
-router.post('/inbox/:messageId/reply', requireRole(...ROLE_ACCESS.ownerManagerCashier), asyncHandler(async (req, res) => {
+router.post('/inbox/:messageId/reply', requireRole(...ROLE_ACCESS.ownerManager), asyncHandler(async (req, res) => {
   const { body } = req.body ?? {};
   if (!body || typeof body !== 'string') {
     res.status(400).json({ error: 'body required', reason: 'body_required' });

--- a/main/server-app.ts
+++ b/main/server-app.ts
@@ -281,6 +281,7 @@ export function startServerApp(): Promise<void> {
     app.get('/api/customers-search', requireServerAppAuth, (req, res) => forwardToMainApi(req, res, '/customers-search'));
     app.get('/api/crm/lookup', requireServerAppAuth, (req, res) => forwardToMainApi(req, res, '/crm/lookup'));
     app.post('/api/customers', requireServerAppAuth, (req, res) => forwardToMainApi(req, res, '/customers'));
+    app.post('/api/printers/print-kot', requireServerAppAuth, (req, res) => forwardToMainApi(req, res, '/printers/print-kot'));
 
     const staticDir = getStaticDir();
     if (staticDir) {

--- a/tests/issue-133-kds-kot-toggles.test.ts
+++ b/tests/issue-133-kds-kot-toggles.test.ts
@@ -112,10 +112,7 @@ async function main() {
       403,
       'server remains forbidden from POST /api/printers/print-bill',
     );
-    // The table/waiter terminal (server role) can create orders but never
-    // reaches the main POS, so it needs print-kot access to notify the
-    // kitchen of orders it places — unlike print-bill, which stays owner/
-    // manager/cashier-only.
+    // The waiter terminal (server role) needs print-kot to notify the kitchen; print-bill stays restricted.
     const waiterKotRes = await request(app)
       .post('/api/printers/print-kot')
       .set(waiterAuth)

--- a/tests/issue-133-kds-kot-toggles.test.ts
+++ b/tests/issue-133-kds-kot-toggles.test.ts
@@ -112,11 +112,16 @@ async function main() {
       403,
       'server remains forbidden from POST /api/printers/print-bill',
     );
-    assertEqual(
-      (await request(app).post('/api/printers/print-kot').set(waiterAuth).send({ orderId: 999999 })).status,
-      403,
-      'server remains forbidden from POST /api/printers/print-kot',
-    );
+    // The table/waiter terminal (server role) can create orders but never
+    // reaches the main POS, so it needs print-kot access to notify the
+    // kitchen of orders it places — unlike print-bill, which stays owner/
+    // manager/cashier-only.
+    const waiterKotRes = await request(app)
+      .post('/api/printers/print-kot')
+      .set(waiterAuth)
+      .send({ orderId: 999999 });
+    assertEqual(waiterKotRes.status, 400, 'server reaches POST /api/printers/print-kot handler');
+    assertEqual(waiterKotRes.body.error, 'No default printer configured. Add a printer in Settings.', 'server print-kot fails at printer validation, not role gating');
     assertEqual(
       (await request(app).post('/api/printers/print-bill').send({ billId: 999999 })).status,
       401,

--- a/tests/orders-authz.test.ts
+++ b/tests/orders-authz.test.ts
@@ -57,6 +57,8 @@ async function main() {
   db.prepare(`INSERT INTO categories (id, name, sort_order) VALUES ('authz-category', 'Authz', 1)`).run();
   db.prepare(`INSERT INTO products (id, category_id, name, price, is_active, sort_order)
     VALUES ('authz-product', 'authz-category', 'Authz item', 100, 1, 1)`).run();
+  db.prepare(`INSERT INTO printers (id, name, connection_type, ip_address, port, is_default, paper_width, created_at, updated_at)
+    VALUES ('authz-printer', 'Authz Printer', 'network', '127.0.0.1', 9100, 1, '80mm', ?, ?)`).run(now(), now());
 
   const app = express();
   app.use(express.json());
@@ -112,6 +114,19 @@ async function main() {
       method: 'PATCH', body: { override_pin: '1234' }, headers: waiterAuth,
     });
     assertEqual(waiterOtherItem.status, 403, 'server cannot void another user\'s item');
+
+    // print-kot: server role may print its own orders but not another user's.
+    const waiterKotOwnOrder = seedOrderWithItem(db, 'WAITER-KOT-OWN', 'server-authz');
+    db.prepare(`UPDATE order_items SET status = 'ready' WHERE order_id = ?`).run(waiterKotOwnOrder.orderId);
+    const waiterKotOwn = await api(baseUrl, '/api/printers/print-kot', {
+      method: 'POST', body: { orderId: waiterKotOwnOrder.orderId }, headers: waiterAuth,
+    });
+    assertEqual(waiterKotOwn.status, 200, 'server can print-kot for their own order');
+    const waiterKotOther = await api(baseUrl, '/api/printers/print-kot', {
+      method: 'POST', body: { orderId: otherOrder.orderId }, headers: waiterAuth,
+    });
+    assertEqual(waiterKotOther.status, 403, 'server cannot print-kot for another user\'s order');
+    assertEqual(waiterKotOther.data.error, 'Servers can only print their own orders', 'print-kot ownership error identifies the restriction');
 
     const invalidPinOrder = seedOrderWithItem(db, 'INVALID-PIN', 'cashier-authz');
     const invalidPin = await api(baseUrl, `/api/orders/${invalidPinOrder.orderId}/items/${invalidPinOrder.itemId}/cancel`, {


### PR DESCRIPTION
## Summary

Five more low-hanging-fruit fixes. Only #700 and #713 remained as open `type:Bug` issues; the other three ([#712](https://github.com/FreeOpenSourcePOS/FloCafe/issues/712), [#710](https://github.com/FreeOpenSourcePOS/FloCafe/issues/710), [#715](https://github.com/FreeOpenSourcePOS/FloCafe/issues/715)) are small, well-scoped `enhancement` issues picked to round out the batch.

- **Native number-input spinners** — one global CSS rule hides the redundant native spinner across all 37 existing numeric fields (they already have custom +/- controls).
- **WhatsApp Inbox restricted to owner/manager** — the page already computed `isAdmin` but never used it to gate the Inbox tab; the two inbox API routes accepted the cashier role too. Hidden client-side and narrowed server-side. Sending receipts is untouched.
- **Dark-mode contrast** — scoped to the three spots named in the report: POS table-picker status chips, KDS standalone's disabled/loading screens (which ignored the theme setting entirely), and the Z-report variance box/error banner.
- **Discounts can now be disabled entirely** — a new `discount_mode: 'none'` hides the discount UI everywhere and is rejected server-side, for businesses that never discount.
- **KOT printing from the waiter terminal** — the standalone Table Terminal could create orders but never notified the kitchen. Added the missing backend proxy route and widened `print-kot`'s role gate to include the `server` role (which can't reach the main POS at all otherwise); `print-bill` stays restricted since it's payment-adjacent. Updated a test that had pinned the old behavior as an invariant.

Each fix is its own commit; see commit messages for detail.

**Discovered but not fixed** (noted per scope discipline, not expanded): the Orders page has an order-level discount-editing modal (`discountModal` state, PATCH `/orders/:id/discount`) with no reachable UI trigger anywhere in that file — it can only be programmatically reached via an internal auto-correction effect, never opened fresh. Pre-existing, unrelated to this PR.

Fixes #712, #710, #713, #715, #700

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run build` (backend) — clean
- [x] `npm run build:frontend` — clean
- [x] `npm run i18n:check` — all locales pass (added `discountNone` and `kotPrintFailed` keys across all 8 languages)
- [x] Focused suites: discount (integration/system/settings), authz (phase3/staff/orders/server-app-server-role), issue-133 KOT toggles (updated + passing), printer, addons, whatsapp, loyalty — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “No discounts” option with discount controls automatically hidden or blocked when selected.
  - Server-role staff can now print kitchen tickets for orders they place.
- **Bug Fixes**
  - Kitchen-ticket print failures now provide clear feedback while preserving successful orders.
  - Non-admin users no longer see or access the WhatsApp inbox.
- **Style**
  - Improved dark-mode colors across standalone screens, cash closing, and table status displays.
  - Removed browser number-input spinners where custom controls are available.
- **Localization**
  - Added translated labels and kitchen-ticket printing error messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->