### PR TITLE
fix(pos): drop icons from Dine In and Online order-type buttons

### DIFF
--- a/frontend/src/components/pos/CartPanel.tsx
+++ b/frontend/src/components/pos/CartPanel.tsx
@@ -78,18 +78,19 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
             .filter((type) => isRestaurant || type !== 'dine_in')
             .map((type) => {
               const Icon = orderTypeIcons[type];
+              const showIcon = type !== 'dine_in' && type !== 'online';
               const label = type === 'dine_in' ? t('orderTypeDineIn') : type === 'takeaway' ? t('orderTypeTakeaway') : type === 'delivery' ? t('orderTypeDelivery') : t('orderTypeOnline');
               return (
                 <button
                   key={type}
                   onClick={() => cart.setOrderType(type)}
-                  className={`touch-target flex-1 gap-1 px-2 rounded-md text-xs font-medium transition-colors ${
+                  className={`touch-target flex-1 gap-1 px-2 rounded-md text-xs font-medium transition-colors whitespace-nowrap ${
                     cart.orderType === type
                       ? 'bg-card text-brand shadow-sm'
                       : 'text-muted-foreground hover:text-foreground'
                   }`}
                 >
-                  <Icon size={14} />
+                  {showIcon && <Icon size={14} />}
                   {label}
                 </button>
               );

--- a/frontend/src/components/pos/CartPanel.tsx
+++ b/frontend/src/components/pos/CartPanel.tsx
@@ -84,7 +84,7 @@ export default function CartPanel({ tables, submitting, onPlaceOrder, onEditItem
                 <button
                   key={type}
                   onClick={() => cart.setOrderType(type)}
-                  className={`touch-target flex-1 gap-1 px-2 rounded-md text-xs font-medium transition-colors whitespace-nowrap ${
+                  className={`touch-target flex-1 gap-1 px-2 rounded-md text-xs font-medium transition-colors ${showIcon ? '' : 'whitespace-nowrap'} ${
                     cart.orderType === type
                       ? 'bg-card text-brand shadow-sm'
                       : 'text-muted-foreground hover:text-foreground'


### PR DESCRIPTION
## Summary
- Remove the icon from the Dine In and Online buttons in the POS cart panel's order-type toggle, keeping icons on Takeaway and Delivery.
- Add `whitespace-nowrap` so each label renders on a single line instead of wrapping.

## Test plan
- [x] `npm run lint` — no new warnings/errors
- [x] Manual code review of the conditional icon rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated order-type button spacing and horizontal padding.
  - Icons remain visible for takeaway and delivery options; dine-in and online options display without icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->