### PR TITLE
chore(release): bump version to 3.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "3.7.6",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "3.7.6",
+      "version": "3.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.7.6",
+  "version": "3.8.0",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- Bump `flo-desktop` version from 3.7.6 to 3.8.0 in `package.json` (and sync `package-lock.json`) ahead of the v3.8.0 release.

## Test plan
- [x] `npm run lint` (0 errors)
- [x] `npm run build`
- [x] `npm run i18n:check`
- [x] `npm run build:frontend`
- [x] `npm test` (full suite, exit code 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)