### PR TITLE
fix(printer): declare local-network usage, stop blocking Send on print

### DIFF
--- a/frontend/src/app/server-standalone/page.tsx
+++ b/frontend/src/app/server-standalone/page.tsx
@@ -362,8 +362,12 @@ export default function ServerStandalonePage() {
       };
       // Printing can hang on an unreachable printer; run it in the background instead of
       // keeping the terminal blocked on "sending" once the order itself is safely placed.
-      void printKotForOrder(orderId, { ...enrichedOrder, items: newItems });
-      void printOrderSlip(orderId, enrichedOrder);
+      // Sequenced, not concurrent: KOT and bill can resolve to the same default printer,
+      // and simultaneous raw socket writes to one thermal printer can corrupt output.
+      void (async () => {
+        await printKotForOrder(orderId, { ...enrichedOrder, items: newItems });
+        await printOrderSlip(orderId, enrichedOrder);
+      })();
     } catch (error: unknown) {
       toastApiError(error, t('couldNotSendOrder'), apiErrorT);
     } finally {

--- a/frontend/src/app/server-standalone/page.tsx
+++ b/frontend/src/app/server-standalone/page.tsx
@@ -360,10 +360,8 @@ export default function ServerStandalonePage() {
         table: activeTable ? { name: activeTable.name || activeTable.number } : undefined,
         customer: currentOrder?.customer || (trimmedCustomerName ? { name: trimmedCustomerName } : undefined),
       };
-      // Printing can hang on an unreachable printer; run it in the background instead of
-      // keeping the terminal blocked on "sending" once the order itself is safely placed.
-      // Sequenced, not concurrent: KOT and bill can resolve to the same default printer,
-      // and simultaneous raw socket writes to one thermal printer can corrupt output.
+      // Backgrounded so an unreachable printer can't block Send; sequenced (not concurrent)
+      // since KOT and bill can share a default printer and race its socket connection.
       void (async () => {
         await printKotForOrder(orderId, { ...enrichedOrder, items: newItems });
         await printOrderSlip(orderId, enrichedOrder);

--- a/frontend/src/app/server-standalone/page.tsx
+++ b/frontend/src/app/server-standalone/page.tsx
@@ -360,8 +360,10 @@ export default function ServerStandalonePage() {
         table: activeTable ? { name: activeTable.name || activeTable.number } : undefined,
         customer: currentOrder?.customer || (trimmedCustomerName ? { name: trimmedCustomerName } : undefined),
       };
-      await printKotForOrder(orderId, { ...enrichedOrder, items: newItems });
-      await printOrderSlip(orderId, enrichedOrder);
+      // Printing can hang on an unreachable printer; run it in the background instead of
+      // keeping the terminal blocked on "sending" once the order itself is safely placed.
+      void printKotForOrder(orderId, { ...enrichedOrder, items: newItems });
+      void printOrderSlip(orderId, enrichedOrder);
     } catch (error: unknown) {
       toastApiError(error, t('couldNotSendOrder'), apiErrorT);
     } finally {

--- a/package.json
+++ b/package.json
@@ -360,7 +360,13 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": true,
-      "artifactName": "flocafe-${version}-mac-${arch}.${ext}"
+      "artifactName": "flocafe-${version}-mac-${arch}.${ext}",
+      "extendInfo": {
+        "NSLocalNetworkUsageDescription": "Flo Cafe connects to thermal printers, KDS displays, and the Waiter & Table Terminal on your local network.",
+        "NSBonjourServices": [
+          "_http._tcp"
+        ]
+      }
     },
     "mas": {
       "category": "public.app-category.business",
@@ -373,7 +379,11 @@
       "gatekeeperAssess": false,
       "type": "distribution",
       "extendInfo": {
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSLocalNetworkUsageDescription": "Flo Cafe connects to thermal printers, KDS displays, and the Waiter & Table Terminal on your local network.",
+        "NSBonjourServices": [
+          "_http._tcp"
+        ]
       },
       "target": [
         {


### PR DESCRIPTION
## Summary
- Declares `NSLocalNetworkUsageDescription` (+ `NSBonjourServices` for the `flo.local` mDNS advertisement) on both the notarized DMG/zip build and the Mac App Store build, so macOS actually prompts for local-network access instead of silently denying the app's outbound connections to LAN thermal printers. Follows up on user feedback reporting the kitchen printer no longer printing, and the Waiter & Table Terminal hanging at "Send Order," on macOS 26.6.1 Tahoe after upgrading to 3.8.0 — the same user had filed #700, fixed by #724/#728 in 3.8.0, but the fix apparently doesn't reach them on Tahoe.
- Stops the Waiter & Table Terminal's Send/Add-to-Order button from blocking on print completion: KOT and bill print attempts now fire without being awaited once the order itself is safely created, instead of the button staying disabled through up to ~20s of chained socket timeouts when a printer is unreachable. Both print calls already catch and toast their own failures internally, so error visibility is unchanged.

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run build:frontend` — compiles and type-checks clean
- [x] `npm run build` — backend TS build clean
- [x] `npm test` — full suite (see CI / follow-up comment)
- [ ] Reporter confirms the kitchen printer prints again after upgrading, and the Send button no longer hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Order placement now completes more quickly without waiting for KOT and order-slip printing to finish.
  - After an order is placed, printing continues in the background, allowing you to continue using the app sooner.
  - Existing printing error handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->