### PR TITLE
chore(release): bump version to 3.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flo-desktop",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flo-desktop",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flo-desktop",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Free, open-source, offline-first restaurant POS with KDS, SQLite, and thermal printer support.",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- Patch release bumping `package.json`/`package-lock.json` to 3.8.1, carrying the two printer fixes from #731: local-network usage declaration (macOS Tahoe LNP) and the Waiter & Table Terminal no longer blocking Send on print completion.

## Test plan
- [x] `npm run lint`, `npm run build`, `npm run build:frontend` clean
- [x] Version fields match across `package.json` and `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)